### PR TITLE
fix(team): vibe-team プロンプトが Claude/Codex に届かない競合を修正

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -2,11 +2,6 @@
 //
 // portable-pty 経由で PTY を spawn、SessionRegistry に登録、
 // terminal:data:{id} / terminal:exit:{id} イベントを emit する。
-//
-// **既知の Phase 1 後半 TODO**:
-// - Claude Code セッション ID watcher (~/.claude/projects/<encoded>/*.jsonl 監視)
-// - Codex 用 model_instructions_file 一時書き出し
-// - PATH 解決 (resolve-command 移植)
 
 use crate::pty::{spawn_session, SpawnOptions};
 use crate::state::AppState;
@@ -65,15 +60,76 @@ fn resolve_command(command: Option<String>, args: Option<Vec<String>>) -> (Strin
     (cmd, args.unwrap_or_default())
 }
 
+/// Codex 用 model_instructions_file を一時パスに書き出す。
+/// `~/.vibe-editor/codex-instructions/<uuid>.md` を返す。
+/// 失敗しても PTY spawn 自体は止めず、warn ログだけ残して None を返す。
+fn write_codex_instructions(content: &str) -> Option<std::path::PathBuf> {
+    let dir = dirs::home_dir()?
+        .join(".vibe-editor")
+        .join("codex-instructions");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::warn!("[codex-instructions] mkdir failed: {e}");
+        return None;
+    }
+    let path = dir.join(format!("{}.md", Uuid::new_v4()));
+    if let Err(e) = std::fs::write(&path, content) {
+        tracing::warn!("[codex-instructions] write failed: {e}");
+        return None;
+    }
+    Some(path)
+}
+
+/// 過去に書き出した codex-instructions ファイルのうち 1 日以上古いものを削除。
+/// PTY 終了時の cleanup は ChildKiller を kill した直後では正確に取れない (Codex
+/// が PTY を握ったまま再起動するケースもある) ため、TTL ベースで掃除する。
+fn cleanup_old_codex_instructions(dir: &std::path::Path) {
+    const TTL_SECS: u64 = 24 * 60 * 60;
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let now = std::time::SystemTime::now();
+    for entry in rd.flatten() {
+        let Ok(meta) = entry.metadata() else { continue };
+        let Ok(modified) = meta.modified() else { continue };
+        let age = now.duration_since(modified).unwrap_or_default();
+        if age.as_secs() > TTL_SECS {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn terminal_create(
     app: AppHandle,
     state: State<'_, AppState>,
     opts: TerminalCreateOptions,
 ) -> Result<TerminalCreateResult, String> {
-    let (command, args) = resolve_command(opts.command, opts.args);
+    let (command, mut args) = resolve_command(opts.command, opts.args);
     let (cwd, warning) =
         crate::pty::session::resolve_valid_cwd(&opts.cwd, opts.fallback_cwd.as_deref());
+
+    // Codex の team プロンプト: 一時ファイル化して `-c model_instructions_file=<path>`
+    // を args 先頭に積む。Codex は CLI 引数経由で system instructions を直接渡せない
+    // ため、ファイルに書いて -c で渡すのが唯一の経路。
+    // この処理が無かったため Codex のチームメンバーは team プロンプトを完全に
+    // 受け取れていなかった (TerminalCreateOptions に codex_instructions は来ていたが
+    // 関数内で読まれていない不在実装だった)。
+    if let Some(content) = opts
+        .codex_instructions
+        .as_ref()
+        .filter(|s| !s.trim().is_empty())
+    {
+        if let Some(path) = write_codex_instructions(content) {
+            // ベスト努力で古いファイルを掃除 (paste-images と同じ TTL 方式)。
+            if let Some(parent) = path.parent() {
+                cleanup_old_codex_instructions(parent);
+            }
+            // -c の値部分はクオート不要 (Codex 側で文字列パース)。
+            // 先頭に積むのは、ユーザー指定の -c で上書きされるのを許すため。
+            args.insert(0, format!("model_instructions_file={}", path.display()));
+            args.insert(0, "-c".to_string());
+        }
+    }
 
     tracing::info!(
         "[IPC] terminal_create command={command} args={args:?} cwd={cwd} cols={} rows={}",

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import type {
   TeamMember,
   TeamPreset,
   TeamRole,
+  TeamRosterMember,
   TerminalAgent,
   ThemeName
 } from '../../types/shared';
@@ -124,40 +125,47 @@ const ROLE_ORDER: Record<string, number> = {
 };
 
 /** 重複ロールにレター接尾辞を付けた表示名を返す (例: "programmer A") */
-function getRoleDisplayLabel(tab: TerminalTab, allTabs: TerminalTab[]): string {
-  if (!tab.role) return '';
-  if (!tab.teamId) return tab.role;
-  const sameRole = allTabs
-    .filter((t) => t.teamId === tab.teamId && t.role === tab.role)
+function getRoleDisplayLabel(
+  member: TeamRosterMember,
+  allMembers: TeamRosterMember[]
+): string {
+  const sameRole = allMembers
+    .filter((m) => m.role === member.role)
+    .slice()
     .sort((a, b) => a.agentId.localeCompare(b.agentId));
-  if (sameRole.length <= 1) return tab.role;
-  const idx = sameRole.findIndex((t) => t.id === tab.id);
-  return `${tab.role} ${String.fromCharCode(65 + idx)}`;
+  if (sameRole.length <= 1) return member.role;
+  const idx = sameRole.findIndex((m) => m.agentId === member.agentId);
+  return `${member.role} ${String.fromCharCode(65 + idx)}`;
 }
 
-/** チームのシステムプロンプト（--append-system-prompt 用） */
+/** チームのシステムプロンプト（--append-system-prompt 用）。
+ *  roster は team.members (作成時に確定) から組み立てるので、staggered spawn で
+ *  まだ mount していないメンバーがあっても完全な roster になる。
+ *  以前は terminalTabs を filter して roster を作っていたため、Leader が単独で
+ *  spawn → snapRef で固定 → 後から増えるメンバーが prompt に含まれない、という
+ *  競合が発生していた。 */
 function generateTeamSystemPrompt(
   tab: TerminalTab,
-  allTabs: TerminalTab[],
   team: Team | null
 ): string | undefined {
   if (!tab.role || !tab.teamId || !team) return undefined;
+  const members = team.members ?? [];
+  if (members.length === 0) return undefined;
 
-  const teamTabs = allTabs
-    .filter((t) => t.teamId === tab.teamId)
+  const sorted = members
     .slice()
     .sort((a, b) => {
-      const ra = ROLE_ORDER[a.role ?? ''] ?? 99;
-      const rb = ROLE_ORDER[b.role ?? ''] ?? 99;
+      const ra = ROLE_ORDER[a.role] ?? 99;
+      const rb = ROLE_ORDER[b.role] ?? 99;
       if (ra !== rb) return ra - rb;
       return a.agentId.localeCompare(b.agentId);
     });
-  const roster = teamTabs
-    .map((t) => {
-      const agent = t.agent === 'claude' ? 'Claude Code' : 'Codex';
-      const you = t.id === tab.id ? ' ← あなた' : '';
-      const roleLabel = getRoleDisplayLabel(t, allTabs);
-      return `${roleLabel || 'member'}(${agent})${you}`;
+  const roster = sorted
+    .map((m) => {
+      const agent = m.agent === 'claude' ? 'Claude Code' : 'Codex';
+      const you = m.agentId === tab.agentId ? ' ← あなた' : '';
+      const roleLabel = getRoleDisplayLabel(m, members);
+      return `${roleLabel}(${agent})${you}`;
     })
     .join(', ');
 
@@ -1599,7 +1607,7 @@ export function App(): JSX.Element {
       // Claude のチーム指示は --append-system-prompt で直接渡す。
       if (!isCodex && tab.teamId) {
         const team = teams.find((t) => t.id === tab.teamId) ?? null;
-        const sysPrompt = generateTeamSystemPrompt(tab, terminalTabs, team);
+        const sysPrompt = generateTeamSystemPrompt(tab, team);
         if (sysPrompt) {
           base.push('--append-system-prompt', sysPrompt);
         }
@@ -1626,9 +1634,9 @@ export function App(): JSX.Element {
     (tab: TerminalTab): string | undefined => {
       if (tab.agent !== 'codex' || !tab.teamId) return undefined;
       const team = teams.find((t) => t.id === tab.teamId) ?? null;
-      return generateTeamSystemPrompt(tab, terminalTabs, team);
+      return generateTeamSystemPrompt(tab, team);
     },
-    [teams, terminalTabs]
+    [teams]
   );
 
   /** TeamHub 接続情報（アプリ起動時に1回だけ解決） */
@@ -1695,17 +1703,20 @@ export function App(): JSX.Element {
       // 同時作成レース対策: これ以前の staggered spawn 予約は全て中断する
       clearSpawnTimers();
 
-      setTeams((prev) => [...prev, { id: teamId, name: teamName }]);
-
       // MCP 用のメンバー一覧を事前構築
-      const allMembers = [
-        { agentId: `${teamId}-leader`, role: 'leader', agent: leader.agent },
+      const allMembers: TeamRosterMember[] = [
+        { agentId: `${teamId}-leader`, role: 'leader' as TeamRole, agent: leader.agent },
         ...members.map((m, i) => ({
           agentId: `${teamId}-${m.role}-${i}`,
           role: m.role,
           agent: m.agent
         }))
       ];
+
+      // roster は Team に同梱して保存。staggered spawn で snapRef が固まる前に
+      // teams state が完全な members を持っているので、各タブの sysPrompt が
+      // 「自分一人だけ」になってしまう競合を避けられる。
+      setTeams((prev) => [...prev, { id: teamId, name: teamName, members: allMembers }]);
 
       // MCP サーバーをセットアップ（Claude Code / Codex MCP 設定）
       // mcpAutoSetup === false なら自動書換を一切行わない (設定 → MCP タブで OFF 時)。
@@ -1849,19 +1860,22 @@ export function App(): JSX.Element {
       ]);
       saveTeamHistory(updated);
 
-      // ランタイム Team として登録（既に同じ teamId があればそのまま）
-      setTeams((prev) =>
-        prev.some((t) => t.id === entry.id)
-          ? prev
-          : [...prev, { id: entry.id, name: entry.name }]
-      );
-
-      // MCP は現行の TeamHub 情報で確実に再登録する
-      const allMembers = entry.members.map((m, i) => ({
+      // MCP / spawn 用 roster を先に組んで Team に同梱する。
+      // (setTeams が members を含んだ状態で先に走らないと、resume 直後に最初の
+      //  TerminalView が mount したとき team.members が空で sysPrompt が
+      //  単独 roster になってしまう)
+      const allMembers: TeamRosterMember[] = entry.members.map((m, i) => ({
         agentId: `${entry.id}-${m.role}-${i}`,
         role: m.role,
         agent: m.agent
       }));
+
+      // ランタイム Team として登録（既に同じ teamId があればそのまま）
+      setTeams((prev) =>
+        prev.some((t) => t.id === entry.id)
+          ? prev
+          : [...prev, { id: entry.id, name: entry.name, members: allMembers }]
+      );
       let mcpChanged = false;
       if (settings.mcpAutoSetup !== false) {
         try {

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
@@ -176,7 +176,11 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
 
   const sysPrompt = useMemo(() => {
     if (!teamMembers || !payload.teamId || !payload.agentId || !payload.role) return undefined;
-    if (teamMembers.length < 2) return undefined; // 1 人だけならチームではない
+    if (teamMembers.length === 0) return undefined;
+    // 以前は length < 2 で skip していたが、これは「Leader が canvas に
+    // 1 番目に置かれた瞬間 teamMembers=[self] → undefined」となり、Leader が
+    // team プロンプト無しで起動する競合の原因になっていた。teamId が付いている
+    // 時点でチーム所属なので、メンバー 1 人でも roster を含むプロンプトを出す。
     return buildTeamSystemPrompt(
       payload.agentId,
       payload.role as TeamRole,

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -205,10 +205,20 @@ export type TerminalAgent = string;
 
 export type TeamRole = 'leader' | 'planner' | 'programmer' | 'researcher' | 'reviewer';
 
-/** ランタイムのみ（永続化不要）。チーム所属タブは teamId で紐付く */
+/** Team の roster 1 エントリ。system prompt 構築に必要な最小構成。 */
+export interface TeamRosterMember {
+  agentId: string;
+  role: TeamRole;
+  agent: TerminalAgent;
+}
+
+/** ランタイムのみ（永続化不要）。チーム所属タブは teamId で紐付く。
+ *  members はチーム作成/復元時に確定し、以後不変。
+ *  system prompt の roster はここから引く (terminalTabs の spawn タイミングに依存しない)。 */
 export interface Team {
   id: string;
   name: string;
+  members: TeamRosterMember[];
 }
 
 export interface TeamMember {


### PR DESCRIPTION
## Summary

vibe-team の system prompt がエージェントに届かない / 不完全な roster で焼き付く競合を 2 系統まとめて修正。

### 1. Claude (IDE / Canvas): 「snap 一発取り」と staggered spawn の race

- `usePtySession` の effect deps は `[cwd, command]` のみ。`args` は mount 直後の effect が `snapRef.current` を 1 度読んで固定するため、後から args が変わっても respawn しない (不変式 #2)。
- 旧 `generateTeamSystemPrompt` は roster を `terminalTabs.filter(...)` から組み立てていた。`handleCreateTeam` は **Leader を即時 spawn → 80ms 間隔で member を addTerminalTab** する staggered 方式で、Leader の TerminalView が mount したときの `terminalTabs` には Leader しかいない → snapRef 固定 → Leader の prompt が「自分 1 人だけのチーム」になる (M1, M2... も下流ほど壊れる)。
- Canvas (`AgentNodeCard.tsx`) は `teamMembers.length < 2` で sysPrompt=`undefined` を返していたため、Canvas に最初に置かれた Leader カードは team プロンプト完全 0 で起動していた。

修正方針:

- `Team` 型に `members: TeamRosterMember[]` を追加し、作成/復元時に確定。
- `generateTeamSystemPrompt` / `AgentNodeCard` の roster ソースを `team.members` (Canvas は store 由来) に切り替え、spawn タイミングへの依存を解消。
- `AgentNodeCard` の `< 2` ガードを撤去 (teamId が付いている時点でチーム所属)。

### 2. Codex: `codex_instructions` が Rust 側で読み捨てられていた

- `TerminalCreateOptions` に `codex_instructions: Option<String>` を受け取っていたが、`terminal_create` 関数本体で一度も使われていなかった (`SpawnOptions` にも含まれず、`-c model_instructions_file=...` も積まれていなかった)。`terminal.rs` 冒頭 TODO コメント自体が「Codex 用 model_instructions_file 一時書き出し」を未実装と明記していた。
- 結果、Codex のチームメンバーは team プロンプトを完全に受け取れていなかった。

修正方針:

- `~/.vibe-editor/codex-instructions/<uuid>.md` に書き出し、`-c model_instructions_file=<path>` を args 先頭に積む (= ユーザー指定の `-c` で上書き可能)。
- 1 日以上古いファイルを TTL ベースで掃除 (paste-images と同じ方式)。

## Test plan

- [ ] IDE モードで Leader + planner + programmer のチームを作成し、Leader と各メンバーの初回出力に **チーム全員の roster** が含まれていることを確認 (旧版では Leader が「自分 1 人だけ」になる)
- [ ] Canvas モードで Leader カードを 1 番目に置き、`--append-system-prompt` 付きで起動していることを確認 (起動ステータス文字列で確認可)
- [ ] team-history からの resume 後も roster が完全であることを確認
- [ ] Codex メンバーを含むチームを作成し、`~/.vibe-editor/codex-instructions/` にファイルが書き出され、Codex 起動 args に `-c model_instructions_file=...` が含まれていることを確認
- [ ] `npm run typecheck` 通過 (本 PR で確認済み)
- [ ] `cargo build` (sandbox では GTK 不在で未実行 — ローカル/CI で要確認)

https://claude.ai/code/session_016SeMa2Sj889DAbrYVaq3UN

---
_Generated by [Claude Code](https://claude.ai/code/session_016SeMa2Sj889DAbrYVaq3UN)_