### PR TITLE
fix(terminal): #252 IDE モードの xterm スクロールバーを復活

### DIFF
--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1670,8 +1670,34 @@ body.is-resizing * {
   white-space: pre;
 }
 
+/* Issue #252: xterm v6 + WebGL renderer 利用時、`.xterm-viewport` の上に
+   WebGL canvas が `position: absolute` で被さってネイティブ scrollbar が
+   隠れる問題を回避するため z-index を上げる。背景色の !important は下層
+   canvas の透過防止用に維持。 */
 .terminal-view .xterm-viewport {
   background-color: var(--bg) !important;
+  z-index: 1;
+}
+
+/* Issue #252: ターミナル内 scrollbar の視認性を向上。グローバル
+   ::-webkit-scrollbar-thumb は `background-clip: content-box` で実質 4px 幅
+   + var(--border) のため暗いテーマで目視困難。ターミナル内では tone-up した
+   thumb 色を当てて常時はっきり見えるようにする。 */
+.terminal-view .xterm-viewport::-webkit-scrollbar {
+  width: 10px;
+}
+.terminal-view .xterm-viewport::-webkit-scrollbar-track {
+  background: transparent;
+}
+.terminal-view .xterm-viewport::-webkit-scrollbar-thumb {
+  background: var(--text-mute);
+  border: 2px solid transparent;
+  background-clip: content-box;
+  border-radius: 5px;
+}
+.terminal-view .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: var(--fg);
+  background-clip: content-box;
 }
 
 /* Glass テーマ時は xterm を透過させて親の backdrop-filter を活かす (Issue #89)。


### PR DESCRIPTION
## Summary

xterm v6 + WebglAddon の組み合わせでは `.xterm-viewport` の上に WebGL canvas が `position: absolute` で被さるため、viewport 右端のネイティブスクロールバーが canvas に隠れて見えなくなっていた。

CSS のみで修正:

- `.terminal-view .xterm-viewport` に `z-index: 1` を当てて scrollbar が canvas より前面に来るようにする
- `.terminal-view` スコープの `::-webkit-scrollbar-thumb` 色を `var(--text-mute)` に tone-up して暗いテーマでも視認できるようにする (グローバル scrollbar は `background-clip: content-box` で実質 4px 幅 + `var(--border)` のため目視困難だった)
- 背景色の `!important` は下層 canvas の透過防止用に維持
- Glass テーマの透過挙動 (#89) は変更なし

## ローカル検証済み

- [x] `npm run typecheck` 成功

## Test plan

- [ ] IDE モードでターミナルを開いて大量出力 (`ls /usr/lib`, `pip list` 等) → 右端に scrollbar thumb が見える
- [ ] thumb をマウスでドラッグしてスクロールできる
- [ ] 既存のホイールスクロールが引き続き動作する (regression なし)
- [ ] 6 テーマ全て (claude-dark / claude-light / dark / light / midnight / glass) で scrollbar が視認できる
- [ ] 9 個目以降の DOM renderer fallback ターミナルでも scrollbar が見える
- [ ] 日本語入力中の IME 候補が scrollbar 領域に隠されない
- [ ] Canvas モード (disableWebgl=true) で副作用なし
- [ ] CI (`verify` job) が green
- [ ] vibe-editor-reviewer の自動レビュー指摘があれば対応

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)