### PR TITLE
fix(canvas): #272 v3 — xterm v6 custom scrollbar に切替えて native overflow を撤回

### DIFF
--- a/src/renderer/src/components/TerminalView.tsx
+++ b/src/renderer/src/components/TerminalView.tsx
@@ -20,6 +20,8 @@ export interface TerminalViewHandle {
   sendCommand(text: string, submit?: boolean): void;
   /** ターミナルへフォーカスを移す */
   focus(): void;
+  /** xterm の scroll model に基づき末尾までスクロールする (Issue #272 v3) */
+  scrollToBottom(): void;
 }
 
 interface TerminalViewProps {
@@ -243,6 +245,9 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
         },
         focus(): void {
           termRef.current?.focus();
+        },
+        scrollToBottom(): void {
+          termRef.current?.scrollToBottom();
         }
       }),
       // ptyIdRef / termRef は stable な ref なので deps 不要

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
@@ -8,7 +8,7 @@
  *
  * payload: TerminalPayload + role 必須
  */
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Handle, NodeResizer, Position, type NodeProps } from '@xyflow/react';
 import { TerminalView, type TerminalViewHandle } from '../../TerminalView';
 import { useT } from '../../../lib/i18n';
@@ -297,10 +297,15 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
     [accent]
   );
 
-  // Issue #261 / #272: termContainer のサイズ変化時に .xterm-viewport を末尾まで
-  // スクロールし直す共通 hook。NodeResizer の縮小→拡大で scrollTop が古い値で
-  // 残り、最終行が下端で見切れるのを防ぐ。詳細は `use-xterm-scroll-on-resize.ts`。
-  useXtermScrollToBottomOnResize(termContainerRef);
+  // Issue #261 / #272 / #272 v3: termContainer のサイズ変化時に xterm 自前の
+  // scroll model 経由で末尾までスクロールし直す。NodeResizer の縮小→拡大で
+  // scrollback 末尾が見切れるのを防ぐ。callback は xterm v6 の SmoothScrollableElement
+  // に正しく届くよう `Terminal.scrollToBottom()` を public API 経由で叩く
+  // (DOM の scrollTop 書換えは内部 scroll model と同期しないため使えない)。
+  const scrollToBottom = useCallback(() => {
+    ref.current?.scrollToBottom();
+  }, []);
+  useXtermScrollToBottomOnResize(termContainerRef, scrollToBottom);
 
   return (
     <>

--- a/src/renderer/src/components/canvas/cards/TerminalCard.tsx
+++ b/src/renderer/src/components/canvas/cards/TerminalCard.tsx
@@ -71,9 +71,13 @@ function TerminalCardImpl({ id, data }: NodeProps): JSX.Element {
     return base.length > 0 ? base : undefined;
   }, [payload.args, payload.resumeSessionId, isCodex]);
 
-  // Issue #272: AgentNodeCard と同じ「リサイズ後に末尾までスクロール」補正を適用。
-  // TerminalView の props は変更せず、wrapper div の ref を hook に渡すだけ。
-  useXtermScrollToBottomOnResize(termContainerRef);
+  // Issue #272 / #272 v3: AgentNodeCard と同じ「リサイズ後に末尾までスクロール」補正を適用。
+  // xterm v6 の SmoothScrollableElement は内部 scroll model で scrollback を管理するため、
+  // DOM の scrollTop ではなく `Terminal.scrollToBottom()` を public API 経由で叩く。
+  const scrollToBottom = useCallback(() => {
+    ref.current?.scrollToBottom();
+  }, []);
+  useXtermScrollToBottomOnResize(termContainerRef, scrollToBottom);
 
   return (
     <>

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1716,24 +1716,19 @@ body.is-resizing * {
   background-clip: content-box;
 }
 
-/* Issue #272 follow-up: xterm v6 では実スクロール host が `.xterm-scrollable-element` 側のため、
-   `.xterm-viewport` と同等の scrollbar styling をこちらにも複製する。
-   両方適用しても styling は同一なので副作用なし。 */
-.terminal-view .xterm-scrollable-element::-webkit-scrollbar {
-  width: 10px;
-}
-.terminal-view .xterm-scrollable-element::-webkit-scrollbar-track {
-  background: transparent;
-}
-.terminal-view .xterm-scrollable-element::-webkit-scrollbar-thumb {
-  background: var(--text-mute);
-  border: 2px solid transparent;
-  background-clip: content-box;
+/* Issue #272 v3: xterm v6 の SmoothScrollableElement が描画する custom scrollbar の slider 色を、
+   既存 `.xterm-viewport::-webkit-scrollbar-thumb` (IDE モード) と同じ var(--text-mute) / var(--fg) に揃える。
+   `.xterm-scrollable-element > .scrollbar > .slider` は xterm.css L227 の構造に基づく。
+   PR #286 で追加した `::-webkit-scrollbar*` (native) は xterm v6 の内部 scroll model を起動せず、
+   外部 overflow と組合わさって誤った native scrollbar を生成していたため撤回し、ここで
+   xterm 自前の custom scrollbar (slider) のみに styling を当てる。 */
+.terminal-view .xterm-scrollable-element > .scrollbar > .slider {
+  background: var(--text-mute) !important;
   border-radius: 5px;
 }
-.terminal-view .xterm-scrollable-element::-webkit-scrollbar-thumb:hover {
-  background: var(--fg);
-  background-clip: content-box;
+.terminal-view .xterm-scrollable-element > .scrollbar > .slider:hover,
+.terminal-view .xterm-scrollable-element > .scrollbar > .slider.active {
+  background: var(--fg) !important;
 }
 
 /* Glass テーマ時は xterm を透過させて親の backdrop-filter を活かす (Issue #89)。

--- a/src/renderer/src/lib/use-xterm-scroll-on-resize.ts
+++ b/src/renderer/src/lib/use-xterm-scroll-on-resize.ts
@@ -33,9 +33,15 @@ import { useEffect, type RefObject } from 'react';
 /**
  * @param containerRef xterm-viewport を内包する DOM ノード (例: `.canvas-agent-card__term`)
  *                     の ref。null のときは何もせず early return する。
+ * @param scrollToBottom xterm の public API (`Terminal.scrollToBottom`) を呼ぶ callback。
+ *                     渡された場合は `.xterm-scrollable-element` の DOM scrollTop を直接
+ *                     書き換える代わりに xterm 自前の scroll model 経由でスクロールする
+ *                     (Issue #272 v3)。未指定時は fallback として `.xterm-viewport` に
+ *                     `scrollTop = scrollHeight` を当てる (既存テスト互換)。
  */
 export function useXtermScrollToBottomOnResize(
-  containerRef: RefObject<HTMLElement | null>
+  containerRef: RefObject<HTMLElement | null>,
+  scrollToBottom?: () => void
 ): void {
   useEffect(() => {
     const node = containerRef.current;
@@ -43,20 +49,23 @@ export function useXtermScrollToBottomOnResize(
 
     let rafId: number | null = null;
     const scrollViewportToBottom = (): void => {
-      // Issue #272: xterm v6 の実スクロール host は `.xterm-scrollable-element`。
-      // `.xterm-viewport` への scrollTop 変更は xterm の scroll model と同期しないため、
-      // scrollable-element を優先し、無ければ既存テスト互換のため `.xterm-viewport` に fallback。
-      const scrollHost =
-        node.querySelector<HTMLElement>('.xterm-scrollable-element') ??
-        node.querySelector<HTMLElement>('.xterm-viewport');
-      if (!scrollHost) return;
       // requestAnimationFrame で xterm の reflow を待ってから scroll する。
       if (rafId !== null) {
         window.cancelAnimationFrame(rafId);
       }
       rafId = window.requestAnimationFrame(() => {
         rafId = null;
-        scrollHost.scrollTop = scrollHost.scrollHeight;
+        if (scrollToBottom) {
+          // Issue #272 v3: xterm v6 の SmoothScrollableElement は内部 scroll model で
+          // scrollback を管理しているため、DOM の scrollTop を直接書いても同期しない。
+          // 必ず xterm public API (Terminal.scrollToBottom) を経由する。
+          scrollToBottom();
+          return;
+        }
+        // scrollToBottom callback が無いとき (旧呼出し / 既存テスト互換) のみ
+        // fallback として `.xterm-viewport` に DOM scrollTop を書く。
+        const viewport = node.querySelector<HTMLElement>('.xterm-viewport');
+        if (viewport) viewport.scrollTop = viewport.scrollHeight;
       });
     };
 
@@ -77,7 +86,8 @@ export function useXtermScrollToBottomOnResize(
         rafId = null;
       }
     };
-    // ref オブジェクト自体は安定なので依存配列は空でよい
+    // ref オブジェクト自体は安定。scrollToBottom は呼出し側で useCallback により
+    // 安定化される想定なので、変更時は再 subscribe する。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [scrollToBottom]);
 }

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -500,29 +500,14 @@
   position: relative;
 }
 
-/* Issue #261: Canvas モード限定で xterm-viewport を強制的にスクロール可能にする。
-   - IDE モード (`.terminal-pane .terminal-view`) は親が `min-height: 0` のフレックス
-     で完全フィットするため `overflow: hidden` のままで末尾が隠れない。
-   - Canvas モードは NodeResizer のリサイズ + zoom + Math.round で端数行が出るため、
-     scrollbar を有効化しないと最終行が容器下端で見切れることがある。
-   - `!important` は IDE モード用の `.terminal-view .xterm-viewport`
-     (index.css L1678 周辺) の z-index/background ルールと共存させるため必要。
-   - scrollbar の見た目は index.css L1689-1704 の `.terminal-view .xterm-viewport`
-     スタイルがそのまま適用される (10px 幅 + var(--text-mute) thumb)。 */
-/* Issue #272: xterm v6 の scroll host (`.xterm-scrollable-element`) を Canvas モード限定で
-   カード高さに追従させる。これがないと `.xterm-screen` の固定 px 高さがカード下端に届かず
-   黒帯が残る／最終行が見切れる症状になる。`.react-flow__node` スコープなので IDE モードへの
-   副作用なし。
-   Issue #272 follow-up: overflow-y を明示して scrollbar を確実に表示させる。 */
-.react-flow__node .xterm-scrollable-element {
-  width: 100%;
-  height: 100%;
-  overflow-y: auto;
-}
-
-.react-flow__node .xterm-viewport {
-  overflow-y: auto !important;
-}
+/* Issue #272 v3: xterm v6 の scrollback は SmoothScrollableElement (内部 scroll model) で
+   管理されるため、`.xterm-scrollable-element` や `.xterm-viewport` に外部 CSS で overflow:auto を
+   付与すると native scrollbar が誤起動する。Canvas 側からは触らない（xterm 自前管理に任せる）。
+   PR #284 で `.xterm-scrollable-element { width:100%; height:100%; overflow-y:auto }`、
+   PR #286 で `overflow: hidden auto` に変更し、Issue #261 由来で `.xterm-viewport { overflow-y:auto !important }`
+   も付けていたが、いずれも DOM の native overflow を起動して thumb が track 全範囲を占有 +
+   ホイール無反応の症状を生んでいたため撤回する。`.xterm-screen` 高さ追従は CSS ではなく
+   term.resize() → renderer 側で担保される。 */
 
 /* Issue #261: AgentNodeCard の min-height は内部 xterm-viewport の高さに引っ張られ
    ないようにし、Canvas モードのリサイズで NodeResizer が小さくしたときも


### PR DESCRIPTION
## 概要

Issue #272 PR #284 (rows fit) + #286 (CSS) 後の実機検証で「scrollbar の thumb が track 全範囲を占有 + ホイール動かず」症状が残存。Codex 再診断で原因確定。

## 根本原因（Codex 確定、Viewport.ts:159-162 引用）

xterm v6 の `.xterm-scrollable-element` は **SmoothScrollableElement の内部要素**で、scrollback は DOM の `style.height` ではなく**内部 scroll model**で管理する設計。PR #284/#286 で外部 CSS `overflow-y: auto` + `::-webkit-scrollbar*` を当てたことで、**間違った native scrollbar 機構**が起動し、native overflow の `scrollHeight ≈ clientHeight` で thumb 全範囲占有 + 動かない症状になっていた。

ユーザー実機での「カードリサイズ時に一瞬見える scrollbar」は xterm 自前の **custom scrollbar slider**（`.xterm-scrollable-element > .scrollbar > .slider`）で、これが**正しい挙動**。常時見えている方は誤って作られた native scrollbar。

## 修正内容（Codex C案）

| File | 変更 |
|---|---|
| canvas.css | PR #284/#286 で追加した `.react-flow__node` 配下の `.xterm-scrollable-element` / `.xterm-viewport` への overflow 強制を撤回（xterm 自前管理に戻す） |
| index.css | PR #286 で追加した `.xterm-scrollable-element::-webkit-scrollbar*` (native) を削除し、xterm v6 custom scrollbar の `.xterm-scrollable-element > .scrollbar > .slider` に `var(--text-mute)` / `var(--fg)` styling を当てる |
| TerminalView.tsx | `TerminalViewHandle.scrollToBottom()` を public 化（xterm public API 経由） |
| use-xterm-scroll-on-resize.ts | scrollToBottom callback を受け取り、xterm 自前 scroll model 経由で末尾スクロール |
| AgentNodeCard.tsx + TerminalCard.tsx | callback を hook に渡す |

## 維持される改善
- PR #284 の rows fit 改善 (`getXtermRuntimeCellSize` + useFitToContainer) は不変更
- `.xterm-screen` 高さ追従: CSS ではなく `term.resize()` → renderer 側で担保

## 副作用評価
- IDE モード: 撤回箇所はすべて `.react-flow__node` スコープ。custom slider styling は `.terminal-view` 共通だが既存 `.xterm-viewport::-webkit-scrollbar-thumb` と同じ色値で見た目の連続性維持
- 他テーマ: `var(--text-mute)` / `var(--fg)` を使うので全 6 テーマで一貫
- 既存テスト: 6 files / 55 tests 全件 PASS

Refs #272