### PR TITLE
feat: Auto モード起動メニュー追加 (#2)

### DIFF
--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import { randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { tmpdir } from 'os';
+import { homedir, tmpdir } from 'os';
 import type { IPty } from 'node-pty';
 import type {
   TerminalCreateOptions,
@@ -30,6 +30,29 @@ export const sessions = new Map<string, Session>();
 
 /** agentId → pty セッションの逆引き。TeamHub が team_send 時に使う */
 export const agentSessions = new Map<string, Session>();
+
+/**
+ * Claude Code を --dangerously-skip-permissions で起動する場合、
+ * ~/.claude/settings.json に skipDangerousModePermissionPrompt: true を
+ * 事前設定しておかないと毎回 WARNING ダイアログが表示される。
+ * (anthropics/claude-code#25503)
+ */
+async function ensureBypassPermissionPromptSetting(args: string[] | undefined): Promise<void> {
+  if (!args?.includes('--dangerously-skip-permissions')) return;
+  const claudeDir = join(homedir(), '.claude');
+  const settingsPath = join(claudeDir, 'settings.json');
+  let settings: Record<string, unknown> = {};
+  try {
+    const raw = await fs.readFile(settingsPath, 'utf-8');
+    settings = JSON.parse(raw);
+  } catch {
+    // ファイルが存在しない or パースエラー → 新規作成
+  }
+  if (settings.skipDangerousModePermissionPrompt === true) return;
+  settings.skipDangerousModePermissionPrompt = true;
+  await fs.mkdir(claudeDir, { recursive: true });
+  await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+}
 
 /**
  * Windows では PATH 経由の .cmd ラッパー（例: C:\...\npm\claude.cmd）を
@@ -117,8 +140,11 @@ async function watchClaudeSession(
 export function registerTerminalIpc(): void {
   ipcMain.handle(
     'terminal:create',
-    (event, opts: TerminalCreateOptions): TerminalCreateResult => {
+    async (event, opts: TerminalCreateOptions): Promise<TerminalCreateResult> => {
       try {
+        // --dangerously-skip-permissions 使用時のプリフライト
+        await ensureBypassPermissionPromptSetting(opts.args);
+
         const { command, args } = resolveCommand(opts.command, opts.args);
 
         const pty = nodePty.spawn(command, args, {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -78,6 +78,8 @@ interface TerminalTab {
   hasActivity: boolean;
   /** チーム履歴で使う member インデックス。未所属タブは null */
   teamHistoryMemberIdx: number | null;
+  /** Auto モード（Claude: --dangerously-skip-permissions / Codex: --full-auto） */
+  autoMode?: boolean;
 }
 
 /** ロール別の短い説明（チームプロンプト内で使用） */

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -236,6 +236,7 @@ export function App(): JSX.Element {
       resumeSessionId?: string | null;
       agentId?: string;
       teamHistoryMemberIdx?: number | null;
+      autoMode?: boolean;
     }): number | null => {
       const id = nextTerminalIdRef.current++;
       const tab: TerminalTab = {
@@ -249,7 +250,8 @@ export function App(): JSX.Element {
         exited: false,
         resumeSessionId: opts?.resumeSessionId ?? null,
         hasActivity: false,
-        teamHistoryMemberIdx: opts?.teamHistoryMemberIdx ?? null
+        teamHistoryMemberIdx: opts?.teamHistoryMemberIdx ?? null,
+        autoMode: opts?.autoMode ?? false
       };
       let accepted = false;
       setTerminalTabs((prev) => {
@@ -1079,12 +1081,28 @@ export function App(): JSX.Element {
         run: () => { addTerminalTab({ agent: 'claude' }); }
       },
       {
+        id: 'terminal.addClaudeAuto',
+        title: 'Claude Code (Auto) タブを追加',
+        subtitle: `${terminalTabs.length}/${MAX_TERMINALS}`,
+        category: 'ターミナル',
+        when: () => terminalTabs.length < MAX_TERMINALS,
+        run: () => { addTerminalTab({ agent: 'claude', autoMode: true }); }
+      },
+      {
         id: 'terminal.addCodex',
         title: 'Codex タブを追加',
         subtitle: `${terminalTabs.length}/${MAX_TERMINALS}`,
         category: 'ターミナル',
         when: () => terminalTabs.length < MAX_TERMINALS,
         run: () => { addTerminalTab({ agent: 'codex' }); }
+      },
+      {
+        id: 'terminal.addCodexAuto',
+        title: 'Codex (Auto) タブを追加',
+        subtitle: `${terminalTabs.length}/${MAX_TERMINALS}`,
+        category: 'ターミナル',
+        when: () => terminalTabs.length < MAX_TERMINALS,
+        run: () => { addTerminalTab({ agent: 'codex', autoMode: true }); }
       },
       {
         id: 'terminal.createTeam',
@@ -1243,6 +1261,14 @@ export function App(): JSX.Element {
       const base = parseShellArgs(
         isCodex ? settings.codexArgs || '' : settings.claudeArgs || ''
       );
+      // Auto モード: エージェント別のフラグを付与
+      if (tab.autoMode) {
+        if (isCodex) {
+          if (!base.includes('--full-auto')) base.push('--full-auto');
+        } else {
+          if (!base.includes('--dangerously-skip-permissions')) base.push('--dangerously-skip-permissions');
+        }
+      }
       if (tab.resumeSessionId && !isCodex) {
         base.push('--resume', tab.resumeSessionId);
       }
@@ -1724,10 +1750,24 @@ export function App(): JSX.Element {
                     </button>
                     <button
                       className="tab-create-menu__item"
+                      onClick={() => { addTerminalTab({ agent: 'claude', autoMode: true }); setTabCreateMenuOpen(false); }}
+                    >
+                      <span className="terminal-tab__agent terminal-tab__agent--claude">C</span>
+                      {t('claudePanel.addClaudeAuto')}
+                    </button>
+                    <button
+                      className="tab-create-menu__item"
                       onClick={() => { addTerminalTab({ agent: 'codex' }); setTabCreateMenuOpen(false); }}
                     >
                       <span className="terminal-tab__agent terminal-tab__agent--codex">X</span>
                       {t('claudePanel.addCodex')}
+                    </button>
+                    <button
+                      className="tab-create-menu__item"
+                      onClick={() => { addTerminalTab({ agent: 'codex', autoMode: true }); setTabCreateMenuOpen(false); }}
+                    >
+                      <span className="terminal-tab__agent terminal-tab__agent--codex">X</span>
+                      {t('claudePanel.addCodexAuto')}
                     </button>
                     <div className="tab-create-menu__divider" />
                     <button

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -87,7 +87,9 @@ const ja: Dict = {
   'claudePanel.closeTab': 'タブを閉じる',
   'claudePanel.tabLimit': '上限に達しています（最大{max}）',
   'claudePanel.addClaude': 'Claude Code を追加',
+  'claudePanel.addClaudeAuto': 'Claude Code (Auto) を追加',
   'claudePanel.addCodex': 'Codex を追加',
+  'claudePanel.addCodexAuto': 'Codex (Auto) を追加',
   'claudePanel.createTeam': 'Team を作成…',
 
   // ---------- Team ----------
@@ -254,7 +256,9 @@ const en: Dict = {
   'claudePanel.closeTab': 'Close tab',
   'claudePanel.tabLimit': 'Limit reached (max {max})',
   'claudePanel.addClaude': 'Add Claude Code',
+  'claudePanel.addClaudeAuto': 'Add Claude Code (Auto)',
   'claudePanel.addCodex': 'Add Codex',
+  'claudePanel.addCodexAuto': 'Add Codex (Auto)',
   'claudePanel.createTeam': 'Create Team…',
 
   // ---------- Team ----------


### PR DESCRIPTION
## Summary

- 「＋」メニューに **Claude Code (Auto)** / **Codex (Auto)** の選択肢を追加
- Claude Code (Auto): `--dangerously-skip-permissions` フラグを自動付与
- Codex (Auto): `--full-auto` フラグを自動付与
- Claude Code Auto 起動時に `~/.claude/settings.json` の `skipDangerousModePermissionPrompt` を自動設定（[anthropics/claude-code#25503](https://github.com/anthropics/claude-code/issues/25503) のワークアラウンド）
- 通常モードの既存動作に影響なし

## 変更ファイル（3ファイル, +75/-3）

| ファイル | 変更内容 |
|---------|---------|
| `src/main/ipc/terminal.ts` | プリフライト処理追加（`ensureBypassPermissionPromptSetting`）、ハンドラ async 化 |
| `src/renderer/src/App.tsx` | `autoMode` フラグ、メニュー項目追加、`getTerminalArgs` で Auto フラグ付与 |
| `src/renderer/src/lib/i18n.ts` | 日英翻訳追加 |

## Test plan

- [ ] vibe-editor をビルド・起動し「＋」メニューに4つの選択肢が表示されることを確認
- [ ] 「Claude Code (Auto) を追加」で起動 → bypass permissions モードで即座に起動すること
- [ ] 「Codex (Auto) を追加」で起動 → full-auto モードで起動すること
- [ ] 通常の「Claude Code を追加」は従来通り動作すること
- [ ] `~/.claude/settings.json` に `skipDangerousModePermissionPrompt: true` が自動設定されること

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)