### PR TITLE
fix(pty): #285 IDE 初回ターミナルが空白になる race を pre-subscribe で解消

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -305,6 +305,69 @@ fn is_codex_command(command: &str) -> bool {
 }
 
 #[cfg(test)]
+mod terminal_id_validation_tests {
+    use super::is_valid_terminal_id;
+
+    #[test]
+    fn accepts_uuid_v4() {
+        assert!(is_valid_terminal_id("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn accepts_alphanumeric_and_separators() {
+        assert!(is_valid_terminal_id("abc_123-XYZ"));
+        assert!(is_valid_terminal_id("term-1761800000000-abcd1234"));
+        assert!(is_valid_terminal_id("a"));
+        assert!(is_valid_terminal_id("0"));
+    }
+
+    #[test]
+    fn accepts_max_length() {
+        let s = "a".repeat(64);
+        assert!(is_valid_terminal_id(&s));
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(!is_valid_terminal_id(""));
+    }
+
+    #[test]
+    fn rejects_overlength() {
+        let s = "a".repeat(65);
+        assert!(!is_valid_terminal_id(&s));
+    }
+
+    #[test]
+    fn rejects_path_traversal() {
+        assert!(!is_valid_terminal_id("../etc/passwd"));
+        assert!(!is_valid_terminal_id("./id"));
+    }
+
+    #[test]
+    fn rejects_event_name_injection() {
+        // ":" を入れると `terminal:data:foo:bar` のように Tauri event 名前空間を細工される懸念
+        assert!(!is_valid_terminal_id("foo:bar"));
+        assert!(!is_valid_terminal_id("data:malicious"));
+    }
+
+    #[test]
+    fn rejects_whitespace_and_shell_metachars() {
+        assert!(!is_valid_terminal_id("abc def"));
+        assert!(!is_valid_terminal_id("abc;rm"));
+        assert!(!is_valid_terminal_id("abc|true"));
+        assert!(!is_valid_terminal_id("abc$VAR"));
+        assert!(!is_valid_terminal_id("abc`whoami`"));
+    }
+
+    #[test]
+    fn rejects_non_ascii() {
+        assert!(!is_valid_terminal_id("日本語"));
+        assert!(!is_valid_terminal_id("café"));
+    }
+}
+
+#[cfg(test)]
 mod codex_command_tests {
     use super::is_codex_command;
 
@@ -432,14 +495,28 @@ pub async fn terminal_create(
     }
 
     // Issue #285: renderer が指定した id があれば採用 (event 名 `terminal:data:{id}` に
-    // 安全な文字種だけ通す)。不正値・未指定・既存 PTY との衝突時は UUID v4 を生成する。
-    let id = opts
-        .id
-        .as_deref()
-        .filter(|s| is_valid_terminal_id(s))
-        .filter(|s| state.pty_registry.get(s).is_none())
-        .map(str::to_string)
-        .unwrap_or_else(|| Uuid::new_v4().to_string());
+    // 安全な文字種だけ通す)。`attach_if_exists` 経路は preflight で既に return 済みで、
+    // ここに到達するのは「新規 spawn 経路」だけなので、両者は構造的に直交している。
+    // 不正値・未指定は UUID v4 にフォールバック。既存 PTY との衝突は実質起こらない
+    // (UUID v4 の 122-bit エントロピー) が、安全側で衝突時も UUID にフォールバックする。
+    // ※ 衝突は registry の lock を握らない get→ 採用→ insert の TOCTOU を含むため、
+    //   完全な atomic 化はフォローアップ issue 扱い (実害シナリオは UUID 衝突ほぼ皆無)。
+    let id = match opts.id.as_deref() {
+        Some(s) if !is_valid_terminal_id(s) => {
+            tracing::warn!(
+                "[terminal] renderer-supplied id rejected (invalid charset/length), falling back to UUID v4"
+            );
+            Uuid::new_v4().to_string()
+        }
+        Some(s) if state.pty_registry.get(s).is_some() => {
+            tracing::warn!(
+                "[terminal] renderer-supplied id {s} collides with existing PTY, falling back to UUID v4"
+            );
+            Uuid::new_v4().to_string()
+        }
+        Some(s) => s.to_string(),
+        None => Uuid::new_v4().to_string(),
+    };
 
     // チーム所属端末なら TeamHub の socket/token と team/agent/role を env に注入
     let mut env = opts.env.unwrap_or_default();

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -19,6 +19,10 @@ use uuid::Uuid;
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TerminalCreateOptions {
+    /// Issue #285: renderer が pre-subscribe 用に渡すクライアント側生成 id。
+    /// `[A-Za-z0-9_-]{1,64}` 以外や未指定の場合は Rust 側で UUID を生成する。
+    #[serde(default)]
+    pub id: Option<String>,
     pub cwd: String,
     #[serde(default)]
     pub fallback_cwd: Option<String>,
@@ -65,6 +69,15 @@ pub struct SavePastedImageResult {
     pub ok: bool,
     pub path: Option<String>,
     pub error: Option<String>,
+}
+
+/// Issue #285: renderer から渡される terminal id を検証。
+/// `terminal:data:{id}` 等のイベント名に乗るので、衝突や偽装防止のため
+/// `[A-Za-z0-9_-]{1,64}` のみ許可する (UUID v4 は 36 chars で収まる)。
+fn is_valid_terminal_id(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 64
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
 /// 旧 resolveCommand 相当の最小実装。Phase 1 では「未指定なら 'claude'」だけ。
@@ -418,7 +431,15 @@ pub async fn terminal_create(
         tracing::warn!("[terminal] {w}");
     }
 
-    let id = Uuid::new_v4().to_string();
+    // Issue #285: renderer が指定した id があれば採用 (event 名 `terminal:data:{id}` に
+    // 安全な文字種だけ通す)。不正値・未指定・既存 PTY との衝突時は UUID v4 を生成する。
+    let id = opts
+        .id
+        .as_deref()
+        .filter(|s| is_valid_terminal_id(s))
+        .filter(|s| state.pty_registry.get(s).is_none())
+        .map(str::to_string)
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
 
     // チーム所属端末なら TeamHub の socket/token と team/agent/role を env に注入
     let mut env = opts.env.unwrap_or_default();

--- a/src-tauri/src/pty/batcher.rs
+++ b/src-tauri/src/pty/batcher.rs
@@ -13,11 +13,12 @@ const FLUSH_INTERVAL_MS: u64 = 16;
 const FLUSH_BYTES: usize = 32 * 1024;
 /// 起動直後の emit 抑止時間。
 ///
-/// renderer 側の `listen('terminal:data:{id}', ...)` は非同期登録で、
-/// `terminal_create` が返った直後〜数十 ms の間は未登録のため、
-/// その間に `emit` した分は Tauri によって drop される (= 画面が真っ白のまま残る)。
-/// そこで最初の flush は少し遅らせ、その間 PTY 出力は mpsc に蓄積する。
-const STARTUP_DELAY_MS: u64 = 250;
+/// 旧設計 (Issue #285 以前) は renderer が `terminal_create` の戻り値で id を受け取って
+/// から `listen()` を張る post-subscribe 方式で、cold start 時に 250ms でも取り逃がす
+/// ケースがあった。Issue #285 で renderer は client-generated id で pre-subscribe 後に
+/// create を呼ぶ方式に変更されたため、本 delay は補助的な安全網となった。
+/// pre-subscribe しない旧経路 (id を渡さない呼び出し) のフォールバック用に短い猶予を残す。
+const STARTUP_DELAY_MS: u64 = 50;
 
 /// Issue #53: bounded チャネル容量 (vec chunk 単位)。
 /// PTY reader は 8KB/chunk なので、256 枠 ≒ 2MB の backpressure buffer。
@@ -33,7 +34,7 @@ pub fn spawn_batcher(
     mut rx: mpsc::Receiver<Vec<u8>>,
 ) {
     tokio::spawn(async move {
-        // listener 登録完了までのグレースタイム。詳細は STARTUP_DELAY_MS コメント参照。
+        // 旧 post-subscribe 経路互換のための短い猶予 (詳細は STARTUP_DELAY_MS コメント)。
         tokio::time::sleep(Duration::from_millis(STARTUP_DELAY_MS)).await;
 
         let mut buf = BytesMut::with_capacity(FLUSH_BYTES * 2);

--- a/src/renderer/src/lib/__tests__/use-pty-session-hmr.test.ts
+++ b/src/renderer/src/lib/__tests__/use-pty-session-hmr.test.ts
@@ -50,3 +50,26 @@ describe('Issue #271: TerminalCreateOptions HMR fields', () => {
     expect(legacy.attachIfExists).toBeUndefined();
   });
 });
+
+describe('Issue #285: TerminalCreateOptions client-generated id', () => {
+  it('TerminalCreateOptions に id を載せられる (pre-subscribe 経路)', () => {
+    const opts: TerminalCreateOptions = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      cwd: '/tmp',
+      command: 'bash',
+      cols: 80,
+      rows: 24
+    };
+    expect(opts.id).toBe('550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('id 未指定でも従来通り通る (後方互換)', () => {
+    const opts: TerminalCreateOptions = {
+      cwd: '/tmp',
+      command: 'bash',
+      cols: 80,
+      rows: 24
+    };
+    expect(opts.id).toBeUndefined();
+  });
+});

--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -38,6 +38,26 @@ function subscribeEvent<T>(event: string, cb: (payload: T) => void): () => void 
     unlisten = null;
   };
 }
+
+/**
+ * Issue #285: `subscribeEvent` の async 版。`listen()` の解決を await することで
+ * 「listener が確実に登録された」状態を caller に保証する。`terminal_create` を
+ * 呼ぶ前に pre-subscribe して、PTY の初期出力 (CLI banner / prompt) が listener
+ * 未登録の数十 ms に drop されるレースを排除するために使う。
+ */
+async function subscribeEventReady<T>(
+  event: string,
+  cb: (payload: T) => void
+): Promise<() => void> {
+  let disposed = false;
+  const unlisten = await listen<T>(event, (e) => {
+    if (!disposed) cb(e.payload);
+  });
+  return () => {
+    disposed = true;
+    unlisten();
+  };
+}
 import {
   type AppSettings,
   type AppUserInfo,
@@ -259,7 +279,17 @@ export const api = {
       subscribeEvent<TerminalExitInfo>(`terminal:exit:${id}`, cb),
 
     onSessionId: (id: string, cb: (sessionId: string) => void): (() => void) =>
-      subscribeEvent<string>(`terminal:sessionId:${id}`, cb)
+      subscribeEvent<string>(`terminal:sessionId:${id}`, cb),
+
+    /** Issue #285: pre-subscribe 用。`terminal.create` 前に await して使う。 */
+    onDataReady: (id: string, cb: (data: string) => void): Promise<() => void> =>
+      subscribeEventReady<string>(`terminal:data:${id}`, cb),
+
+    onExitReady: (id: string, cb: (info: TerminalExitInfo) => void): Promise<() => void> =>
+      subscribeEventReady<TerminalExitInfo>(`terminal:exit:${id}`, cb),
+
+    onSessionIdReady: (id: string, cb: (sessionId: string) => void): Promise<() => void> =>
+      subscribeEventReady<string>(`terminal:sessionId:${id}`, cb)
   }
 };
 

--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -9,6 +9,22 @@
 
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import {
+  type AppSettings,
+  type AppUserInfo,
+  type ClaudeCheckResult,
+  type FileListResult,
+  type FileReadResult,
+  type FileWriteResult,
+  type GitDiffResult,
+  type GitStatus,
+  type RoleProfilesFile,
+  type SessionInfo,
+  type TeamHistoryEntry,
+  type TerminalCreateOptions,
+  type TerminalCreateResult,
+  type TerminalExitInfo
+} from '../../../types/shared';
 
 /**
  * `listen()` は Promise で unlisten を返すが、caller が cleanup を同期的に要求することが多い。
@@ -19,6 +35,10 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event';
  * unlisten を行う。したがって:
  *   - 早期 cleanup: resolve 時に即 u() を呼び、永続 listener を残さない
  *   - 通常 cleanup: unlisten を保持し、呼び出し時に u() を実行
+ *
+ * 注: 同期 API のため「listener が登録された瞬間」を caller は知れない。Rust 側 emit が
+ * 数十 ms 〜 数百 ms 早く走るとそのデータは drop される (Issue #285 の元症状)。確実な購読
+ * 完了を待ちたい場合は `subscribeEventReady` (async 版) を使うこと。
  */
 function subscribeEvent<T>(event: string, cb: (payload: T) => void): () => void {
   let unlisten: UnlistenFn | null = null;
@@ -44,6 +64,15 @@ function subscribeEvent<T>(event: string, cb: (payload: T) => void): () => void 
  * 「listener が確実に登録された」状態を caller に保証する。`terminal_create` を
  * 呼ぶ前に pre-subscribe して、PTY の初期出力 (CLI banner / prompt) が listener
  * 未登録の数十 ms に drop されるレースを排除するために使う。
+ *
+ * **Caller の責務**: await が pending の間に component が dispose される race を避けるため、
+ * await 解決直後に caller 側で disposed flag を再判定し、必要なら戻り値の cleanup を即呼ぶ。
+ * 本 helper の `disposed` sentinel は cleanup 関数を caller が受け取ってからしか立てられず、
+ * await pending 中の listen() 完了を取り消せないため、caller 側ガードが必須。
+ *
+ * 参考実装: `use-pty-session.ts` の pre-subscribe ブロック
+ *   `offData = await ...onDataReady(...);`
+ *   `if (localDisposed || disposedRef.current) { unsubscribePtyListeners(); return; }`
  */
 async function subscribeEventReady<T>(
   event: string,
@@ -58,22 +87,6 @@ async function subscribeEventReady<T>(
     unlisten();
   };
 }
-import {
-  type AppSettings,
-  type AppUserInfo,
-  type ClaudeCheckResult,
-  type FileListResult,
-  type FileReadResult,
-  type FileWriteResult,
-  type GitDiffResult,
-  type GitStatus,
-  type RoleProfilesFile,
-  type SessionInfo,
-  type TeamHistoryEntry,
-  type TerminalCreateOptions,
-  type TerminalCreateResult,
-  type TerminalExitInfo
-} from '../../../types/shared';
 
 /** Tauri 側 TeamHub に同期する role profile の要約形 */
 export interface RoleProfileSummary {

--- a/src/renderer/src/lib/use-pty-session.ts
+++ b/src/renderer/src/lib/use-pty-session.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import type { MutableRefObject, RefObject } from 'react';
 import type { Terminal } from '@xterm/xterm';
 import type { FitAddon } from '@xterm/addon-fit';
+import type { TerminalExitInfo } from '../../../types/shared';
 import { computeUnscaledGrid } from './compute-unscaled-grid';
 import type { CellSize } from './measure-cell-size';
 
@@ -216,6 +217,18 @@ export function usePtySession(options: UsePtySessionOptions): void {
     let offExit: (() => void) | null = null;
     let offSessionId: (() => void) | null = null;
 
+    // Issue #285: pre-subscribe / mismatch re-subscribe / cleanup / catch のどこから
+    // 呼んでも安全な listener 解除関数。`?.()` で null も二重解除も safe。try ブロック
+    // 内でも catch でも同じ参照を使えるよう effect スコープに置く。
+    const unsubscribePtyListeners = (): void => {
+      offData?.();
+      offExit?.();
+      offSessionId?.();
+      offData = null;
+      offExit = null;
+      offSessionId = null;
+    };
+
     // Issue #271: bind 世代番号。listener コールバックは「自分が登録された世代と同じ」
     // なら処理し、古い世代なら無視する。これにより HMR remount で 2 重登録された
     // 古い callback が xterm に二重出力するのを防ぐ。
@@ -335,10 +348,48 @@ export function usePtySession(options: UsePtySessionOptions): void {
           return c[skey]?.generation === myGeneration;
         };
 
+        // 新規 spawn (= attached false) 用の listener コールバック群。
+        // pre-subscribe / mismatch re-subscribe で同じ実装を使い回すために effect-local
+        // closure として 1 度だけ作る。`isCurrentGeneration` で世代外 (HMR 旧世代) を
+        // 弾き、observeChunk (auto-initial-message の ready 検出) は常に呼ぶ。
+        const newSpawnDataCb = (data: string): void => {
+          if (!isCurrentGeneration()) return;
+          term.write(data);
+          if (data.includes('\n') || data.includes('\r') || data.length >= 4096) {
+            scheduleRenderRepair();
+          }
+          callbacksRef.current.onActivity?.();
+          observeChunkRef.current(data);
+        };
+        const newSpawnExitCb = (info: TerminalExitInfo): void => {
+          if (!isCurrentGeneration()) return;
+          term.writeln(
+            `\r\n\x1b[33m[プロセス終了: exitCode=${info.exitCode}${info.signal ? `, signal=${info.signal}` : ''}]\x1b[0m`
+          );
+          callbacksRef.current.onStatus?.(`終了 (exitCode=${info.exitCode})`);
+          ptyIdRef.current = null;
+          if (skey) {
+            const c = getHmrPtyCache();
+            if (c) delete c[skey];
+          }
+          callbacksRef.current.onExit?.();
+        };
+        const newSpawnSessionIdCb = (sessionId: string): void => {
+          if (!isCurrentGeneration()) return;
+          try {
+            callbacksRef.current.onSessionId?.(sessionId);
+          } catch {
+            /* noop */
+          }
+        };
+
         // Issue #285: 新規 spawn の race fix — `terminal_create` を呼ぶ前に
         // `terminal:data:{id}` 等を listen() 完了まで待ってから create する。
-        // batcher.rs の固定 delay (250ms) は cold start で取り逃がし得るが、
-        // pre-subscribe なら確実。client-generated id は Rust 側で文字種検証済み。
+        // batcher.rs の startup delay は post-subscribe 旧経路用の保険なので
+        // pre-subscribe ならそれに頼らず確実に拾える。client-generated id は Rust
+        // 側で文字種検証 (`is_valid_terminal_id`) + 既存衝突チェックを通る。
+        // crypto.randomUUID は Tauri 2 の WebView (Edge WebView2 / WKWebView) では
+        // 必ず使えるが、安全側で文字列フォールバックを残す。
         const requestedId =
           wantAttach
             ? null
@@ -346,46 +397,19 @@ export function usePtySession(options: UsePtySessionOptions): void {
               ? crypto.randomUUID()
               : `term-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 
-        // pre-subscribe 経路 (新規 spawn): 必ず attached === false なので observeChunk
-        // も常に呼ぶ (auto-initial-message の ready 検出に必要)。
         if (requestedId) {
-          offData = await window.api.terminal.onDataReady(requestedId, (data) => {
-            if (!isCurrentGeneration()) return;
-            term.write(data);
-            if (data.includes('\n') || data.includes('\r') || data.length >= 4096) {
-              scheduleRenderRepair();
-            }
-            callbacksRef.current.onActivity?.();
-            observeChunkRef.current(data);
-          });
-          offExit = await window.api.terminal.onExitReady(requestedId, (info) => {
-            if (!isCurrentGeneration()) return;
-            term.writeln(
-              `\r\n\x1b[33m[プロセス終了: exitCode=${info.exitCode}${info.signal ? `, signal=${info.signal}` : ''}]\x1b[0m`
-            );
-            callbacksRef.current.onStatus?.(`終了 (exitCode=${info.exitCode})`);
-            ptyIdRef.current = null;
-            if (skey) {
-              const c = getHmrPtyCache();
-              if (c) delete c[skey];
-            }
-            callbacksRef.current.onExit?.();
-          });
-          offSessionId = await window.api.terminal.onSessionIdReady(requestedId, (sessionId) => {
-            if (!isCurrentGeneration()) return;
-            try {
-              callbacksRef.current.onSessionId?.(sessionId);
-            } catch {
-              /* noop */
-            }
-          });
+          offData = await window.api.terminal.onDataReady(requestedId, newSpawnDataCb);
+          offExit = await window.api.terminal.onExitReady(requestedId, newSpawnExitCb);
+          offSessionId = await window.api.terminal.onSessionIdReady(
+            requestedId,
+            newSpawnSessionIdCb
+          );
 
           // pre-subscribe 中に component が dispose された (effect cleanup or 新世代へ
           // 切替) なら、ここで pre-subscribe したリスナーを巻き戻して終了。
+          // PTY はまだ生まれていないので kill 不要。
           if (localDisposed || disposedRef.current) {
-            offData?.();
-            offExit?.();
-            offSessionId?.();
+            unsubscribePtyListeners();
             return;
           }
         }
@@ -413,10 +437,7 @@ export function usePtySession(options: UsePtySessionOptions): void {
           // - HMR cleanup (hmrDisposeArmed.current = true 中): kill せず cache に id を残し、
           //   次の remount で attach できるようにする
           // pre-subscribe したリスナーがあれば必ず解除。
-          offData?.();
-          offExit?.();
-          offSessionId?.();
-          offData = offExit = offSessionId = null;
+          unsubscribePtyListeners();
           if (res.ok && res.id) {
             if (hmrDisposeArmed.current && skey) {
               const c = getHmrPtyCache();
@@ -430,31 +451,39 @@ export function usePtySession(options: UsePtySessionOptions): void {
 
         if (!res.ok || !res.id) {
           // pre-subscribe 経路で create が失敗した場合は orphan listener を必ず解除。
-          offData?.();
-          offExit?.();
-          offSessionId?.();
-          offData = offExit = offSessionId = null;
+          unsubscribePtyListeners();
           term.writeln(`\x1b[31m[起動エラー] ${res.error ?? '不明なエラー'}\x1b[0m`);
           callbacksRef.current.onStatus?.(`起動失敗: ${res.error ?? ''}`);
           return;
         }
 
-        // 不変式: 新規 spawn 経路 (requestedId !== null) では Rust 側 が同 id を採用するか
-        // 衝突時に UUID 再生成にフォールバック。万一 mismatch なら pre-subscribe 経路の
-        // listener が拾えないので post-subscribe で再 bind する。
+        // Issue #285: 新規 spawn 経路 (requestedId !== null) では Rust 側が
+        // `is_valid_terminal_id` か registry 衝突で UUID 再生成にフォールバックする
+        // 稀ケースがある。万一 mismatch したら、pre-subscribe したリスナーは別 id
+        // (誰も emit しない死 channel) を購読してしまっているので、`res.id` で
+        // 再 pre-subscribe (`*Ready`) する。post-subscribe (sync) だと初期出力を
+        // 取り逃がしうる (Issue #285 の元症状) ので必ず *Ready で再 await。
         if (requestedId && res.id !== requestedId) {
-          offData?.();
-          offExit?.();
-          offSessionId?.();
-          offData = offExit = offSessionId = null;
+          unsubscribePtyListeners();
+          offData = await window.api.terminal.onDataReady(res.id, newSpawnDataCb);
+          offExit = await window.api.terminal.onExitReady(res.id, newSpawnExitCb);
+          offSessionId = await window.api.terminal.onSessionIdReady(
+            res.id,
+            newSpawnSessionIdCb
+          );
+          if (localDisposed || disposedRef.current) {
+            unsubscribePtyListeners();
+            void window.api.terminal.kill(res.id);
+            return;
+          }
         }
 
         ptyIdRef.current = res.id;
         // Issue #271: HMR remount で再 attach できるよう ptyId と世代番号を退避。
         if (skey) {
-          const cache2 = getHmrPtyCache();
-          if (cache2) {
-            cache2[skey] = { ptyId: res.id, generation: myGeneration };
+          const c = getHmrPtyCache();
+          if (c) {
+            c[skey] = { ptyId: res.id, generation: myGeneration };
           }
         }
         if (res.warning) {
@@ -475,8 +504,9 @@ export function usePtySession(options: UsePtySessionOptions): void {
         // ないため、安全側に倒して観察を止める。
         const attached = res.attached === true;
 
-        // attach 経路 (HMR remount) または pre-subscribe id mismatch 時は post-subscribe。
-        // 通常の新規 spawn は pre-subscribe 済みなので skip する。
+        // attach 経路 (HMR remount): pre-subscribe を skip しているのでここで sync
+        // post-subscribe する。PTY は既に動作中で startup race は起きないため
+        // post-subscribe で十分。新規 spawn 経路は上で pre-subscribe 済みなので skip。
         if (!offData) {
           offData = window.api.terminal.onData(res.id, (data) => {
             if (!isCurrentGeneration()) return;
@@ -499,8 +529,8 @@ export function usePtySession(options: UsePtySessionOptions): void {
             callbacksRef.current.onStatus?.(`終了 (exitCode=${info.exitCode})`);
             ptyIdRef.current = null;
             if (skey) {
-              const cache3 = getHmrPtyCache();
-              if (cache3) delete cache3[skey];
+              const c = getHmrPtyCache();
+              if (c) delete c[skey];
             }
             callbacksRef.current.onExit?.();
           });
@@ -518,7 +548,14 @@ export function usePtySession(options: UsePtySessionOptions): void {
           });
         }
       } catch (err) {
-        term.writeln(`\x1b[31m[例外] ${String(err)}\x1b[0m`);
+        // Issue #285 self-review: 例外発生から effect cleanup までの窓で pre-subscribe
+        // した listener が orphan になるのを防ぐため、catch でも明示的に解除する。
+        unsubscribePtyListeners();
+        try {
+          term.writeln(`\x1b[31m[例外] ${String(err)}\x1b[0m`);
+        } catch {
+          /* term が dispose 済み等で writeln 自体が落ちる可能性に備える */
+        }
         callbacksRef.current.onStatus?.(`例外: ${String(err)}`);
       }
     })();

--- a/src/renderer/src/lib/use-pty-session.ts
+++ b/src/renderer/src/lib/use-pty-session.ts
@@ -324,7 +324,74 @@ export function usePtySession(options: UsePtySessionOptions): void {
         const cache = getHmrPtyCache();
         const cachedPtyId = cache && skey ? cache[skey]?.ptyId : undefined;
         const wantAttach = Boolean(skey && cachedPtyId);
+
+        // Issue #271 と独立: HMR cache の世代比較。listener が登録された後に
+        // 別 mount で世代番号が更新された場合、古い callback は no-op に倒す。
+        // pre-subscribe 経路 / post-subscribe 経路の両方で参照する。
+        const isCurrentGeneration = (): boolean => {
+          if (!skey) return true;
+          const c = getHmrPtyCache();
+          if (!c) return true;
+          return c[skey]?.generation === myGeneration;
+        };
+
+        // Issue #285: 新規 spawn の race fix — `terminal_create` を呼ぶ前に
+        // `terminal:data:{id}` 等を listen() 完了まで待ってから create する。
+        // batcher.rs の固定 delay (250ms) は cold start で取り逃がし得るが、
+        // pre-subscribe なら確実。client-generated id は Rust 側で文字種検証済み。
+        const requestedId =
+          wantAttach
+            ? null
+            : typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+              ? crypto.randomUUID()
+              : `term-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+        // pre-subscribe 経路 (新規 spawn): 必ず attached === false なので observeChunk
+        // も常に呼ぶ (auto-initial-message の ready 検出に必要)。
+        if (requestedId) {
+          offData = await window.api.terminal.onDataReady(requestedId, (data) => {
+            if (!isCurrentGeneration()) return;
+            term.write(data);
+            if (data.includes('\n') || data.includes('\r') || data.length >= 4096) {
+              scheduleRenderRepair();
+            }
+            callbacksRef.current.onActivity?.();
+            observeChunkRef.current(data);
+          });
+          offExit = await window.api.terminal.onExitReady(requestedId, (info) => {
+            if (!isCurrentGeneration()) return;
+            term.writeln(
+              `\r\n\x1b[33m[プロセス終了: exitCode=${info.exitCode}${info.signal ? `, signal=${info.signal}` : ''}]\x1b[0m`
+            );
+            callbacksRef.current.onStatus?.(`終了 (exitCode=${info.exitCode})`);
+            ptyIdRef.current = null;
+            if (skey) {
+              const c = getHmrPtyCache();
+              if (c) delete c[skey];
+            }
+            callbacksRef.current.onExit?.();
+          });
+          offSessionId = await window.api.terminal.onSessionIdReady(requestedId, (sessionId) => {
+            if (!isCurrentGeneration()) return;
+            try {
+              callbacksRef.current.onSessionId?.(sessionId);
+            } catch {
+              /* noop */
+            }
+          });
+
+          // pre-subscribe 中に component が dispose された (effect cleanup or 新世代へ
+          // 切替) なら、ここで pre-subscribe したリスナーを巻き戻して終了。
+          if (localDisposed || disposedRef.current) {
+            offData?.();
+            offExit?.();
+            offSessionId?.();
+            return;
+          }
+        }
+
         const res = await window.api.terminal.create({
+          id: requestedId ?? undefined,
           cwd,
           fallbackCwd,
           command,
@@ -345,6 +412,11 @@ export function usePtySession(options: UsePtySessionOptions): void {
           // - 通常 cleanup (タブ close / restart): kill する
           // - HMR cleanup (hmrDisposeArmed.current = true 中): kill せず cache に id を残し、
           //   次の remount で attach できるようにする
+          // pre-subscribe したリスナーがあれば必ず解除。
+          offData?.();
+          offExit?.();
+          offSessionId?.();
+          offData = offExit = offSessionId = null;
           if (res.ok && res.id) {
             if (hmrDisposeArmed.current && skey) {
               const c = getHmrPtyCache();
@@ -357,17 +429,32 @@ export function usePtySession(options: UsePtySessionOptions): void {
         }
 
         if (!res.ok || !res.id) {
+          // pre-subscribe 経路で create が失敗した場合は orphan listener を必ず解除。
+          offData?.();
+          offExit?.();
+          offSessionId?.();
+          offData = offExit = offSessionId = null;
           term.writeln(`\x1b[31m[起動エラー] ${res.error ?? '不明なエラー'}\x1b[0m`);
           callbacksRef.current.onStatus?.(`起動失敗: ${res.error ?? ''}`);
           return;
         }
 
+        // 不変式: 新規 spawn 経路 (requestedId !== null) では Rust 側 が同 id を採用するか
+        // 衝突時に UUID 再生成にフォールバック。万一 mismatch なら pre-subscribe 経路の
+        // listener が拾えないので post-subscribe で再 bind する。
+        if (requestedId && res.id !== requestedId) {
+          offData?.();
+          offExit?.();
+          offSessionId?.();
+          offData = offExit = offSessionId = null;
+        }
+
         ptyIdRef.current = res.id;
         // Issue #271: HMR remount で再 attach できるよう ptyId と世代番号を退避。
         if (skey) {
-          const cache = getHmrPtyCache();
-          if (cache) {
-            cache[skey] = { ptyId: res.id, generation: myGeneration };
+          const cache2 = getHmrPtyCache();
+          if (cache2) {
+            cache2[skey] = { ptyId: res.id, generation: myGeneration };
           }
         }
         if (res.warning) {
@@ -379,25 +466,6 @@ export function usePtySession(options: UsePtySessionOptions): void {
             : `実行中: ${res.command ?? command}`
         );
 
-        const isCurrentGeneration = (): boolean => {
-          if (!skey) return true;
-          const cache = getHmrPtyCache();
-          if (!cache) return true;
-          // 自分が登録した世代と一致するか確認 (古い世代の listener なら無視)
-          return cache[skey]?.generation === myGeneration;
-        };
-
-        // セッション id は main プロセスが `~/.claude/projects/.../*.jsonl` の
-        // 差分から検出し、`terminal:sessionId:<id>` で通知してくる。
-        offSessionId = window.api.terminal.onSessionId(res.id, (sessionId) => {
-          if (!isCurrentGeneration()) return;
-          try {
-            callbacksRef.current.onSessionId?.(sessionId);
-          } catch {
-            /* noop */
-          }
-        });
-
         // Issue #271: attach 復帰時は `observeChunkRef` (auto-initial-message のチャンク
         // 観察) を起動しない。useAutoInitialMessage は spawnKey ごとに「ready 検出 →
         // initialMessage 送信」を 1 回だけ行うが、HMR remount で観察フックは新しく作り
@@ -406,32 +474,49 @@ export function usePtySession(options: UsePtySessionOptions): void {
         // ユーザーが入力済みかもしれないので initialMessage を再送する判断が UI 側に
         // ないため、安全側に倒して観察を止める。
         const attached = res.attached === true;
-        offData = window.api.terminal.onData(res.id, (data) => {
-          if (!isCurrentGeneration()) return;
-          term.write(data);
-          if (data.includes('\n') || data.includes('\r') || data.length >= 4096) {
-            scheduleRenderRepair();
-          }
-          callbacksRef.current.onActivity?.();
-          if (!attached) {
-            observeChunkRef.current(data);
-          }
-        });
 
-        offExit = window.api.terminal.onExit(res.id, (info) => {
-          if (!isCurrentGeneration()) return;
-          term.writeln(
-            `\r\n\x1b[33m[プロセス終了: exitCode=${info.exitCode}${info.signal ? `, signal=${info.signal}` : ''}]\x1b[0m`
-          );
-          callbacksRef.current.onStatus?.(`終了 (exitCode=${info.exitCode})`);
-          ptyIdRef.current = null;
-          // Issue #271: 終了した PTY は HMR cache からも消す (以後 attach 不可)。
-          if (skey) {
-            const cache = getHmrPtyCache();
-            if (cache) delete cache[skey];
-          }
-          callbacksRef.current.onExit?.();
-        });
+        // attach 経路 (HMR remount) または pre-subscribe id mismatch 時は post-subscribe。
+        // 通常の新規 spawn は pre-subscribe 済みなので skip する。
+        if (!offData) {
+          offData = window.api.terminal.onData(res.id, (data) => {
+            if (!isCurrentGeneration()) return;
+            term.write(data);
+            if (data.includes('\n') || data.includes('\r') || data.length >= 4096) {
+              scheduleRenderRepair();
+            }
+            callbacksRef.current.onActivity?.();
+            if (!attached) {
+              observeChunkRef.current(data);
+            }
+          });
+        }
+        if (!offExit) {
+          offExit = window.api.terminal.onExit(res.id, (info) => {
+            if (!isCurrentGeneration()) return;
+            term.writeln(
+              `\r\n\x1b[33m[プロセス終了: exitCode=${info.exitCode}${info.signal ? `, signal=${info.signal}` : ''}]\x1b[0m`
+            );
+            callbacksRef.current.onStatus?.(`終了 (exitCode=${info.exitCode})`);
+            ptyIdRef.current = null;
+            if (skey) {
+              const cache3 = getHmrPtyCache();
+              if (cache3) delete cache3[skey];
+            }
+            callbacksRef.current.onExit?.();
+          });
+        }
+        if (!offSessionId) {
+          // セッション id は main プロセスが `~/.claude/projects/.../*.jsonl` の
+          // 差分から検出し、`terminal:sessionId:<id>` で通知してくる。
+          offSessionId = window.api.terminal.onSessionId(res.id, (sessionId) => {
+            if (!isCurrentGeneration()) return;
+            try {
+              callbacksRef.current.onSessionId?.(sessionId);
+            } catch {
+              /* noop */
+            }
+          });
+        }
       } catch (err) {
         term.writeln(`\x1b[31m[例外] ${String(err)}\x1b[0m`);
         callbacksRef.current.onStatus?.(`例外: ${String(err)}`);

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -375,6 +375,12 @@ export interface FileWriteResult {
 // ---------- ターミナル ----------
 
 export interface TerminalCreateOptions {
+  /**
+   * Issue #285: renderer 側が `terminal:data:{id}` 等を pre-subscribe してから
+   * spawn できるよう、client が事前生成した terminal id を渡せる。`[A-Za-z0-9_-]{1,64}`
+   * のみ有効で、不正値や未指定の場合は Rust 側で UUID を再生成して採用する。
+   */
+  id?: string;
   cwd: string;
   /**
    * `cwd` が無効(存在しない or ディレクトリでない)だった場合に


### PR DESCRIPTION
## Summary
Issue #285 (#285 IDE モードの 1 つ目のターミナルが空白) を pre-subscribe + client-generated id 方式で解消する。

### 原因
renderer 側が `terminal_create` の戻り値で id を受け取った後に `listen('terminal:data:{id}', ...)` を張る post-subscribe 方式は、cold start 時に PTY が banner / prompt を吐くタイミングと listener 登録の race で初期出力を取り逃がし、画面が空白のまま残る。`batcher.rs` の固定 250ms delay は cold start で取り逃がし得る。

### 修正
1. **client-generated id**: renderer が `crypto.randomUUID()` で id を作って `terminal.create({ id, ... })` で渡す
2. **pre-subscribe**: `await window.api.terminal.onDataReady(requestedId, ...)` で listener 登録完了を保証してから create する
3. **Rust 側 id 検証**: `is_valid_terminal_id` (`[A-Za-z0-9_-]{1,64}`) + 既存 PTY との衝突チェックを通った id だけ採用、不正値・衝突時は UUID v4 にフォールバック
4. **batcher delay 短縮**: `STARTUP_DELAY_MS` 250 → 50ms (主対策が pre-subscribe に移ったため補助網扱い)
5. **HMR attach 経路**: 従来通り post-subscribe (PTY 既に動作中、startup race なし)

### 自己レビュー (Codex 不在のため Claude サブエージェント 3 視点で代替)
- 🟦 信頼性 / race: critical なし、warning 4 件
- 🟥 セキュリティ: critical なし、warning 4 件
- 🟨 設計 / 規約: critical 2 件、warning 6 件

→ 第 2 コミット (`refactor(pty): #285 self-review 指摘 9 件を反映`) で以下を反映:
- D1: 不正値 / 衝突時の `tracing::warn!` 追加 (デバッグ性)
- D2: `attach_if_exists` × `id` の構造的直交をコメント明示
- D6: `is_valid_terminal_id` の unit test 9 ケース
- R1: catch 節の listener orphan 窓を閉じる
- R3: id mismatch path を `*Ready` 再 await (取り逃がし防止)
- R2/S5: `subscribeEventReady` docstring に caller 責務明記
- D8/D11/D12: 命名・import 順・コメント drift 整理

### スコープ外 (別 issue 化予定)
- TOCTOU `get→insert` の atomic 化 (registry に `insert_if_absent`)
- PTY 数上限 / レート制限 (DoS 対策)
- `subscribeEvent` を `subscribeEventReady` ベースに統一する大規模リファクタ
- `usePtySession` の async block 切り出し
- pre-subscribe ユニットテストの追加
- vibeeditor SKILL.md に pre-subscribe パターンを追記

Closes #285

## Test plan
- [x] `npm run typecheck` 通過
- [ ] CI: `cargo test` で `terminal_id_validation_tests` 9 ケース通過
- [ ] CI: `cargo check` 通過
- [ ] 手動: IDE モード初回起動で 1 つ目のターミナルに Claude/Codex の banner / prompt が表示される
- [ ] 手動: 追加ターミナル作成 → 同様に初期出力が表示
- [ ] 手動: ターミナル restart → 再度初期出力が表示
- [ ] 手動: HMR remount 経路 (dev) で attach 表示 → regression なし
- [ ] 手動: Canvas 側 TerminalCard / AgentNodeCard で regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZbPD1tz6utgZx6PNgeHh3)_