### PR TITLE
fix(ci): set rust toolchain input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master @ 2026-04-26
+        with:
+          toolchain: stable
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@400e7407cfd7a091e5fbb6afec01ec146c432b7c # v2.7.7


### PR DESCRIPTION
## Summary
- Add the required `toolchain: stable` input to the SHA-pinned `dtolnay/rust-toolchain` step in CI.
- Keep the fix intentionally small so Dependabot PRs can be rechecked after CI recovers.

## Why
The SHA-pinned `dtolnay/rust-toolchain` action requires an explicit `toolchain` input. Without it, open PRs fail immediately with `'toolchain' is a required input`, so dependency update PRs cannot be evaluated.

## Validation
- `npm run typecheck`
- `npm run build:vite`
- `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`
- `cargo test --locked --manifest-path src-tauri/Cargo.toml`