### PR TITLE
fix(canvas): #272 TerminalCard のリサイズ後スクロール補正を共有 hook 化

### DIFF
--- a/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
@@ -16,6 +16,7 @@ import { useSettings } from '../../../lib/settings-context';
 import { useCanvasStore, NODE_MIN_W, NODE_MIN_H } from '../../../stores/canvas';
 import { useCanvasTerminalFit } from '../../../lib/use-canvas-terminal-fit';
 import { useConfirmRemoveCard } from '../../../lib/use-confirm-remove-card';
+import { useXtermScrollToBottomOnResize } from '../../../lib/use-xterm-scroll-on-resize';
 import { fallbackProfile, profileText, renderSystemPrompt, useRoleProfiles } from '../../../lib/role-profiles-context';
 import { parseShellArgs } from '../../../lib/parse-args';
 import { resolveAgentConfig } from '../../../lib/agent-resolver';
@@ -296,36 +297,10 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
     [accent]
   );
 
-  // Issue #261: termContainer のサイズが変化したら .xterm-viewport を末尾までスクロール。
-  //   - NodeResizer でカードを広げたとき → 末尾行が新たに見えるべき領域に出る
-  //   - 縮めたとき → scrollTop が古い位置で残ると「下端が空白」になるので末尾に詰める
-  //   - 初回 mount 時 (xterm-viewport が生まれた直後) → こちらも末尾合わせ
-  // xterm.js は内部の Buffer に scrollback があり、自動末尾追従しているが、
-  // ResizeObserver の発火タイミングと xterm 側 fit の合流がずれると
-  // viewport.scrollTop だけ古い値で残ることがある。明示的に補正する。
-  useEffect(() => {
-    const node = termContainerRef.current;
-    if (!node) return;
-    const scrollViewportToBottom = (): void => {
-      const viewport = node.querySelector<HTMLElement>('.xterm-viewport');
-      if (!viewport) return;
-      // scrollHeight は xterm の rows 数 * cellH に追従する。
-      // requestAnimationFrame で xterm の reflow を待ってから scroll する。
-      window.requestAnimationFrame(() => {
-        viewport.scrollTop = viewport.scrollHeight;
-      });
-    };
-    const ro = new ResizeObserver(() => {
-      scrollViewportToBottom();
-    });
-    ro.observe(node);
-    // 初回 mount で .xterm-viewport が後から生成されるケース用に少し遅らせて 1 回試す
-    const initialTimer = window.setTimeout(scrollViewportToBottom, 100);
-    return () => {
-      ro.disconnect();
-      window.clearTimeout(initialTimer);
-    };
-  }, []);
+  // Issue #261 / #272: termContainer のサイズ変化時に .xterm-viewport を末尾まで
+  // スクロールし直す共通 hook。NodeResizer の縮小→拡大で scrollTop が古い値で
+  // 残り、最終行が下端で見切れるのを防ぐ。詳細は `use-xterm-scroll-on-resize.ts`。
+  useXtermScrollToBottomOnResize(termContainerRef);
 
   return (
     <>

--- a/src/renderer/src/components/canvas/cards/TerminalCard.tsx
+++ b/src/renderer/src/components/canvas/cards/TerminalCard.tsx
@@ -12,6 +12,7 @@ import { TerminalView, type TerminalViewHandle } from '../../TerminalView';
 import { useSettings } from '../../../lib/settings-context';
 import { useCanvasStore, NODE_MIN_W, NODE_MIN_H } from '../../../stores/canvas';
 import { useCanvasTerminalFit } from '../../../lib/use-canvas-terminal-fit';
+import { useXtermScrollToBottomOnResize } from '../../../lib/use-xterm-scroll-on-resize';
 
 interface TerminalPayload {
   agent?: 'claude' | 'codex';
@@ -31,6 +32,10 @@ interface TerminalPayload {
 
 function TerminalCardImpl({ id, data }: NodeProps): JSX.Element {
   const ref = useRef<TerminalViewHandle | null>(null);
+  // Issue #272: NodeResizer でカードをリサイズしたとき、内部 `.xterm-viewport`
+  // の scrollTop が古い値で残り最終行が下端で見切れるのを防ぐため、
+  // wrapper div の ref を ResizeObserver に渡して末尾追従させる。
+  const termContainerRef = useRef<HTMLDivElement | null>(null);
   const { settings } = useSettings();
   const payload = (data?.payload ?? {}) as TerminalPayload;
   const title = (data?.title as string) ?? 'Terminal';
@@ -66,32 +71,38 @@ function TerminalCardImpl({ id, data }: NodeProps): JSX.Element {
     return base.length > 0 ? base : undefined;
   }, [payload.args, payload.resumeSessionId, isCodex]);
 
+  // Issue #272: AgentNodeCard と同じ「リサイズ後に末尾までスクロール」補正を適用。
+  // TerminalView の props は変更せず、wrapper div の ref を hook に渡すだけ。
+  useXtermScrollToBottomOnResize(termContainerRef);
+
   return (
     <>
       <Handle type="target" position={Position.Left} style={{ background: '#7a7afd' }} />
       <CardFrame id={id} title={title} minWidth={NODE_MIN_W} minHeight={NODE_MIN_H}>
-        <TerminalView
-          ref={ref}
-          cwd={cwd}
-          fallbackCwd={cwd}
-          command={command}
-          args={args}
-          visible={true}
-          teamId={payload.teamId}
-          agentId={payload.agentId}
-          role={payload.role}
-          // Issue #63: payload.codexInstructions を TerminalView に伝播
-          codexInstructions={payload.codexInstructions}
-          onStatus={setStatus}
-          onSessionId={handleSessionId}
-          // Canvas zoom で滲まないよう WebGL を切る (DOM renderer 固定)
-          disableWebgl
-          // Issue #253: 論理 px ベース fit + zoom 購読 + 可観測性
-          unscaledFit={fit.unscaledFit}
-          getCellSize={fit.getCellSize}
-          zoomSubscribe={fit.zoomSubscribe}
-          getZoom={fit.getZoom}
-        />
+        <div className="canvas-terminal-card__term" ref={termContainerRef}>
+          <TerminalView
+            ref={ref}
+            cwd={cwd}
+            fallbackCwd={cwd}
+            command={command}
+            args={args}
+            visible={true}
+            teamId={payload.teamId}
+            agentId={payload.agentId}
+            role={payload.role}
+            // Issue #63: payload.codexInstructions を TerminalView に伝播
+            codexInstructions={payload.codexInstructions}
+            onStatus={setStatus}
+            onSessionId={handleSessionId}
+            // Canvas zoom で滲まないよう WebGL を切る (DOM renderer 固定)
+            disableWebgl
+            // Issue #253: 論理 px ベース fit + zoom 購読 + 可観測性
+            unscaledFit={fit.unscaledFit}
+            getCellSize={fit.getCellSize}
+            zoomSubscribe={fit.zoomSubscribe}
+            getZoom={fit.getZoom}
+          />
+        </div>
       </CardFrame>
       <Handle type="source" position={Position.Right} style={{ background: '#7a7afd' }} />
     </>

--- a/src/renderer/src/lib/__tests__/use-xterm-scroll-on-resize.test.tsx
+++ b/src/renderer/src/lib/__tests__/use-xterm-scroll-on-resize.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * useXtermScrollToBottomOnResize の最小動作テスト。
+ *
+ * jsdom の ResizeObserver は no-op polyfill (test-setup.ts) のため、
+ * 「resize でコールバックが発火する」経路はテストできない。
+ * 代わりに以下の 2 点を検証する:
+ *   1. 初回 mount 後の 100ms 遅延 timer 経由で `.xterm-viewport` の
+ *      scrollTop が scrollHeight に補正されること
+ *   2. `.xterm-viewport` が存在しないコンテナでも例外を投げないこと
+ */
+import { useRef } from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { useXtermScrollToBottomOnResize } from '../use-xterm-scroll-on-resize';
+
+// rAF を即時実行に置換して timer/rAF 連携をテストしやすくする。
+const originalRaf = globalThis.requestAnimationFrame;
+const originalCaf = globalThis.cancelAnimationFrame;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    // 即時に呼ぶ。戻り値は number 互換であれば良い。
+    cb(0);
+    return 1;
+  }) as unknown as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame = (() => undefined) as typeof cancelAnimationFrame;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  globalThis.requestAnimationFrame = originalRaf;
+  globalThis.cancelAnimationFrame = originalCaf;
+  cleanup();
+});
+
+function HookHarness({
+  withViewport
+}: {
+  withViewport: boolean;
+}): JSX.Element {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useXtermScrollToBottomOnResize(ref);
+  return (
+    <div ref={ref} data-testid="host">
+      {withViewport ? (
+        <div className="xterm-viewport" data-testid="viewport" />
+      ) : null}
+    </div>
+  );
+}
+
+describe('useXtermScrollToBottomOnResize', () => {
+  it('初回 mount 後の遅延 timer で scrollTop が scrollHeight に補正される', () => {
+    const { getByTestId } = render(<HookHarness withViewport={true} />);
+    const viewport = getByTestId('viewport') as HTMLDivElement;
+
+    // jsdom は scrollHeight を 0 で返すため、テスト用に scrollHeight を上書きする。
+    Object.defineProperty(viewport, 'scrollHeight', { value: 5000, configurable: true });
+    // scrollTop は意図的に途中の値で残しておく。
+    viewport.scrollTop = 1234;
+
+    // 100ms timer を進める
+    vi.advanceTimersByTime(150);
+
+    expect(viewport.scrollTop).toBe(5000);
+  });
+
+  it('.xterm-viewport が無いコンテナでも例外を投げない', () => {
+    expect(() => {
+      render(<HookHarness withViewport={false} />);
+      vi.advanceTimersByTime(150);
+    }).not.toThrow();
+  });
+});

--- a/src/renderer/src/lib/use-xterm-scroll-on-resize.ts
+++ b/src/renderer/src/lib/use-xterm-scroll-on-resize.ts
@@ -1,0 +1,78 @@
+/**
+ * useXtermScrollToBottomOnResize — Canvas 上の xterm 端末を、
+ * 親コンテナのサイズ変化時に末尾までスクロールし直す共有 hook。
+ *
+ * 背景 (Issue #261 / #272):
+ *   NodeResizer でカードを縮める→広げる→縮める…と操作したとき、内部
+ *   `.xterm-viewport` の `scrollTop` が中途半端な値で残り、最終行が
+ *   下端で見切れる現象がある。xterm.js は内部 Buffer に scrollback を
+ *   持ち、自動末尾追従しているが、ResizeObserver の発火タイミングと
+ *   xterm 側 fit の合流がずれると `scrollTop` だけ古い値で残ることがある。
+ *
+ *   PR #269 (Issue #261) で AgentNodeCard.tsx に inline で同等のロジックを
+ *   実装済み。Issue #272 で TerminalCard.tsx にも同じ補正が必要となったため、
+ *   Canvas terminal 用の小さな共有 hook として切り出した。
+ *
+ * 動作:
+ *   - container 内の `.xterm-viewport` を都度 `querySelector` で引く
+ *     (xterm.js が動的に生成するので、mount/remount に追従するため)。
+ *   - ResizeObserver で container のサイズ変化を監視し、変化を検知したら
+ *     `requestAnimationFrame` で xterm の reflow を待ってから
+ *     `scrollTop = scrollHeight` を設定。
+ *   - 初回 mount 時点で `.xterm-viewport` がまだ生成されていないケースに
+ *     備え、100ms 遅延の補正を 1 回だけ走らせる。
+ *   - cleanup で ResizeObserver / timer を解放する。
+ *
+ * 適用範囲:
+ *   - Canvas モードの TerminalCard / AgentNodeCard でのみ使う想定。
+ *   - IDE モードの TerminalView は親が `min-height: 0` の flex で完全
+ *     フィットするため本 hook は適用しない (挙動が変わらないこと)。
+ */
+import { useEffect, type RefObject } from 'react';
+
+/**
+ * @param containerRef xterm-viewport を内包する DOM ノード (例: `.canvas-agent-card__term`)
+ *                     の ref。null のときは何もせず early return する。
+ */
+export function useXtermScrollToBottomOnResize(
+  containerRef: RefObject<HTMLElement | null>
+): void {
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    let rafId: number | null = null;
+    const scrollViewportToBottom = (): void => {
+      const viewport = node.querySelector<HTMLElement>('.xterm-viewport');
+      if (!viewport) return;
+      // requestAnimationFrame で xterm の reflow を待ってから scroll する。
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId);
+      }
+      rafId = window.requestAnimationFrame(() => {
+        rafId = null;
+        viewport.scrollTop = viewport.scrollHeight;
+      });
+    };
+
+    const ro = new ResizeObserver(() => {
+      scrollViewportToBottom();
+    });
+    ro.observe(node);
+
+    // 初回 mount 直後は `.xterm-viewport` がまだ生成されていないケースが
+    // あるため 100ms 遅延で 1 回だけ補正する。
+    const initialTimer = window.setTimeout(scrollViewportToBottom, 100);
+
+    return () => {
+      ro.disconnect();
+      window.clearTimeout(initialTimer);
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+    };
+    // ref オブジェクト自体は安定なので依存配列は空でよい
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -485,6 +485,21 @@
   position: relative;
 }
 
+/* Issue #272: TerminalCard 用の scroll host wrapper。
+   AgentNodeCard と異なり TerminalCard は CardFrame 経由で TerminalView を
+   埋めているため、wrapper div を 1 段挟んで ResizeObserver の観測対象とする。
+   親 CardFrame body は既に `flex: 1; min-height: 0; display: flex` なので
+   この wrapper も同じ flex 設定にして高さが正しく伝わるようにする。 */
+.canvas-terminal-card__term {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
 /* Issue #261: Canvas モード限定で xterm-viewport を強制的にスクロール可能にする。
    - IDE モード (`.terminal-pane .terminal-view`) は親が `min-height: 0` のフレックス
      で完全フィットするため `overflow: hidden` のままで末尾が隠れない。


### PR DESCRIPTION
Closes #272

## 概要
PR #269 (Issue #261) で `AgentNodeCard.tsx` に inline 実装した
ResizeObserver + `scrollTop` 末尾補正を、Canvas terminal 用の共有 hook
`useXtermScrollToBottomOnResize` に切り出し、`TerminalCard.tsx` にも
同等の補正を適用する。

## 背景
- PR #269 (Issue #261) では `AgentNodeCard` 経由のターミナルでのみ
  リサイズ後の最終行表示問題を修正した。
- Issue #272 で同じ症状が `TerminalCard` 経由でも再発する可能性が
  指摘されたため、共有 hook 化して両カードに適用する。

## 変更点
| ファイル | 種別 | 内容 |
|---|---|---|
| `src/renderer/src/lib/use-xterm-scroll-on-resize.ts` | 新規 | container ref を受け取り、内部 `.xterm-viewport` の scrollTop を末尾に保つ共有 hook |
| `src/renderer/src/components/canvas/cards/AgentNodeCard.tsx` | 修正 | inline effect を hook 呼び出しに置換 (挙動同一) |
| `src/renderer/src/components/canvas/cards/TerminalCard.tsx` | 修正 | `TerminalView` を `.canvas-terminal-card__term` wrapper で包み、ref を hook に渡す。`TerminalView` の props は変更しない |
| `src/renderer/src/styles/components/canvas.css` | 修正 | TerminalCard 用 scroll host class を追加 (`flex / min-height / overflow`) |
| `src/renderer/src/lib/__tests__/use-xterm-scroll-on-resize.test.tsx` | 新規 | 初回 timer での scroll 補正 + viewport 不在時の安全性テスト |

## 設計判断
- `TerminalView` の public handle / props は変更しない (#271 で追加予定の `sessionKey` prop と非衝突)。
- `CardFrame` も変更しない (他カードへの副作用回避)。
- AgentNodeCard / TerminalCard の二重管理を避けるため、補正ロジックは hook に一元化。

## 品質ゲート
- `npm run typecheck`: エラー 0 で PASS
- `npm run build`: tauri build まで成功 (NSIS bundle 生成完了 / 署名鍵未設定の警告のみ)
- `npm run test`: 全 7 ファイル / 52 テスト PASS (新規 hook テスト 2 件含む)

## テスト計画
- [x] 単体: hook が初回 100ms timer 経由で `scrollTop = scrollHeight` に補正
- [x] 単体: `.xterm-viewport` 不在時に例外を投げない
- [x] 型検証: `npm run typecheck`
- [x] ビルド: `npm run build`
- [ ] E2E (リーダー Phase B): Canvas で TerminalCard を多行出力後にリサイズ→拡大→縮小して最終行が下端まで見えること
- [ ] E2E (リーダー Phase B): AgentNodeCard で #269 の挙動が維持されること
- [ ] E2E (リーダー Phase B): Canvas zoom 0.5 / 1.0 / 1.5 で下端追従が機能すること
- [ ] E2E (リーダー Phase B): IDE モードの TerminalView 挙動が変わらないこと

## 受け入れ条件
Canvas モードで `TerminalCard` 経由のターミナルを NodeResizer でリサイズしても
`.xterm-viewport` の scrollTop が末尾へ補正され、最終行が完全に表示される。
`AgentNodeCard` 経路は #269 と同等に維持される。

## ロールバック
本 PR を `git revert` すれば、wrapper / hook / css / AgentNodeCard refactor を
まとめて戻せる。永続データ・DB 変更なし。