### PR TITLE
fix(filetree): #283 右クリックメニューが sidebar 幅に閉じ込められて見切れる問題を修正

### DIFF
--- a/src/renderer/src/components/ContextMenu.tsx
+++ b/src/renderer/src/components/ContextMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 
 export interface ContextMenuItem {
   label: string;
@@ -110,7 +111,11 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps): JSX.Ele
     };
   }, [onClose, items, focusedIndex]);
 
-  return (
+  // Issue #283: 親 (.sidebar など) に backdrop-filter が掛かっていると、
+  // それが position: fixed の containing block になってしまい、メニューが
+  // sidebar の幅 (272px) に閉じ込められて右側が見切れる。document.body 直下に
+  // Portal でレンダーして containing block を viewport に戻す。
+  return createPortal(
     <div
       ref={ref}
       className="context-menu"
@@ -145,6 +150,7 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps): JSX.Ele
           {item.divider && <div className="context-menu__divider" />}
         </div>
       ))}
-    </div>
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
## Summary
- `ContextMenu` を React Portal で `document.body` 直下にレンダーするよう変更
- `.sidebar` の `backdrop-filter` (index.css L236) が `position: fixed` の containing block を sidebar (272px 幅) に変えてしまっていたため、FileTreePanel から開く右クリックメニューの座標 `left/top` が viewport ではなく sidebar 内座標として解釈され、メニューの右側が sidebar 右端で見切れていた
- Portal で body 直下にレンダーすることで containing block を viewport に戻し、画面端のクリックでもメニュー全体が表示されるようにする
- 既存の `useLayoutEffect` による画面外はみ出し補正 (L35-49) はそのまま機能 (`getBoundingClientRect` / `window.innerWidth` は viewport 基準)

Closes #283

## Test plan
- [ ] `npm run typecheck` 通過 ← 確認済み
- [ ] `npm run dev` で IDE モード起動 → ファイルツリーで右クリック → メニュー全体が表示される (sidebar 右端で見切れない)
- [ ] 画面右端付近でも右クリックして clamping (画面内に収まる動き) が引き続き効くことを確認
- [ ] Escape / 外クリック / 矢印キー (Issue #163 の WAI-ARIA menu pattern) のキー操作が回帰していないこと
- [ ] テーマを `glass` / `claude-dark` / `dark` / `midnight` / `light` で切り替えてレイアウト崩れがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZbPD1tz6utgZx6PNgeHh3)_