### PR TITLE
fix(canvas): #272 xterm runtime cell size を使って Canvas の rows fit を修正

### DIFF
--- a/src/renderer/src/lib/get-xterm-runtime-cell-size.ts
+++ b/src/renderer/src/lib/get-xterm-runtime-cell-size.ts
@@ -1,0 +1,79 @@
+/**
+ * xterm.js v5/v6 の内部レンダラから実 cell サイズ (px) を取得する純関数。
+ *
+ * Issue #272: `measureCellSize()` の `cellH = fontSize * lineHeight` は xterm v6
+ * `CharSizeService` の `measureText('W') + fontBoundingBoxAscent + Descent` と
+ * ずれており、`useFitToContainer` の rows fit が xterm 内部 rows と不一致。結果
+ * `.xterm-screen.style.height = rows * cellH` の固定 px がカード高さと合わず下半分が
+ * 黒く残る／最終行が見切れる。本関数は xterm 自身が保持する実 cell px を読み取り、
+ * Canvas モード fit の rows 算出基準を renderer 実寸に揃える。
+ *
+ * private API への依存:
+ *   `(term as any)._core._renderService.dimensions.css.cell.{width,height}`
+ *   xterm v5/v6 のソース (`@xterm/xterm/src/browser/CoreBrowserTerminal.ts`,
+ *   `src/browser/renderer/shared/Types.ts`, `src/browser/services/CharSizeService.ts`)
+ *   で確認済み。renderer がまだ初期化されていない (mount 直後等) は null を返す。
+ *
+ * 取得失敗時は呼出側 (`useFitToContainer`) が `getCellSize()` (Canvas 2D measureText
+ * ベース) にフォールバックする。
+ */
+import type { Terminal } from '@xterm/xterm';
+
+export interface XtermRuntimeCellSize {
+  cellW: number;
+  cellH: number;
+}
+
+// xterm v5/v6 の主要パスを優先順で並べる。先頭が現行 v6、後ろは将来/旧版/test double 互換。
+const RUNTIME_CELL_PATHS = [
+  ['_core', '_renderService', 'dimensions', 'css', 'cell'],
+  ['_renderService', 'dimensions', 'css', 'cell'],
+  ['_core', 'renderService', 'dimensions', 'css', 'cell'],
+  ['renderService', 'dimensions', 'css', 'cell'],
+  ['_core', '_core', '_renderService', 'dimensions', 'css', 'cell']
+] as const;
+
+function isPositiveFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function readPath(root: unknown, path: readonly string[]): unknown {
+  try {
+    let value: unknown = root;
+    for (const key of path) {
+      if (!value || typeof value !== 'object') return null;
+      value = (value as Record<string, unknown>)[key];
+    }
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+function toRuntimeCellSize(value: unknown): XtermRuntimeCellSize | null {
+  if (!value || typeof value !== 'object') return null;
+  const cell = value as Record<string, unknown>;
+  const width = cell.width;
+  const height = cell.height;
+
+  if (!isPositiveFiniteNumber(width) || !isPositiveFiniteNumber(height)) {
+    return null;
+  }
+
+  return { cellW: width, cellH: height };
+}
+
+export function getXtermRuntimeCellSize(term: Terminal | null): XtermRuntimeCellSize | null {
+  if (!term) return null;
+
+  try {
+    for (const path of RUNTIME_CELL_PATHS) {
+      const cell = toRuntimeCellSize(readPath(term, path));
+      if (cell) return cell;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}

--- a/src/renderer/src/lib/use-fit-to-container.ts
+++ b/src/renderer/src/lib/use-fit-to-container.ts
@@ -3,6 +3,7 @@ import type { MutableRefObject, RefObject } from 'react';
 import type { Terminal } from '@xterm/xterm';
 import type { FitAddon } from '@xterm/addon-fit';
 import { computeUnscaledGrid } from './compute-unscaled-grid';
+import { getXtermRuntimeCellSize } from './get-xterm-runtime-cell-size';
 import type { CellSize } from './measure-cell-size';
 
 const VISIBLE_FIT_DELAY_MS = 30;
@@ -134,9 +135,14 @@ export function useFitToContainer(options: UseFitToContainerOptions): void {
     // 購読 / fonts.ready 経路で再 refit を待つ方が安全。
     if (unscaledFitRef.current) {
       if (!container) return;
-      const getCell = getCellSizeRef.current;
-      const cell = getCell?.();
+      // Issue #272: xterm 自身が保持する実 cell サイズを優先。取れなければ Canvas 2D
+      // measureText ベースの getCellSize にフォールバック。これで rows fit が xterm
+      // 内部 rows と一致し、`.xterm-screen` の固定 px 高さがカード高さに揃う。
+      const runtimeCell = getXtermRuntimeCellSize(term);
+      const fallbackCell = getCellSizeRef.current?.() ?? null;
+      const cell = runtimeCell ?? fallbackCell;
       if (!cell) return;
+      const source = runtimeCell ? 'unscaled-runtime' : 'unscaled-fallback';
       const grid = computeUnscaledGrid(
         container.clientWidth,
         container.clientHeight,
@@ -155,10 +161,10 @@ export function useFitToContainer(options: UseFitToContainerOptions): void {
             cols: grid.cols,
             rows: grid.rows,
             zoom: getZoomRef.current?.() ?? null,
-            source: 'unscaled',
+            source,
             cellW: cell.cellW,
             cellH: cell.cellH,
-            fallback: cell.fallback
+            fallback: runtimeCell ? false : fallbackCell?.fallback
           });
         }
       } catch {

--- a/src/renderer/src/lib/use-xterm-scroll-on-resize.ts
+++ b/src/renderer/src/lib/use-xterm-scroll-on-resize.ts
@@ -43,15 +43,20 @@ export function useXtermScrollToBottomOnResize(
 
     let rafId: number | null = null;
     const scrollViewportToBottom = (): void => {
-      const viewport = node.querySelector<HTMLElement>('.xterm-viewport');
-      if (!viewport) return;
+      // Issue #272: xterm v6 の実スクロール host は `.xterm-scrollable-element`。
+      // `.xterm-viewport` への scrollTop 変更は xterm の scroll model と同期しないため、
+      // scrollable-element を優先し、無ければ既存テスト互換のため `.xterm-viewport` に fallback。
+      const scrollHost =
+        node.querySelector<HTMLElement>('.xterm-scrollable-element') ??
+        node.querySelector<HTMLElement>('.xterm-viewport');
+      if (!scrollHost) return;
       // requestAnimationFrame で xterm の reflow を待ってから scroll する。
       if (rafId !== null) {
         window.cancelAnimationFrame(rafId);
       }
       rafId = window.requestAnimationFrame(() => {
         rafId = null;
-        viewport.scrollTop = viewport.scrollHeight;
+        scrollHost.scrollTop = scrollHost.scrollHeight;
       });
     };
 

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -509,6 +509,15 @@
      (index.css L1678 周辺) の z-index/background ルールと共存させるため必要。
    - scrollbar の見た目は index.css L1689-1704 の `.terminal-view .xterm-viewport`
      スタイルがそのまま適用される (10px 幅 + var(--text-mute) thumb)。 */
+/* Issue #272: xterm v6 の scroll host (`.xterm-scrollable-element`) を Canvas モード限定で
+   カード高さに追従させる。これがないと `.xterm-screen` の固定 px 高さがカード下端に届かず
+   黒帯が残る／最終行が見切れる症状になる。`.react-flow__node` スコープなので IDE モードへの
+   副作用なし。 */
+.react-flow__node .xterm-scrollable-element {
+  width: 100%;
+  height: 100%;
+}
+
 .react-flow__node .xterm-viewport {
   overflow-y: auto !important;
 }


### PR DESCRIPTION
## 概要

Issue #272 の 1 次対応 (PR #279) は scroll host を取り違えており、ユーザー実機では下端が見えない／スクロールバーが出ない症状が再発していた。

## 根本原因 (Codex 診断結果)

xterm v6 の DomRenderer は `.xterm-screen.style.height = rows * cellH` を **px 固定**で書き込み、親追従しない。`useFitToContainer` の Canvas 経路は `container.clientHeight / cellH` で rows を計算しているが、`measureCellSize()` の cellH (`fontSize * lineHeight`) は xterm v6 `CharSizeService` の `measureText('W') + fontBoundingBoxAscent + Descent` とずれており、rows fit が xterm 内部 rows と不一致。結果 `.xterm-screen` の固定 px 高さがカード高さに足りず下半分が黒く残る／最終行が見切れる。

加えて xterm v6 の実スクロール host は `.xterm-viewport` ではなく `.xterm-scrollable-element` 側。PR #279 の scroll 補正 hook は scroll host を取り違えていた。

## 変更内容

| File | 内容 |
|---|---|
| 新規 `get-xterm-runtime-cell-size.ts` | xterm 自身の実 cell px を private API から読み取る純関数 |
| `use-fit-to-container.ts` | unscaledFit 経路で xterm runtime cell を優先、なければ既存 measureCellSize にフォールバック |
| `use-xterm-scroll-on-resize.ts` | scroll host を `.xterm-scrollable-element` 優先 + `.xterm-viewport` fallback |
| `canvas.css` | `.react-flow__node .xterm-scrollable-element { width:100%; height:100% }` 追加 |

## 既存テスト維持 (壊さない)

- `measure-cell-size.test.ts`: `measureCellSize` 本体未変更 → 全件 PASS
- `use-xterm-scroll-on-resize.test.tsx`: `.xterm-viewport` のみ存在する DOM でも fallback で動く → 全件 PASS
- `compute-unscaled-grid.test.ts`: 未変更 → 全件 PASS

## 副作用評価

- IDE モード (`unscaledFit=false`): 完全に既存挙動 (`fit.fit()` 経路に手を入れていない)
- xterm private API が将来変わった場合: 自動的に既存 `measureCellSize` 経路にフォールバック
- CSS は `.react-flow__node` 配下限定で IDE モードに影響なし

## テスト

- `npm run typecheck`: PASS
- `npx vitest run`: 全件 PASS (8 ファイル / 55 件)
- 実機 `npm run dev` での Canvas Leader カード動作確認は本 PR マージ後にユーザーが手動実施

Closes #272