### PR TITLE
fix(editor): React #310 を修正し v1.4.5 をリリース

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5189,7 +5189,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.4.4"
+version = "1.4.5"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",

--- a/src/renderer/src/components/EditorView.tsx
+++ b/src/renderer/src/components/EditorView.tsx
@@ -37,6 +37,10 @@ export function EditorView({
   const { settings } = useSettings();
   const theme = useMonacoTheme();
   const t = useT();
+  // .md ファイルは既定でプレビュー表示。トグルでコード編集に切替。
+  // 早期 return より後で useState すると Rules of Hooks 違反になるので、
+  // フックは全て先頭で呼ぶ。
+  const [previewMode, setPreviewMode] = useState<boolean>(true);
 
   if (loading) {
     return (
@@ -68,8 +72,6 @@ export function EditorView({
 
   const language = detectLanguage(path);
   const isMarkdown = language === 'markdown';
-  // .md ファイルは既定でプレビュー表示。トグルでコード編集に切替。
-  const [previewMode, setPreviewMode] = useState<boolean>(true);
   const showPreview = isMarkdown && previewMode;
 
   return (


### PR DESCRIPTION
## Summary
- v1.4.4 で発生していた React minified error #310 ("Rendered more hooks than during the previous render.") を修正。
- 原因: `EditorView.tsx` で `useState(previewMode)` が 3 つの早期 return (`loading` / `error` / `isBinary`) より後ろで呼ばれており、ファイル読込完了の遷移時に hook 数が変わって Rules of Hooks 違反になっていた。
- `useState` を関数先頭の hook 群と同じ位置に移動して解消。併せて `package.json` / `Cargo.toml` / `Cargo.lock` / `tauri.conf.json` を 1.4.5 に bump。

## Test plan
- [x] `npm run typecheck` PASS (fix agent 実行済み)
- [ ] dev 起動 → `loading=true` → `loading=false` の遷移で真っ黒画面が再現しないことを目視
- [ ] markdown ファイルを開いて preview ↔ source 切替が動くことを目視
- [ ] バイナリ・読み込みエラー時の placeholder が引き続き正常表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)