### PR TITLE
fix: open issues #191-#197 の 7 件をバンドル修正

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -198,10 +198,13 @@ pub async fn app_setup_team_mcp(
                 "[setup_team_mcp] skipping skill install: no active project_root configured"
             );
         } else {
-            match (
-                std::fs::canonicalize(trimmed),
-                std::fs::canonicalize(active.trim()),
-            ) {
+            // canonicalize は async fn 内では tokio::fs を使う (network mount 等で blocking I/O が
+            // Tokio worker を塞ぐのを避けるため)。req と active は独立なので join で並列実行。
+            let (req_res, active_res) = tokio::join!(
+                tokio::fs::canonicalize(trimmed),
+                tokio::fs::canonicalize(active.trim())
+            );
+            match (req_res, active_res) {
                 (Ok(req_canon), Ok(active_canon)) if req_canon == active_canon => {
                     crate::commands::vibe_team_skill::install_skill_best_effort(
                         &req_canon.to_string_lossy(),

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -218,10 +218,19 @@ pub async fn app_setup_team_mcp(
                         active_canon.display()
                     );
                 }
-                (Err(e), _) | (_, Err(e)) => {
-                    tracing::warn!(
-                        "[setup_team_mcp] canonicalize failed for skill install gate: {e}"
-                    );
+                (req_res, active_res) => {
+                    // どちらか / 両方失敗。両方分けて出すことで「片方だけ失敗 → ディスク破損疑い」
+                    // 「両方失敗 → 設定経路の不整合」のデバッグ材料を残す。
+                    if let Err(e) = req_res {
+                        tracing::warn!(
+                            "[setup_team_mcp] canonicalize requested project_root failed: {e}"
+                        );
+                    }
+                    if let Err(e) = active_res {
+                        tracing::warn!(
+                            "[setup_team_mcp] canonicalize active project_root failed: {e}"
+                        );
+                    }
                 }
             }
         }

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -183,9 +183,45 @@ pub async fn app_setup_team_mcp(
     // どのケースでも install_skill_best_effort はバージョンヘッダで idempotent (内容一致なら no-op、
     // 同バージョンヘッダで内容差分があれば自動上書き、ヘッダ無しのユーザー編集ファイルには触らない)
     // なので team_id を問わず常に呼んでよい。アプリ起動毎に最新の SKILL.md が確実に同期される。
+    //
+    // Issue #191 (Security): 旧実装は renderer 由来の project_root をそのまま install に流して
+    // いたため、改ざん済み bundled JS から任意ディレクトリ配下に SKILL.md を plant 可能だった
+    // (#135 で app_install_vibe_team_skill だけに付けたガードが、setup 経路では空転していた)。
+    // → app_install_vibe_team_skill と同じく req_canon == active_canon を検証してから install する。
     let trimmed = project_root.trim();
     if !trimmed.is_empty() {
-        crate::commands::vibe_team_skill::install_skill_best_effort(trimmed).await;
+        let active = crate::state::lock_project_root_recover(&state.project_root)
+            .clone()
+            .unwrap_or_default();
+        if active.trim().is_empty() {
+            tracing::warn!(
+                "[setup_team_mcp] skipping skill install: no active project_root configured"
+            );
+        } else {
+            match (
+                std::fs::canonicalize(trimmed),
+                std::fs::canonicalize(active.trim()),
+            ) {
+                (Ok(req_canon), Ok(active_canon)) if req_canon == active_canon => {
+                    crate::commands::vibe_team_skill::install_skill_best_effort(
+                        &req_canon.to_string_lossy(),
+                    )
+                    .await;
+                }
+                (Ok(req_canon), Ok(active_canon)) => {
+                    tracing::warn!(
+                        "[setup_team_mcp] skill install denied: requested {} != active {}",
+                        req_canon.display(),
+                        active_canon.display()
+                    );
+                }
+                (Err(e), _) | (_, Err(e)) => {
+                    tracing::warn!(
+                        "[setup_team_mcp] canonicalize failed for skill install gate: {e}"
+                    );
+                }
+            }
+        }
     }
     let (port, token, bridge_path) = hub.info().await;
     let socket = format!("127.0.0.1:{port}");

--- a/src-tauri/src/team_hub/inject.rs
+++ b/src-tauri/src/team_hub/inject.rs
@@ -69,10 +69,21 @@ pub fn build_chunks(banner: &str, body: &str) -> Vec<Vec<u8>> {
     let banner_clean = sanitize_for_paste(banner);
     let body_clean = sanitize_for_paste(body);
 
+    // Issue #193: 旧実装は判定が body_clean.len() (バイト) なのに切詰が chars().take(MAX_PAYLOAD)
+    // (文字数) で、UTF-8 マルチバイトでは MAX_PAYLOAD バイト超過判定後に最大 4 倍長を残してしまい、
+    // 32 KiB 上限が事実上機能していなかった。
+    // 修正: バイト単位で UTF-8 境界を保ったまま切る。char_indices で 1 文字ずつ加算長を計算し、
+    // MAX_PAYLOAD バイトに収まる最後の境界を end として slice する。
     let truncated: String = if body_clean.len() > MAX_PAYLOAD {
-        let mut s: String = body_clean.chars().take(MAX_PAYLOAD).collect();
-        s.push_str(" …(truncated)");
-        s
+        let mut end = 0usize;
+        for (i, ch) in body_clean.char_indices() {
+            let next = i + ch.len_utf8();
+            if next > MAX_PAYLOAD {
+                break;
+            }
+            end = next;
+        }
+        format!("{} …(truncated)", &body_clean[..end])
     } else {
         body_clean
     };
@@ -187,4 +198,72 @@ pub async fn inject(
     let _ = tokio::task::spawn_blocking(move || s.write(b"\r")).await;
     tracing::debug!("[inject] -> agent {agent_id} delivered");
     true
+}
+
+#[cfg(test)]
+mod build_chunks_tests {
+    use super::{build_chunks, BP_END, BP_START, MAX_PAYLOAD};
+
+    fn join(chunks: &[Vec<u8>]) -> Vec<u8> {
+        let mut v = Vec::new();
+        for c in chunks {
+            v.extend_from_slice(c);
+        }
+        v
+    }
+
+    #[test]
+    fn short_message_is_wrapped_in_bracketed_paste() {
+        let chunks = build_chunks("[Team] ", "hello");
+        let bytes = join(&chunks);
+        assert!(bytes.starts_with(BP_START));
+        assert!(bytes.ends_with(BP_END));
+        assert!(bytes.windows(5).any(|w| w == b"hello"));
+    }
+
+    #[test]
+    fn ascii_oversize_is_truncated_to_byte_limit() {
+        let body = "a".repeat(MAX_PAYLOAD + 100);
+        let chunks = build_chunks("", &body);
+        let bytes = join(&chunks);
+        let inner = &bytes[BP_START.len()..bytes.len() - BP_END.len()];
+        let inner_str = std::str::from_utf8(inner).unwrap();
+        let marker = " …(truncated)";
+        assert!(inner_str.ends_with(marker));
+        // 本文部分 (marker を除いた前半) が MAX_PAYLOAD バイトを超えないこと。
+        // marker 文字列は 'a' を 1 つ含む (trunc[a]ted) ので char count では合算されてしまう。
+        // バイト長で本文のサイズを直接検証する。
+        let body_only_bytes = inner.len() - marker.len();
+        assert!(
+            body_only_bytes <= MAX_PAYLOAD,
+            "body_only_bytes {body_only_bytes} exceeded MAX_PAYLOAD {MAX_PAYLOAD}"
+        );
+        assert!(
+            body_only_bytes >= MAX_PAYLOAD - 1,
+            "kept too few bytes: {body_only_bytes}"
+        );
+    }
+
+    /// Issue #193 回帰テスト: マルチバイト UTF-8 でも MAX_PAYLOAD バイトに収まること。
+    /// 旧実装は chars().take(MAX_PAYLOAD) で「文字数」で切っていたため、3 byte 文字なら
+    /// 最大 ~3 倍長を残していた。
+    #[test]
+    fn multibyte_oversize_stays_within_byte_limit() {
+        // 「あ」は UTF-8 で 3 bytes。MAX_PAYLOAD バイト換算で約 32768/3 = 10922 文字までしか入らない。
+        // 旧実装はここで chars().take(MAX_PAYLOAD)=32768 文字 ~= 98 KiB を残してしまう。
+        let body = "あ".repeat(MAX_PAYLOAD); // 約 98 KiB
+        let chunks = build_chunks("", &body);
+        let bytes = join(&chunks);
+        let inner = &bytes[BP_START.len()..bytes.len() - BP_END.len()];
+        // truncated 末尾分は許容する (固定 14 byte 程度) が、本文部分は MAX_PAYLOAD 以下
+        let truncated_marker = " …(truncated)";
+        assert!(inner.windows(truncated_marker.len()).any(|w| w == truncated_marker.as_bytes()));
+        let body_only_len = inner.len() - truncated_marker.len();
+        assert!(
+            body_only_len <= MAX_PAYLOAD,
+            "body bytes {body_only_len} exceeded MAX_PAYLOAD {MAX_PAYLOAD}"
+        );
+        // UTF-8 として valid であること (境界で切れていないこと)
+        assert!(std::str::from_utf8(&inner[..body_only_len]).is_ok());
+    }
 }

--- a/src/renderer/src/components/OnboardingWizard.tsx
+++ b/src/renderer/src/components/OnboardingWizard.tsx
@@ -130,12 +130,11 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps): JSX.Ele
     void onComplete(patch);
   }, [draftLanguage, draftTheme, draftFolder, onComplete]);
 
-  // Done 画面は 2 秒放置で自動完了
-  useEffect(() => {
-    if (step !== 'done') return;
-    const id = setTimeout(finish, 2000);
-    return () => clearTimeout(id);
-  }, [step, finish]);
+  // Issue #197: 旧実装は Done 画面を 2 秒で自動完了させていたが、
+  //   - スクリーンリーダーは <dl> サマリ (language/theme/folder) を読み始めた直後に modal が消える
+  //   - 認知負荷の高いユーザー / スクリーンショット作成が画面を確認できない
+  //   - WCAG 2.2.1 (Timing Adjustable) 違反
+  // 「完了」CTA はすでに画面下部にあるので、自動 finish を撤去してユーザー操作のみで閉じる仕様にする。
 
   const progressIndex = useMemo(() => {
     if (step === 'done') return PROGRESS_STEPS.length;

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -304,8 +304,8 @@ export function SettingsModal({
           // Issue #195: Escape で閉じる + Tab で focus trap。
           if (e.key === 'Escape') {
             // IME 変換中の Escape は確定キャンセルとして使われるので絶対に握らない。
-            const composing = (e.nativeEvent as KeyboardEvent).isComposing;
-            if (composing) return;
+            // React 17+ では e.nativeEvent は KeyboardEvent 型に推論されるためキャスト不要。
+            if (e.nativeEvent.isComposing) return;
             const target = e.target as HTMLElement | null;
             const tag = target?.tagName;
             const isTextField =
@@ -336,11 +336,13 @@ export function SettingsModal({
           ).filter((el) => {
             // 1. dialog root 自身 (tabIndex=-1) を除外する保険
             if (el.tabIndex < 0) return false;
-            // 2. レイアウト上見えていない要素を除外。旧実装は offsetParent === null で判定していたが、
-            //    position: fixed の要素は offsetParent が常に null になるため誤って除外される。
-            //    getComputedStyle.display !== 'none' + visibility !== 'hidden' で堅牢にチェック。
-            const style = window.getComputedStyle(el);
-            return style.display !== 'none' && style.visibility !== 'hidden';
+            // 2. レイアウト上見えていない要素を除外。
+            //    旧実装は offsetParent === null だったが position: fixed で常に null になり誤除外。
+            //    getComputedStyle は確実だが Tab 押下ごとに layout thrashing しうるため、
+            //    getBoundingClientRect の width/height でレイアウト 1 回だけ走らせる軽量版に統一。
+            //    (display:none / visibility:hidden / 0 サイズ要素はすべて 0 になるので網羅できる)
+            const rect = el.getBoundingClientRect();
+            return rect.width > 0 || rect.height > 0;
           });
           if (focusables.length === 0) return;
           const first = focusables[0];

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -78,8 +78,7 @@ export function SettingsModal({
   // 描画完了直後の最初のフレームで focus を移す。
   useEffect(() => {
     if (!open) return;
-    let raf = 0;
-    raf = window.requestAnimationFrame(() => {
+    const raf = window.requestAnimationFrame(() => {
       const root = dialogRef.current;
       if (!root) return;
       const target = root.querySelector<HTMLElement>(
@@ -297,20 +296,31 @@ export function SettingsModal({
         role="dialog"
         aria-modal="true"
         aria-label={isJa ? '設定' : 'Settings'}
+        // Issue #195: dialog root を programmatic focus ターゲットにするため tabindex=-1。
+        // Escape を入力フィールドから受けたとき、まず root に focus を退避してから次の
+        // Escape で閉じる UX (vscode / macOS native と同じ) を実現する。
+        tabIndex={-1}
         onKeyDown={(e) => {
           // Issue #195: Escape で閉じる + Tab で focus trap。
-          // Escape は input/textarea/IME 確定中はスキップ (IME 確定キャンセル等の標準挙動を妨げない)。
           if (e.key === 'Escape') {
+            // IME 変換中の Escape は確定キャンセルとして使われるので絶対に握らない。
+            const composing = (e.nativeEvent as KeyboardEvent).isComposing;
+            if (composing) return;
             const target = e.target as HTMLElement | null;
             const tag = target?.tagName;
             const isTextField =
               tag === 'INPUT' ||
               tag === 'TEXTAREA' ||
               target?.getAttribute('contenteditable') === 'true';
-            // nativeEvent.isComposing は IME 変換中 true。確定前の Escape を漏らさない。
-            const composing = (e.nativeEvent as KeyboardEvent).isComposing;
-            if (isTextField && composing) return;
             e.preventDefault();
+            // 入力中の Escape で即閉じると入力中のテキストが lost するため、
+            // 1 回目は input から blur して dialog root に focus を退避するだけにする。
+            // (2 回目の Escape は target=dialog なのでこの分岐に入らず onClose に進む)
+            if (isTextField && target) {
+              target.blur();
+              dialogRef.current?.focus();
+              return;
+            }
             onClose();
             return;
           }
@@ -319,9 +329,15 @@ export function SettingsModal({
           if (!root) return;
           const focusables = Array.from(
             root.querySelectorAll<HTMLElement>(
-              'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex="-1"])'
+              'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable]:not([contenteditable="false"]), [tabindex]'
             )
-          ).filter((el) => el.offsetParent !== null);
+          ).filter(
+            // 1. レイアウト上見えていない要素 (display:none 等) を除外
+            // 2. tabindex の負値 ("-1" / "-2" 等) を除外
+            //    旧実装は :not([tabindex="-1"]) のみで -2 等が漏れていた → el.tabIndex >= 0 で網羅
+            //    また dialog root 自身 (tabIndex=-1) もここで除外される
+            (el) => el.offsetParent !== null && el.tabIndex >= 0
+          );
           if (focusables.length === 0) return;
           const first = focusables[0];
           const last = focusables[focusables.length - 1];

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -329,12 +329,13 @@ export function SettingsModal({
           if (!root) return;
           const focusables = Array.from(
             root.querySelectorAll<HTMLElement>(
-              // 負値 tabindex はセレクタ側で除外 ([tabindex^="-"] にマッチする要素を NOT する)。
-              // querySelector レベルで切ると後段 filter のコストが減る。
-              'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex^="-"])'
+              // セレクタ側は典型的な -1 だけを除外し、それ以外の負値や空文字 ([tabindex=""] 等) は
+              // 後段 filter の el.tabIndex < 0 に委ねる (CSS attribute selector の前方一致は
+              // ブラウザ間で挙動差があり、正規実装に統一するほうが堅牢)。
+              'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex="-1"])'
             )
           ).filter((el) => {
-            // 1. dialog root 自身 (tabIndex=-1) を除外する保険
+            // 1. tabIndex の負値 (-2 等) と dialog root (tabIndex=-1) を除外
             if (el.tabIndex < 0) return false;
             // 2. レイアウト上見えていない要素を除外。
             //    旧実装は offsetParent === null だったが position: fixed で常に null になり誤除外。

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -72,34 +72,22 @@ export function SettingsModal({
     if (!exists) setActiveSection('general');
   }, [activeSection, draft.customAgents]);
 
-  // Issue #195 (a11y): document レベルで Escape をキャッチして閉じる。
-  // (modal 内 input にフォーカスが当たっていても効くように window 経由で listen する)
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onClose();
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [open, onClose]);
-
   // Issue #195: マウント直後にダイアログ内の最初の focusable に focus を移す。
   // 何もせず開くと focus は背景 (Canvas/FileTree) に残り、Tab で背後に抜ける起点になる。
+  // setTimeout のマジックナンバーを避けるため requestAnimationFrame を使い、
+  // 描画完了直後の最初のフレームで focus を移す。
   useEffect(() => {
     if (!open) return;
-    // 描画完了を待ってから focus (transition 中の hidden 要素を選ばないため遅延)
-    const id = window.setTimeout(() => {
+    let raf = 0;
+    raf = window.requestAnimationFrame(() => {
       const root = dialogRef.current;
       if (!root) return;
       const target = root.querySelector<HTMLElement>(
-        '[autofocus], button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        '[autofocus], button, [href], input, select, textarea, [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex="-1"])'
       );
       target?.focus();
-    }, 30);
-    return () => window.clearTimeout(id);
+    });
+    return () => window.cancelAnimationFrame(raf);
   }, [open]);
 
   const { mounted, dataState, motion } = useSpringMount(open, 180);
@@ -310,13 +298,28 @@ export function SettingsModal({
         aria-modal="true"
         aria-label={isJa ? '設定' : 'Settings'}
         onKeyDown={(e) => {
-          // Issue #195: 簡易 focus trap。Tab/Shift+Tab で末尾⇄先頭をループさせる。
+          // Issue #195: Escape で閉じる + Tab で focus trap。
+          // Escape は input/textarea/IME 確定中はスキップ (IME 確定キャンセル等の標準挙動を妨げない)。
+          if (e.key === 'Escape') {
+            const target = e.target as HTMLElement | null;
+            const tag = target?.tagName;
+            const isTextField =
+              tag === 'INPUT' ||
+              tag === 'TEXTAREA' ||
+              target?.getAttribute('contenteditable') === 'true';
+            // nativeEvent.isComposing は IME 変換中 true。確定前の Escape を漏らさない。
+            const composing = (e.nativeEvent as KeyboardEvent).isComposing;
+            if (isTextField && composing) return;
+            e.preventDefault();
+            onClose();
+            return;
+          }
           if (e.key !== 'Tab') return;
           const root = dialogRef.current;
           if (!root) return;
           const focusables = Array.from(
             root.querySelectorAll<HTMLElement>(
-              'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+              'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex="-1"])'
             )
           ).filter((el) => el.offsetParent !== null);
           if (focusables.length === 0) return;

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -47,6 +47,8 @@ export function SettingsModal({
   const t = useT();
   const [draft, setDraft] = useState<AppSettings>(initial);
   const [activeSection, setActiveSection] = useState<SectionId>('general');
+  // Issue #195: focus trap + Escape + autofocus 用のルート ref
+  const dialogRef = useRef<HTMLDivElement | null>(null);
 
   // Issue #178: open 中に外部から settings が更新されると useEffect が再発火して
   // ユーザー入力中の draft が消える事故があった。
@@ -69,6 +71,36 @@ export function SettingsModal({
     );
     if (!exists) setActiveSection('general');
   }, [activeSection, draft.customAgents]);
+
+  // Issue #195 (a11y): document レベルで Escape をキャッチして閉じる。
+  // (modal 内 input にフォーカスが当たっていても効くように window 経由で listen する)
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  // Issue #195: マウント直後にダイアログ内の最初の focusable に focus を移す。
+  // 何もせず開くと focus は背景 (Canvas/FileTree) に残り、Tab で背後に抜ける起点になる。
+  useEffect(() => {
+    if (!open) return;
+    // 描画完了を待ってから focus (transition 中の hidden 要素を選ばないため遅延)
+    const id = window.setTimeout(() => {
+      const root = dialogRef.current;
+      if (!root) return;
+      const target = root.querySelector<HTMLElement>(
+        '[autofocus], button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      target?.focus();
+    }, 30);
+    return () => window.clearTimeout(id);
+  }, [open]);
 
   const { mounted, dataState, motion } = useSpringMount(open, 180);
   if (!mounted) return null;
@@ -269,10 +301,36 @@ export function SettingsModal({
       onClick={onClose}
     >
       <div
+        ref={dialogRef}
         className="modal modal--settings"
         data-state={dataState}
         data-motion={motion}
         onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={isJa ? '設定' : 'Settings'}
+        onKeyDown={(e) => {
+          // Issue #195: 簡易 focus trap。Tab/Shift+Tab で末尾⇄先頭をループさせる。
+          if (e.key !== 'Tab') return;
+          const root = dialogRef.current;
+          if (!root) return;
+          const focusables = Array.from(
+            root.querySelectorAll<HTMLElement>(
+              'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+            )
+          ).filter((el) => el.offsetParent !== null);
+          if (focusables.length === 0) return;
+          const first = focusables[0];
+          const last = focusables[focusables.length - 1];
+          const active = document.activeElement as HTMLElement | null;
+          if (e.shiftKey && active === first) {
+            e.preventDefault();
+            last.focus();
+          } else if (!e.shiftKey && active === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }}
       >
         <header className="modal__header">
           <div className="modal__title-group" style={{ display: 'flex', alignItems: 'center' }}>

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -329,15 +329,19 @@ export function SettingsModal({
           if (!root) return;
           const focusables = Array.from(
             root.querySelectorAll<HTMLElement>(
-              'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable]:not([contenteditable="false"]), [tabindex]'
+              // 負値 tabindex はセレクタ側で除外 ([tabindex^="-"] にマッチする要素を NOT する)。
+              // querySelector レベルで切ると後段 filter のコストが減る。
+              'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex^="-"])'
             )
-          ).filter(
-            // 1. レイアウト上見えていない要素 (display:none 等) を除外
-            // 2. tabindex の負値 ("-1" / "-2" 等) を除外
-            //    旧実装は :not([tabindex="-1"]) のみで -2 等が漏れていた → el.tabIndex >= 0 で網羅
-            //    また dialog root 自身 (tabIndex=-1) もここで除外される
-            (el) => el.offsetParent !== null && el.tabIndex >= 0
-          );
+          ).filter((el) => {
+            // 1. dialog root 自身 (tabIndex=-1) を除外する保険
+            if (el.tabIndex < 0) return false;
+            // 2. レイアウト上見えていない要素を除外。旧実装は offsetParent === null で判定していたが、
+            //    position: fixed の要素は offsetParent が常に null になるため誤って除外される。
+            //    getComputedStyle.display !== 'none' + visibility !== 'hidden' で堅牢にチェック。
+            const style = window.getComputedStyle(el);
+            return style.display !== 'none' && style.visibility !== 'hidden';
+          });
           if (focusables.length === 0) return;
           const first = focusables[0];
           const last = focusables[focusables.length - 1];

--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -95,11 +95,15 @@ function FlowApp(): JSX.Element {
       //   - pendingPosIds / pendingDimIds: remaining 内に既存の position/dimensions 変更がある id の Set
       //     (旧 remaining.some 二重ループを Set.has の O(1) に置換)
       //   - lockedTeams: teamId → boolean のキャッシュ (isTeamLocked の重複呼び出しを削減)
+      // payload は CardData 内で複数のサブ型を持つため { teamId?: string } で局所キャストする。
+      // 同じキャストが index 構築 + position/dimensions 分岐で計 3 回走るので helper に集約。
+      const teamIdOf = (n: Node<CardData>): string | undefined =>
+        (n.data?.payload as { teamId?: string } | undefined)?.teamId;
       const nodesById = new Map<string, Node<CardData>>();
       const teamMembers = new Map<string, Node<CardData>[]>();
       for (const n of nodes) {
         nodesById.set(n.id, n);
-        const tid = (n.data?.payload as { teamId?: string } | undefined)?.teamId;
+        const tid = teamIdOf(n);
         if (tid) {
           let bucket = teamMembers.get(tid);
           if (!bucket) {
@@ -131,7 +135,7 @@ function FlowApp(): JSX.Element {
         if (c.type === 'position' && c.position) {
           const node = nodesById.get(c.id);
           if (!node) continue;
-          const teamId = (node.data?.payload as { teamId?: string } | undefined)?.teamId;
+          const teamId = teamIdOf(node);
           if (!teamId || !isLocked(teamId)) continue;
           const dx = c.position.x - node.position.x;
           const dy = c.position.y - node.position.y;
@@ -154,7 +158,7 @@ function FlowApp(): JSX.Element {
         if (c.type === 'dimensions' && c.dimensions && c.resizing) {
           const node = nodesById.get(c.id);
           if (!node) continue;
-          const teamId = (node.data?.payload as { teamId?: string } | undefined)?.teamId;
+          const teamId = teamIdOf(node);
           if (!teamId || !isLocked(teamId)) continue;
           const w = c.dimensions.width;
           const h = c.dimensions.height;

--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -85,33 +85,62 @@ function FlowApp(): JSX.Element {
         : changes;
       if (remaining.length === 0) return;
 
+      // Issue #196: 旧実装は変更ごとに `nodes.find` + `for (other of nodes)` + 内側 `remaining.some(...)`
+      // で O(N×M) になっており、6 人チーム × 4 種カード = 24 ノード規模で 1 px ドラッグごとに
+      // 数百ステップ走り 16ms フレーム予算を超えやすかった。
+      //
+      // 修正: 1 フレームに 1 度だけインデックスを構築し、内部ループを O(チームサイズ) + O(1) に落とす。
+      //   - nodesById: id → Node のマップ (旧 nodes.find = O(N))
+      //   - teamMembers: teamId → Node[] のマップ (旧 nodes 全走査をチーム単位に絞る)
+      //   - pendingPosIds / pendingDimIds: remaining 内に既存の position/dimensions 変更がある id の Set
+      //     (旧 remaining.some 二重ループを Set.has の O(1) に置換)
+      //   - lockedTeams: teamId → boolean のキャッシュ (isTeamLocked の重複呼び出しを削減)
+      const nodesById = new Map<string, Node<CardData>>();
+      const teamMembers = new Map<string, Node<CardData>[]>();
+      for (const n of nodes) {
+        nodesById.set(n.id, n);
+        const tid = (n.data?.payload as { teamId?: string } | undefined)?.teamId;
+        if (tid) {
+          let bucket = teamMembers.get(tid);
+          if (!bucket) {
+            bucket = [];
+            teamMembers.set(tid, bucket);
+          }
+          bucket.push(n);
+        }
+      }
+      const pendingPosIds = new Set<string>();
+      const pendingDimIds = new Set<string>();
+      for (const c of remaining) {
+        if (c.type === 'position' && 'id' in c) pendingPosIds.add(c.id);
+        else if (c.type === 'dimensions' && 'id' in c) pendingDimIds.add(c.id);
+      }
+      const lockedTeams = new Map<string, boolean>();
+      const isLocked = (tid: string): boolean => {
+        const cached = lockedTeams.get(tid);
+        if (cached !== undefined) return cached;
+        const v = isTeamLocked(tid);
+        lockedTeams.set(tid, v);
+        return v;
+      };
+
       // ----- チーム同期ドラッグ + 同期リサイズ -----
-      // teamId を持つカードがロック状態でドラッグ / リサイズされたら、同 teamId の他カードへ
-      // 同じ変化を broadcast する。これでチーム全員が一塊で動き、揃ったサイズに変わる。
       const extra: NodeChange<Node<CardData>>[] = [];
       for (const c of remaining) {
         // 位置同期 (ドラッグ): delta を全員に伝える
         if (c.type === 'position' && c.position) {
-          const node = nodes.find((n) => n.id === c.id);
+          const node = nodesById.get(c.id);
           if (!node) continue;
           const teamId = (node.data?.payload as { teamId?: string } | undefined)?.teamId;
-          if (!teamId) continue;
-          if (!isTeamLocked(teamId)) continue;
+          if (!teamId || !isLocked(teamId)) continue;
           const dx = c.position.x - node.position.x;
           const dy = c.position.y - node.position.y;
           if (dx === 0 && dy === 0) continue;
-          for (const other of nodes) {
+          const members = teamMembers.get(teamId);
+          if (!members) continue;
+          for (const other of members) {
             if (other.id === node.id) continue;
-            const otherTeam = (other.data?.payload as { teamId?: string } | undefined)?.teamId;
-            if (otherTeam !== teamId) continue;
-            // 既にこのフレームで同じ id の position 変更が来ていたらスキップ (二重適用回避)
-            if (
-              remaining.some(
-                (x) => x.type === 'position' && 'id' in x && x.id === other.id
-              )
-            ) {
-              continue;
-            }
+            if (pendingPosIds.has(other.id)) continue;
             extra.push({
               id: other.id,
               type: 'position',
@@ -123,25 +152,17 @@ function FlowApp(): JSX.Element {
         }
         // サイズ同期 (NodeResizer): リサイズ後のサイズに全員揃える
         if (c.type === 'dimensions' && c.dimensions && c.resizing) {
-          const node = nodes.find((n) => n.id === c.id);
+          const node = nodesById.get(c.id);
           if (!node) continue;
           const teamId = (node.data?.payload as { teamId?: string } | undefined)?.teamId;
-          if (!teamId) continue;
-          if (!isTeamLocked(teamId)) continue;
+          if (!teamId || !isLocked(teamId)) continue;
           const w = c.dimensions.width;
           const h = c.dimensions.height;
-          for (const other of nodes) {
+          const members = teamMembers.get(teamId);
+          if (!members) continue;
+          for (const other of members) {
             if (other.id === node.id) continue;
-            const otherTeam = (other.data?.payload as { teamId?: string } | undefined)?.teamId;
-            if (otherTeam !== teamId) continue;
-            // 既に同じ id の dimensions 変更が来ていたらスキップ
-            if (
-              remaining.some(
-                (x) => x.type === 'dimensions' && 'id' in x && x.id === other.id
-              )
-            ) {
-              continue;
-            }
+            if (pendingDimIds.has(other.id)) continue;
             extra.push({
               id: other.id,
               type: 'dimensions',

--- a/src/renderer/src/components/canvas/QuickNav.tsx
+++ b/src/renderer/src/components/canvas/QuickNav.tsx
@@ -41,11 +41,17 @@ export function QuickNav({ open, onClose }: QuickNavProps): JSX.Element | null {
         const data = n.data ?? {};
         const title = String(data.title ?? n.id);
         const cardType = String(data.cardType ?? n.type ?? '');
-        const role = (data.payload as { role?: string } | undefined)?.role;
-        const meta = metaOf(role);
+        // Issue #194: canvas store v2 マイグレーションで legacy `role` は基本 undefined になり、
+        // 全カードがデフォルト紫 + 汎用 glyph で表示されて QuickNav が機能ほぼ無価値だった。
+        // AgentNodeCard と同じく roleProfileId を優先し、無ければ legacy role を fallback。
+        const payload = data.payload as
+          | { roleProfileId?: string; role?: string }
+          | undefined;
+        const roleId = payload?.roleProfileId ?? payload?.role;
+        const meta = metaOf(roleId);
         const subtitle = meta ? meta.label : cardType;
-        const haystack = `${title} ${subtitle} ${role ?? ''}`.toLowerCase();
-        return { node: n, title, subtitle, role, haystack };
+        const haystack = `${title} ${subtitle} ${roleId ?? ''}`.toLowerCase();
+        return { node: n, title, subtitle, role: roleId, haystack };
       })
       .filter((i) => !q || i.haystack.includes(q));
   }, [nodes, query]);

--- a/src/renderer/src/lib/use-team-handoff.ts
+++ b/src/renderer/src/lib/use-team-handoff.ts
@@ -58,15 +58,20 @@ export function useTeamHandoff(callback: (p: HandoffPayload) => void): void {
     return () => {
       listeners.delete(wrapper);
       if (listeners.size !== 0) return;
-      // 全 subscriber が抜けた → Tauri listener を止めて initPromise をリセット。
-      // listen() がまだ resolve していなくても、Promise.then で resolve 後に必ず unlisten を
-      // 呼ぶことで「unlisten が孤児になり次マウントで二重 listen」 (Issue #192) を防ぐ。
-      // 再マウントは ensureRegistered() で新しい listen を作るので、古い myInit は確実に閉じる。
-      // (旧コミットでは「再マウントが間に合えば stale を再活用」する最適化を入れていたが、
-      //  cleanup 高頻度時の世代管理が複雑になりレビューで race を指摘された。listen 1 回分の
-      //  コストは無視できるので常に閉じる単純形に戻す。)
-      initPromise = null;
-      void myInit.then((u) => u()).catch(() => {});
+      // Issue #192: cleanup 時点で listeners=0 でも、unlisten 完了前に再マウントが間に合うと
+      // 「古い initPromise を即 null → 新マウントが NEW listen を生成 → 古い listen は
+      //  まだ生きていて二重発火」となる race があるため、resolve まで initPromise を null に
+      // しない。resolve 時に listeners.size を再確認し、
+      //   - 0 のまま: 本当に誰も居ない → u() で unlisten + initPromise クリア
+      //   - >0     : 再マウントが間に合った → 既存 listen を再利用 (initPromise=myInit のまま)
+      // どちらの分岐でも listen は 1 本だけ、二重発火しない。
+      void myInit
+        .then((u) => {
+          if (listeners.size > 0) return;
+          u();
+          if (initPromise === myInit) initPromise = null;
+        })
+        .catch(() => {});
     };
   }, []);
 }

--- a/src/renderer/src/lib/use-team-handoff.ts
+++ b/src/renderer/src/lib/use-team-handoff.ts
@@ -82,7 +82,11 @@ export function useTeamHandoff(callback: (p: HandoffPayload) => void): void {
           u();
           if (initPromise === myInit) initPromise = null;
         })
-        .catch(() => {});
+        .catch((err) => {
+          // 旧コードは catch を空に握り潰していたが、Tauri IPC が壊れた等で listen() が
+          // 失敗したケースが完全に sile になってしまうため最低限 console.warn で残す。
+          console.warn('[handoff] listen() failed in cleanup path:', err);
+        });
     };
   }, []);
 }

--- a/src/renderer/src/lib/use-team-handoff.ts
+++ b/src/renderer/src/lib/use-team-handoff.ts
@@ -65,6 +65,17 @@ export function useTeamHandoff(callback: (p: HandoffPayload) => void): void {
       //   - 0 のまま: 本当に誰も居ない → u() で unlisten + initPromise クリア
       //   - >0     : 再マウントが間に合った → 既存 listen を再利用 (initPromise=myInit のまま)
       // どちらの分岐でも listen は 1 本だけ、二重発火しない。
+      //
+      // 詳細な race シナリオ (レビュー検証用):
+      //   t0: マウント A cleanup → listeners.delete(wrapperA) → listeners.size = 0
+      //   t1: ensureRegistered() を呼んでいたマウント B が listeners.add(wrapperB) → size = 1
+      //       B の myInit は ensureRegistered の if (initPromise) return initPromise で
+      //       同じ Promise (= A の myInit) を取得済み
+      //   t2: A の cleanup .then が resolve → listeners.size > 0 → return (unlisten せず)
+      //   t3: B の cleanup → listeners.size = 0
+      //   t4: B の cleanup .then が resolve → listeners.size = 0 → u() で unlisten
+      //       initPromise === myInit (B) なので null クリア
+      // listen は 1 本だけ、unlisten も 1 回だけ。リークなし。
       void myInit
         .then((u) => {
           if (listeners.size > 0) return;

--- a/src/renderer/src/lib/use-team-handoff.ts
+++ b/src/renderer/src/lib/use-team-handoff.ts
@@ -31,7 +31,7 @@ let initPromise: Promise<UnlistenFn> | null = null;
 
 function ensureRegistered(): Promise<UnlistenFn> {
   if (initPromise) return initPromise;
-  initPromise = listen<HandoffPayload>('team:handoff', (e) => {
+  const p = listen<HandoffPayload>('team:handoff', (e) => {
     for (const cb of listeners) {
       try {
         cb(e.payload);
@@ -40,7 +40,16 @@ function ensureRegistered(): Promise<UnlistenFn> {
       }
     }
   });
-  return initPromise;
+  initPromise = p;
+  // 防御的フェールセーフ: listen() が reject した場合 initPromise が rejected のまま固着し、
+  // 後続マウントの `if (initPromise) return initPromise` が永遠に rejected を返し続ける。
+  // ここで attach する .catch は元の Promise (p) と同じチェーン上だが、cleanup 側 .then().catch()
+  // が rejection を別途 console.warn で観測しているため二重 warn にならない (こちらは無言で reset)。
+  // p === initPromise の同一性チェックで、別マウントが先に新しい listen を張った後の stale clear を防ぐ。
+  p.catch(() => {
+    if (initPromise === p) initPromise = null;
+  });
+  return p;
 }
 
 /**

--- a/src/renderer/src/lib/use-team-handoff.ts
+++ b/src/renderer/src/lib/use-team-handoff.ts
@@ -59,20 +59,14 @@ export function useTeamHandoff(callback: (p: HandoffPayload) => void): void {
       listeners.delete(wrapper);
       if (listeners.size !== 0) return;
       // 全 subscriber が抜けた → Tauri listener を止めて initPromise をリセット。
-      // listen() がまだ resolve していなくても、Promise.then で resolve 後に呼ぶことで
-      // 「unlisten が孤児になり次マウントで二重 listen」 (Issue #192) を防ぐ。
-      // ただし then 内で listeners.size を再確認し、別フックが先に再 mount していれば
-      // unlisten せずにそのまま使い回す (false-positive cleanup を避ける)。
-      const stale = initPromise;
+      // listen() がまだ resolve していなくても、Promise.then で resolve 後に必ず unlisten を
+      // 呼ぶことで「unlisten が孤児になり次マウントで二重 listen」 (Issue #192) を防ぐ。
+      // 再マウントは ensureRegistered() で新しい listen を作るので、古い myInit は確実に閉じる。
+      // (旧コミットでは「再マウントが間に合えば stale を再活用」する最適化を入れていたが、
+      //  cleanup 高頻度時の世代管理が複雑になりレビューで race を指摘された。listen 1 回分の
+      //  コストは無視できるので常に閉じる単純形に戻す。)
       initPromise = null;
-      void myInit.then((u) => {
-        if (listeners.size > 0 && initPromise === null) {
-          // 再マウントが間に合った: この listen をそのまま再活用する
-          initPromise = stale;
-        } else {
-          u();
-        }
-      });
+      void myInit.then((u) => u()).catch(() => {});
     };
   }, []);
 }

--- a/src/renderer/src/lib/use-team-handoff.ts
+++ b/src/renderer/src/lib/use-team-handoff.ts
@@ -21,10 +21,15 @@ export interface HandoffPayload {
 
 type Listener = (p: HandoffPayload) => void;
 const listeners = new Set<Listener>();
-let unlisten: UnlistenFn | null = null;
-let initPromise: Promise<void> | null = null;
+/**
+ * Issue #192: 旧実装は `unlisten` を別変数に保持し、`listen()` の resolve を待たずに
+ * cleanup が走ると「resolve 後に届く unlisten が誰からも呼ばれない孤児」になり、
+ * 次のマウントで `initPromise === null` を見て 2 本目の listen が張られて二重発火していた。
+ * 修正: Promise 自体に UnlistenFn を持たせ、cleanup は必ず resolve を待ってから unlisten を呼ぶ。
+ */
+let initPromise: Promise<UnlistenFn> | null = null;
 
-function ensureRegistered(): Promise<void> {
+function ensureRegistered(): Promise<UnlistenFn> {
   if (initPromise) return initPromise;
   initPromise = listen<HandoffPayload>('team:handoff', (e) => {
     for (const cb of listeners) {
@@ -34,8 +39,6 @@ function ensureRegistered(): Promise<void> {
         console.warn('[handoff] listener threw:', err);
       }
     }
-  }).then((u) => {
-    unlisten = u;
   });
   return initPromise;
 }
@@ -51,16 +54,25 @@ export function useTeamHandoff(callback: (p: HandoffPayload) => void): void {
   useEffect(() => {
     const wrapper: Listener = (p) => cbRef.current(p);
     listeners.add(wrapper);
-    void ensureRegistered();
+    const myInit = ensureRegistered();
     return () => {
       listeners.delete(wrapper);
-      // すべての subscriber が抜けたら Tauri listener も止める。
-      if (listeners.size === 0) {
-        const u = unlisten;
-        unlisten = null;
-        initPromise = null;
-        if (u) u();
-      }
+      if (listeners.size !== 0) return;
+      // 全 subscriber が抜けた → Tauri listener を止めて initPromise をリセット。
+      // listen() がまだ resolve していなくても、Promise.then で resolve 後に呼ぶことで
+      // 「unlisten が孤児になり次マウントで二重 listen」 (Issue #192) を防ぐ。
+      // ただし then 内で listeners.size を再確認し、別フックが先に再 mount していれば
+      // unlisten せずにそのまま使い回す (false-positive cleanup を避ける)。
+      const stale = initPromise;
+      initPromise = null;
+      void myInit.then((u) => {
+        if (listeners.size > 0 && initPromise === null) {
+          // 再マウントが間に合った: この listen をそのまま再活用する
+          initPromise = stale;
+        } else {
+          u();
+        }
+      });
     };
   }, []);
 }


### PR DESCRIPTION
## Summary
オープン issue 7 件を 1 commit/issue でバンドル修正。

| # | 種別 | 内容 |
|---|------|------|
| #191 | security | app_setup_team_mcp に project_root canonicalize ガードを追加 (任意ディレクトリへの SKILL.md plant 防止) |
| #192 | bug | use-team-handoff の listen 解決前 unmount で listener が孤児化 → 次マウントで二重発火する race を解消 |
| #193 | bug | inject::build_chunks のバイト判定 vs char 切詰の不整合を修正 (UTF-8 マルチバイトでも MAX_PAYLOAD バイト上限を実効化) |
| #194 | bug | QuickNav が legacy payload.role のみ参照 → roleProfileId を優先して読むように修正 (canvas v2 でカード色/ラベルが壊れていた) |
| #195 | a11y | SettingsModal に role=dialog / aria-modal / Escape / focus trap / autofocus を追加 |
| #196 | perf | Canvas.onNodesChange のチーム同期を索引マップで O(チームサイズ) 化 (旧 O(N×M) のドラッグカクつき解消) |
| #197 | a11y | OnboardingWizard Done ステップの 2 秒自動 close を撤去 (WCAG 2.2.1 適合) |

スキップ:
- **#141**: TCP→UDS migration は invasive のため別 issue で追跡 (#198 で loopback peer check を入れた状態のまま)
- **#190**: 症状記述が曖昧で再現困難 (再現手順を募集)

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`cargo test --lib\` 45 tests pass (#193 build_chunks 単体テスト 3 件追加)
- [ ] 手動 #191: DevTools から \`invoke('app_setup_team_mcp', { projectRoot: '/tmp/xxx', ... })\` で SKILL.md が書かれず warn ログが出ること
- [ ] 手動 #192: Ctrl+Shift+M (Canvas/IDE 切替) を高速トグルし、handoff イベントが二重発火しないこと
- [ ] 手動 #194: programmer / researcher エージェント生成後 Ctrl+Shift+K で QuickNav を開き、各カードに正しい色/ロール名が出ること
- [ ] 手動 #195: SettingsModal を開いて Esc で閉じる / Tab で循環 / 開いた直後に focus 表示されること
- [ ] 手動 #196: 6 人チーム + lock 状態で leader をドラッグし、Chrome perf で \`onNodesChange\` のフレーム時間が改善していること
- [ ] 手動 #197: OnboardingWizard Done 画面で 2 秒経っても自動 close せず、CTA ボタンでのみ閉じること

## 影響範囲
- Rust: \`commands/app.rs\` (#191), \`team_hub/inject.rs\` (#193 + tests)
- TS: \`use-team-handoff.ts\` (#192), \`canvas/QuickNav.tsx\` (#194), \`SettingsModal.tsx\` (#195), \`Canvas.tsx\` (#196), \`OnboardingWizard.tsx\` (#197)

🤖 Generated with [Claude Code](https://claude.com/claude-code)