### PR TITLE
fix(canvas): #272 v4 — scrollbar 常時表示 + ホイール scrollback ルーティング

### DIFF
--- a/src/renderer/src/components/TerminalView.tsx
+++ b/src/renderer/src/components/TerminalView.tsx
@@ -69,6 +69,13 @@ interface TerminalViewProps {
    */
   disableWebgl?: boolean;
   /**
+   * Issue #272 v4: Canvas モード限定で、マウスホイールを xterm の scrollback スクロールへ
+   * 強制ルーティングする。`term.attachCustomWheelEventHandler` 経由で normal buffer +
+   * scrollback ありの時のみ `term.scrollLines()` を発火させる。
+   * alt buffer (vim/less/htop) や Ctrl/Shift wheel は xterm 既定動作のまま (TUI 側に届く)。
+   */
+  forceWheelScrollback?: boolean;
+  /**
    * Issue #253: Canvas モード (transform: scale(zoom) 配下) で論理 px ベース fit を有効化。
    * true にすると getBoundingClientRect 経由ではなく container.clientWidth/clientHeight と
    * `getCellSize()` から cols/rows を直接計算するので、zoom が変わっても PTY サイズが安定する。
@@ -113,6 +120,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       onSessionId,
       onUserInput,
       disableWebgl,
+      forceWheelScrollback,
       unscaledFit,
       getCellSize,
       zoomSubscribe,
@@ -123,7 +131,11 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
     const { settings } = useSettings();
 
     // --- Terminal インスタンス ---
-    const { containerRef, termRef, fitRef } = useXtermInstance(settings, disableWebgl);
+    const { containerRef, termRef, fitRef } = useXtermInstance(
+      settings,
+      disableWebgl,
+      forceWheelScrollback
+    );
 
     // --- ref で state を hook 間共有 ---
     const ptyIdRef = useRef<string | null>(null);

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
@@ -376,6 +376,9 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
             // Canvas zoom で xterm canvas が滲むのを避けるため WebGL を切る (DOM renderer 固定)。
             // text は実 DOM になるので Chromium が親 transform に応じて再ラスタライズしシャープに描く。
             disableWebgl
+            // Issue #272 v4: Canvas モードではホイールを scrollback スクロールへ強制ルーティング
+            // (xterm mouse protocol が wheel を消費して scrollback が動かない問題の対策)
+            forceWheelScrollback
             // Issue #253: 論理 px ベース fit + zoom 購読 + 可観測性
             unscaledFit={fit.unscaledFit}
             getCellSize={fit.getCellSize}

--- a/src/renderer/src/components/canvas/cards/TerminalCard.tsx
+++ b/src/renderer/src/components/canvas/cards/TerminalCard.tsx
@@ -103,6 +103,9 @@ function TerminalCardImpl({ id, data }: NodeProps): JSX.Element {
             onSessionId={handleSessionId}
             // Canvas zoom で滲まないよう WebGL を切る (DOM renderer 固定)
             disableWebgl
+            // Issue #272 v4: Canvas モードではホイールを scrollback スクロールへ強制ルーティング
+            // (xterm mouse protocol が wheel を消費して scrollback が動かない問題の対策)
+            forceWheelScrollback
             // Issue #253: 論理 px ベース fit + zoom 購読 + 可観測性
             unscaledFit={fit.unscaledFit}
             getCellSize={fit.getCellSize}

--- a/src/renderer/src/lib/use-xterm-instance.ts
+++ b/src/renderer/src/lib/use-xterm-instance.ts
@@ -19,6 +19,20 @@ import { buildXtermTheme } from './xterm-theme';
 const SCROLLBACK_LINES = 2000;
 
 /*
+ * Issue #272 v4: ホイール → scrollback の lines 換算で使う px-per-line。
+ * Chromium 系で deltaMode=DOM_DELTA_PIXEL のとき、1 ノッチ ~100px 出る環境が多いので
+ * 50 で割って 2 行/ノッチ程度に収める。DOM_DELTA_LINE/DOM_DELTA_PAGE はそれぞれ
+ * 行/ページ単位なのでそのまま使う。
+ */
+const WHEEL_PIXEL_PER_LINE = 50;
+
+function wheelEventToLineDelta(event: WheelEvent, rows: number): number {
+  if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) return event.deltaY * rows;
+  if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) return event.deltaY;
+  return event.deltaY / WHEEL_PIXEL_PER_LINE;
+}
+
+/*
  * Issue #126: Chromium の active WebGL context 上限は通常 16 (実装依存だが Tauri/WebView2
  * でも同等)。MAX_TERMINALS=30 のうち 16 個目以降の WebGL 作成が成功しても、新しい context
  * を作るたびに古い context が暗黙 lost され、ランダムに DOM renderer に降格する。
@@ -91,7 +105,8 @@ function ensureBoxDrawingFallbacks(family: string): string {
  */
 export function useXtermInstance(
   settings: AppSettings,
-  disableWebgl = false
+  disableWebgl = false,
+  forceWheelScrollback = false
 ): {
   containerRef: RefObject<HTMLDivElement>;
   termRef: MutableRefObject<Terminal | null>;
@@ -148,6 +163,53 @@ export function useXtermInstance(
     const fit = new FitAddon();
     term.loadAddon(fit);
     term.open(container);
+
+    /*
+     * Issue #272 v4: Canvas モード限定で「ホイール → scrollback スクロール」を強制する。
+     *
+     * 背景:
+     *   xterm v6 は mouse protocol が wheel を要求 (Claude/Codex TUI が CoreMouseEventType.WHEEL
+     *   を enable) すると Viewport の `handleMouseWheel` を false にして、wheel を
+     *   CoreBrowserTerminal 側で app mouse wheel report として消費する。
+     *   結果、Canvas のカード上でホイールを回しても scrollback が動かない。scrollbar drag は
+     *   別経路 (DOM scrollbar.vertical) なので影響を受けない。
+     *
+     *   IDE モードでは scrollback を読みたいときも mouse mode を解除する習慣があるので
+     *   既定挙動を維持する方が望ましい。Canvas モードでは「カードの中身を読み返す」用途が強いので
+     *   wheel を scrollback に流すことを優先する。
+     *
+     * 仕様:
+     *   - alt buffer (vim/less/htop など) では `return true` で xterm 既定動作 (TUI に通知)
+     *   - Ctrl/Shift wheel は xterm 既定動作 (フォントサイズ変更など)
+     *   - scrollback が 0 (baseY <= 0) なら xterm 既定動作
+     *   - normal buffer + scrollback あり時のみ preventDefault + term.scrollLines() で末尾スクロール
+     */
+    if (forceWheelScrollback) {
+      let wheelLineRemainder = 0;
+      term.attachCustomWheelEventHandler((event) => {
+        if (event.ctrlKey || event.shiftKey || event.deltaY === 0) return true;
+
+        const activeBuffer = term.buffer.active;
+        if (activeBuffer.type !== 'normal' || activeBuffer.baseY <= 0) {
+          wheelLineRemainder = 0;
+          return true;
+        }
+
+        wheelLineRemainder += wheelEventToLineDelta(event, term.rows);
+        const lines = wheelLineRemainder > 0
+          ? Math.floor(wheelLineRemainder)
+          : Math.ceil(wheelLineRemainder);
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (lines !== 0) {
+          wheelLineRemainder -= lines;
+          term.scrollLines(lines);
+        }
+        return false;
+      });
+    }
 
     // WebGL レンダラ (主ケース): DOM renderer を GPU 描画に置き換え。
     // 環境 (headless / GPU 無効 / context lost) で失敗したら try/catch + webgl "contextlost"

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -507,6 +507,20 @@
    ホイール無反応の症状を生んでいたため撤回する。`.xterm-screen` 高さ追従は CSS ではなく
    term.resize() → renderer 側で担保される。 */
 
+/* Issue #272 v4: Canvas のターミナルは xterm v6 の custom scrollbar を「常時表示」にする。
+   xterm の SmoothScrollableElement は `vertical: ScrollbarVisibility.Auto` で生成され、
+   JS が要素の `.visible` / `.invisible` クラスを切替えて opacity/pointer-events を絞る。
+   public API には可視性制御がないため、Canvas スコープの !important で xterm.css の
+   autohide スタイルを上書きする。`.react-flow__node` 配下に限定するので IDE モードへの
+   影響はない (IDE 側ターミナルは React Flow ノード外)。
+   transition も無効化して即時表示 (フェードによるチラつきを避ける)。 */
+.react-flow__node .terminal-view .xterm-scrollable-element > .scrollbar.vertical {
+  opacity: 1 !important;
+  visibility: visible !important;
+  pointer-events: auto !important;
+  transition: none !important;
+}
+
 /* Issue #261: AgentNodeCard の min-height は内部 xterm-viewport の高さに引っ張られ
    ないようにし、Canvas モードのリサイズで NodeResizer が小さくしたときも
    scrollbar が出る (xterm 内部スクロールが活きる) ようにする。


### PR DESCRIPTION
## 概要

Issue #272 PR #287 後の実機確認で2件残課題:
1. scrollbar が一瞬しか表示されない (xterm v6 autohide)
2. マウスホイールでスクロール不可 (scrollbar drag は機能)

## 根本原因 (Codex 診断)

### 課題1: scrollbar autohide
xterm v6 の SmoothScrollableElement は `vertical: ScrollbarVisibility.Auto` で生成され、JS が `.visible` / `.invisible` クラスを切替える。public API には制御不可。CSS `!important` で勝てる。

### 課題2: ホイール
xterm の mouse protocol が wheel を要求 (`CoreMouseEventType.WHEEL` を Claude/Codex TUI が enable) すると、`Viewport.ts` が `handleMouseWheel: false` に切替えて `CoreBrowserTerminal.ts` 側で app mouse wheel として消費する。**scrollbar drag は別経路 (DOM scrollbar.vertical) なので影響を受けない**。

解決: Canvas 限定で `term.attachCustomWheelEventHandler` をフックし、normal buffer + scrollback あり (`baseY > 0`) の時だけ `term.scrollLines()` で scrollback スクロールに流す。alt buffer / Ctrl・Shift wheel は xterm 既定動作 (`return true`)。

## 変更内容

| File | 変更 |
|---|---|
| `use-xterm-instance.ts` | `forceWheelScrollback` 引数追加、`attachCustomWheelEventHandler` で Canvas 限定 custom wheel handler 装着 |
| `TerminalView.tsx` | `forceWheelScrollback` prop pass-through |
| `TerminalCard.tsx` / `AgentNodeCard.tsx` | `forceWheelScrollback` を有効化 |
| `canvas.css` | scrollbar 常時可視の CSS `!important` 追加 |

## 副作用評価

- IDE モード: `forceWheelScrollback` 未指定 (undefined → false) で既存挙動完全維持
- alt buffer (vim/less/htop 等): `activeBuffer.type !== 'normal'` で xterm 既定動作 (TUI 側でホイール処理)
- Ctrl/Shift wheel: `return true` で xterm 既定動作 (フォントサイズ変更等)
- scrollback なし: `baseY <= 0` で xterm 既定動作
- 他テーマ: 影響なし

## テスト
- typecheck PASS
- vitest 全件 PASS

Refs #272