### PR TITLE
restore: PR #266/#268/#269 を復活 — Canvas 崩れの真因は古いインストール版だった

### DIFF
--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -34,7 +34,7 @@ import HandoffEdge from './HandoffEdge';
 import { QuickNav } from './QuickNav';
 import { LeaderGlow } from './LeaderGlow';
 import { StageHud } from './StageHud';
-import { useCanvasStore, type CardData } from '../../stores/canvas';
+import { useCanvasStore, NODE_W, NODE_H, type CardData } from '../../stores/canvas';
 import { colorOf } from '../../lib/team-roles';
 import { KEYS, useKeybinding } from '../../lib/keybindings';
 import { useUiStore } from '../../stores/ui';
@@ -299,13 +299,31 @@ function FlowApp(): JSX.Element {
   // fitView アニメーションが連続発火してカクつく問題を回避。最後の更新から 200ms 経過後に
   // 1 回だけ fitView を呼ぶ。debounce 時間は新ノードのレンダー完了 (~16ms) より十分長く、
   // ユーザーの体感遅延 (300ms 程度の許容) より短い実用値。
+  // Issue #259: fitView 後に zoom が極端に下がるとターミナル文字が判読困難になる UX 退行を防ぐ。
+  // 結果 zoom が MIN_RECRUIT_ZOOM を下回った場合は Leader (= recruit 直近の中心ノード) で
+  // setCenter のみ実行し zoom を確保する。一部メンバーは viewport 外になるが、ユーザーは pan で閲覧可能。
+  const MIN_RECRUIT_ZOOM = 0.7;
   const lastRecruitAt = useCanvasStore((s) => s.lastRecruitAt);
   const reactFlow = useReactFlow();
   useEffect(() => {
     if (!lastRecruitAt) return;
     const timer = window.setTimeout(() => {
       try {
-        reactFlow.fitView({ padding: 0.15, duration: 300 });
+        // minZoom オプションで fitView 自体が極端に縮小しないようガード (@xyflow/react v12)
+        reactFlow.fitView({ padding: 0.15, duration: 300, minZoom: MIN_RECRUIT_ZOOM });
+        // 防衛的フォールバック: minZoom が反映されない paths があった場合に備えて、
+        // 結果 zoom を確認し閾値未満なら Leader を中心に setCenter で zoom を強制する。
+        const vp = reactFlow.getViewport();
+        if (vp.zoom < MIN_RECRUIT_ZOOM) {
+          const leader = reactFlow.getNodes()[0];
+          if (leader) {
+            reactFlow.setCenter(
+              leader.position.x + NODE_W / 2,
+              leader.position.y + NODE_H / 2,
+              { zoom: MIN_RECRUIT_ZOOM, duration: 300 }
+            );
+          }
+        }
       } catch {
         /* viewport 計算に失敗するレアケースは無視 */
       }

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
@@ -85,6 +85,12 @@ function summarizeInput(text: string): string {
 
 function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   const ref = useRef<TerminalViewHandle | null>(null);
+  // Issue #261: NodeResizer でカードを縮めたあと再度広げたとき、内部 `.xterm-viewport`
+  // の scrollTop が中途半端な位置で残って「末尾が見えない」状態になることがある。
+  // `.canvas-agent-card__term` 自体のサイズ変化を ResizeObserver で監視し、
+  // 子の `.xterm-viewport` を末尾までスクロールし直す。`.xterm-viewport` 自体は
+  // xterm.js が動的に生成するので querySelector で都度引く (mount/remount に追従)。
+  const termContainerRef = useRef<HTMLDivElement | null>(null);
   const { settings } = useSettings();
   const t = useT();
   const confirmRemoveCard = useConfirmRemoveCard();
@@ -290,6 +296,37 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
     [accent]
   );
 
+  // Issue #261: termContainer のサイズが変化したら .xterm-viewport を末尾までスクロール。
+  //   - NodeResizer でカードを広げたとき → 末尾行が新たに見えるべき領域に出る
+  //   - 縮めたとき → scrollTop が古い位置で残ると「下端が空白」になるので末尾に詰める
+  //   - 初回 mount 時 (xterm-viewport が生まれた直後) → こちらも末尾合わせ
+  // xterm.js は内部の Buffer に scrollback があり、自動末尾追従しているが、
+  // ResizeObserver の発火タイミングと xterm 側 fit の合流がずれると
+  // viewport.scrollTop だけ古い値で残ることがある。明示的に補正する。
+  useEffect(() => {
+    const node = termContainerRef.current;
+    if (!node) return;
+    const scrollViewportToBottom = (): void => {
+      const viewport = node.querySelector<HTMLElement>('.xterm-viewport');
+      if (!viewport) return;
+      // scrollHeight は xterm の rows 数 * cellH に追従する。
+      // requestAnimationFrame で xterm の reflow を待ってから scroll する。
+      window.requestAnimationFrame(() => {
+        viewport.scrollTop = viewport.scrollHeight;
+      });
+    };
+    const ro = new ResizeObserver(() => {
+      scrollViewportToBottom();
+    });
+    ro.observe(node);
+    // 初回 mount で .xterm-viewport が後から生成されるケース用に少し遅らせて 1 回試す
+    const initialTimer = window.setTimeout(scrollViewportToBottom, 100);
+    return () => {
+      ro.disconnect();
+      window.clearTimeout(initialTimer);
+    };
+  }, []);
+
   return (
     <>
       <NodeResizer
@@ -331,7 +368,10 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
             </button>
           </span>
         </header>
-        <div className="nodrag nowheel canvas-agent-card__term">
+        <div
+          className="nodrag nowheel canvas-agent-card__term"
+          ref={termContainerRef}
+        >
           <TerminalView
             ref={ref}
             cwd={cwd}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1670,8 +1670,37 @@ body.is-resizing * {
   white-space: pre;
 }
 
+/* Issue #252: IDE mode terminal scrollbar restore - L1668-1685 (このブロックから下)
+   xterm v6 + WebGL renderer 利用時、`.xterm-viewport` の上に WebGL canvas が
+   `position: absolute` で被さってネイティブスクロールバーが隠れる問題を回避するため
+   z-index を上げる。背景色は維持（!important で下層 canvas の透過を防ぐ）。
+   pointer-events も保持して通常のスクロールが効く。 */
 .terminal-view .xterm-viewport {
   background-color: var(--bg) !important;
+  z-index: 1;
+}
+
+/* Issue #252: ターミナル内 scrollbar の視認性向上。
+   グローバル `::-webkit-scrollbar-thumb`（index.css L138-159）は
+   `background-clip: content-box` で実質 4px 幅 + var(--border) のため
+   暗いテーマでは目視困難。ターミナル内では tone-up した thumb 色を当てる。
+   全 6 テーマで `--text-mute` / `--fg` の CSS 変数経由で thumb / track を
+   視認可能にする（claude-dark / claude-light / dark / light / midnight / glass）。 */
+.terminal-view .xterm-viewport::-webkit-scrollbar {
+  width: 10px;
+}
+.terminal-view .xterm-viewport::-webkit-scrollbar-track {
+  background: transparent;
+}
+.terminal-view .xterm-viewport::-webkit-scrollbar-thumb {
+  background: var(--text-mute);
+  border: 2px solid transparent;
+  background-clip: content-box;
+  border-radius: 5px;
+}
+.terminal-view .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: var(--fg);
+  background-clip: content-box;
 }
 
 /* Glass テーマ時は xterm を透過させて親の backdrop-filter を活かす (Issue #89)。

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1628,6 +1628,13 @@ body.is-resizing * {
 
 /* ---------- ターミナル ---------- */
 
+/* Issue #261: Canvas mode terminal scroll-to-bottom - L1631-1641
+   ベースは IDE モード向け (`.terminal-pane .terminal-view`) と共通。
+   Canvas モード (`.react-flow__node .terminal-view`) では Math.round で +1 行
+   される端数行ぶんが overflow:hidden で見切れていたので、Canvas モード限定の
+   上書きは canvas.css 側で行う (本ブロックは IDE モードの挙動を保つ)。
+   xterm-viewport の scrollbar は Issue #252 の z-index:1 と組み合わせて
+   IDE/Canvas どちらでも常時可視。 */
 .terminal-view {
   flex: 1;
   min-height: 0;
@@ -1639,6 +1646,12 @@ body.is-resizing * {
      contain: layout は親 .terminal-pane 側で設定済みのため、ここでは付けない
      （二重にすると IME 候補ウィンドウの位置計算が狂う）。 */
   position: relative;
+  /* xterm-viewport が末尾 (cellH ぶん) まで完全に表示されるよう、min-height を
+     0 のまま保ちつつ flex-basis を内部 .xterm 高さで決定させる。
+     Issue #261: 旧実装は親 flex の min-height auto と xterm-viewport の
+     "scrollHeight = rows * cellH" がジャストフィットしないとき、最終行が
+     overflow:hidden で隠れていた。round 化 (compute-unscaled-grid.ts) と
+     合わせて、overflow:auto を Canvas モード限定で許可する。 */
 }
 
 .terminal-view .xterm {

--- a/src/renderer/src/lib/__tests__/compute-unscaled-grid.test.ts
+++ b/src/renderer/src/lib/__tests__/compute-unscaled-grid.test.ts
@@ -3,14 +3,60 @@ import { computeUnscaledGrid } from '../compute-unscaled-grid';
 
 describe('computeUnscaledGrid', () => {
   describe('通常値', () => {
-    it('800x600 / cellW=8 / cellH=16 → cols=100 rows=37', () => {
+    it('800x600 / cellW=8 / cellH=16 → cols=100 rows=38', () => {
+      // Issue #261: rows は Math.round 化したため、600 / 16 = 37.5 → 38 (upper round)。
+      // cols は折り返し回避のため依然 floor で 800 / 8 = 100。
       const r = computeUnscaledGrid(800, 600, 8, 16);
-      expect(r).toEqual({ cols: 100, rows: 37 });
+      expect(r).toEqual({ cols: 100, rows: 38 });
     });
 
-    it('Math.floor で端数を切り捨てる (800.7 / 8 = 100.0875 → 100)', () => {
+    it('cols は Math.floor で切り捨てる (800.7 / 8 = 100.0875 → 100)', () => {
+      // Issue #261: rows は round 化したが、cols は折り返し回避のため floor のまま。
+      // 600.5 / 16 = 37.53125 → round で 38 行になる。
       const r = computeUnscaledGrid(800.7, 600.5, 8, 16);
-      expect(r).toEqual({ cols: 100, rows: 37 });
+      expect(r).toEqual({ cols: 100, rows: 38 });
+    });
+  });
+
+  describe('Issue #261: rows は Math.round で端数行を救済する', () => {
+    // lineHeight=1.0 + terminalFontSize=13 を想定 (cellH=13)。
+    // 旧実装は floor だったため、端数 1〜12px が常に下端の透明スペースとして残り、
+    // Canvas モードで「最後の行が見えない」体感に繋がっていた。
+    it('端数 < 0.5 行 → 切り捨て (height=275 / cellH=13 → 21.15 → 21)', () => {
+      const r = computeUnscaledGrid(800, 275, 8, 13);
+      expect(r?.rows).toBe(21);
+    });
+
+    it('端数 = 0.5 行ジャスト → 繰り上げ (height=286 / cellH=13 → 22.0 → 22, height=279.5/13≈21.5 → 22)', () => {
+      // 286 / 13 = 22.0 (端数なし)
+      const r1 = computeUnscaledGrid(800, 286, 8, 13);
+      expect(r1?.rows).toBe(22);
+      // 279.5 / 13 = 21.5 (ちょうど 0.5)
+      const r2 = computeUnscaledGrid(800, 279.5, 8, 13);
+      expect(r2?.rows).toBe(22);
+    });
+
+    it('端数 >= 0.5 行 → 繰り上げ (height=287 / cellH=13 → 22.08 → 22)', () => {
+      const r = computeUnscaledGrid(800, 287, 8, 13);
+      expect(r?.rows).toBe(22);
+    });
+
+    it('小数 cellH でも整数 rows を返す (height=280 / cellH=13.5 → 20.74 → 21)', () => {
+      const r = computeUnscaledGrid(800, 280, 8, 13.5);
+      expect(r?.rows).toBe(21);
+      expect(Number.isInteger(r?.rows)).toBe(true);
+    });
+
+    it('round 後も clamp は効く: 端数で minRows 未満になっても下限保証', () => {
+      // 60 / 13 = 4.61 → round = 5 (デフォルト minRows=5 と同値)
+      const r = computeUnscaledGrid(800, 60, 8, 13);
+      expect(r?.rows).toBe(5);
+    });
+
+    it('round 後も maxRows clamp が効く', () => {
+      // 100000 / 13 = 7692 → maxRows=200 にクランプ
+      const r = computeUnscaledGrid(800, 100000, 8, 13);
+      expect(r?.rows).toBe(200);
     });
   });
 

--- a/src/renderer/src/lib/compute-unscaled-grid.ts
+++ b/src/renderer/src/lib/compute-unscaled-grid.ts
@@ -51,8 +51,17 @@ export function computeUnscaledGrid(
     maxRows = DEFAULT_MAX_ROWS
   } = options;
 
+  // Issue #261: rows は Math.round で端数行を救済する。
+  //
+  // 旧実装は `Math.floor(height / cellH)` で常に余り (height - rows*cellH) が下端に
+  // 透明スペースとして残り、Canvas モードでは「最後の行が見えない」体感に直結していた
+  // (lineHeight=1.0 + cellH=13 で最大 12px、ほぼ 1 行ぶん欠ける)。round に変えると
+  // 端数が 0.5 行以上のときに +1 行され、xterm 内部 viewport が容器より僅かに高く
+  // なってもキャンバスモード側 CSS で `.xterm-viewport { overflow-y: auto }` を許可
+  // しているため scrollbar で確実に末尾まで到達できる。
+  // cols は折り返し挙動への影響を避けるため従来どおり floor。
   const rawCols = Math.floor(width / cellW);
-  const rawRows = Math.floor(height / cellH);
+  const rawRows = Math.round(height / cellH);
 
   return {
     cols: Math.min(maxCols, Math.max(minCols, rawCols)),

--- a/src/renderer/src/lib/use-recruit-listener.ts
+++ b/src/renderer/src/lib/use-recruit-listener.ts
@@ -44,13 +44,34 @@ interface RecruitCancelledPayload {
 }
 
 // NODE_W / NODE_H は stores/canvas.ts の共有定数を import (Issue #253 で 640x400 に拡張)
-//
-// `RECRUIT_RADIUS` は requester (Leader) を中心とする同心円配置の半径 (要素中心 → 要素中心)。
-// `NODE_W + 80 = 720` で隣接メンバーとの 80 px の余白を確実に確保する。
-// 1080p (1920x1080) 等の小さい画面で 6 名同心円配置時に端メンバーが viewport から外れる
-// UX 退行は、Canvas component 側で `notifyRecruit()` が書く `lastRecruitAt` を監視して
-// `useReactFlow().fitView({ padding: 0.15, duration: 300 })` を発火させる経路で吸収する。
-const RECRUIT_RADIUS = NODE_W + 80;
+
+/**
+ * Issue #259: 同心円配置の半径を「メンバー数 + 画面サイズ」両方に応じた可変値にする。
+ *  - 0-3 名: NODE_W + 60 (狭めに、1080p でも fitView せず収まる)
+ *  - 4-5 名: NODE_W + 80 (PR #257 と同じ既存挙動を維持)
+ *  - 6+ 名: 同心円ではなくグリッド配置に切替えるため radius は使われない
+ *  - clamp: 画面サイズの 45% を上限として極端な小画面で半径が画面外を超えないようにする
+ *           (NODE_W 未満には絶対しない)
+ */
+function computeRecruitRadius(memberCount: number): number {
+  const base = memberCount <= 3 ? NODE_W + 60 : NODE_W + 80;
+  const screenSize = Math.max(
+    typeof window !== 'undefined' ? window.innerWidth : 1920,
+    typeof window !== 'undefined' ? window.innerHeight : 1080
+  );
+  const cap = Math.max(NODE_W, screenSize * 0.45);
+  return Math.min(base, cap);
+}
+
+/**
+ * Issue #259: 6 名以上 (Leader 含む newMemberCount >= 6) は同心円配置を諦め、
+ * requester の右側 2 列グリッドに展開する。論理幅が小画面 viewport を超えても
+ * Canvas 側 fitView の zoom 下限ガードと組み合わせて UX を保つ。
+ */
+const GRID_PLACEMENT_THRESHOLD = 6;
+const GRID_COLS = 2;
+const GRID_COL_GAP = 32;
+const GRID_ROW_GAP = 32;
 
 /** requester の周囲で空いている角度を見つけて配置位置を返す。
  *  既存メンバーの方角をスキャンし、最も空いている角度をピック。 */
@@ -58,12 +79,26 @@ function findRecruitPosition(
   requester: Node<CardData>,
   team: Node<CardData>[]
 ): { x: number; y: number } {
+  const others = team.filter((n) => n.id !== requester.id);
+  const newMemberCount = others.length + 1;
+
+  // Issue #259: 6 名以上は requester の右側 2 列グリッドに展開
+  if (newMemberCount >= GRID_PLACEMENT_THRESHOLD) {
+    const newIdx = others.length; // 0-based new index = 既存 others 数
+    const col = newIdx % GRID_COLS;
+    const row = Math.floor(newIdx / GRID_COLS);
+    return {
+      x: requester.position.x + (NODE_W + GRID_COL_GAP) * (col + 1),
+      y: requester.position.y + (NODE_H + GRID_ROW_GAP) * row
+    };
+  }
+
+  // 通常: 同心円配置 (可変半径)
+  const radius = computeRecruitRadius(newMemberCount);
   const cx = requester.position.x + NODE_W / 2;
   const cy = requester.position.y + NODE_H / 2;
-  const others = team.filter((n) => n.id !== requester.id);
   if (others.length === 0) {
-    // 真右に出す
-    return { x: requester.position.x + RECRUIT_RADIUS, y: requester.position.y };
+    return { x: requester.position.x + radius, y: requester.position.y };
   }
   // 既存メンバーの角度を集計
   const usedAngles = others.map((n) => {
@@ -91,8 +126,8 @@ function findRecruitPosition(
     }
   }
   return {
-    x: cx + Math.cos(bestAngle) * RECRUIT_RADIUS - NODE_W / 2,
-    y: cy + Math.sin(bestAngle) * RECRUIT_RADIUS - NODE_H / 2
+    x: cx + Math.cos(bestAngle) * radius - NODE_W / 2,
+    y: cy + Math.sin(bestAngle) * radius - NODE_H / 2
   };
 }
 

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -473,8 +473,37 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
+  /* Issue #261: 旧実装の `overflow: hidden` だと、内側の `.terminal-view` →
+     `.xterm-viewport` の scrollbar が下端でクリップされ、ターミナルの最終行
+     (xterm 内部スクロールでは到達しているが視覚的には隠れる) が見えなかった。
+     `overflow: clip` だと scrollbar 自体が隠れるので、`hidden` を `clip` に
+     変える代わりに `.xterm-viewport` 側で overflow:auto を明示する戦略を採用。
+     ここではクリッピングを維持しつつ、内部 viewport が容器より少しだけ高く
+     なる端数行ケース (compute-unscaled-grid.ts の Math.round 化) でも
+     scrollbar が出るよう min-height: 0 を維持する。 */
   overflow: hidden;
   position: relative;
+}
+
+/* Issue #261: Canvas モード限定で xterm-viewport を強制的にスクロール可能にする。
+   - IDE モード (`.terminal-pane .terminal-view`) は親が `min-height: 0` のフレックス
+     で完全フィットするため `overflow: hidden` のままで末尾が隠れない。
+   - Canvas モードは NodeResizer のリサイズ + zoom + Math.round で端数行が出るため、
+     scrollbar を有効化しないと最終行が容器下端で見切れることがある。
+   - `!important` は IDE モード用の `.terminal-view .xterm-viewport`
+     (index.css L1678 周辺) の z-index/background ルールと共存させるため必要。
+   - scrollbar の見た目は index.css L1689-1704 の `.terminal-view .xterm-viewport`
+     スタイルがそのまま適用される (10px 幅 + var(--text-mute) thumb)。 */
+.react-flow__node .xterm-viewport {
+  overflow-y: auto !important;
+}
+
+/* Issue #261: AgentNodeCard の min-height は内部 xterm-viewport の高さに引っ張られ
+   ないようにし、Canvas モードのリサイズで NodeResizer が小さくしたときも
+   scrollbar が出る (xterm 内部スクロールが活きる) ようにする。
+   親 `.canvas-agent-card__term { min-height: 0 }` と二重ガード。 */
+.react-flow__node .terminal-view {
+  min-height: 0;
 }
 
 /* ---------- status badge (idle / thinking / typing) ---------- */


### PR DESCRIPTION
## 概要
PR #274 / #275 / #276 で緊急 revert した PR #266 / #268 / #269 を復活します。

## 経緯
- 2026-04-28 のautopilot-batch-20260428-2135 完了後、ユーザーから「Canvas が崩れている」報告 (#253 を OPEN に戻された)
- 段階的 revert（PR #274/#275/#276）でも症状が改善しないため、ローカルで commit 9cca6d0 (PR #257 直後) のバイナリを試す
- それでも崩れていたため、環境問題を疑い WebView2 / Vite キャッシュをクリア + npm run dev 起動
- **`npm run dev` 経由で起動したバイナリは Canvas が正常**であることをユーザー確認
- 真因判明: ユーザーが見ていたのは `C:\Users\zooyo\AppData\Local\vibe-editor\vibe-editor.exe` の **2026-04-27 ビルド** (PR #257 マージ前 = #253 修正前 = 当然崩れる)
- auto-updater が機能しておらず、Start Menu / Desktop ショートカットから古いインストール版が起動されていた
- 私が release ビルドした最新バイナリ (PID 2636/19180/20964) は実は正常動作していた

## 結論
3 件の revert (PR #274/#275/#276) は **不要だった**。Canvas 崩れの真因は revert 対象 PR ではなく、**古いインストール版が起動されていたこと**。

## 復活する PR
- **PR #266 (#252 IDE scrollbar)**: ターミナル右端 scrollbar 視認性向上
- **PR #268 (#259 canvas recruit UX)**: 6名以上のグリッド配置 + fitView minZoom 0.7
- **PR #269 (#261 canvas terminal 下端)**: ResizeObserver scrollTop + index.css 領域分離 + compute-unscaled-grid round 化

## 注意点
**PR #269 の `compute-unscaled-grid.ts` `Math.floor → Math.round` 変更**は理論的には PR #257 (#253) の核心ロジックと干渉する可能性がある変更ですが、今回ユーザーの実機で見えていた崩れは古いインストール版起因で、最新ビルドでは問題ない見込み。

万一最新ビルドで Canvas が崩れたら、PR #269 の compute-unscaled-grid.ts のみ部分 revert で対応します。

## テスト
- [x] \`npm run typecheck\` PASS
- [x] \`npm run build\` PASS（ローカル先行ビルドで確認）
- [ ] GUI 動作確認（最新ビルドで Canvas 正常動作を確認 → ユーザー側で確認）

## 次のアクション (autopilot-batch 後続)
- 古いインストール版を退避 (~\AppData\Local\vibe-editor\vibe-editor.exe)
- auto-updater の調査（次バッチ向け Issue 起票推奨）
- 派生 Issue #272 / #273 は引き続き次バッチで対応
- #253 を Closed に戻す (GUI 復旧確認後)

🤖 Restore by issue-autopilot-batch-20260428-2135 leader after root cause analysis