### PR TITLE
fix(canvas): #261 Canvas モード内ターミナルの下端スクロールを復活

### DIFF
--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -773,3 +773,33 @@
   border-radius: 999px;
   background: var(--role-color, var(--success));
 }
+
+/* ===========================================================================
+ * Issue #261: Canvas モード内ターミナルの下端スクロール
+ * ===========================================================================
+ * Canvas モードの AgentNodeCard / TerminalCard では `.canvas-agent-card` /
+ * `.canvas-agent-card__term` / `.terminal-view` が連鎖して overflow:hidden に
+ * なっており、xterm v6 が自前で持つ `.xterm-viewport` の scrollbar が外側に
+ * 隠れて scroll できないように見えていた。Canvas の `.react-flow__node` 配下に
+ * 限定して xterm-viewport の scrollbar を強制表示し、最終行までユーザーが
+ * 確実に到達できるようにする。 IDE モード (.terminal-pane 配下) は既存ルールが
+ * 別途扱うため不変。 */
+.react-flow__node .xterm-viewport {
+  overflow-y: auto !important;
+}
+.react-flow__node .xterm-viewport::-webkit-scrollbar {
+  width: 8px;
+}
+.react-flow__node .xterm-viewport::-webkit-scrollbar-track {
+  background: transparent;
+}
+.react-flow__node .xterm-viewport::-webkit-scrollbar-thumb {
+  background: var(--text-mute);
+  border: 2px solid transparent;
+  background-clip: content-box;
+  border-radius: 4px;
+}
+.react-flow__node .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: var(--fg);
+  background-clip: content-box;
+}


### PR DESCRIPTION
## Summary

Canvas モードの AgentNodeCard / TerminalCard では `.canvas-agent-card` / `.canvas-agent-card__term` / `.terminal-view` が連鎖して `overflow: hidden` になっており、xterm v6 が自前で持つ `.xterm-viewport` のネイティブ scrollbar が外側のクリップで隠れていた。ホイールでは内部スクロールは効くが、scrollbar 自体が見えず最終行への到達が体感として確認できなかった。

`.react-flow__node` 配下に限定して `.xterm-viewport` の `overflow-y: auto !important` を強制し、`var(--text-mute)` 基調の細い scrollbar を明示する。IDE モード (`.terminal-pane` 配下) は別の既存ルートが扱うため不変。

## ローカル検証済み

- [x] `npm run typecheck` 成功

## Test plan

- [ ] Canvas モードで Claude / Codex AgentNodeCard を起動 → `ls -la /usr/bin` 等で 100+ 行出力 → 右端に scrollbar が見える、ホイールで上下スクロールでき最終行が完全に表示される
- [ ] TerminalCard でも同様
- [ ] NodeResizer でカードを最小サイズ (480x280) → 最大 (画面いっぱい) までドラッグし、各サイズで「下端が見える」
- [ ] Canvas zoom 0.5 / 1.0 / 1.5 で scrollbar が視認できる
- [ ] 6 テーマ (claude-dark / claude-light / dark / light / midnight / glass) で違和感ない
- [ ] IDE モードのターミナル (#252 で導入済み scrollbar style) に regression なし
- [ ] CI (`verify` job) が green
- [ ] vibe-editor-reviewer の自動レビュー指摘があれば対応

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)