### PR TITLE
fix(canvas): #272 follow-up — Canvas で scrollbar が見えない問題を修正

### DIFF
--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1716,6 +1716,26 @@ body.is-resizing * {
   background-clip: content-box;
 }
 
+/* Issue #272 follow-up: xterm v6 では実スクロール host が `.xterm-scrollable-element` 側のため、
+   `.xterm-viewport` と同等の scrollbar styling をこちらにも複製する。
+   両方適用しても styling は同一なので副作用なし。 */
+.terminal-view .xterm-scrollable-element::-webkit-scrollbar {
+  width: 10px;
+}
+.terminal-view .xterm-scrollable-element::-webkit-scrollbar-track {
+  background: transparent;
+}
+.terminal-view .xterm-scrollable-element::-webkit-scrollbar-thumb {
+  background: var(--text-mute);
+  border: 2px solid transparent;
+  background-clip: content-box;
+  border-radius: 5px;
+}
+.terminal-view .xterm-scrollable-element::-webkit-scrollbar-thumb:hover {
+  background: var(--fg);
+  background-clip: content-box;
+}
+
 /* Glass テーマ時は xterm を透過させて親の backdrop-filter を活かす (Issue #89)。
    `.terminal-view` の solid 背景と `.xterm-viewport` の `!important` 背景を両方打ち消す。 */
 [data-theme="glass"] .terminal-view {

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -512,10 +512,12 @@
 /* Issue #272: xterm v6 の scroll host (`.xterm-scrollable-element`) を Canvas モード限定で
    カード高さに追従させる。これがないと `.xterm-screen` の固定 px 高さがカード下端に届かず
    黒帯が残る／最終行が見切れる症状になる。`.react-flow__node` スコープなので IDE モードへの
-   副作用なし。 */
+   副作用なし。
+   Issue #272 follow-up: overflow-y を明示して scrollbar を確実に表示させる。 */
 .react-flow__node .xterm-scrollable-element {
   width: 100%;
   height: 100%;
+  overflow-y: auto;
 }
 
 .react-flow__node .xterm-viewport {


### PR DESCRIPTION
## 概要

Issue #272 PR #284 後の実機検証で「Canvas モードで scrollbar がほぼ見えない、カードリサイズ中の一瞬だけ表示される」症状が残存。

## 根本原因

既存 scrollbar styling は `.terminal-view .xterm-viewport::-webkit-scrollbar*` (index.css L1702-1717) にしか当たっておらず、xterm v6 の実スクロール host である `.xterm-scrollable-element` には styling が当たっていなかった。結果として Canvas モードでは scrollbar が **0px 幅 / default の autohiding 挙動**になり、リサイズ瞬間以外は見えない状態になっていた。

## 修正内容（CSS のみ）

| File | 変更 |
|---|---|
| `index.css` | `.terminal-view .xterm-scrollable-element::-webkit-scrollbar*` に既存 viewport と同等 styling を複製 |
| `canvas.css` | `.react-flow__node .xterm-scrollable-element` に `overflow-y: auto` を明示 |

## 副作用評価

- IDE モード: 既存 `.terminal-view .xterm-viewport` styling は維持。新規 `.xterm-scrollable-element` styling は両モードで同じスタイルが当たるので見た目変わらず
- 他テーマ: `var(--text-mute)` / `var(--fg)` を使うので全 6 テーマで一貫
- TypeScript: 影響なし
- 既存テスト: CSS のみなので影響なし（typecheck + vitest 全件 PASS）

Refs #272