### PR TITLE
revert(canvas): PR #269 (#261) — #253 への退行を確認したため緊急 revert

### DIFF
--- a/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
@@ -85,12 +85,6 @@ function summarizeInput(text: string): string {
 
 function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   const ref = useRef<TerminalViewHandle | null>(null);
-  // Issue #261: NodeResizer でカードを縮めたあと再度広げたとき、内部 `.xterm-viewport`
-  // の scrollTop が中途半端な位置で残って「末尾が見えない」状態になることがある。
-  // `.canvas-agent-card__term` 自体のサイズ変化を ResizeObserver で監視し、
-  // 子の `.xterm-viewport` を末尾までスクロールし直す。`.xterm-viewport` 自体は
-  // xterm.js が動的に生成するので querySelector で都度引く (mount/remount に追従)。
-  const termContainerRef = useRef<HTMLDivElement | null>(null);
   const { settings } = useSettings();
   const t = useT();
   const confirmRemoveCard = useConfirmRemoveCard();
@@ -296,37 +290,6 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
     [accent]
   );
 
-  // Issue #261: termContainer のサイズが変化したら .xterm-viewport を末尾までスクロール。
-  //   - NodeResizer でカードを広げたとき → 末尾行が新たに見えるべき領域に出る
-  //   - 縮めたとき → scrollTop が古い位置で残ると「下端が空白」になるので末尾に詰める
-  //   - 初回 mount 時 (xterm-viewport が生まれた直後) → こちらも末尾合わせ
-  // xterm.js は内部の Buffer に scrollback があり、自動末尾追従しているが、
-  // ResizeObserver の発火タイミングと xterm 側 fit の合流がずれると
-  // viewport.scrollTop だけ古い値で残ることがある。明示的に補正する。
-  useEffect(() => {
-    const node = termContainerRef.current;
-    if (!node) return;
-    const scrollViewportToBottom = (): void => {
-      const viewport = node.querySelector<HTMLElement>('.xterm-viewport');
-      if (!viewport) return;
-      // scrollHeight は xterm の rows 数 * cellH に追従する。
-      // requestAnimationFrame で xterm の reflow を待ってから scroll する。
-      window.requestAnimationFrame(() => {
-        viewport.scrollTop = viewport.scrollHeight;
-      });
-    };
-    const ro = new ResizeObserver(() => {
-      scrollViewportToBottom();
-    });
-    ro.observe(node);
-    // 初回 mount で .xterm-viewport が後から生成されるケース用に少し遅らせて 1 回試す
-    const initialTimer = window.setTimeout(scrollViewportToBottom, 100);
-    return () => {
-      ro.disconnect();
-      window.clearTimeout(initialTimer);
-    };
-  }, []);
-
   return (
     <>
       <NodeResizer
@@ -368,10 +331,7 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
             </button>
           </span>
         </header>
-        <div
-          className="nodrag nowheel canvas-agent-card__term"
-          ref={termContainerRef}
-        >
+        <div className="nodrag nowheel canvas-agent-card__term">
           <TerminalView
             ref={ref}
             cwd={cwd}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1628,13 +1628,6 @@ body.is-resizing * {
 
 /* ---------- ターミナル ---------- */
 
-/* Issue #261: Canvas mode terminal scroll-to-bottom - L1631-1641
-   ベースは IDE モード向け (`.terminal-pane .terminal-view`) と共通。
-   Canvas モード (`.react-flow__node .terminal-view`) では Math.round で +1 行
-   される端数行ぶんが overflow:hidden で見切れていたので、Canvas モード限定の
-   上書きは canvas.css 側で行う (本ブロックは IDE モードの挙動を保つ)。
-   xterm-viewport の scrollbar は Issue #252 の z-index:1 と組み合わせて
-   IDE/Canvas どちらでも常時可視。 */
 .terminal-view {
   flex: 1;
   min-height: 0;
@@ -1646,12 +1639,6 @@ body.is-resizing * {
      contain: layout は親 .terminal-pane 側で設定済みのため、ここでは付けない
      （二重にすると IME 候補ウィンドウの位置計算が狂う）。 */
   position: relative;
-  /* xterm-viewport が末尾 (cellH ぶん) まで完全に表示されるよう、min-height を
-     0 のまま保ちつつ flex-basis を内部 .xterm 高さで決定させる。
-     Issue #261: 旧実装は親 flex の min-height auto と xterm-viewport の
-     "scrollHeight = rows * cellH" がジャストフィットしないとき、最終行が
-     overflow:hidden で隠れていた。round 化 (compute-unscaled-grid.ts) と
-     合わせて、overflow:auto を Canvas モード限定で許可する。 */
 }
 
 .terminal-view .xterm {

--- a/src/renderer/src/lib/__tests__/compute-unscaled-grid.test.ts
+++ b/src/renderer/src/lib/__tests__/compute-unscaled-grid.test.ts
@@ -3,60 +3,14 @@ import { computeUnscaledGrid } from '../compute-unscaled-grid';
 
 describe('computeUnscaledGrid', () => {
   describe('通常値', () => {
-    it('800x600 / cellW=8 / cellH=16 → cols=100 rows=38', () => {
-      // Issue #261: rows は Math.round 化したため、600 / 16 = 37.5 → 38 (upper round)。
-      // cols は折り返し回避のため依然 floor で 800 / 8 = 100。
+    it('800x600 / cellW=8 / cellH=16 → cols=100 rows=37', () => {
       const r = computeUnscaledGrid(800, 600, 8, 16);
-      expect(r).toEqual({ cols: 100, rows: 38 });
+      expect(r).toEqual({ cols: 100, rows: 37 });
     });
 
-    it('cols は Math.floor で切り捨てる (800.7 / 8 = 100.0875 → 100)', () => {
-      // Issue #261: rows は round 化したが、cols は折り返し回避のため floor のまま。
-      // 600.5 / 16 = 37.53125 → round で 38 行になる。
+    it('Math.floor で端数を切り捨てる (800.7 / 8 = 100.0875 → 100)', () => {
       const r = computeUnscaledGrid(800.7, 600.5, 8, 16);
-      expect(r).toEqual({ cols: 100, rows: 38 });
-    });
-  });
-
-  describe('Issue #261: rows は Math.round で端数行を救済する', () => {
-    // lineHeight=1.0 + terminalFontSize=13 を想定 (cellH=13)。
-    // 旧実装は floor だったため、端数 1〜12px が常に下端の透明スペースとして残り、
-    // Canvas モードで「最後の行が見えない」体感に繋がっていた。
-    it('端数 < 0.5 行 → 切り捨て (height=275 / cellH=13 → 21.15 → 21)', () => {
-      const r = computeUnscaledGrid(800, 275, 8, 13);
-      expect(r?.rows).toBe(21);
-    });
-
-    it('端数 = 0.5 行ジャスト → 繰り上げ (height=286 / cellH=13 → 22.0 → 22, height=279.5/13≈21.5 → 22)', () => {
-      // 286 / 13 = 22.0 (端数なし)
-      const r1 = computeUnscaledGrid(800, 286, 8, 13);
-      expect(r1?.rows).toBe(22);
-      // 279.5 / 13 = 21.5 (ちょうど 0.5)
-      const r2 = computeUnscaledGrid(800, 279.5, 8, 13);
-      expect(r2?.rows).toBe(22);
-    });
-
-    it('端数 >= 0.5 行 → 繰り上げ (height=287 / cellH=13 → 22.08 → 22)', () => {
-      const r = computeUnscaledGrid(800, 287, 8, 13);
-      expect(r?.rows).toBe(22);
-    });
-
-    it('小数 cellH でも整数 rows を返す (height=280 / cellH=13.5 → 20.74 → 21)', () => {
-      const r = computeUnscaledGrid(800, 280, 8, 13.5);
-      expect(r?.rows).toBe(21);
-      expect(Number.isInteger(r?.rows)).toBe(true);
-    });
-
-    it('round 後も clamp は効く: 端数で minRows 未満になっても下限保証', () => {
-      // 60 / 13 = 4.61 → round = 5 (デフォルト minRows=5 と同値)
-      const r = computeUnscaledGrid(800, 60, 8, 13);
-      expect(r?.rows).toBe(5);
-    });
-
-    it('round 後も maxRows clamp が効く', () => {
-      // 100000 / 13 = 7692 → maxRows=200 にクランプ
-      const r = computeUnscaledGrid(800, 100000, 8, 13);
-      expect(r?.rows).toBe(200);
+      expect(r).toEqual({ cols: 100, rows: 37 });
     });
   });
 

--- a/src/renderer/src/lib/compute-unscaled-grid.ts
+++ b/src/renderer/src/lib/compute-unscaled-grid.ts
@@ -51,17 +51,8 @@ export function computeUnscaledGrid(
     maxRows = DEFAULT_MAX_ROWS
   } = options;
 
-  // Issue #261: rows は Math.round で端数行を救済する。
-  //
-  // 旧実装は `Math.floor(height / cellH)` で常に余り (height - rows*cellH) が下端に
-  // 透明スペースとして残り、Canvas モードでは「最後の行が見えない」体感に直結していた
-  // (lineHeight=1.0 + cellH=13 で最大 12px、ほぼ 1 行ぶん欠ける)。round に変えると
-  // 端数が 0.5 行以上のときに +1 行され、xterm 内部 viewport が容器より僅かに高く
-  // なってもキャンバスモード側 CSS で `.xterm-viewport { overflow-y: auto }` を許可
-  // しているため scrollbar で確実に末尾まで到達できる。
-  // cols は折り返し挙動への影響を避けるため従来どおり floor。
   const rawCols = Math.floor(width / cellW);
-  const rawRows = Math.round(height / cellH);
+  const rawRows = Math.floor(height / cellH);
 
   return {
     cols: Math.min(maxCols, Math.max(minCols, rawCols)),

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -473,37 +473,8 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  /* Issue #261: 旧実装の `overflow: hidden` だと、内側の `.terminal-view` →
-     `.xterm-viewport` の scrollbar が下端でクリップされ、ターミナルの最終行
-     (xterm 内部スクロールでは到達しているが視覚的には隠れる) が見えなかった。
-     `overflow: clip` だと scrollbar 自体が隠れるので、`hidden` を `clip` に
-     変える代わりに `.xterm-viewport` 側で overflow:auto を明示する戦略を採用。
-     ここではクリッピングを維持しつつ、内部 viewport が容器より少しだけ高く
-     なる端数行ケース (compute-unscaled-grid.ts の Math.round 化) でも
-     scrollbar が出るよう min-height: 0 を維持する。 */
   overflow: hidden;
   position: relative;
-}
-
-/* Issue #261: Canvas モード限定で xterm-viewport を強制的にスクロール可能にする。
-   - IDE モード (`.terminal-pane .terminal-view`) は親が `min-height: 0` のフレックス
-     で完全フィットするため `overflow: hidden` のままで末尾が隠れない。
-   - Canvas モードは NodeResizer のリサイズ + zoom + Math.round で端数行が出るため、
-     scrollbar を有効化しないと最終行が容器下端で見切れることがある。
-   - `!important` は IDE モード用の `.terminal-view .xterm-viewport`
-     (index.css L1678 周辺) の z-index/background ルールと共存させるため必要。
-   - scrollbar の見た目は index.css L1689-1704 の `.terminal-view .xterm-viewport`
-     スタイルがそのまま適用される (10px 幅 + var(--text-mute) thumb)。 */
-.react-flow__node .xterm-viewport {
-  overflow-y: auto !important;
-}
-
-/* Issue #261: AgentNodeCard の min-height は内部 xterm-viewport の高さに引っ張られ
-   ないようにし、Canvas モードのリサイズで NodeResizer が小さくしたときも
-   scrollbar が出る (xterm 内部スクロールが活きる) ようにする。
-   親 `.canvas-agent-card__term { min-height: 0 }` と二重ガード。 */
-.react-flow__node .terminal-view {
-  min-height: 0;
 }
 
 /* ---------- status badge (idle / thinking / typing) ---------- */


### PR DESCRIPTION
## 概要
PR #269 (Closes #261) によって **#253 のターミナル表示崩れが再発**したため、PR #269 全体を revert します。

ユーザー報告（#253 コメント 2026-04-28T13:37:41Z）: 「再発しました。表示が崩れています」

## 原因の特定

PR #269 の `src/renderer/src/lib/compute-unscaled-grid.ts` で行われた変更:

```diff
-  const rawRows = Math.floor(height / cellH);
+  const rawRows = Math.round(height / cellH);
```

これは PR #257（fortress-implement Tier I2 / 8 Slice、Closes #253）の核心修正を直接破壊しています。

PR #257 の主因解消ロジック（compute-unscaled-grid.ts L51-L60 / 元実装）:
- React Flow の `transform: scale(zoom)` 配下では `getBoundingClientRect()` が scale 適用後の視覚矩形を返す
- 解決策として `container.clientWidth/Height`（transform 非影響の論理 px）と `measureText('M')` で zoom 非依存の cellW/cellH を取得し、**`Math.floor` で「容器に収まる整数行/列」**を計算
- これを **`Math.round` に変更すると、0.5 行以上の端数で +1 行**され、PTY に容器より大きい rows が渡る → xterm 内部 viewport が容器を超えて表示崩壊

時系列もクロスチェック:
- PR #269 マージ: 2026-04-28T13:06:45Z
- ユーザー再発報告: 2026-04-28T13:37:41Z（**約 30 分後**）

## 影響範囲

revert する 5 ファイル（PR #269 の全変更）:
- `src/renderer/src/components/canvas/cards/AgentNodeCard.tsx`
- `src/renderer/src/index.css`
- `src/renderer/src/lib/__tests__/compute-unscaled-grid.test.ts`
- `src/renderer/src/lib/compute-unscaled-grid.ts`
- `src/renderer/src/styles/components/canvas.css`

差分: **+6 / -143**（PR #269 の +143/-6 を完全反転）

## テスト
- [x] \`npm run typecheck\` PASS
- [ ] \`npm run build\` (bot レビュー時に CI で検証)
- [ ] GUI 動作確認（ユーザー側で revert merge 後に \`npm run dev\` で #253 解消を確認）

## 関連 Issue / PR
- 退行を引き起こした PR: **#269** (Closes #261)
- 退行した本来の修正 PR: **#257** (Closes #253、fortress-implement Tier I2)
- ユーザーが OPEN に戻した Issue: **#253**
- 元 Issue: **#261**（再設計後に別 PR で再対応予定）
- 派生 Issue（autopilot-batch で起票）: **#272**（TerminalCard ResizeObserver、本 revert で AgentNodeCard 側も消えるので #272 も再評価が必要）

## 検出経緯
issue-autopilot-batch-20260428-2135 のクアドレビュー Lane 0/4 では floor→round 変更を critical として検出できず、autopilot-batch のコードパス整合性検証 proxy も GUI 退行を検出できなかった（**ビルド PASS ≠ GUI 動作正常**）。
教訓として、**PTY/xterm/React Flow transform に触れる変更は GUI 実機検証必須**。

## 次のアクション
- 本 revert PR を bot 自動 merge
- #253 を Closed に戻す（merge 後にユーザー or リーダーが確認）
- #261 を OPEN に戻し、#253 と衝突しない設計（floor 維持 + 別アプローチで「最終行が見えない」を解決）を issue-planner で再計画
- #272 を再評価（必要なら close）

🤖 Emergency revert by issue-autopilot-batch-20260428-2135 leader after user-confirmed regression