### PR TITLE
revert(canvas): PR #268 (#259) — #253 退行が PR #269 revert 後も継続のため追加 revert

### DIFF
--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -34,7 +34,7 @@ import HandoffEdge from './HandoffEdge';
 import { QuickNav } from './QuickNav';
 import { LeaderGlow } from './LeaderGlow';
 import { StageHud } from './StageHud';
-import { useCanvasStore, NODE_W, NODE_H, type CardData } from '../../stores/canvas';
+import { useCanvasStore, type CardData } from '../../stores/canvas';
 import { colorOf } from '../../lib/team-roles';
 import { KEYS, useKeybinding } from '../../lib/keybindings';
 import { useUiStore } from '../../stores/ui';
@@ -299,31 +299,13 @@ function FlowApp(): JSX.Element {
   // fitView アニメーションが連続発火してカクつく問題を回避。最後の更新から 200ms 経過後に
   // 1 回だけ fitView を呼ぶ。debounce 時間は新ノードのレンダー完了 (~16ms) より十分長く、
   // ユーザーの体感遅延 (300ms 程度の許容) より短い実用値。
-  // Issue #259: fitView 後に zoom が極端に下がるとターミナル文字が判読困難になる UX 退行を防ぐ。
-  // 結果 zoom が MIN_RECRUIT_ZOOM を下回った場合は Leader (= recruit 直近の中心ノード) で
-  // setCenter のみ実行し zoom を確保する。一部メンバーは viewport 外になるが、ユーザーは pan で閲覧可能。
-  const MIN_RECRUIT_ZOOM = 0.7;
   const lastRecruitAt = useCanvasStore((s) => s.lastRecruitAt);
   const reactFlow = useReactFlow();
   useEffect(() => {
     if (!lastRecruitAt) return;
     const timer = window.setTimeout(() => {
       try {
-        // minZoom オプションで fitView 自体が極端に縮小しないようガード (@xyflow/react v12)
-        reactFlow.fitView({ padding: 0.15, duration: 300, minZoom: MIN_RECRUIT_ZOOM });
-        // 防衛的フォールバック: minZoom が反映されない paths があった場合に備えて、
-        // 結果 zoom を確認し閾値未満なら Leader を中心に setCenter で zoom を強制する。
-        const vp = reactFlow.getViewport();
-        if (vp.zoom < MIN_RECRUIT_ZOOM) {
-          const leader = reactFlow.getNodes()[0];
-          if (leader) {
-            reactFlow.setCenter(
-              leader.position.x + NODE_W / 2,
-              leader.position.y + NODE_H / 2,
-              { zoom: MIN_RECRUIT_ZOOM, duration: 300 }
-            );
-          }
-        }
+        reactFlow.fitView({ padding: 0.15, duration: 300 });
       } catch {
         /* viewport 計算に失敗するレアケースは無視 */
       }

--- a/src/renderer/src/lib/use-recruit-listener.ts
+++ b/src/renderer/src/lib/use-recruit-listener.ts
@@ -44,34 +44,13 @@ interface RecruitCancelledPayload {
 }
 
 // NODE_W / NODE_H は stores/canvas.ts の共有定数を import (Issue #253 で 640x400 に拡張)
-
-/**
- * Issue #259: 同心円配置の半径を「メンバー数 + 画面サイズ」両方に応じた可変値にする。
- *  - 0-3 名: NODE_W + 60 (狭めに、1080p でも fitView せず収まる)
- *  - 4-5 名: NODE_W + 80 (PR #257 と同じ既存挙動を維持)
- *  - 6+ 名: 同心円ではなくグリッド配置に切替えるため radius は使われない
- *  - clamp: 画面サイズの 45% を上限として極端な小画面で半径が画面外を超えないようにする
- *           (NODE_W 未満には絶対しない)
- */
-function computeRecruitRadius(memberCount: number): number {
-  const base = memberCount <= 3 ? NODE_W + 60 : NODE_W + 80;
-  const screenSize = Math.max(
-    typeof window !== 'undefined' ? window.innerWidth : 1920,
-    typeof window !== 'undefined' ? window.innerHeight : 1080
-  );
-  const cap = Math.max(NODE_W, screenSize * 0.45);
-  return Math.min(base, cap);
-}
-
-/**
- * Issue #259: 6 名以上 (Leader 含む newMemberCount >= 6) は同心円配置を諦め、
- * requester の右側 2 列グリッドに展開する。論理幅が小画面 viewport を超えても
- * Canvas 側 fitView の zoom 下限ガードと組み合わせて UX を保つ。
- */
-const GRID_PLACEMENT_THRESHOLD = 6;
-const GRID_COLS = 2;
-const GRID_COL_GAP = 32;
-const GRID_ROW_GAP = 32;
+//
+// `RECRUIT_RADIUS` は requester (Leader) を中心とする同心円配置の半径 (要素中心 → 要素中心)。
+// `NODE_W + 80 = 720` で隣接メンバーとの 80 px の余白を確実に確保する。
+// 1080p (1920x1080) 等の小さい画面で 6 名同心円配置時に端メンバーが viewport から外れる
+// UX 退行は、Canvas component 側で `notifyRecruit()` が書く `lastRecruitAt` を監視して
+// `useReactFlow().fitView({ padding: 0.15, duration: 300 })` を発火させる経路で吸収する。
+const RECRUIT_RADIUS = NODE_W + 80;
 
 /** requester の周囲で空いている角度を見つけて配置位置を返す。
  *  既存メンバーの方角をスキャンし、最も空いている角度をピック。 */
@@ -79,26 +58,12 @@ function findRecruitPosition(
   requester: Node<CardData>,
   team: Node<CardData>[]
 ): { x: number; y: number } {
-  const others = team.filter((n) => n.id !== requester.id);
-  const newMemberCount = others.length + 1;
-
-  // Issue #259: 6 名以上は requester の右側 2 列グリッドに展開
-  if (newMemberCount >= GRID_PLACEMENT_THRESHOLD) {
-    const newIdx = others.length; // 0-based new index = 既存 others 数
-    const col = newIdx % GRID_COLS;
-    const row = Math.floor(newIdx / GRID_COLS);
-    return {
-      x: requester.position.x + (NODE_W + GRID_COL_GAP) * (col + 1),
-      y: requester.position.y + (NODE_H + GRID_ROW_GAP) * row
-    };
-  }
-
-  // 通常: 同心円配置 (可変半径)
-  const radius = computeRecruitRadius(newMemberCount);
   const cx = requester.position.x + NODE_W / 2;
   const cy = requester.position.y + NODE_H / 2;
+  const others = team.filter((n) => n.id !== requester.id);
   if (others.length === 0) {
-    return { x: requester.position.x + radius, y: requester.position.y };
+    // 真右に出す
+    return { x: requester.position.x + RECRUIT_RADIUS, y: requester.position.y };
   }
   // 既存メンバーの角度を集計
   const usedAngles = others.map((n) => {
@@ -126,8 +91,8 @@ function findRecruitPosition(
     }
   }
   return {
-    x: cx + Math.cos(bestAngle) * radius - NODE_W / 2,
-    y: cy + Math.sin(bestAngle) * radius - NODE_H / 2
+    x: cx + Math.cos(bestAngle) * RECRUIT_RADIUS - NODE_W / 2,
+    y: cy + Math.sin(bestAngle) * RECRUIT_RADIUS - NODE_H / 2
   };
 }
 


### PR DESCRIPTION
## 概要
PR #274 で PR #269 を revert したが、**Canvas 表示崩れが継続**するためユーザー指示により PR #268 (Closes #259) も追加 revert します。

## 経緯
1. autopilot-batch-20260428-2135 で PR #266 (#252), PR #269 (#261) をマージ。
2. PR #257 (#253) を fortress-implement Tier I2 で本格修正済みだったが、ユーザー報告で Canvas 崩れ再発。
3. PR #274 で PR #269 を緊急 revert → 改善せず。
4. PR #268 が `Canvas.tsx` の fitView ロジックに minZoom + setCenter フォールバックを追加し、PR #257 の Canvas 描画経路に副作用を起こしている疑い。
5. ユーザー承認を得て PR #268 も revert。

## PR #268 が触っていた領域
- `src/renderer/src/components/canvas/Canvas.tsx`: \`MIN_RECRUIT_ZOOM = 0.7\` + \`reactFlow.fitView({ minZoom })\` + 結果 zoom 監視 + \`setCenter\` フォールバック (\`getNodes()[0]\` を Leader として依存)
- \`src/renderer/src/lib/use-recruit-listener.ts\`: 6名以上のグリッド配置切替、\`computeRecruitRadius\` の screenSize 連動

## Codex Lane 0 で当時受容した Normal 6 件（事後分析）
- \`fitView\` の Promise await 不在（fitView が非同期完了する前に getViewport を読む race）
- \`getNodes()[0]\` を Leader と仮定する依存（順序保証なし）
- \`window.innerWidth/Height\` を SSR 想定なしで参照
- これらが PR #257 の Canvas 描画と組み合わさると顕在化した可能性

## 影響
- **#259（recruit UX 改善）が無効化**される。6名以上 recruit でズームが過剰に縮む UX 退行が再発（ただし表示自体は正常）
- IDE モード（#252 PR #266）と filetree（#250 PR #264, #251 PR #265）には影響なし
- **#253 が完全復旧することを期待**（commit 9cca6d0 直後の Canvas 状態）

## テスト
- [x] \`npm run typecheck\` PASS
- [x] \`npm run build\` PASS（ローカル先行ビルドで確認）
- [ ] GUI 動作確認（ユーザー側で merge 後 + ローカル先行起動済みバイナリで Canvas 復旧確認）

## 次のアクション
- 本 revert PR を bot 自動 merge
- #253 を Closed に戻す（GUI 復旧確認後）
- #259 を OPEN に戻し、別解（fitView を触らず recruit 配置のみ最適化）で再計画
- #261 / #272 / #273 も再評価

🤖 Emergency follow-up revert by issue-autopilot-batch-20260428-2135 leader, user-confirmed