### PR TITLE
feat(settings): モーダル UI を Linear/Raycast 風に再設計

### DIFF
--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -160,8 +160,10 @@ export function SettingsModal({
         '__addCustom'
       ]
     },
-    { label: isJa ? 'チーム' : 'Team', items: ['roles'] },
-    { label: 'MCP', items: ['mcp'] }
+    // vibe-team MCP のセットアップ手順は「チーム」機能の一部なので同グループに収める。
+    // 旧構成では MCP を独立グループにしていたが、グループラベル "MCP" と唯一の項目 "MCP" が
+    // 同名で並び、サイドバー上で MCP が 2 行重複しているように見える UI バグを生んでいた。
+    { label: isJa ? 'チーム' : 'Team', items: ['roles', 'mcp'] }
   ];
 
   const renderSection = (id: SectionId): JSX.Element | null => {
@@ -175,7 +177,7 @@ export function SettingsModal({
               <div className="settings-shell__replay">
                 <button
                   type="button"
-                  className="toolbar__btn"
+                  className="toolbar__btn settings-shell__replay-btn"
                   onClick={() => {
                     onClose();
                     onReplayOnboarding();
@@ -343,7 +345,11 @@ export function SettingsModal({
         </div>
 
         <footer className="modal__footer">
-          <button type="button" className="toolbar__btn" onClick={handleReset}>
+          <button
+            type="button"
+            className="toolbar__btn settings-shell__reset"
+            onClick={handleReset}
+          >
             {t('settings.reset')}
           </button>
           <div className="modal__footer-right">

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -82,8 +82,9 @@ export function SettingsModal({
   // 「適用して保存」押下時に短時間だけ ✓ アイコンに切り替えて操作完了を伝える
   const [saved, setSaved] = useState(false);
   // saved → false / onClose に切り替える deferred timer。
-  // unmount / 直前の Apply キャンセルで必ずクリアする (アンマウント済み state 更新警告を防ぐ)
-  const saveTimerRef = useRef<number | null>(null);
+  // unmount / 直前の Apply キャンセルで必ずクリアする (アンマウント済み state 更新警告を防ぐ)。
+  // 型は ReturnType を使うことで browser (number) / Node 系 (NodeJS.Timeout) どちらでも安全。
+  const saveTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   // サイドバー検索 (空文字なら全表示)
   const [navQuery, setNavQuery] = useState('');
 
@@ -96,6 +97,9 @@ export function SettingsModal({
     if (open && !wasOpenRef.current) {
       setDraft(initial);
       setActiveSection('general');
+      // 直前の保存フィードバックが残っていれば初期化 (handleApply が onClose 後に setSaved(false)
+      // を省略したぶんを、再オープン時にここで戻す)
+      setSaved(false);
     }
     wasOpenRef.current = open;
   }, [open, initial]);
@@ -136,7 +140,8 @@ export function SettingsModal({
     if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
     saveTimerRef.current = window.setTimeout(() => {
       saveTimerRef.current = null;
-      setSaved(false);
+      // setSaved(false) は呼ばない: onClose で親がアンマウントするので不要な再レンダーを生むだけ。
+      // (再 open 時は wasOpenRef effect が draft を initial に戻し、saved も初期値 false に戻る)
       onClose();
     }, 380);
   };
@@ -235,24 +240,33 @@ export function SettingsModal({
 
   // 検索ワードで items を絞り込む。`__addCustom` は検索中だけ非表示 (新規追加は通常時のみ)。
   // 検索結果が空のグループはラベルごと除外する。
-  // labelOf はレンダー毎に再生成されるが内部の参照 (customAgents/isJa) は groupsRaw と同根なので、
-  // groupsRaw の deps に揃えて実質同じタイミングで再評価される。eslint-disable は外せる。
+  // labelOf を closure で参照していた旧実装は eslint-disable で exhaustive-deps を抑制していたが、
+  // 将来 labelOf が customAgents / isJa 以外の state も読むようになるとメモ化バグの種になる。
+  // → 検索フィルタ用のラベル解決を useMemo 内にインライン化し、必要な依存を明示する。
   const groups = useMemo(() => {
     const q = navQuery.trim().toLowerCase();
     if (!q) return groupsRaw;
+    const fixedLabelMap = fixedLabels;
+    const customLabelMap = new Map(customAgents.map((a) => [a.id, a.name] as const));
+    const labelForFilter = (id: SectionId): string => {
+      if (fixedLabelMap[id]) return fixedLabelMap[id].label;
+      if (id.startsWith('custom:')) {
+        const aid = id.slice('custom:'.length);
+        return customLabelMap.get(aid) || (isJa ? '（無名）' : '(untitled)');
+      }
+      return id;
+    };
     return groupsRaw
       .map((g) => ({
         label: g.label,
         items: g.items.filter((id) => {
           if (id === '__addCustom') return false;
-          const { label } = labelOf(id);
+          const label = labelForFilter(id);
           return label.toLowerCase().includes(q) || id.toLowerCase().includes(q);
         })
       }))
       .filter((g) => g.items.length > 0);
-    // labelOf は closure 経由で customAgents/isJa を読むが、それらは groupsRaw 経由で再評価される
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [navQuery, groupsRaw]);
+  }, [navQuery, groupsRaw, fixedLabels, customAgents, isJa]);
 
   const renderSection = (id: SectionId): JSX.Element | null => {
     switch (id) {

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -12,7 +12,8 @@ import {
   Sparkles,
   Type,
   Users,
-  X
+  X,
+  type LucideIcon
 } from 'lucide-react';
 import type { AgentConfig, AppSettings } from '../../../types/shared';
 import { DEFAULT_SETTINGS } from '../../../types/shared';
@@ -61,7 +62,10 @@ type SectionId = string;
  *     共通定数として再利用、JSX は呼び出しごとに都度生成する形に統一する。
  *     パフォーマンスへの影響はこの規模では実測差が出ないため、安全側に倒す。 */
 const ICON_PROPS = { size: 14, strokeWidth: 1.85 } as const;
-const SECTION_ICON_TYPES: Record<string, React.ComponentType<typeof ICON_PROPS>> = {
+// SECTION_ICON_TYPES の値は lucide-react のアイコン (LucideIcon) なので、
+// 旧 React.ComponentType<typeof ICON_PROPS> (リテラル {size:14}) ではなく
+// LucideIcon 型を使うほうが正確で意図が伝わる (レビュー指摘)。
+const SECTION_ICON_TYPES: Record<string, LucideIcon> = {
   general: SettingsIcon,
   appearance: Palette,
   fonts: Type,
@@ -99,6 +103,12 @@ const FIXED_LABELS_EN: Record<string, FixedLabelEntry> = {
   roles: { label: 'Role profiles', title: 'Role profiles', desc: 'Team member role templates' },
   mcp: { label: 'MCP', title: 'MCP', desc: 'How to install vibe-team MCP' }
 };
+
+/** 名前未設定のカスタムエージェントに使う fallback 文字列。
+ *  fixedLabels と同じく言語切替で同期するモジュール定数として持つことで、
+ *  groups useMemo の closure から isJa を直接参照しないで済むようにする。 */
+const UNTITLED_FALLBACK_JA = '（無名）';
+const UNTITLED_FALLBACK_EN = '(untitled)';
 
 export function SettingsModal({
   open,
@@ -173,12 +183,14 @@ export function SettingsModal({
     try {
       onApply(draft);
     } catch (err) {
+      // err.message はスタックトレース / ファイルパス等の機微情報を含みうるため、
+      // ユーザー向け toast には汎用文言だけ出し、詳細は console.error にだけ残す (レビュー指摘)。
       console.error('[settings] apply failed:', err);
-      // toast でユーザーにも保存失敗を明示 (旧実装は console のみで UI 上は無音だった)。
-      const detail = err instanceof Error ? err.message : String(err);
       const isJaNow = draft.language === 'ja';
       showToast(
-        isJaNow ? `設定の保存に失敗しました: ${detail}` : `Failed to save settings: ${detail}`,
+        isJaNow
+          ? '設定の保存に失敗しました。詳細は開発者ツールのコンソールを確認してください。'
+          : 'Failed to save settings. See the developer console for details.',
         { tone: 'error', duration: 6000 }
       );
       return; // saved=true / setTimeout を始動しないことで、モーダルを閉じない
@@ -288,11 +300,16 @@ export function SettingsModal({
     const fixedLabelMap = fixedLabels;
     const agents = draft.customAgents ?? [];
     const customLabelMap = new Map(agents.map((a) => [a.id, a.name] as const));
+    // fixedLabels と untitled fallback は draft.language で同期して切り替わるため、
+    // どちらかを deps に入れれば言語切替を検知できる。closure から isJa を直接参照しないことで
+    // eslint exhaustive-deps 違反を解消する (レビュー指摘)。
+    const untitled =
+      fixedLabelMap === FIXED_LABELS_JA ? UNTITLED_FALLBACK_JA : UNTITLED_FALLBACK_EN;
     const labelForFilter = (id: SectionId): string => {
       if (fixedLabelMap[id]) return fixedLabelMap[id].label;
       if (id.startsWith('custom:')) {
         const aid = id.slice('custom:'.length);
-        return customLabelMap.get(aid) || (isJa ? '（無名）' : '(untitled)');
+        return customLabelMap.get(aid) || untitled;
       }
       return id;
     };
@@ -306,27 +323,30 @@ export function SettingsModal({
         })
       }))
       .filter((g) => g.items.length > 0);
-    // 旧コードは fixedLabels と isJa の両方を deps に入れていたが、fixedLabels は
-    // FIXED_LABELS_JA / _EN のモジュール定数を isJa で選んだだけなので isJa は冗長 (レビュー指摘)。
-    // fixedLabels が変われば必然的に isJa も切り替わっており、`fixedLabels` だけで十分。
-    // groupsRaw deps は draft.customAgents と draft.language をモジュールスコープ参照で
-    // 拾うので isJa を抜くのと同様の理由で `draft.customAgents` を直接入れる。
-  }, [navQuery, groupsRaw, fixedLabels, draft.customAgents]);
+    // deps 構成: navQuery (検索ワード) と groupsRaw (構造) と fixedLabels (言語切替) のみ。
+    // closure 内の untitled fallback は fixedLabels === FIXED_LABELS_JA で判別するため
+    // fixedLabels の参照変化で必然的に再評価される (= 言語切替を fixedLabels だけで検知できる)。
+    // customAgents は groupsRaw 経由で参照変化が伝播する。
+  }, [navQuery, groupsRaw, fixedLabels]);
 
   // 検索フィルタ後の groups に activeSection が含まれない場合、右ペインとサイドバーの
   // 選択状態が乖離する (例: "font" 検索で nav は fonts だけ表示するのに右ペインは general のまま)。
-  // → フィルタ結果の最初の項目に自動で切り替えて整合させる。検索クリア時は最後に選んだ
-  //    項目を維持する (ユーザーが意図的にクリアした想定)。
-  // deps から activeSection を外し、setActiveSection(prev => ...) の関数型更新で自分自身を読む。
-  // (deps に入れると setActiveSection → 再レンダー → useEffect 再実行のループが理論上発生しうる)
+  // → クエリが変わった瞬間にだけフィルタ結果の最初の項目に切り替えて整合させる。
+  //
+  // 旧コードは deps に groups を入れていたが、検索中に customAgents が増減すると groups が
+  // 変わって意図せず activeSection が先頭にリセットされる edge case があった (レビュー指摘)。
+  // → 同期は navQuery 変化時のみに限定し、groups は ref 経由で最新値を読む。
+  // 関数型更新で activeSection 自身を比較することで再レンダーループも防ぐ。
+  const groupsRef = useRef(groups);
+  groupsRef.current = groups;
   useEffect(() => {
     if (!navQuery.trim()) return;
-    const flat: SectionId[] = groups
+    const flat: SectionId[] = groupsRef.current
       .flatMap((g) => g.items)
       .filter((id) => id !== '__addCustom');
     if (flat.length === 0) return;
     setActiveSection((prev) => (flat.includes(prev) ? prev : flat[0]));
-  }, [navQuery, groups]);
+  }, [navQuery]);
 
   const renderSection = (id: SectionId): JSX.Element | null => {
     switch (id) {

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1,5 +1,19 @@
-import { useEffect, useRef, useState } from 'react';
-import { ArrowLeft, Check, Plus } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ArrowLeft,
+  Bot,
+  Check,
+  Code2,
+  Palette,
+  Plug,
+  Plus,
+  Search,
+  Settings as SettingsIcon,
+  Sparkles,
+  Type,
+  Users,
+  X
+} from 'lucide-react';
 import type { AgentConfig, AppSettings } from '../../../types/shared';
 import { DEFAULT_SETTINGS } from '../../../types/shared';
 import { useT } from '../lib/i18n';
@@ -49,6 +63,8 @@ export function SettingsModal({
   const [activeSection, setActiveSection] = useState<SectionId>('general');
   // 「適用して保存」押下時に短時間だけ ✓ アイコンに切り替えて操作完了を伝える
   const [saved, setSaved] = useState(false);
+  // サイドバー検索 (空文字なら全表示)
+  const [navQuery, setNavQuery] = useState('');
 
   // Issue #178: open 中に外部から settings が更新されると useEffect が再発火して
   // ユーザー入力中の draft が消える事故があった。
@@ -120,6 +136,31 @@ export function SettingsModal({
         mcp: { label: 'MCP', title: 'MCP', desc: 'How to install vibe-team MCP' }
       };
 
+  /** セクション ID → サイドバー Lucide アイコン (視認性向上 + 視覚スキャン高速化)。
+   *  カスタムエージェントは Sparkles で代用。 */
+  const iconFor = (id: SectionId): JSX.Element => {
+    const props = { size: 14, strokeWidth: 1.85 } as const;
+    switch (id) {
+      case 'general':
+        return <SettingsIcon {...props} />;
+      case 'appearance':
+        return <Palette {...props} />;
+      case 'fonts':
+        return <Type {...props} />;
+      case 'claude':
+        return <Bot {...props} />;
+      case 'codex':
+        return <Code2 {...props} />;
+      case 'roles':
+        return <Users {...props} />;
+      case 'mcp':
+        return <Plug {...props} />;
+      default:
+        if (id.startsWith('custom:')) return <Sparkles {...props} />;
+        return <SettingsIcon {...props} />;
+    }
+  };
+
   /** 指定 id のラベル情報を返す (固定 + カスタム動的) */
   const labelOf = (id: SectionId): { label: string; title: string; desc: string } => {
     if (fixedLabels[id]) return fixedLabels[id];
@@ -157,7 +198,7 @@ export function SettingsModal({
     setActiveSection(`custom:${id}`);
   };
 
-  const groups: Array<{ label: string | null; items: SectionId[] }> = [
+  const groupsRaw: Array<{ label: string | null; items: SectionId[] }> = [
     { label: null, items: ['general', 'appearance', 'fonts'] },
     {
       label: isJa ? 'エージェント' : 'Agents',
@@ -173,6 +214,25 @@ export function SettingsModal({
     // 同名で並び、サイドバー上で MCP が 2 行重複しているように見える UI バグを生んでいた。
     { label: isJa ? 'チーム' : 'Team', items: ['roles', 'mcp'] }
   ];
+
+  // 検索ワードで items を絞り込む。`__addCustom` は検索中だけ非表示 (新規追加は通常時のみ)。
+  // 検索結果が空のグループはラベルごと除外する。
+  const groups = useMemo(() => {
+    const q = navQuery.trim().toLowerCase();
+    if (!q) return groupsRaw;
+    return groupsRaw
+      .map((g) => ({
+        label: g.label,
+        items: g.items.filter((id) => {
+          if (id === '__addCustom') return false;
+          const { label } = labelOf(id);
+          return label.toLowerCase().includes(q) || id.toLowerCase().includes(q);
+        })
+      }))
+      .filter((g) => g.items.length > 0);
+    // labelOf は customAgents と isJa から導出されるラベルを返すので両方を deps に
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [navQuery, customAgents, isJa]);
 
   const renderSection = (id: SectionId): JSX.Element | null => {
     switch (id) {
@@ -285,7 +345,7 @@ export function SettingsModal({
         onClick={(e) => e.stopPropagation()}
       >
         <header className="modal__header">
-          <div className="modal__title-group" style={{ display: 'flex', alignItems: 'center' }}>
+          <div className="modal__title-group">
             <button
               type="button"
               className="settings-back-btn"
@@ -301,44 +361,75 @@ export function SettingsModal({
 
         <div className="modal__body modal__body--settings">
           <nav className="settings-shell__nav" aria-label="Settings sections">
-            {groups.map((g, gi) => (
-              <div key={gi} style={{ display: 'contents' }}>
-                {g.label && (
-                  <div className="settings-shell__nav-group-label">{g.label}</div>
-                )}
-                {g.items.map((id) => {
-                  // 擬似項目: カスタムエージェント追加ボタン
-                  if (id === '__addCustom') {
-                    return (
-                      <button
-                        key={id}
-                        type="button"
-                        className="settings-shell__nav-item settings-shell__nav-item--add"
-                        onClick={addCustomAgent}
-                      >
-                        <Plus size={13} strokeWidth={2} />
-                        <span className="settings-shell__nav-label">
-                          {t('settings.customAgents.add')}
-                        </span>
-                      </button>
-                    );
-                  }
-                  const { label } = labelOf(id);
-                  return (
-                    <button
-                      key={id}
-                      type="button"
-                      className={`settings-shell__nav-item${
-                        id === activeSection ? ' is-active' : ''
-                      }`}
-                      onClick={() => setActiveSection(id)}
-                    >
-                      <span className="settings-shell__nav-label">{label}</span>
-                    </button>
-                  );
-                })}
-              </div>
-            ))}
+            <div className="settings-shell__search">
+              <Search size={13} strokeWidth={2} className="settings-shell__search-icon" />
+              <input
+                type="text"
+                className="settings-shell__search-input"
+                placeholder={isJa ? '設定を検索…' : 'Search settings…'}
+                value={navQuery}
+                onChange={(e) => setNavQuery(e.target.value)}
+                aria-label={isJa ? '設定を検索' : 'Search settings'}
+              />
+              {navQuery && (
+                <button
+                  type="button"
+                  className="settings-shell__search-clear"
+                  onClick={() => setNavQuery('')}
+                  aria-label={isJa ? 'クリア' : 'Clear'}
+                >
+                  <X size={12} strokeWidth={2.2} />
+                </button>
+              )}
+            </div>
+            <div className="settings-shell__nav-list">
+              {groups.length === 0 ? (
+                <div className="settings-shell__nav-empty">
+                  {isJa ? '一致する項目がありません' : 'No matches'}
+                </div>
+              ) : (
+                groups.map((g, gi) => (
+                  <div key={gi} style={{ display: 'contents' }}>
+                    {g.label && (
+                      <div className="settings-shell__nav-group-label">{g.label}</div>
+                    )}
+                    {g.items.map((id) => {
+                      // 擬似項目: カスタムエージェント追加ボタン
+                      if (id === '__addCustom') {
+                        return (
+                          <button
+                            key={id}
+                            type="button"
+                            className="settings-shell__nav-item settings-shell__nav-item--add"
+                            onClick={addCustomAgent}
+                          >
+                            <Plus size={13} strokeWidth={2} />
+                            <span className="settings-shell__nav-label">
+                              {t('settings.customAgents.add')}
+                            </span>
+                          </button>
+                        );
+                      }
+                      const { label } = labelOf(id);
+                      const active = id === activeSection;
+                      return (
+                        <button
+                          key={id}
+                          type="button"
+                          className={`settings-shell__nav-item${active ? ' is-active' : ''}`}
+                          onClick={() => setActiveSection(id)}
+                        >
+                          <span className="settings-shell__nav-icon" aria-hidden="true">
+                            {iconFor(id)}
+                          </span>
+                          <span className="settings-shell__nav-label">{label}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                ))
+              )}
+            </div>
           </nav>
 
           <div className="settings-shell__content">

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { ArrowLeft, Plus } from 'lucide-react';
+import { ArrowLeft, Check, Plus } from 'lucide-react';
 import type { AgentConfig, AppSettings } from '../../../types/shared';
 import { DEFAULT_SETTINGS } from '../../../types/shared';
 import { useT } from '../lib/i18n';
@@ -47,6 +47,8 @@ export function SettingsModal({
   const t = useT();
   const [draft, setDraft] = useState<AppSettings>(initial);
   const [activeSection, setActiveSection] = useState<SectionId>('general');
+  // 「適用して保存」押下時に短時間だけ ✓ アイコンに切り替えて操作完了を伝える
+  const [saved, setSaved] = useState(false);
 
   // Issue #178: open 中に外部から settings が更新されると useEffect が再発火して
   // ユーザー入力中の draft が消える事故があった。
@@ -79,7 +81,13 @@ export function SettingsModal({
 
   const handleApply = (): void => {
     onApply(draft);
-    onClose();
+    // 保存ボタンを 380ms だけ ✓ 表示にしてから閉じる。
+    // 「押した → 保存された → モーダルが消える」の因果が体感できるようにする (Linear / Vercel 風)。
+    setSaved(true);
+    window.setTimeout(() => {
+      setSaved(false);
+      onClose();
+    }, 380);
   };
 
   // Issue #28: Reset は draft だけを DEFAULT_SETTINGS に戻す。
@@ -358,10 +366,18 @@ export function SettingsModal({
             </button>
             <button
               type="button"
-              className="toolbar__btn toolbar__btn--primary"
+              className={`toolbar__btn toolbar__btn--primary settings-shell__apply${
+                saved ? ' is-saved' : ''
+              }`}
               onClick={handleApply}
+              disabled={saved}
+              aria-label={t('settings.apply')}
             >
-              {t('settings.apply')}
+              {saved ? (
+                <Check size={14} strokeWidth={2.5} />
+              ) : (
+                t('settings.apply')
+              )}
             </button>
           </div>
         </footer>

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -178,13 +178,10 @@ export function SettingsModal({
     // saved=true の状態で再度押されるのはボタンの disabled で防いでいるが、
     // 380ms 中に外部から閉じる操作が走ったあとに別経路でこの関数が呼ばれた場合の二重実行ガード。
     if (saved) return;
-    // onApply が throw した場合に「保存された ✓」のフィードバックを見せて閉じてしまうと
-    // ユーザーは保存に成功したと誤解する。例外を捕まえて、success path だけで saved=true に倒す。
-    try {
-      onApply(draft);
-    } catch (err) {
-      // err.message はスタックトレース / ファイルパス等の機微情報を含みうるため、
-      // ユーザー向け toast には汎用文言だけ出し、詳細は console.error にだけ残す (レビュー指摘)。
+    // onApply が同期で throw する場合と async (Promise reject) の両方をハンドリングする。
+    // 現状の SettingsModalProps では onApply は同期だが、将来 async 化されたときに
+    // unhandled rejection を起こさないよう Promise.resolve でラップしてから .catch する (レビュー指摘)。
+    const reportFailure = (err: unknown): void => {
       console.error('[settings] apply failed:', err);
       const isJaNow = draft.language === 'ja';
       showToast(
@@ -193,7 +190,18 @@ export function SettingsModal({
           : 'Failed to save settings. See the developer console for details.',
         { tone: 'error', duration: 6000 }
       );
-      return; // saved=true / setTimeout を始動しないことで、モーダルを閉じない
+    };
+    let result: unknown;
+    try {
+      result = onApply(draft);
+    } catch (err) {
+      // 同期 throw のケース
+      reportFailure(err);
+      return;
+    }
+    // 戻り値が thenable なら reject も拾う。non-thenable (void) なら何もしない。
+    if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
+      Promise.resolve(result).catch(reportFailure);
     }
     // 保存ボタンを 380ms だけ ✓ 表示にしてから閉じる。
     // 「押した → 保存された → モーダルが消える」の因果が体感できるようにする (Linear / Vercel 風)。
@@ -323,25 +331,32 @@ export function SettingsModal({
         })
       }))
       .filter((g) => g.items.length > 0);
-    // deps 構成: navQuery (検索ワード) と groupsRaw (構造) と fixedLabels (言語切替) のみ。
-    // closure 内の untitled fallback は fixedLabels === FIXED_LABELS_JA で判別するため
-    // fixedLabels の参照変化で必然的に再評価される (= 言語切替を fixedLabels だけで検知できる)。
-    // customAgents は groupsRaw 経由で参照変化が伝播する。
-  }, [navQuery, groupsRaw, fixedLabels]);
+    // deps 構成: navQuery / groupsRaw / draft.language。
+    // 旧実装は fixedLabels (派生) を deps に入れていたが、groupsRaw のほうは
+    // [draft.customAgents, draft.language] という生プロパティ参照になっていて非対称だった (レビュー指摘)。
+    // → 言語切替を検知する deps を draft.language に統一して、両 useMemo の deps スタイルを揃える。
+    // closure 内の fixedLabels / untitled は draft.language が変わると再評価されるので問題ない。
+  }, [navQuery, groupsRaw, draft.language]);
 
   // 検索フィルタ後の groups に activeSection が含まれない場合、右ペインとサイドバーの
   // 選択状態が乖離する (例: "font" 検索で nav は fonts だけ表示するのに右ペインは general のまま)。
-  // → クエリが変わった瞬間にだけフィルタ結果の最初の項目に切り替えて整合させる。
+  // → クエリが変わった瞬間に整合チェックする。
   //
   // 旧コードは deps に groups を入れていたが、検索中に customAgents が増減すると groups が
-  // 変わって意図せず activeSection が先頭にリセットされる edge case があった (レビュー指摘)。
+  // 変わって意図せず activeSection が先頭にリセットされる edge case があった。
   // → 同期は navQuery 変化時のみに限定し、groups は ref 経由で最新値を読む。
   // 関数型更新で activeSection 自身を比較することで再レンダーループも防ぐ。
+  //
+  // クリア時 (navQuery="") の挙動: フィルタ前の groupsRaw に activeSection が含まれていれば
+  // そのまま維持、含まれていない (異常系) のみ先頭に戻す。これで「検索したまま放置 → クリア」
+  // の流れで activeSection がフィルタ中の先頭に張り付く問題 (レビュー指摘) を解消する。
   const groupsRef = useRef(groups);
   groupsRef.current = groups;
+  const groupsRawRef = useRef(groupsRaw);
+  groupsRawRef.current = groupsRaw;
   useEffect(() => {
-    if (!navQuery.trim()) return;
-    const flat: SectionId[] = groupsRef.current
+    const source = navQuery.trim() ? groupsRef.current : groupsRawRef.current;
+    const flat: SectionId[] = source
       .flatMap((g) => g.items)
       .filter((id) => id !== '__addCustom');
     if (flat.length === 0) return;

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -51,6 +51,24 @@ interface SettingsModalProps {
  */
 type SectionId = string;
 
+/** セクション ID → サイドバー Lucide アイコン。
+ *  関数内で定義するとレンダーごとに新規 JSX が生成されるため、コンポーネント外に置く。 */
+const SECTION_ICONS: Record<string, JSX.Element> = {
+  general: <SettingsIcon size={14} strokeWidth={1.85} />,
+  appearance: <Palette size={14} strokeWidth={1.85} />,
+  fonts: <Type size={14} strokeWidth={1.85} />,
+  claude: <Bot size={14} strokeWidth={1.85} />,
+  codex: <Code2 size={14} strokeWidth={1.85} />,
+  roles: <Users size={14} strokeWidth={1.85} />,
+  mcp: <Plug size={14} strokeWidth={1.85} />
+};
+const CUSTOM_ICON: JSX.Element = <Sparkles size={14} strokeWidth={1.85} />;
+function iconFor(id: SectionId): JSX.Element {
+  if (SECTION_ICONS[id]) return SECTION_ICONS[id];
+  if (id.startsWith('custom:')) return CUSTOM_ICON;
+  return SECTION_ICONS.general;
+}
+
 export function SettingsModal({
   open,
   initial,
@@ -63,6 +81,9 @@ export function SettingsModal({
   const [activeSection, setActiveSection] = useState<SectionId>('general');
   // 「適用して保存」押下時に短時間だけ ✓ アイコンに切り替えて操作完了を伝える
   const [saved, setSaved] = useState(false);
+  // saved → false / onClose に切り替える deferred timer。
+  // unmount / 直前の Apply キャンセルで必ずクリアする (アンマウント済み state 更新警告を防ぐ)
+  const saveTimerRef = useRef<number | null>(null);
   // サイドバー検索 (空文字なら全表示)
   const [navQuery, setNavQuery] = useState('');
 
@@ -88,6 +109,18 @@ export function SettingsModal({
     if (!exists) setActiveSection('general');
   }, [activeSection, draft.customAgents]);
 
+  // unmount 時に保存フィードバックタイマーを必ずクリア。
+  // 旧実装は handleApply 内の window.setTimeout を握っておらず、
+  // 380ms 以内に外部から閉じられるとアンマウント済みコンポーネントへの setSaved(false) が走る。
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+      }
+    };
+  }, []);
+
   const { mounted, dataState, motion } = useSpringMount(open, 180);
   if (!mounted) return null;
 
@@ -100,7 +133,9 @@ export function SettingsModal({
     // 保存ボタンを 380ms だけ ✓ 表示にしてから閉じる。
     // 「押した → 保存された → モーダルが消える」の因果が体感できるようにする (Linear / Vercel 風)。
     setSaved(true);
-    window.setTimeout(() => {
+    if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = window.setTimeout(() => {
+      saveTimerRef.current = null;
       setSaved(false);
       onClose();
     }, 380);
@@ -135,31 +170,6 @@ export function SettingsModal({
         roles: { label: 'Role profiles', title: 'Role profiles', desc: 'Team member role templates' },
         mcp: { label: 'MCP', title: 'MCP', desc: 'How to install vibe-team MCP' }
       };
-
-  /** セクション ID → サイドバー Lucide アイコン (視認性向上 + 視覚スキャン高速化)。
-   *  カスタムエージェントは Sparkles で代用。 */
-  const iconFor = (id: SectionId): JSX.Element => {
-    const props = { size: 14, strokeWidth: 1.85 } as const;
-    switch (id) {
-      case 'general':
-        return <SettingsIcon {...props} />;
-      case 'appearance':
-        return <Palette {...props} />;
-      case 'fonts':
-        return <Type {...props} />;
-      case 'claude':
-        return <Bot {...props} />;
-      case 'codex':
-        return <Code2 {...props} />;
-      case 'roles':
-        return <Users {...props} />;
-      case 'mcp':
-        return <Plug {...props} />;
-      default:
-        if (id.startsWith('custom:')) return <Sparkles {...props} />;
-        return <SettingsIcon {...props} />;
-    }
-  };
 
   /** 指定 id のラベル情報を返す (固定 + カスタム動的) */
   const labelOf = (id: SectionId): { label: string; title: string; desc: string } => {
@@ -198,25 +208,35 @@ export function SettingsModal({
     setActiveSection(`custom:${id}`);
   };
 
-  const groupsRaw: Array<{ label: string | null; items: SectionId[] }> = [
-    { label: null, items: ['general', 'appearance', 'fonts'] },
-    {
-      label: isJa ? 'エージェント' : 'Agents',
-      items: [
-        'claude',
-        'codex',
-        ...customAgents.map((a) => `custom:${a.id}`),
-        '__addCustom'
-      ]
-    },
-    // vibe-team MCP のセットアップ手順は「チーム」機能の一部なので同グループに収める。
-    // 旧構成では MCP を独立グループにしていたが、グループラベル "MCP" と唯一の項目 "MCP" が
-    // 同名で並び、サイドバー上で MCP が 2 行重複しているように見える UI バグを生んでいた。
-    { label: isJa ? 'チーム' : 'Team', items: ['roles', 'mcp'] }
-  ];
+  // groupsRaw は customAgents と isJa から導出される。useMemo で安定化させ、
+  // 後段 useMemo (groups) の依存配列で正しく検出させる。
+  // (旧実装は毎レンダーで新しい配列を作っており groups の useMemo がメモ化されていなかった)
+  const groupsRaw = useMemo<
+    Array<{ label: string | null; items: SectionId[] }>
+  >(
+    () => [
+      { label: null, items: ['general', 'appearance', 'fonts'] },
+      {
+        label: isJa ? 'エージェント' : 'Agents',
+        items: [
+          'claude',
+          'codex',
+          ...customAgents.map((a) => `custom:${a.id}`),
+          '__addCustom'
+        ]
+      },
+      // vibe-team MCP のセットアップ手順は「チーム」機能の一部なので同グループに収める。
+      // 旧構成では MCP を独立グループにしていたが、グループラベル "MCP" と唯一の項目 "MCP" が
+      // 同名で並び、サイドバー上で MCP が 2 行重複しているように見える UI バグを生んでいた。
+      { label: isJa ? 'チーム' : 'Team', items: ['roles', 'mcp'] }
+    ],
+    [customAgents, isJa]
+  );
 
   // 検索ワードで items を絞り込む。`__addCustom` は検索中だけ非表示 (新規追加は通常時のみ)。
   // 検索結果が空のグループはラベルごと除外する。
+  // labelOf はレンダー毎に再生成されるが内部の参照 (customAgents/isJa) は groupsRaw と同根なので、
+  // groupsRaw の deps に揃えて実質同じタイミングで再評価される。eslint-disable は外せる。
   const groups = useMemo(() => {
     const q = navQuery.trim().toLowerCase();
     if (!q) return groupsRaw;
@@ -230,9 +250,9 @@ export function SettingsModal({
         })
       }))
       .filter((g) => g.items.length > 0);
-    // labelOf は customAgents と isJa から導出されるラベルを返すので両方を deps に
+    // labelOf は closure 経由で customAgents/isJa を読むが、それらは groupsRaw 経由で再評価される
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [navQuery, customAgents, isJa]);
+  }, [navQuery, groupsRaw]);
 
   const renderSection = (id: SectionId): JSX.Element | null => {
     switch (id) {

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -17,6 +17,7 @@ import {
 import type { AgentConfig, AppSettings } from '../../../types/shared';
 import { DEFAULT_SETTINGS } from '../../../types/shared';
 import { useT } from '../lib/i18n';
+import { useToast } from '../lib/toast-context';
 import { useSpringMount } from '../lib/use-animated-mount';
 import { EDITOR_FONT_PRESETS, UI_FONT_PRESETS } from '../lib/settings-options';
 import { LanguageSection } from './settings/LanguageSection';
@@ -107,6 +108,7 @@ export function SettingsModal({
   onReplayOnboarding
 }: SettingsModalProps): JSX.Element | null {
   const t = useT();
+  const { showToast } = useToast();
   const [draft, setDraft] = useState<AppSettings>(initial);
   const [activeSection, setActiveSection] = useState<SectionId>('general');
   // 「適用して保存」押下時に短時間だけ ✓ アイコンに切り替えて操作完了を伝える
@@ -172,7 +174,14 @@ export function SettingsModal({
       onApply(draft);
     } catch (err) {
       console.error('[settings] apply failed:', err);
-      return; // saved=true / setTimeout を始動しないことで、エラーは UI から飲み込まれない
+      // toast でユーザーにも保存失敗を明示 (旧実装は console のみで UI 上は無音だった)。
+      const detail = err instanceof Error ? err.message : String(err);
+      const isJaNow = draft.language === 'ja';
+      showToast(
+        isJaNow ? `設定の保存に失敗しました: ${detail}` : `Failed to save settings: ${detail}`,
+        { tone: 'error', duration: 6000 }
+      );
+      return; // saved=true / setTimeout を始動しないことで、モーダルを閉じない
     }
     // 保存ボタンを 380ms だけ ✓ 表示にしてから閉じる。
     // 「押した → 保存された → モーダルが消える」の因果が体感できるようにする (Linear / Vercel 風)。
@@ -262,7 +271,10 @@ export function SettingsModal({
         { label: isJa ? 'チーム' : 'Team', items: ['roles', 'mcp'] }
       ];
     },
-    [draft.customAgents, isJa]
+    // deps は customAgents と同じく draft の生プロパティを直接参照する形で統一する。
+    // isJa は draft.language === 'ja' の派生 boolean で毎レンダー再評価されるため、
+    // 意図を明確にするには元の draft.language を deps に入れる方が読みやすい (レビュー指摘)。
+    [draft.customAgents, draft.language]
   );
 
   // 検索ワードで items を絞り込む。`__addCustom` は検索中だけ非表示 (新規追加は通常時のみ)。
@@ -294,22 +306,27 @@ export function SettingsModal({
         })
       }))
       .filter((g) => g.items.length > 0);
-  }, [navQuery, groupsRaw, fixedLabels, draft.customAgents, isJa]);
+    // 旧コードは fixedLabels と isJa の両方を deps に入れていたが、fixedLabels は
+    // FIXED_LABELS_JA / _EN のモジュール定数を isJa で選んだだけなので isJa は冗長 (レビュー指摘)。
+    // fixedLabels が変われば必然的に isJa も切り替わっており、`fixedLabels` だけで十分。
+    // groupsRaw deps は draft.customAgents と draft.language をモジュールスコープ参照で
+    // 拾うので isJa を抜くのと同様の理由で `draft.customAgents` を直接入れる。
+  }, [navQuery, groupsRaw, fixedLabels, draft.customAgents]);
 
   // 検索フィルタ後の groups に activeSection が含まれない場合、右ペインとサイドバーの
   // 選択状態が乖離する (例: "font" 検索で nav は fonts だけ表示するのに右ペインは general のまま)。
   // → フィルタ結果の最初の項目に自動で切り替えて整合させる。検索クリア時は最後に選んだ
   //    項目を維持する (ユーザーが意図的にクリアした想定)。
+  // deps から activeSection を外し、setActiveSection(prev => ...) の関数型更新で自分自身を読む。
+  // (deps に入れると setActiveSection → 再レンダー → useEffect 再実行のループが理論上発生しうる)
   useEffect(() => {
     if (!navQuery.trim()) return;
     const flat: SectionId[] = groups
       .flatMap((g) => g.items)
       .filter((id) => id !== '__addCustom');
     if (flat.length === 0) return;
-    if (!flat.includes(activeSection)) {
-      setActiveSection(flat[0]);
-    }
-  }, [navQuery, groups, activeSection]);
+    setActiveSection((prev) => (flat.includes(prev) ? prev : flat[0]));
+  }, [navQuery, groups]);
 
   const renderSection = (id: SectionId): JSX.Element | null => {
     switch (id) {

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -52,21 +52,28 @@ interface SettingsModalProps {
 type SectionId = string;
 
 /** セクション ID → サイドバー Lucide アイコン。
- *  関数内で定義するとレンダーごとに新規 JSX が生成されるため、コンポーネント外に置く。 */
-const SECTION_ICONS: Record<string, JSX.Element> = {
-  general: <SettingsIcon size={14} strokeWidth={1.85} />,
-  appearance: <Palette size={14} strokeWidth={1.85} />,
-  fonts: <Type size={14} strokeWidth={1.85} />,
-  claude: <Bot size={14} strokeWidth={1.85} />,
-  codex: <Code2 size={14} strokeWidth={1.85} />,
-  roles: <Users size={14} strokeWidth={1.85} />,
-  mcp: <Plug size={14} strokeWidth={1.85} />
+ *
+ *  旧実装は JSX リテラルをモジュールスコープに保持していたが、これは
+ *  React.StrictMode の二重レンダリングや React Server Components 移行時に
+ *  「複数のレンダーが同一インスタンスを共有する」前提が崩れる懸念がある。
+ *  → アイコンコンポーネント自体だけを参照し、props (size/strokeWidth) は
+ *     共通定数として再利用、JSX は呼び出しごとに都度生成する形に統一する。
+ *     パフォーマンスへの影響はこの規模では実測差が出ないため、安全側に倒す。 */
+const ICON_PROPS = { size: 14, strokeWidth: 1.85 } as const;
+const SECTION_ICON_TYPES: Record<string, React.ComponentType<typeof ICON_PROPS>> = {
+  general: SettingsIcon,
+  appearance: Palette,
+  fonts: Type,
+  claude: Bot,
+  codex: Code2,
+  roles: Users,
+  mcp: Plug
 };
-const CUSTOM_ICON: JSX.Element = <Sparkles size={14} strokeWidth={1.85} />;
 function iconFor(id: SectionId): JSX.Element {
-  if (SECTION_ICONS[id]) return SECTION_ICONS[id];
-  if (id.startsWith('custom:')) return CUSTOM_ICON;
-  return SECTION_ICONS.general;
+  const Icon =
+    SECTION_ICON_TYPES[id] ??
+    (id.startsWith('custom:') ? Sparkles : SECTION_ICON_TYPES.general);
+  return <Icon {...ICON_PROPS} />;
 }
 
 /** 固定セクションのラベル / タイトル / 説明 (i18n)。
@@ -159,7 +166,14 @@ export function SettingsModal({
     // saved=true の状態で再度押されるのはボタンの disabled で防いでいるが、
     // 380ms 中に外部から閉じる操作が走ったあとに別経路でこの関数が呼ばれた場合の二重実行ガード。
     if (saved) return;
-    onApply(draft);
+    // onApply が throw した場合に「保存された ✓」のフィードバックを見せて閉じてしまうと
+    // ユーザーは保存に成功したと誤解する。例外を捕まえて、success path だけで saved=true に倒す。
+    try {
+      onApply(draft);
+    } catch (err) {
+      console.error('[settings] apply failed:', err);
+      return; // saved=true / setTimeout を始動しないことで、エラーは UI から飲み込まれない
+    }
     // 保存ボタンを 380ms だけ ✓ 表示にしてから閉じる。
     // 「押した → 保存された → モーダルが消える」の因果が体感できるようにする (Linear / Vercel 風)。
     setSaved(true);
@@ -222,29 +236,33 @@ export function SettingsModal({
     setActiveSection(`custom:${id}`);
   };
 
-  // groupsRaw は customAgents と isJa から導出される。useMemo で安定化させ、
-  // 後段 useMemo (groups) の依存配列で正しく検出させる。
-  // (旧実装は毎レンダーで新しい配列を作っており groups の useMemo がメモ化されていなかった)
+  // groupsRaw は customAgents と isJa から導出される。useMemo で安定化させる。
+  // deps には `customAgents` ローカル (`draft.customAgents ?? []`) ではなく `draft.customAgents` を
+  // 直接入れる。`?? []` は undefined のとき毎レンダー新しい [] を返してしまい、参照比較で常に
+  // 不一致 → メモ化が無効化される。`draft.customAgents` 自体は同一更新内では安定。
   const groupsRaw = useMemo<
     Array<{ label: string | null; items: SectionId[] }>
   >(
-    () => [
-      { label: null, items: ['general', 'appearance', 'fonts'] },
-      {
-        label: isJa ? 'エージェント' : 'Agents',
-        items: [
-          'claude',
-          'codex',
-          ...customAgents.map((a) => `custom:${a.id}`),
-          '__addCustom'
-        ]
-      },
-      // vibe-team MCP のセットアップ手順は「チーム」機能の一部なので同グループに収める。
-      // 旧構成では MCP を独立グループにしていたが、グループラベル "MCP" と唯一の項目 "MCP" が
-      // 同名で並び、サイドバー上で MCP が 2 行重複しているように見える UI バグを生んでいた。
-      { label: isJa ? 'チーム' : 'Team', items: ['roles', 'mcp'] }
-    ],
-    [customAgents, isJa]
+    () => {
+      const agents = draft.customAgents ?? [];
+      return [
+        { label: null, items: ['general', 'appearance', 'fonts'] },
+        {
+          label: isJa ? 'エージェント' : 'Agents',
+          items: [
+            'claude',
+            'codex',
+            ...agents.map((a) => `custom:${a.id}`),
+            '__addCustom'
+          ]
+        },
+        // vibe-team MCP のセットアップ手順は「チーム」機能の一部なので同グループに収める。
+        // 旧構成では MCP を独立グループにしていたが、グループラベル "MCP" と唯一の項目 "MCP" が
+        // 同名で並び、サイドバー上で MCP が 2 行重複しているように見える UI バグを生んでいた。
+        { label: isJa ? 'チーム' : 'Team', items: ['roles', 'mcp'] }
+      ];
+    },
+    [draft.customAgents, isJa]
   );
 
   // 検索ワードで items を絞り込む。`__addCustom` は検索中だけ非表示 (新規追加は通常時のみ)。
@@ -256,7 +274,8 @@ export function SettingsModal({
     const q = navQuery.trim().toLowerCase();
     if (!q) return groupsRaw;
     const fixedLabelMap = fixedLabels;
-    const customLabelMap = new Map(customAgents.map((a) => [a.id, a.name] as const));
+    const agents = draft.customAgents ?? [];
+    const customLabelMap = new Map(agents.map((a) => [a.id, a.name] as const));
     const labelForFilter = (id: SectionId): string => {
       if (fixedLabelMap[id]) return fixedLabelMap[id].label;
       if (id.startsWith('custom:')) {
@@ -275,7 +294,22 @@ export function SettingsModal({
         })
       }))
       .filter((g) => g.items.length > 0);
-  }, [navQuery, groupsRaw, fixedLabels, customAgents, isJa]);
+  }, [navQuery, groupsRaw, fixedLabels, draft.customAgents, isJa]);
+
+  // 検索フィルタ後の groups に activeSection が含まれない場合、右ペインとサイドバーの
+  // 選択状態が乖離する (例: "font" 検索で nav は fonts だけ表示するのに右ペインは general のまま)。
+  // → フィルタ結果の最初の項目に自動で切り替えて整合させる。検索クリア時は最後に選んだ
+  //    項目を維持する (ユーザーが意図的にクリアした想定)。
+  useEffect(() => {
+    if (!navQuery.trim()) return;
+    const flat: SectionId[] = groups
+      .flatMap((g) => g.items)
+      .filter((id) => id !== '__addCustom');
+    if (flat.length === 0) return;
+    if (!flat.includes(activeSection)) {
+      setActiveSection(flat[0]);
+    }
+  }, [navQuery, groups, activeSection]);
 
   const renderSection = (id: SectionId): JSX.Element | null => {
     switch (id) {

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -69,6 +69,29 @@ function iconFor(id: SectionId): JSX.Element {
   return SECTION_ICONS.general;
 }
 
+/** 固定セクションのラベル / タイトル / 説明 (i18n)。
+ *  毎レンダー新規オブジェクトを生成すると useMemo の deps チェーンが無効化されるため、
+ *  ja / en それぞれをモジュールスコープで 1 度だけ作る。 */
+type FixedLabelEntry = { label: string; title: string; desc: string };
+const FIXED_LABELS_JA: Record<string, FixedLabelEntry> = {
+  general: { label: '一般', title: '一般', desc: '言語と密度設定' },
+  appearance: { label: '表示', title: '表示', desc: 'テーマと配色' },
+  fonts: { label: 'フォント', title: 'フォント', desc: 'UI / エディタ / ターミナルのフォント' },
+  claude: { label: 'Claude Code', title: 'Claude Code', desc: '起動コマンドと引数' },
+  codex: { label: 'Codex', title: 'Codex', desc: '起動コマンドと引数' },
+  roles: { label: 'ロール定義', title: 'ロール定義', desc: 'チームメンバーの役割テンプレ' },
+  mcp: { label: 'MCP', title: 'MCP', desc: 'vibe-team MCP の導入方法' }
+};
+const FIXED_LABELS_EN: Record<string, FixedLabelEntry> = {
+  general: { label: 'General', title: 'General', desc: 'Language and density' },
+  appearance: { label: 'Appearance', title: 'Appearance', desc: 'Theme and surfaces' },
+  fonts: { label: 'Fonts', title: 'Typography', desc: 'UI / editor / terminal fonts' },
+  claude: { label: 'Claude Code', title: 'Claude Code', desc: 'Launch command and args' },
+  codex: { label: 'Codex', title: 'Codex', desc: 'Launch command and args' },
+  roles: { label: 'Role profiles', title: 'Role profiles', desc: 'Team member role templates' },
+  mcp: { label: 'MCP', title: 'MCP', desc: 'How to install vibe-team MCP' }
+};
+
 export function SettingsModal({
   open,
   initial,
@@ -133,6 +156,9 @@ export function SettingsModal({
   };
 
   const handleApply = (): void => {
+    // saved=true の状態で再度押されるのはボタンの disabled で防いでいるが、
+    // 380ms 中に外部から閉じる操作が走ったあとに別経路でこの関数が呼ばれた場合の二重実行ガード。
+    if (saved) return;
     onApply(draft);
     // 保存ボタンを 380ms だけ ✓ 表示にしてから閉じる。
     // 「押した → 保存された → モーダルが消える」の因果が体感できるようにする (Linear / Vercel 風)。
@@ -141,7 +167,7 @@ export function SettingsModal({
     saveTimerRef.current = window.setTimeout(() => {
       saveTimerRef.current = null;
       // setSaved(false) は呼ばない: onClose で親がアンマウントするので不要な再レンダーを生むだけ。
-      // (再 open 時は wasOpenRef effect が draft を initial に戻し、saved も初期値 false に戻る)
+      // 再 open 時の saved リセットは wasOpenRef effect (上) に集約してあるのでここでは不要。
       onClose();
     }, 380);
   };
@@ -155,26 +181,9 @@ export function SettingsModal({
   const isJa = draft.language === 'ja';
   const customAgents = draft.customAgents ?? [];
 
-  // 固定ラベル
-  const fixedLabels: Record<string, { label: string; title: string; desc: string }> = isJa
-    ? {
-        general: { label: '一般', title: '一般', desc: '言語と密度設定' },
-        appearance: { label: '表示', title: '表示', desc: 'テーマと配色' },
-        fonts: { label: 'フォント', title: 'フォント', desc: 'UI / エディタ / ターミナルのフォント' },
-        claude: { label: 'Claude Code', title: 'Claude Code', desc: '起動コマンドと引数' },
-        codex: { label: 'Codex', title: 'Codex', desc: '起動コマンドと引数' },
-        roles: { label: 'ロール定義', title: 'ロール定義', desc: 'チームメンバーの役割テンプレ' },
-        mcp: { label: 'MCP', title: 'MCP', desc: 'vibe-team MCP の導入方法' }
-      }
-    : {
-        general: { label: 'General', title: 'General', desc: 'Language and density' },
-        appearance: { label: 'Appearance', title: 'Appearance', desc: 'Theme and surfaces' },
-        fonts: { label: 'Fonts', title: 'Typography', desc: 'UI / editor / terminal fonts' },
-        claude: { label: 'Claude Code', title: 'Claude Code', desc: 'Launch command and args' },
-        codex: { label: 'Codex', title: 'Codex', desc: 'Launch command and args' },
-        roles: { label: 'Role profiles', title: 'Role profiles', desc: 'Team member role templates' },
-        mcp: { label: 'MCP', title: 'MCP', desc: 'How to install vibe-team MCP' }
-      };
+  // 固定ラベルはモジュールスコープのため毎レンダーで参照が変わらない。
+  // useMemo deps に直接入れても安定性を保てる。
+  const fixedLabels = isJa ? FIXED_LABELS_JA : FIXED_LABELS_EN;
 
   /** 指定 id のラベル情報を返す (固定 + カスタム動的) */
   const labelOf = (id: SectionId): { label: string; title: string; desc: string } => {

--- a/src/renderer/src/styles/components/modal.css
+++ b/src/renderer/src/styles/components/modal.css
@@ -224,6 +224,26 @@
   justify-content: flex-start;
 }
 
+/* 「セットアップをもう一度」ボタンを outlined にして単独テキストの浮き感を解消 */
+.settings-shell__replay-btn.toolbar__btn {
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
+.settings-shell__replay-btn.toolbar__btn:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+  color: var(--text);
+}
+
+/* footer 左の「デフォルトに戻す」を destructive secondary 風に dim させ、
+   右の primary 「適用して保存」とのアクション優先度差を視覚的に明確化する */
+.modal--settings .modal__footer .settings-shell__reset.toolbar__btn {
+  color: var(--text-mute);
+}
+.modal--settings .modal__footer .settings-shell__reset.toolbar__btn:hover:not(:disabled) {
+  color: var(--warning, var(--text));
+}
+
 /* ---------- カスタムエージェント追加ボタン (nav) ---------- */
 .settings-shell__nav-item--add {
   color: var(--text-dim);

--- a/src/renderer/src/styles/components/modal.css
+++ b/src/renderer/src/styles/components/modal.css
@@ -588,9 +588,9 @@
   border-color: var(--border-strong);
   transform: translateY(-1px);
   box-shadow: 0 4px 14px -8px rgba(0, 0, 0, 0.45);
-  /* 旧コミットでは will-change: transform をカードに常時付けていたが、
-     全カード分の GPU レイヤを常駐させて余計な VRAM を食う。hover 時だけに絞る。 */
-  will-change: transform;
+  /* will-change: transform は撤去。hover で初めて付与してもブラウザが GPU 準備する時間が無く
+     最適化効果が薄い (レビュー指摘)。常時付与は GPU メモリを無駄に食うので、
+     Chromium の auto-promote ヒューリスティックに任せる方が賢明。 */
 }
 
 .modal--settings .theme-card:active,

--- a/src/renderer/src/styles/components/modal.css
+++ b/src/renderer/src/styles/components/modal.css
@@ -8,8 +8,9 @@
 
 .modal-backdrop[data-state='opening'],
 .modal-backdrop[data-state='open'] {
-  background: rgba(6, 8, 12, 0.52);
-  backdrop-filter: blur(12px);
+  background: rgba(6, 8, 12, 0.45);
+  backdrop-filter: blur(18px) saturate(135%);
+  -webkit-backdrop-filter: blur(18px) saturate(135%);
 }
 
 .modal-backdrop[data-state='closing'] {
@@ -22,9 +23,21 @@
   max-width: 1180px;
   height: min(820px, calc(100vh - 64px));
   max-height: calc(100vh - 64px);
-  border-radius: 14px;
-  background: var(--bg-panel);
-  border: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
+  border-radius: 16px;
+  /* リキッドグラス: 半透明 panel + サブグラデでわずかな立体感を出す。
+     backdrop-filter は backdrop が既に blur されているので二重 blur は控えめに */
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--bg-panel) 96%, transparent) 0%,
+      color-mix(in srgb, var(--bg-panel) 92%, transparent) 100%
+    );
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  /* 強めの soft drop-shadow + 内側の subtle highlight */
+  box-shadow:
+    0 24px 64px -16px rgba(0, 0, 0, 0.55),
+    0 4px 12px -4px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 color-mix(in srgb, white 6%, transparent);
   opacity: 0;
   transform: translateY(16px) scale(0.98);
   transition:
@@ -48,22 +61,26 @@
 }
 
 .modal--settings .modal__header {
-  padding: 14px 20px;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  background: var(--bg-panel);
+  padding: 16px 24px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+  background: color-mix(in srgb, var(--bg-panel) 70%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   flex-shrink: 0;
 }
 
 .modal--settings .modal__footer {
-  padding: 12px 20px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  background: var(--bg-panel);
+  padding: 14px 24px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+  background: color-mix(in srgb, var(--bg-panel) 70%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   flex-shrink: 0;
 }
 
 .modal--settings .modal__header h2 {
-  font-size: 15px;
-  font-weight: 500;
+  font-size: 14px;
+  font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--text);
   margin: 0;
@@ -91,7 +108,7 @@
 .modal__title-group {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
 }
 
 .modal__status {
@@ -109,7 +126,7 @@
 
 .modal__body--settings {
   display: grid;
-  grid-template-columns: 220px minmax(0, 1fr);
+  grid-template-columns: 232px minmax(0, 1fr);
   gap: 0;
   padding: 0;
   flex: 1;
@@ -120,40 +137,113 @@
 .settings-shell__nav {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 24px 12px;
-  background: color-mix(in srgb, var(--bg) 60%, transparent);
-  border-right: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  padding: 16px 10px 16px 12px;
+  background: color-mix(in srgb, var(--bg) 45%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
   overflow-y: auto;
+  gap: 12px;
+}
+
+/* 検索ボックス */
+.settings-shell__search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.settings-shell__search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-mute);
+  pointer-events: none;
+}
+.settings-shell__search-input {
+  width: 100%;
+  padding: 7px 28px 7px 30px;
+  background: color-mix(in srgb, var(--bg-panel) 70%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 12.5px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 140ms cubic-bezier(0.25, 1, 0.5, 1),
+    background-color 140ms cubic-bezier(0.25, 1, 0.5, 1),
+    box-shadow 200ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+.settings-shell__search-input::placeholder {
+  color: var(--text-mute);
+}
+.settings-shell__search-input:focus {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  background: var(--bg-panel);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+}
+.settings-shell__search-clear {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  color: var(--text-mute);
+  cursor: pointer;
+}
+.settings-shell__search-clear:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.settings-shell__nav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.settings-shell__nav-empty {
+  padding: 16px 12px;
+  font-size: 12px;
+  color: var(--text-mute);
+  text-align: center;
 }
 
 .settings-shell__nav-group-label {
-  padding: 16px 12px 6px;
-  font-size: 11px;
+  padding: 14px 10px 4px;
+  font-size: 10.5px;
   color: var(--text-mute);
-  letter-spacing: 0.02em;
-  font-weight: 500;
-  text-transform: none;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  text-transform: uppercase;
 }
 
 .settings-shell__nav-group-label:first-child {
-  padding-top: 0;
+  padding-top: 4px;
 }
 
+/* nav item: Linear 風の active indicator (左端の縦バー) */
 .settings-shell__nav-item {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
+  gap: 9px;
+  padding: 7px 10px 7px 12px;
   border: 0;
-  border-radius: 8px;
+  border-radius: 7px;
   background: transparent;
   color: var(--text-dim);
   text-align: left;
   cursor: pointer;
   font-family: inherit;
-  font-size: 13px;
-  font-weight: 400;
+  font-size: 12.5px;
+  font-weight: 450;
   letter-spacing: -0.005em;
   width: 100%;
   transition:
@@ -161,15 +251,52 @@
     color 120ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 
+.settings-shell__nav-item::before {
+  /* 左端 active bar */
+  content: '';
+  position: absolute;
+  left: 2px;
+  top: 50%;
+  width: 2px;
+  height: 0;
+  border-radius: 2px;
+  background: var(--claude-brand, var(--accent));
+  transform: translateY(-50%);
+  transition: height 160ms cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 160ms cubic-bezier(0.4, 0, 0.2, 1);
+  opacity: 0;
+}
+
+.settings-shell__nav-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: var(--text-mute);
+  flex-shrink: 0;
+  transition: color 120ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
 .settings-shell__nav-item:hover {
-  background: var(--bg-hover);
+  background: color-mix(in srgb, var(--bg-hover) 70%, transparent);
   color: var(--text);
+}
+.settings-shell__nav-item:hover .settings-shell__nav-icon {
+  color: var(--text-dim);
 }
 
 .settings-shell__nav-item.is-active {
-  background: color-mix(in srgb, var(--bg-active) 92%, transparent);
+  background: color-mix(in srgb, var(--bg-active) 75%, transparent);
   color: var(--text);
-  font-weight: 500;
+  font-weight: 550;
+}
+.settings-shell__nav-item.is-active::before {
+  height: 16px;
+  opacity: 1;
+}
+.settings-shell__nav-item.is-active .settings-shell__nav-icon {
+  color: var(--claude-brand, var(--accent));
 }
 
 .settings-shell__nav-label {
@@ -190,29 +317,48 @@
   display: flex;
   flex-direction: column;
   overflow-y: auto;
-  padding: 32px 40px 48px;
-  gap: 32px;
+  padding: 36px 44px 48px;
+  gap: 28px;
+}
+
+/* スクロール時にタイトル下に subtle な fade があるように見せる */
+.settings-shell__content::before {
+  content: '';
+  position: sticky;
+  top: 0;
+  height: 0;
+  pointer-events: none;
 }
 
 .settings-shell__pane-title {
-  font-size: 22px;
-  font-weight: 500;
-  letter-spacing: -0.02em;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
   color: var(--text);
-  margin: 0 0 4px;
+  margin: 0 0 6px;
+  /* subtle text gradient: 完全な白すぎず、claude-light 系で潰れないよう color-mix を使う */
+  background: linear-gradient(
+    180deg,
+    var(--text) 0%,
+    color-mix(in srgb, var(--text) 88%, transparent) 100%
+  );
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .settings-shell__pane-desc {
   font-size: 13px;
   color: var(--text-dim);
   margin: 0;
+  letter-spacing: -0.005em;
 }
 
 .settings-shell__panel {
   display: flex;
   flex-direction: column;
   gap: 28px;
-  animation: settings-panel-in 180ms cubic-bezier(0.25, 1, 0.5, 1);
+  animation: settings-panel-in 220ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* General セクションの「セットアップをもう一度」導線 */
@@ -348,7 +494,7 @@
 @keyframes settings-panel-in {
   from {
     opacity: 0;
-    transform: translateY(4px);
+    transform: translateY(6px);
   }
   to {
     opacity: 1;
@@ -371,12 +517,12 @@
 }
 
 .modal--settings .modal__section h3 {
-  margin: 0 0 16px;
-  font-size: 16px;
+  margin: 0 0 14px;
+  font-size: 13px;
   font-weight: 600;
-  letter-spacing: -0.01em;
-  color: var(--text);
-  text-transform: none;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  text-transform: uppercase;
 }
 
 .modal--settings .modal__row {

--- a/src/renderer/src/styles/components/modal.css
+++ b/src/renderer/src/styles/components/modal.css
@@ -579,7 +579,6 @@
     border-color 160ms cubic-bezier(0.25, 1, 0.5, 1),
     box-shadow 200ms cubic-bezier(0.25, 1, 0.5, 1),
     transform 200ms cubic-bezier(0.25, 1, 0.5, 1);
-  will-change: transform;
 }
 
 .modal--settings .theme-card:hover,
@@ -589,6 +588,9 @@
   border-color: var(--border-strong);
   transform: translateY(-1px);
   box-shadow: 0 4px 14px -8px rgba(0, 0, 0, 0.45);
+  /* 旧コミットでは will-change: transform をカードに常時付けていたが、
+     全カード分の GPU レイヤを常駐させて余計な VRAM を食う。hover 時だけに絞る。 */
+  will-change: transform;
 }
 
 .modal--settings .theme-card:active,

--- a/src/renderer/src/styles/components/modal.css
+++ b/src/renderer/src/styles/components/modal.css
@@ -581,16 +581,21 @@
     transform 200ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 
-.modal--settings .theme-card:hover,
-.modal--settings .lang-card:hover,
-.modal--settings .density-card:hover {
-  background: var(--bg-elev);
-  border-color: var(--border-strong);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 14px -8px rgba(0, 0, 0, 0.45);
-  /* will-change: transform は撤去。hover で初めて付与してもブラウザが GPU 準備する時間が無く
-     最適化効果が薄い (レビュー指摘)。常時付与は GPU メモリを無駄に食うので、
-     Chromium の auto-promote ヒューリスティックに任せる方が賢明。 */
+/* hover による translateY と shadow はマウス系デバイスのみで有効化する。
+   タッチデバイスでは hover 状態がスティッキーになり、タップ後にカードが浮いたままになる。
+   @media (hover: hover) で hover が走り去れる環境だけに絞る (レビュー指摘)。 */
+@media (hover: hover) {
+  .modal--settings .theme-card:hover,
+  .modal--settings .lang-card:hover,
+  .modal--settings .density-card:hover {
+    background: var(--bg-elev);
+    border-color: var(--border-strong);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 14px -8px rgba(0, 0, 0, 0.45);
+    /* will-change: transform は撤去。hover で初めて付与してもブラウザが GPU 準備する時間が無く
+       最適化効果が薄い。常時付与は GPU メモリを無駄に食うので、Chromium の auto-promote に
+       任せる方が賢明。 */
+  }
 }
 
 .modal--settings .theme-card:active,

--- a/src/renderer/src/styles/components/modal.css
+++ b/src/renderer/src/styles/components/modal.css
@@ -598,6 +598,10 @@
   }
 }
 
+/* :active は @media (hover: hover) の外に置く (意図的)。
+   タッチデバイスでも :active は短時間走るが、translateY(0) / box-shadow:none は
+   どちらも「初期状態に戻す」値なので視覚的な悪影響なし。むしろ hover が出ない端末で
+   tap 後の sticky transform を確実にリセットする保険として役立つ。 */
 .modal--settings .theme-card:active,
 .modal--settings .lang-card:active,
 .modal--settings .density-card:active {

--- a/src/renderer/src/styles/components/modal.css
+++ b/src/renderer/src/styles/components/modal.css
@@ -8,9 +8,9 @@
 
 .modal-backdrop[data-state='opening'],
 .modal-backdrop[data-state='open'] {
-  background: rgba(6, 8, 12, 0.45);
-  backdrop-filter: blur(18px) saturate(135%);
-  -webkit-backdrop-filter: blur(18px) saturate(135%);
+  background: rgba(6, 8, 12, 0.52);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
 .modal-backdrop[data-state='closing'] {
@@ -24,16 +24,10 @@
   height: min(820px, calc(100vh - 64px));
   max-height: calc(100vh - 64px);
   border-radius: 16px;
-  /* リキッドグラス: 半透明 panel + サブグラデでわずかな立体感を出す。
-     backdrop-filter は backdrop が既に blur されているので二重 blur は控えめに */
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--bg-panel) 96%, transparent) 0%,
-      color-mix(in srgb, var(--bg-panel) 92%, transparent) 100%
-    );
+  /* WebView2 で backdrop-filter のネストが画面真っ白を起こすことがあったので、
+     モーダル本体は不透明 bg-panel をベースにし、subtle な立体感だけ重ねる */
+  background: var(--bg-panel);
   border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
-  /* 強めの soft drop-shadow + 内側の subtle highlight */
   box-shadow:
     0 24px 64px -16px rgba(0, 0, 0, 0.55),
     0 4px 12px -4px rgba(0, 0, 0, 0.35),
@@ -62,19 +56,17 @@
 
 .modal--settings .modal__header {
   padding: 16px 24px;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
-  background: color-mix(in srgb, var(--bg-panel) 70%, transparent);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  /* nested backdrop-filter は WebView2 でレンダリング崩壊を起こすので使わない。
+     代わりに subtle にだけ色を変える */
+  background: color-mix(in srgb, var(--bg-panel) 96%, var(--bg) 4%);
   flex-shrink: 0;
 }
 
 .modal--settings .modal__footer {
   padding: 14px 24px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
-  background: color-mix(in srgb, var(--bg-panel) 70%, transparent);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  background: color-mix(in srgb, var(--bg-panel) 96%, var(--bg) 4%);
   flex-shrink: 0;
 }
 
@@ -138,7 +130,8 @@
   display: flex;
   flex-direction: column;
   padding: 16px 10px 16px 12px;
-  background: color-mix(in srgb, var(--bg) 45%, transparent);
+  /* 半透明だと背景が透けて視認性が落ちるので、モーダル本体より少し暗い不透明色にする */
+  background: color-mix(in srgb, var(--bg) 65%, var(--bg-panel) 35%);
   border-right: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
   overflow-y: auto;
   gap: 12px;
@@ -321,30 +314,12 @@
   gap: 28px;
 }
 
-/* スクロール時にタイトル下に subtle な fade があるように見せる */
-.settings-shell__content::before {
-  content: '';
-  position: sticky;
-  top: 0;
-  height: 0;
-  pointer-events: none;
-}
-
 .settings-shell__pane-title {
   font-size: 24px;
   font-weight: 600;
   letter-spacing: -0.025em;
   color: var(--text);
   margin: 0 0 6px;
-  /* subtle text gradient: 完全な白すぎず、claude-light 系で潰れないよう color-mix を使う */
-  background: linear-gradient(
-    180deg,
-    var(--text) 0%,
-    color-mix(in srgb, var(--text) 88%, transparent) 100%
-  );
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
 }
 
 .settings-shell__pane-desc {

--- a/src/renderer/src/styles/components/modal.css
+++ b/src/renderer/src/styles/components/modal.css
@@ -433,25 +433,32 @@
 .modal--settings .modal__theme-grid,
 .modal--settings .lang-grid,
 .modal--settings .density-grid {
-  gap: 12px;
+  gap: 10px;
 }
 
 /*
- * Claude 公式風: theme/lang/density カード選択 UI をフラットに統一。
- * hover で translate/shadow を付与せず、border/bg の微変化のみ。
- * selected は brand-glow の ring で明示 (heavy shadow は禁止)。
+ * Linear / Raycast 風カード選択 UI:
+ *   - アクセントカラーは「保存ボタン」など主アクションのために温存。
+ *     選択状態は subtle な背景 + 1px border + 右上の小さな accent dot で表現する
+ *     (heavy ring / 太枠は避け、画面全体の色ノイズを抑える)。
+ *   - hover で translateY(-1px) + soft shadow をかけて触覚的な反応を出す
+ *     (マイクロインタラクション)。
+ *   - 密度は若干高め: padding 12px / radius 12px / gap 10px。
  */
 .modal--settings .theme-card,
 .modal--settings .lang-card,
 .modal--settings .density-card {
-  padding: 14px;
-  border-width: 1px;
-  border-radius: var(--radius-md, 14px);
+  position: relative;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
   background: var(--bg-panel);
   transition:
-    background-color var(--dur-fast, 180ms) var(--ease-standard),
-    border-color var(--dur-fast, 180ms) var(--ease-standard),
-    box-shadow var(--dur-fast, 180ms) var(--ease-standard);
+    background-color 160ms cubic-bezier(0.25, 1, 0.5, 1),
+    border-color 160ms cubic-bezier(0.25, 1, 0.5, 1),
+    box-shadow 200ms cubic-bezier(0.25, 1, 0.5, 1),
+    transform 200ms cubic-bezier(0.25, 1, 0.5, 1);
+  will-change: transform;
 }
 
 .modal--settings .theme-card:hover,
@@ -459,13 +466,84 @@
 .modal--settings .density-card:hover {
   background: var(--bg-elev);
   border-color: var(--border-strong);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px -8px rgba(0, 0, 0, 0.45);
+}
+
+.modal--settings .theme-card:active,
+.modal--settings .lang-card:active,
+.modal--settings .density-card:active {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
 .modal--settings .theme-card.is-selected,
 .modal--settings .lang-card.is-selected,
 .modal--settings .density-card.is-selected {
-  border-color: var(--claude-brand, var(--accent));
-  box-shadow: 0 0 0 3px var(--claude-brand-glow, rgba(217, 119, 87, 0.12));
+  /* 選択は「ほんの少し明るい背景 + やや強い境界」だけで示し、
+     accent はカード右上の dot にのみ用いる */
+  background: var(--bg-elev);
+  border-color: var(--border-strong);
+  box-shadow: none;
+}
+
+/* 選択カード右上の accent dot (アクセント色を 1 ヶ所に集約) */
+.modal--settings .theme-card.is-selected::after,
+.modal--settings .lang-card.is-selected::after,
+.modal--settings .density-card.is-selected::after {
+  content: '';
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--claude-brand, var(--accent));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--claude-brand, var(--accent)) 18%, transparent);
+}
+
+/* タイポグラフィ階層: ラベル (主表記) を 1px 強く、補足はより dim に。
+   モーダル内のカード共通 (lang / density) で揃える */
+.modal--settings .lang-card strong,
+.modal--settings .density-card strong {
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+.modal--settings .lang-card span,
+.modal--settings .density-card span {
+  color: var(--text-mute);
+  opacity: 0.85;
+}
+
+/* 「適用して保存」ボタン: 押下時の ✓ フィードバック幅をチラつかせない */
+.settings-shell__apply.toolbar__btn {
+  min-width: 96px;
+  justify-content: center;
+}
+.settings-shell__apply.toolbar__btn.is-saved {
+  /* 保存完了の瞬間だけ accent をやや明るく + 軽くスケール */
+  background: color-mix(in srgb, var(--accent) 92%, white 8%);
+  transform: scale(0.985);
+  pointer-events: none;
+}
+.settings-shell__apply.toolbar__btn.is-saved svg {
+  animation: settings-saved-pop 240ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes settings-saved-pop {
+  0% {
+    transform: scale(0.6);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.15);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 @media (max-width: 860px) {


### PR DESCRIPTION
## Summary
設定モーダルの UI を視覚的階層 / 密度 / マイクロインタラクションの 3 軸で刷新。

### 主な変更
- **サイドバー MCP 重複バグ解消**: グループラベル "MCP" と項目 "MCP" が並んで重複表示されていた問題を、MCP セクションを「チーム」グループ配下に統合して解消
- **Linear/Raycast 風カード**: 選択カードのアクセント枠を撤廃し、subtle な bg + 1px border + 右上 6px accent dot に置換 (画面全体のアクセント密度を下げ、視線が「保存」に集まる)
- **アイコン付きナビ**: Lucide アイコン (Settings/Palette/Type/Bot/Code2/Users/Plug/Sparkles) を各セクションに追加し視覚スキャンを高速化
- **active indicator**: Linear 風に左端 2px の accent bar を縦に伸ばす表現
- **検索ボックス**: サイドバー上部にリアルタイム filter (空一致時は empty state)
- **タイポグラフィ階層強化**: pane-title 24px/600、section h3 を uppercase 小見出し化、グループラベルを uppercase + letter-spacing
- **保存ボタンのフィードバック**: 押下後 380ms だけ Check アイコンに pop-in アニメで切り替え → モーダルを閉じる
- **マイクロインタラクション**: カード hover で translateY(-1px) + soft shadow、active で押下感

### WebView2 描画破綻対策
nested backdrop-filter / background-clip:text を使って画面が真っ白になる事象を確認したため:
- nested backdrop-filter (header/footer 内側の二重 blur) を撤去
- pane-title の text-gradient を撤去
- 背景は単純な color-mix で代替して見た目はほぼ維持

## Test plan
- [x] \`npm run typecheck\` clean
- [ ] 手動: 各テーマ (claude-dark/light, dark, midnight, light) で開いて文字 / 背景が正しく描画されること
- [ ] 手動: 設定セクションを切り替えて section-in transition (220ms) が滑らかに走ること
- [ ] 手動: 検索ボックスに 'font' / 'mcp' 等を入力して該当セクションだけ残ること
- [ ] 手動: 保存ボタン押下で ✓ アイコンに切り替わり 380ms 後に閉じること
- [ ] 手動: サイドバーに MCP が 1 行 (「チーム」配下) だけ表示されること

## 影響範囲
SettingsModal.tsx と modal.css のみ変更。中身の Section コンポーネント (LanguageSection / ThemeSection / etc) と CSS 変数は全て無変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)