### PR TITLE
fix(terminal): IDEモードのスクロールバーを復活 (#252)

### DIFF
--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1670,8 +1670,37 @@ body.is-resizing * {
   white-space: pre;
 }
 
+/* Issue #252: IDE mode terminal scrollbar restore - L1668-1685 (このブロックから下)
+   xterm v6 + WebGL renderer 利用時、`.xterm-viewport` の上に WebGL canvas が
+   `position: absolute` で被さってネイティブスクロールバーが隠れる問題を回避するため
+   z-index を上げる。背景色は維持（!important で下層 canvas の透過を防ぐ）。
+   pointer-events も保持して通常のスクロールが効く。 */
 .terminal-view .xterm-viewport {
   background-color: var(--bg) !important;
+  z-index: 1;
+}
+
+/* Issue #252: ターミナル内 scrollbar の視認性向上。
+   グローバル `::-webkit-scrollbar-thumb`（index.css L138-159）は
+   `background-clip: content-box` で実質 4px 幅 + var(--border) のため
+   暗いテーマでは目視困難。ターミナル内では tone-up した thumb 色を当てる。
+   全 6 テーマで `--text-mute` / `--fg` の CSS 変数経由で thumb / track を
+   視認可能にする（claude-dark / claude-light / dark / light / midnight / glass）。 */
+.terminal-view .xterm-viewport::-webkit-scrollbar {
+  width: 10px;
+}
+.terminal-view .xterm-viewport::-webkit-scrollbar-track {
+  background: transparent;
+}
+.terminal-view .xterm-viewport::-webkit-scrollbar-thumb {
+  background: var(--text-mute);
+  border: 2px solid transparent;
+  background-clip: content-box;
+  border-radius: 5px;
+}
+.terminal-view .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: var(--fg);
+  background-clip: content-box;
 }
 
 /* Glass テーマ時は xterm を透過させて親の backdrop-filter を活かす (Issue #89)。


### PR DESCRIPTION
## Summary
- IDE モードの xterm ターミナルで、WebGL canvas が `.xterm-viewport` を覆い隠してネイティブスクロールバーが消失していた問題を修正
- `.terminal-view .xterm-viewport` に `z-index: 1` を付与し、scrollbar を canvas より前面で描画
- ターミナル内 scrollbar の視認性向上スタイル（width: 10px / thumb: `var(--text-mute)` / hover: `var(--fg)` / border-radius: 5px）を追加し、全 6 テーマで thumb/track が見えるようにした
- WebGL renderer（IDE モード規定）と DOM fallback（9個目以降）の両方で有効
- 関連 issue: #252

## 変更内容
- `src/renderer/src/index.css` L1670 周辺
  - **Step 1**: `.terminal-view .xterm-viewport` に `z-index: 1` を追加（既存の `background-color: var(--bg) !important` は維持）
  - **Step 2 派生**: `.terminal-view .xterm-viewport::-webkit-scrollbar` / `::-webkit-scrollbar-track` / `::-webkit-scrollbar-thumb` / `::-webkit-scrollbar-thumb:hover` の 4 ルールを追加。全 6 テーマで CSS 変数経由（`--text-mute` / `--fg`）に色を統一
  - 領域識別コメント `/* Issue #252: IDE mode terminal scrollbar restore - L1668-1685 */` を追加
- 別途バッチ進行中の Issue #261（canvas モード scrollbar 改善）が編集予定の L1631-1641 とは行範囲が完全分離。意味的にも `.terminal-view` 自体の宣言部 vs xterm-viewport の挙動制御で別レイヤ

## Test plan
- [x] `npm run typecheck` PASS
- [x] `npm run build` PASS（アプリ本体ビルド & NSIS bundle 完了。`TAURI_SIGNING_PRIVATE_KEY` 未設定の updater 署名警告は環境変数の問題でコード変更と無関係）
- [x] CSS 変数 `--text-mute` / `--fg` が全 6 テーマで定義済みであることを確認
- [x] WebGL renderer / DOM fallback 両 renderer で `.xterm-viewport` 共通スタイルとして適用される
- [x] `[data-theme="glass"] .terminal-view .xterm-viewport { background-color: transparent !important }` の既存ルールに干渉しない（z-index と scrollbar 系プロパティのみ追加）

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code) via issue-autopilot-batch