### PR TITLE
feat(filetree): #251 ファイルツリー右クリックメニューを追加

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -469,6 +469,57 @@ pub async fn app_open_external(
     }
 }
 
+/// Issue #251: OS のファイルマネージャ (Explorer / Finder / Nautilus) を開いて
+/// 該当ファイルをハイライトする。renderer から `api.app.revealInFileManager(absPath)` 経由で呼ぶ。
+///
+/// セキュリティ:
+///   - 絶対パスのみ許可 (PATH lookup や CWD 相対は拒否)
+///   - パストラバーサル (`..`) を拒否
+///   - 4096 文字超は拒否 (OS によっては DoS 抑止)
+#[tauri::command]
+pub async fn app_reveal_in_file_manager(
+    app: tauri::AppHandle,
+    path: String,
+) -> OpenExternalResult {
+    use tauri_plugin_opener::OpenerExt;
+
+    let trimmed = path.trim();
+    if trimmed.is_empty() || trimmed.len() > 4096 {
+        return OpenExternalResult {
+            ok: false,
+            error: Some("invalid path length".into()),
+        };
+    }
+    let p = std::path::Path::new(trimmed);
+    if !p.is_absolute() {
+        return OpenExternalResult {
+            ok: false,
+            error: Some("only absolute path is allowed".into()),
+        };
+    }
+    if p.components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return OpenExternalResult {
+            ok: false,
+            error: Some("path traversal (..) is not allowed".into()),
+        };
+    }
+    match app.opener().reveal_item_in_dir(p) {
+        Ok(_) => OpenExternalResult {
+            ok: true,
+            error: None,
+        },
+        Err(e) => {
+            tracing::warn!("[app_reveal_in_file_manager] failed: {e}");
+            OpenExternalResult {
+                ok: false,
+                error: Some(e.to_string()),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod open_external_tests {
     use super::is_safe_external_url;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,6 +57,7 @@ pub fn run() {
             commands::app::app_cancel_recruit,
             commands::app::app_get_user_info,
             commands::app::app_open_external,
+            commands::app::app_reveal_in_file_manager,
             // ---- git ----
             commands::git::git_status,
             commands::git::git_diff,

--- a/src/renderer/src/components/FileTreePanel.tsx
+++ b/src/renderer/src/components/FileTreePanel.tsx
@@ -12,6 +12,9 @@ import {
 import type { FileNode } from '../../../types/shared';
 import { useT } from '../lib/i18n';
 import { fileIcon } from '../lib/file-icon-color';
+import { ContextMenu, type ContextMenuItem } from './ContextMenu';
+import { useToast } from '../lib/toast-context';
+import { api } from '../lib/tauri-api';
 
 interface FileTreePanelProps {
   /** メインのプロジェクトルート(ターミナル/Git 等はこちら基準で動作する) */
@@ -79,6 +82,11 @@ export function FileTreePanel({
   const [collapsedRoots, setCollapsedRoots] = useState<Set<string>>(
     () => initialCollapsedRoots ?? new Set()
   );
+  /** Issue #251: ファイル右クリックで開く ContextMenu の表示状態 */
+  const [contextMenu, setContextMenu] = useState<
+    { x: number; y: number; items: ContextMenuItem[] } | null
+  >(null);
+  const showToast = useToast();
 
   /** 現在サイドバーに表示するルート一覧(primary + extras から重複除去)。
    *  Issue #129: 配列リテラルを毎レンダー作ると useEffect deps や子供 props が
@@ -237,6 +245,57 @@ export function FileTreePanel({
     [expanded, onPersistState]
   );
 
+  // Issue #251: ファイル/ディレクトリ右クリックでパスコピー / エクスプローラ表示の
+  // ContextMenu を開く。renderer 側のみで完結 (絶対パスは rootPath + relPath を結合)。
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent, rootPath: string, node: FileNode) => {
+      e.preventDefault();
+      e.stopPropagation();
+      // node.path は POSIX 区切り。Windows の絶対パスを作る場合のみ \ に置換する。
+      const sep = rootPath.includes('\\') ? '\\' : '/';
+      const absPath =
+        node.path === ''
+          ? rootPath
+          : `${rootPath}${sep}${node.path.split('/').join(sep)}`;
+      const relPath = node.path; // POSIX 区切りのまま
+      const copy = (text: string): void => {
+        navigator.clipboard
+          .writeText(text)
+          .then(() => showToast(t('toast.pathCopied'), { tone: 'info' }))
+          .catch(() => showToast(t('toast.copyFailed'), { tone: 'error' }));
+      };
+      const items: ContextMenuItem[] = [
+        {
+          label: t('ctxMenu.copyAbsolutePath'),
+          action: () => copy(absPath)
+        },
+        {
+          label: t('ctxMenu.copyRelativePath'),
+          action: () => copy(relPath || node.name),
+          disabled: relPath === '',
+          divider: true
+        },
+        {
+          label: t('ctxMenu.copyFileName'),
+          action: () => copy(node.name),
+          divider: true
+        },
+        {
+          label: t('ctxMenu.revealInFolder'),
+          action: () => {
+            void api.app.revealInFileManager(absPath).then((res) => {
+              if (!res.ok) {
+                showToast(t('toast.revealFailed'), { tone: 'error' });
+              }
+            });
+          }
+        }
+      ];
+      setContextMenu({ x: e.clientX, y: e.clientY, items });
+    },
+    [showToast, t]
+  );
+
   const renderChildren = (
     rootPath: string,
     relPath: string,
@@ -283,6 +342,7 @@ export function FileTreePanel({
               childState={childState}
               onToggle={toggleDir}
               onOpenFile={onOpenFile}
+              onContextMenu={handleContextMenu}
               renderChildren={renderChildren}
             />
           );
@@ -360,6 +420,14 @@ export function FileTreePanel({
           );
         })}
       </div>
+      {contextMenu && (
+        <ContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          items={contextMenu.items}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
     </div>
   );
 }
@@ -374,6 +442,8 @@ interface FileTreeNodeProps {
   childState: DirState | null;
   onToggle: (rootPath: string, node: FileNode) => void;
   onOpenFile: (rootPath: string, relPath: string) => void;
+  /** Issue #251: 右クリックメニュー要求 */
+  onContextMenu: (e: React.MouseEvent, rootPath: string, node: FileNode) => void;
   renderChildren: (
     rootPath: string,
     relPath: string,
@@ -389,6 +459,7 @@ function FileTreeNodeImpl({
   isActive,
   onToggle,
   onOpenFile,
+  onContextMenu,
   renderChildren
 }: FileTreeNodeProps): JSX.Element {
   const fileIconDef = node.isDir ? undefined : fileIcon(node.name);
@@ -421,6 +492,7 @@ function FileTreeNodeImpl({
         className={`filetree__row${isActive ? ' is-active' : ''}`}
         style={guideStyle}
         onClick={handleClick}
+        onContextMenu={(e) => onContextMenu(e, rootPath, node)}
       >
         {node.isDir ? (
           <>
@@ -484,7 +556,8 @@ const FileTreeNode = memo(FileTreeNodeImpl, (prev, next) => {
     prev.isActive === next.isActive &&
     prev.childState === next.childState &&
     prev.onToggle === next.onToggle &&
-    prev.onOpenFile === next.onOpenFile
+    prev.onOpenFile === next.onOpenFile &&
+    prev.onContextMenu === next.onContextMenu
     // renderChildren は意図的に比較しない (毎レンダー新参照になるが、
     // 開いているディレクトリは isOpen + childState の変化で再レンダーが
     // 既に走るので問題なし。閉じているノード/葉は早期 return できる)。

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -165,6 +165,11 @@ const ja: Dict = {
   'ctxMenu.openDiff': '差分を開く',
   'ctxMenu.reviewDiff': '差分レビューを Claude Code に依頼',
   'ctxMenu.copyPath': 'パスをコピー',
+  // Issue #251: ファイルツリー右クリックメニュー
+  'ctxMenu.copyAbsolutePath': '絶対パスをコピー',
+  'ctxMenu.copyRelativePath': '相対パスをコピー',
+  'ctxMenu.copyFileName': 'ファイル名をコピー',
+  'ctxMenu.revealInFolder': 'エクスプローラーで開く',
   'canvasMenu.lockTeam': 'チームで一緒に動かす',
   'canvasMenu.unlockTeam': 'チーム固定を解除',
   'canvasMenu.deleteCard': 'カードを削除',
@@ -295,6 +300,8 @@ const ja: Dict = {
   // ---------- Toast ----------
   'toast.reviewRequested': '差分レビューを依頼: {path}',
   'toast.pathCopied': 'パスをクリップボードにコピー',
+  'toast.copyFailed': 'クリップボードへのコピーに失敗しました',
+  'toast.revealFailed': 'ファイルマネージャでの表示に失敗しました',
   'toast.sessionResumed': 'セッションに復帰: {title}',
   'toast.recentCleared': '最近のプロジェクト履歴をクリアしました',
   'toast.newProject': '新規プロジェクトを作成',
@@ -610,6 +617,11 @@ const en: Dict = {
   'ctxMenu.openDiff': 'Open diff',
   'ctxMenu.reviewDiff': 'Ask Claude Code to review this diff',
   'ctxMenu.copyPath': 'Copy path',
+  // Issue #251: file tree right-click menu
+  'ctxMenu.copyAbsolutePath': 'Copy absolute path',
+  'ctxMenu.copyRelativePath': 'Copy relative path',
+  'ctxMenu.copyFileName': 'Copy file name',
+  'ctxMenu.revealInFolder': 'Reveal in File Explorer',
   'canvasMenu.lockTeam': 'Move team together',
   'canvasMenu.unlockTeam': 'Unlock team movement',
   'canvasMenu.deleteCard': 'Delete card',
@@ -741,6 +753,8 @@ const en: Dict = {
   // ---------- Toast ----------
   'toast.reviewRequested': 'Review requested: {path}',
   'toast.pathCopied': 'Path copied to clipboard',
+  'toast.copyFailed': 'Failed to copy to clipboard',
+  'toast.revealFailed': 'Failed to reveal in file manager',
   'toast.sessionResumed': 'Resumed session: {title}',
   'toast.recentCleared': 'Recent projects cleared',
   'toast.newProject': 'New project created',

--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -155,7 +155,10 @@ export const api = {
     }> =>
       invoke('app_install_vibe_team_skill', { projectRoot, forceOverwrite: !!forceOverwrite }),
     getUserInfo: (): Promise<AppUserInfo> => invoke('app_get_user_info'),
-    openExternal: (url: string): Promise<OpenExternalResult> => invoke('app_open_external', { url })
+    openExternal: (url: string): Promise<OpenExternalResult> => invoke('app_open_external', { url }),
+    /** Issue #251: OS のファイルマネージャで親フォルダを開き該当ファイルをハイライト */
+    revealInFileManager: (path: string): Promise<OpenExternalResult> =>
+      invoke('app_reveal_in_file_manager', { path })
   },
 
   git: {


### PR DESCRIPTION
## Summary

ファイルツリー上で右クリックすると無反応だった件を解消し、VSCode / Windsurf 同等の右クリックメニューを `FileTreePanel` に追加。

メニュー項目:
- **絶対パスをコピー**
- **相対パスをコピー** (ルート直下では disabled)
- **ファイル名をコピー**
- **エクスプローラーで開く** (親フォルダを開き該当ファイルを選択)

## 実装

| 層 | 変更 |
|---|---|
| Rust | `app_reveal_in_file_manager` IPC を新規追加 (`tauri-plugin-opener::OpenerExt::reveal_item_in_dir`)。絶対パス / パストラバーサル / 4096 文字超のセキュリティガード付き |
| `src-tauri/src/lib.rs` | `invoke_handler!` に登録 |
| `src/renderer/src/lib/tauri-api.ts` | `api.app.revealInFileManager(path)` wrapper を追加 |
| `src/renderer/src/lib/i18n.ts` | `ctxMenu.copy{Absolute,Relative,FileName}Path` / `ctxMenu.revealInFolder` / `toast.{copy,reveal}Failed` を ja/en に追加 |
| `src/renderer/src/components/FileTreePanel.tsx` | `useToast` / `api` / `ContextMenu` を import。各 `filetree__row` に `onContextMenu` を追加し、`FileTreeNode` の memo 比較に `onContextMenu` を含める |

capabilities は変更不要 (renderer は自前 IPC `app_reveal_in_file_manager` を経由するため、`opener:allow-reveal-item-in-dir` 権限は不要。Rust 側で plugin API を直接呼ぶ既存パターン `app_open_external` と同じ)。

## ローカル検証済み

- [x] `npm run typecheck` 成功
- [x] `cargo check --all-targets` 成功

## Test plan

- [ ] IDE モードでファイルを右クリック → 4 項目のメニューが表示される
- [ ] 「絶対パスをコピー」 / 「相対パスをコピー」 / 「ファイル名をコピー」 → クリップボードに正しい値、トーストが出る
- [ ] 「エクスプローラーで開く」 → Windows エクスプローラで親フォルダが開き、該当ファイルがハイライト
- [ ] ディレクトリで右クリック → 同様にメニューが出る (相対パスも有効)
- [ ] ルート直下のファイル (relPath が node.path に等しいケース) でも正しく動く
- [ ] CI (`verify` job) が green
- [ ] vibe-editor-reviewer の自動レビュー指摘があれば対応

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)