### PR TITLE
refactor(filetree): #273 永続化を FileTreeStateProvider に集約

### DIFF
--- a/src/renderer/src/components/FileTreePanel.tsx
+++ b/src/renderer/src/components/FileTreePanel.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useState, useCallback } from 'react';
+import { memo, useEffect, useId, useMemo, useState, useCallback } from 'react';
 import {
   ChevronDown,
   ChevronRight,
@@ -15,6 +15,7 @@ import { fileIcon } from '../lib/file-icon-color';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 import { useToast } from '../lib/toast-context';
 import { api } from '../lib/tauri-api';
+import { dirKey, useFileTreeState, type DirState } from '../lib/filetree-state-context';
 
 interface FileTreePanelProps {
   /** メインのプロジェクトルート(ターミナル/Git 等はこちら基準で動作する) */
@@ -29,30 +30,9 @@ interface FileTreePanelProps {
   onOpenFile: (rootPath: string, relPath: string) => void;
   onAddWorkspaceFolder: () => void;
   onRemoveWorkspaceFolder: (path: string) => void;
-  /**
-   * Issue #250: 永続化された展開状態の初期値。
-   * lazy 初期化のためマウント時の値だけが使われる (再レンダーでは無視される)。
-   */
-  initialExpanded?: Set<string>;
-  /** Issue #250: 永続化された折り畳み済みルートの初期値 */
-  initialCollapsedRoots?: Set<string>;
-  /** Issue #250: 状態変化時の永続化コールバック (親で settings に保存) */
-  onPersistState?: (state: { expanded: Set<string>; collapsedRoots: Set<string> }) => void;
 }
 
-interface DirState {
-  loading: boolean;
-  error: string | null;
-  entries: FileNode[];
-}
-
-/**
- * (rootPath, relPath) を一意キーに変換。Map のキーにする。
- * 区切りには NUL 文字を使う (パス内に出現しないため衝突しない)。
- */
 const KEY_SEP = '\0';
-const dirKey = (rootPath: string, relPath: string): string =>
-  `${rootPath}${KEY_SEP}${relPath}`;
 
 const shortName = (abs: string): string => {
   const parts = abs.split(/[\\/]/).filter(Boolean);
@@ -65,28 +45,33 @@ export function FileTreePanel({
   activeFilePath,
   onOpenFile,
   onAddWorkspaceFolder,
-  onRemoveWorkspaceFolder,
-  initialExpanded,
-  initialCollapsedRoots,
-  onPersistState
+  onRemoveWorkspaceFolder
 }: FileTreePanelProps): JSX.Element {
   const t = useT();
-  /**
-   * 全ルート共通のディレクトリキャッシュ。
-   * key = `${rootPath}\0${relPath}` ('' がそのルートの直下)
-   */
-  const [dirs, setDirs] = useState<Map<string, DirState>>(new Map());
-  /** 展開済みディレクトリ集合(同じ key 形式) */
-  const [expanded, setExpanded] = useState<Set<string>>(() => initialExpanded ?? new Set());
-  /** 折り畳み状態のルート集合。primary は初期展開、extra はユーザー操作に委ねる */
-  const [collapsedRoots, setCollapsedRoots] = useState<Set<string>>(
-    () => initialCollapsedRoots ?? new Set()
-  );
+  // Issue #273: 展開状態 / 折り畳み / dir キャッシュは Provider に集約。
+  // 同じ Provider を見ている Sidebar / FileTreeCard は同じ参照を持つので、
+  // 一方でトグルした結果が他方に即時反映され、`update({ fileTreeExpanded })` の
+  // last-writer-wins 上書きも起きない。
+  const {
+    dirs,
+    expanded,
+    collapsedRoots,
+    toggleDir: ctxToggleDir,
+    toggleRoot,
+    loadDir,
+    refreshAll: ctxRefreshAll,
+    registerRoots,
+    unregisterRoots
+  } = useFileTreeState();
+
   /** Issue #251: ファイル右クリックで開く ContextMenu の表示状態 */
   const [contextMenu, setContextMenu] = useState<
     { x: number; y: number; items: ContextMenuItem[] } | null
   >(null);
   const showToast = useToast();
+  // Issue #273: 当該 instance を Provider に登録する一意 id。Sidebar と FileTreeCard が
+  // 同居しても useId で生成された値は重複しない (React 18 の機能)。
+  const instanceId = useId();
 
   /** 現在サイドバーに表示するルート一覧(primary + extras から重複除去)。
    *  Issue #129: 配列リテラルを毎レンダー作ると useEffect deps や子供 props が
@@ -100,59 +85,18 @@ export function FileTreePanel({
     [primaryRoot, extraRoots.join('')]
   );
 
-  const loadDir = useCallback(
-    async (rootPath: string, relPath: string): Promise<void> => {
-      if (!rootPath) return;
-      if (!window.api.files) {
-        setDirs((prev) => {
-          const next = new Map(prev);
-          next.set(dirKey(rootPath, relPath), {
-            loading: false,
-            error: 'アプリを再起動してください（preload 更新のため）',
-            entries: []
-          });
-          return next;
-        });
-        return;
-      }
-      const key = dirKey(rootPath, relPath);
-      setDirs((prev) => {
-        const next = new Map(prev);
-        next.set(key, {
-          loading: true,
-          error: null,
-          entries: prev.get(key)?.entries ?? []
-        });
-        return next;
-      });
-      try {
-        const res = await window.api.files.list(rootPath, relPath);
-        setDirs((prev) => {
-          const next = new Map(prev);
-          next.set(key, {
-            loading: false,
-            error: res.ok ? null : res.error ?? 'error',
-            entries: res.entries
-          });
-          return next;
-        });
-      } catch (err) {
-        setDirs((prev) => {
-          const next = new Map(prev);
-          next.set(key, {
-            loading: false,
-            error: String(err),
-            entries: []
-          });
-          return next;
-        });
-      }
-    },
-    []
-  );
+  // Issue #273 #3: 当該 instance の roots を Provider に登録。Provider 側で全 instance の
+  // 和集合に含まれない expanded entry を prune する。unmount 時に解除して、UI 非表示中の
+  // 過剰 prune を避ける。
+  useEffect(() => {
+    registerRoots(instanceId, roots);
+    return () => unregisterRoots(instanceId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [instanceId, primaryRoot, extraRoots.join(''), registerRoots, unregisterRoots]);
 
   // ルート構成が変わったら、まだロードしていないルートの直下を自動ロード。
-  // 既にキャッシュ済みのルートは触らず(折り畳みや展開状態を保持)。
+  // dirs キャッシュは Provider 共有なので、Sidebar と FileTreeCard を行き来しても
+  // 既にロード済みのルートは再ロードされない (Issue #273 #4 にも貢献)。
   useEffect(() => {
     for (const root of roots) {
       const key = dirKey(root, '');
@@ -160,29 +104,15 @@ export function FileTreePanel({
         void loadDir(root, '');
       }
     }
-    // 削除されたルートのキャッシュは掃除する
-    setDirs((prev) => {
-      const validPrefixes = new Set(roots.map((r) => `${r}\0`));
-      let changed = false;
-      const next = new Map(prev);
-      for (const key of next.keys()) {
-        const hit = Array.from(validPrefixes).some((p) => key.startsWith(p));
-        if (!hit) {
-          next.delete(key);
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
-    // roots は毎回新しい配列なので primaryRoot + extraRoots 依存にする
+    // dirs は Provider state なので毎回新参照だが、`dirs.has` の結果で
+    // load 必要性を判定するので exhaustive-deps の警告は黙殺する。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [primaryRoot, extraRoots.join('\u0001'), loadDir]);
+  }, [primaryRoot, extraRoots.join(''), loadDir]);
 
-  // Issue #250: 永続化された expanded から (initialExpanded として) 復元した
-  // ディレクトリを dirs キャッシュに非同期で読み込む。toggleDir 経由でない展開
-  // 状態 = 復元時のみ意味があり、通常の操作では toggleDir 内で loadDir が呼ばれる。
+  // Issue #250 + #273: 永続化された expanded を Provider 経由で受け取り、未ロードな
+  // ものだけ load を queue に積む (Provider 内の concurrency-limited queue で発火)。
   // expanded を deps に入れると毎トグル再走するので、roots と loadDir のみ依存にする
-  // (mount + ルート切替時に 1 回だけ走る)。
+  // (mount + ルート切替時のみ走る)。
   useEffect(() => {
     for (const key of expanded) {
       if (dirs.has(key)) continue;
@@ -190,60 +120,25 @@ export function FileTreePanel({
       if (sep <= 0) continue;
       const rootPath = key.slice(0, sep);
       const relPath = key.slice(sep + 1);
-      // 永続化値に他プロジェクトの root が混在することを防ぐため、現在の roots に
-      // 含まれているもののみ load する。relPath が '' のものはルート直下なので
-      // 上の useEffect が読み込むためここでは無視。
       if (relPath !== '' && roots.includes(rootPath)) {
         void loadDir(rootPath, relPath);
       }
     }
-    // expanded を意図的に deps から除外 (mount + roots 変動時のみ走る)
+    // expanded / dirs を意図的に deps から除外 (mount + roots 変動時のみ走る)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [primaryRoot, extraRoots.join(KEY_SEP), loadDir]);
 
   const toggleDir = useCallback(
     (rootPath: string, node: FileNode) => {
       if (!node.isDir) return;
-      const key = dirKey(rootPath, node.path);
-      const wasOpen = expanded.has(key);
-      setExpanded((prev) => {
-        const next = new Set(prev);
-        if (next.has(key)) next.delete(key);
-        else next.add(key);
-        onPersistState?.({ expanded: next, collapsedRoots });
-        return next;
-      });
-      if (!wasOpen && !dirs.has(key)) {
-        void loadDir(rootPath, node.path);
-      }
+      ctxToggleDir(rootPath, node.path);
     },
-    [expanded, collapsedRoots, dirs, loadDir, onPersistState]
+    [ctxToggleDir]
   );
 
   const refreshAll = useCallback(() => {
-    // 展開済みと各ルート直下を再ロード
-    for (const root of roots) {
-      void loadDir(root, '');
-    }
-    for (const key of expanded) {
-      const [rootPath, relPath] = key.split('\0');
-      if (rootPath) void loadDir(rootPath, relPath);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [expanded, loadDir, primaryRoot, extraRoots.join('\u0001')]);
-
-  const toggleRoot = useCallback(
-    (rootPath: string) => {
-      setCollapsedRoots((prev) => {
-        const next = new Set(prev);
-        if (next.has(rootPath)) next.delete(rootPath);
-        else next.add(rootPath);
-        onPersistState?.({ expanded, collapsedRoots: next });
-        return next;
-      });
-    },
-    [expanded, onPersistState]
-  );
+    ctxRefreshAll(roots);
+  }, [ctxRefreshAll, roots]);
 
   // Issue #251: ファイル/ディレクトリ右クリックでパスコピー / エクスプローラ表示の
   // ContextMenu を開く。renderer 側のみで完結 (絶対パスは rootPath + relPath を結合)。
@@ -329,7 +224,9 @@ export function FileTreePanel({
         {state.entries.map((node) => {
           const childKey = dirKey(rootPath, node.path);
           const isOpen = node.isDir && expanded.has(childKey);
-          const childState = node.isDir ? dirs.get(childKey) ?? null : null;
+          const childState: DirState | null = node.isDir
+            ? dirs.get(childKey) ?? null
+            : null;
           const isActive = !node.isDir && activeFilePath === node.path;
           return (
             <FileTreeNode

--- a/src/renderer/src/components/FileTreePanel.tsx
+++ b/src/renderer/src/components/FileTreePanel.tsx
@@ -15,7 +15,13 @@ import { fileIcon } from '../lib/file-icon-color';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 import { useToast } from '../lib/toast-context';
 import { api } from '../lib/tauri-api';
-import { dirKey, useFileTreeState, type DirState } from '../lib/filetree-state-context';
+import {
+  KEY_SEP,
+  dirKey,
+  splitKey,
+  useFileTreeState,
+  type DirState
+} from '../lib/filetree-state-context';
 
 interface FileTreePanelProps {
   /** メインのプロジェクトルート(ターミナル/Git 等はこちら基準で動作する) */
@@ -31,8 +37,6 @@ interface FileTreePanelProps {
   onAddWorkspaceFolder: () => void;
   onRemoveWorkspaceFolder: (path: string) => void;
 }
-
-const KEY_SEP = '\0';
 
 const shortName = (abs: string): string => {
   const parts = abs.split(/[\\/]/).filter(Boolean);
@@ -82,7 +86,7 @@ export function FileTreePanel({
         (p, i, arr) => p && arr.indexOf(p) === i
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [primaryRoot, extraRoots.join('')]
+    [primaryRoot, extraRoots.join(KEY_SEP)]
   );
 
   // Issue #273 #3: 当該 instance の roots を Provider に登録。Provider 側で全 instance の
@@ -92,7 +96,7 @@ export function FileTreePanel({
     registerRoots(instanceId, roots);
     return () => unregisterRoots(instanceId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [instanceId, primaryRoot, extraRoots.join(''), registerRoots, unregisterRoots]);
+  }, [instanceId, primaryRoot, extraRoots.join(KEY_SEP), registerRoots, unregisterRoots]);
 
   // ルート構成が変わったら、まだロードしていないルートの直下を自動ロード。
   // dirs キャッシュは Provider 共有なので、Sidebar と FileTreeCard を行き来しても
@@ -107,7 +111,7 @@ export function FileTreePanel({
     // dirs は Provider state なので毎回新参照だが、`dirs.has` の結果で
     // load 必要性を判定するので exhaustive-deps の警告は黙殺する。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [primaryRoot, extraRoots.join(''), loadDir]);
+  }, [primaryRoot, extraRoots.join(KEY_SEP), loadDir]);
 
   // Issue #250 + #273: 永続化された expanded を Provider 経由で受け取り、未ロードな
   // ものだけ load を queue に積む (Provider 内の concurrency-limited queue で発火)。
@@ -116,12 +120,10 @@ export function FileTreePanel({
   useEffect(() => {
     for (const key of expanded) {
       if (dirs.has(key)) continue;
-      const sep = key.indexOf(KEY_SEP);
-      if (sep <= 0) continue;
-      const rootPath = key.slice(0, sep);
-      const relPath = key.slice(sep + 1);
-      if (relPath !== '' && roots.includes(rootPath)) {
-        void loadDir(rootPath, relPath);
+      const split = splitKey(key);
+      if (!split) continue;
+      if (split.relPath !== '' && roots.includes(split.rootPath)) {
+        void loadDir(split.rootPath, split.relPath);
       }
     }
     // expanded / dirs を意図的に deps から除外 (mount + roots 変動時のみ走る)

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useMemo } from 'react';
 import type {
   GitFileChange,
   GitStatus,
@@ -10,10 +9,6 @@ import { SessionsPanel } from './SessionsPanel';
 import { FileTreePanel } from './FileTreePanel';
 import { NotesPanel } from './NotesPanel';
 import { UserMenu } from './UserMenu';
-import { useSettings } from '../lib/settings-context';
-
-/** Issue #250: FileTreePanel と同じ NUL 区切りキー (`<rootPath>\0<relPath>`) */
-const KEY_SEP = '\0';
 
 export type SidebarView = 'files' | 'changes' | 'sessions' | 'notes';
 
@@ -44,46 +39,12 @@ interface SidebarProps {
   onOpenSettings: () => void;
 }
 
+/**
+ * Issue #273: 展開状態 / 永続化は `FileTreeStateProvider` (main.tsx) に集約。
+ * Sidebar 自身は settings を読まず、FileTreePanel が Provider 経由で
+ * 直接 state を扱う。これで Canvas (FileTreeCard) との last-writer-wins が起きない。
+ */
 export function Sidebar(props: SidebarProps): JSX.Element {
-  const { settings, update } = useSettings();
-
-  // Issue #250: 永続化された展開状態を Set<NULキー> に展開して FileTreePanel に渡す。
-  // useMemo は settings の参照変動 (200ms debounce save 後の context 更新) で再計算される。
-  const initialExpanded = useMemo(() => {
-    const set = new Set<string>();
-    const map = settings.fileTreeExpanded ?? {};
-    for (const [root, rels] of Object.entries(map)) {
-      for (const rel of rels) {
-        set.add(`${root}${KEY_SEP}${rel}`);
-      }
-    }
-    return set;
-  }, [settings.fileTreeExpanded]);
-
-  const initialCollapsedRoots = useMemo(
-    () => new Set(settings.fileTreeCollapsedRoots ?? []),
-    [settings.fileTreeCollapsedRoots]
-  );
-
-  const handlePersistFileTreeState = useCallback(
-    ({ expanded, collapsedRoots }: { expanded: Set<string>; collapsedRoots: Set<string> }) => {
-      const map: Record<string, string[]> = {};
-      for (const key of expanded) {
-        const sep = key.indexOf(KEY_SEP);
-        if (sep <= 0) continue;
-        const root = key.slice(0, sep);
-        const rel = key.slice(sep + 1);
-        (map[root] ??= []).push(rel);
-      }
-      // settings-context 内で 200ms debounce → atomic_write されるので二重 debounce 不要。
-      void update({
-        fileTreeExpanded: map,
-        fileTreeCollapsedRoots: Array.from(collapsedRoots)
-      });
-    },
-    [update]
-  );
-
   return (
     <aside className="sidebar">
       <div className="sidebar__body" key={props.view}>
@@ -95,9 +56,6 @@ export function Sidebar(props: SidebarProps): JSX.Element {
             onOpenFile={props.onOpenFile}
             onAddWorkspaceFolder={props.onAddWorkspaceFolder}
             onRemoveWorkspaceFolder={props.onRemoveWorkspaceFolder}
-            initialExpanded={initialExpanded}
-            initialCollapsedRoots={initialCollapsedRoots}
-            onPersistState={handlePersistFileTreeState}
           />
         ) : props.view === 'changes' ? (
           <ChangesPanel

--- a/src/renderer/src/components/canvas/cards/FileTreeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/FileTreeCard.tsx
@@ -4,7 +4,7 @@
  *
  * payload: { projectRoot, extraRoots? }
  */
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import { CardFrame } from '../CardFrame';
 import { FileTreePanel } from '../../FileTreePanel';
@@ -16,9 +16,6 @@ interface FileTreePayload {
   projectRoot?: string;
   extraRoots?: string[];
 }
-
-/** Issue #250: FileTreePanel と同じ NUL 区切りキー (`<rootPath>\0<relPath>`) */
-const KEY_SEP = '\0';
 
 function FileTreeCardImpl({ id, data, positionAbsoluteX, positionAbsoluteY }: NodeProps): JSX.Element {
   const { settings, update } = useSettings();
@@ -65,42 +62,8 @@ function FileTreeCardImpl({ id, data, positionAbsoluteX, positionAbsoluteY }: No
     [settings.workspaceFolders, update]
   );
 
-  // Issue #250: IDE モード (Sidebar) と同じ map を共有することで Canvas 上の
-  // FileTreeCard でも展開状態が永続化され、再起動後も保たれる。
-  const initialExpanded = useMemo(() => {
-    const set = new Set<string>();
-    const map = settings.fileTreeExpanded ?? {};
-    for (const [root, rels] of Object.entries(map)) {
-      for (const rel of rels) {
-        set.add(`${root}${KEY_SEP}${rel}`);
-      }
-    }
-    return set;
-  }, [settings.fileTreeExpanded]);
-
-  const initialCollapsedRoots = useMemo(
-    () => new Set(settings.fileTreeCollapsedRoots ?? []),
-    [settings.fileTreeCollapsedRoots]
-  );
-
-  const handlePersistFileTreeState = useCallback(
-    ({ expanded, collapsedRoots }: { expanded: Set<string>; collapsedRoots: Set<string> }) => {
-      const map: Record<string, string[]> = {};
-      for (const key of expanded) {
-        const sep = key.indexOf(KEY_SEP);
-        if (sep <= 0) continue;
-        const root = key.slice(0, sep);
-        const rel = key.slice(sep + 1);
-        (map[root] ??= []).push(rel);
-      }
-      void update({
-        fileTreeExpanded: map,
-        fileTreeCollapsedRoots: Array.from(collapsedRoots)
-      });
-    },
-    [update]
-  );
-
+  // Issue #273: 展開状態 / 永続化は FileTreeStateProvider に集約済み。FileTreeCard 自身は
+  // 永続化ロジックを持たない (Sidebar との last-writer-wins 排除)。
   return (
     <>
       <Handle type="target" position={Position.Left} style={{ background: '#a7c8ff' }} />
@@ -113,9 +76,6 @@ function FileTreeCardImpl({ id, data, positionAbsoluteX, positionAbsoluteY }: No
             onOpenFile={handleOpen}
             onAddWorkspaceFolder={() => void handleAddWorkspaceFolder()}
             onRemoveWorkspaceFolder={(p) => void handleRemoveWorkspaceFolder(p)}
-            initialExpanded={initialExpanded}
-            initialCollapsedRoots={initialCollapsedRoots}
-            onPersistState={handlePersistFileTreeState}
           />
         </div>
       </CardFrame>

--- a/src/renderer/src/lib/__tests__/filetree-state-context.test.tsx
+++ b/src/renderer/src/lib/__tests__/filetree-state-context.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * Issue #273 + 自己レビュー: FileTreeStateProvider の動作テスト。
+ *
+ * カバレッジ:
+ * - hydration: settings load 完了まで persist が走らないこと (自己レビュー C1/C2 回帰)
+ * - concurrency queue: MAX_CONCURRENT_LOADS=4 を超えて同時実行しないこと (Issue #273 #4)
+ * - 重複 enqueue 抑止: 同 key を多重 loadDir しても files.list は 1 回 (W3 統一 Promise)
+ * - lazy prune: loadDir 失敗時に該当 expanded entry が prune されること (Issue #273 #3)
+ * - serialize / deserialize: settings 保存形式と Set の往復
+ *
+ * `@testing-library/react` は `useXtermScrollToBottomOnResize.test.tsx` で使われている
+ * のと同じパターン。jsdom 環境で renderHook を使う。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook, cleanup } from '@testing-library/react';
+import {
+  FileTreeStateProvider,
+  useFileTreeState,
+  dirKey,
+  splitKey,
+  KEY_SEP
+} from '../filetree-state-context';
+import { SettingsProvider } from '../settings-context';
+import type { ReactNode } from 'react';
+
+// ---- shared test fixtures ----------------------------------------------
+
+interface MockFilesApi {
+  list: ReturnType<typeof vi.fn>;
+}
+
+function installWindowApi(
+  filesApi: MockFilesApi,
+  settingsLoad: (() => Promise<unknown>) | null = null
+): void {
+  // SettingsProvider が要求する settings.load / save。settingsLoad が null なら
+  // load は永遠に pending にして「loading=true のまま」を再現する。
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).window = (globalThis as any).window ?? {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).api = {
+    files: filesApi,
+    settings: {
+      load: settingsLoad ?? (() => new Promise(() => undefined)),
+      save: vi.fn(() => Promise.resolve())
+    },
+    app: {}
+  };
+}
+
+function makeFilesApi(initialResolveImmediately = true): MockFilesApi {
+  return {
+    list: vi.fn(async () => ({
+      ok: true,
+      entries: initialResolveImmediately ? [] : []
+    }))
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <SettingsProvider>
+      <FileTreeStateProvider>{children}</FileTreeStateProvider>
+    </SettingsProvider>
+  );
+}
+
+beforeEach(() => {
+  // 各テストで window.api をリセット
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+// ---- helpers -----------------------------------------------------------
+
+describe('dirKey / splitKey', () => {
+  it('dirKey は NUL 区切りで結合する', () => {
+    expect(dirKey('/p1', 'src')).toBe(`/p1${KEY_SEP}src`);
+    expect(dirKey('/p1', '')).toBe(`/p1${KEY_SEP}`);
+  });
+
+  it('splitKey は dirKey の逆操作 (有効な key)', () => {
+    const key = dirKey('/p1', 'src/lib');
+    expect(splitKey(key)).toEqual({ rootPath: '/p1', relPath: 'src/lib' });
+  });
+
+  it('splitKey は不正な key で null を返す', () => {
+    expect(splitKey('no-separator')).toBeNull();
+    expect(splitKey(`${KEY_SEP}rel`)).toBeNull(); // root が空
+    expect(splitKey('')).toBeNull();
+  });
+});
+
+// ---- hydration --------------------------------------------------------
+
+describe('FileTreeStateProvider — hydration', () => {
+  it('settings load 完了前 (loading=true) は persist が走らない (自己レビュー C1 回帰)', async () => {
+    const filesApi = makeFilesApi();
+    const saveMock = vi.fn(() => Promise.resolve());
+    // settings.load を pending にして loading=true を維持
+    let resolveLoad: (v: unknown) => void = () => undefined;
+    const loadPromise = new Promise((resolve) => {
+      resolveLoad = resolve;
+    });
+    installWindowApi(filesApi, () => loadPromise);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).api.settings.save = saveMock;
+
+    const { result } = renderHook(() => useFileTreeState(), { wrapper });
+
+    // hydrate 前は expanded が空 + persist なし
+    expect(result.current.expanded.size).toBe(0);
+    expect(saveMock).not.toHaveBeenCalled();
+
+    // settings load を完了 (空の settings.json 相当)
+    await act(async () => {
+      resolveLoad({ schemaVersion: 6 });
+      await loadPromise;
+    });
+
+    // hydrate 後も expanded が空のままなら save は走るがディスク書き戻しは
+    // settings-context の 200ms debounce 経由なので即時には呼ばれない。
+    // ここでは「persist effect が hydrate 前に発火していないこと」だけ検証。
+    expect(saveMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ fileTreeExpanded: expect.anything() })
+    );
+  });
+});
+
+// ---- concurrency queue ------------------------------------------------
+
+describe('FileTreeStateProvider — concurrency queue', () => {
+  it('MAX_CONCURRENT_LOADS=4 を超えて同時実行しない', async () => {
+    // 全リクエストを手動で resolve できるようにする
+    const resolvers: Array<(v: { ok: boolean; entries: unknown[] }) => void> = [];
+    const filesApi: MockFilesApi = {
+      list: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolvers.push(resolve);
+          })
+      )
+    };
+    installWindowApi(filesApi, () => Promise.resolve({ schemaVersion: 6 }));
+
+    const { result } = renderHook(() => useFileTreeState(), { wrapper });
+
+    // 10 個の loadDir を発火
+    await act(async () => {
+      for (let i = 0; i < 10; i++) {
+        void result.current.loadDir('/root', `dir-${i}`);
+      }
+    });
+
+    // 同時実行は 4 まで (MAX_CONCURRENT_LOADS)
+    expect(filesApi.list).toHaveBeenCalledTimes(4);
+
+    // 1 つ resolve すると次の 1 つが queue から取り出される
+    await act(async () => {
+      resolvers[0]({ ok: true, entries: [] });
+      // microtask 進行
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(filesApi.list).toHaveBeenCalledTimes(5);
+
+    // 残り全部 resolve
+    await act(async () => {
+      for (let i = 1; i < resolvers.length; i++) {
+        resolvers[i]({ ok: true, entries: [] });
+      }
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
+  it('同 key への重複 loadDir 呼び出しは files.list を 1 回しか叩かない (自己レビュー W3)', async () => {
+    let resolved = false;
+    const filesApi: MockFilesApi = {
+      list: vi.fn(async () => {
+        if (resolved) return { ok: true, entries: [] };
+        resolved = true;
+        return { ok: true, entries: [] };
+      })
+    };
+    installWindowApi(filesApi, () => Promise.resolve({ schemaVersion: 6 }));
+
+    const { result } = renderHook(() => useFileTreeState(), { wrapper });
+
+    await act(async () => {
+      const p1 = result.current.loadDir('/root', 'src');
+      const p2 = result.current.loadDir('/root', 'src');
+      const p3 = result.current.loadDir('/root', 'src');
+      // 同じ Promise が返ること (semantics 統一)
+      expect(p1).toBe(p2);
+      expect(p2).toBe(p3);
+      await p1;
+    });
+
+    expect(filesApi.list).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---- lazy prune --------------------------------------------------------
+
+describe('FileTreeStateProvider — lazy prune on load failure', () => {
+  it('loadDir が ok=false を返したら expanded から該当 key を除去する (Issue #273 #3)', async () => {
+    const filesApi: MockFilesApi = {
+      list: vi.fn(async () => ({
+        ok: false,
+        error: 'ENOENT',
+        entries: []
+      }))
+    };
+    installWindowApi(filesApi, () => Promise.resolve({ schemaVersion: 6 }));
+
+    const { result } = renderHook(() => useFileTreeState(), { wrapper });
+
+    // toggleDir で展開状態を作って load を発火
+    await act(async () => {
+      result.current.toggleDir('/root', 'orphan-dir');
+      // queue が回るのを待つ
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(filesApi.list).toHaveBeenCalledWith('/root', 'orphan-dir');
+
+    // load 失敗後、expanded から prune されている
+    await act(async () => {
+      // microtask 経由で setState が反映される
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const orphanKey = dirKey('/root', 'orphan-dir');
+    expect(result.current.expanded.has(orphanKey)).toBe(false);
+  });
+});

--- a/src/renderer/src/lib/filetree-state-context.tsx
+++ b/src/renderer/src/lib/filetree-state-context.tsx
@@ -8,10 +8,20 @@
  *   2. setState updater 内で `onPersistState` を呼んでいた副作用混在 → effect で expanded/
  *      collapsedRoots の変化に追従して persist する。React Strict Mode / concurrent rendering
  *      で updater が複数回実行されても副作用が二重発火しない。
- *   3. 存在しない root / orphan dir の prune 未実装 → mount 時に現在の roots に含まれない
- *      entry を expanded から除去。`loadDir` 失敗時にもそのキーを expanded から除去 (lazy)。
+ *   3. 存在しない root / orphan dir の prune 未実装 → settings.workspaceFolders と
+ *      lastOpenedRoot を canonical な root truth として参照、これに含まれない expanded
+ *      entry を prune。`loadDir` 失敗時にもそのキーを expanded から prune (lazy)。
  *   4. 復元時の I/O storm → `loadDir` を最大 4 並列の queue で発火し、CLI の files.list が
- *      同時多発するのを防ぐ。
+ *      同時多発するのを防ぐ。pending Promise Map で重複呼び出しを統一 Promise 化。
+ *
+ * 自己レビュー (Codex 不在の代替) で発覚した critical 問題への対応:
+ *   - 初期 mount 直後の persist が settings 未ロードの空値で過去保存値を上書きする問題
+ *     → useSettingsLoading + hydratedRef で hydrate 完了まで persist 抑止。
+ *   - useSettings 全購読で他 settings の変化が Provider re-render を誘発する問題
+ *     → useSettingsValue / useSettingsActions の細粒度 selector に置換。
+ *   - toggleDir の closure stale な wasOpen 判定 → setExpanded updater 内で nowOpened 捕捉。
+ *   - Canvas FileTreeCard が limited extraRoots を持つと sidebar の expanded が prune される
+ *     問題 → registerRoots ではなく settings の workspace truth で prune する。
  */
 import {
   createContext,
@@ -24,13 +34,28 @@ import {
   type ReactNode
 } from 'react';
 import type { FileNode } from '../../../types/shared';
-import { useSettings } from './settings-context';
+import {
+  useSettingsActions,
+  useSettingsLoading,
+  useSettingsValue
+} from './settings-context';
 
-const KEY_SEP = '\0';
+const KEY_SEP_CHAR = '\0';
 
-/** (rootPath, relPath) を一意キーに変換する。Map のキーにする。 */
+/** `(rootPath, relPath)` を区切る NUL 文字。パス内に出現しないので衝突しない。
+ *  外部 (FileTreePanel 等) でもこの定数を使い、定義の重複を避ける。 */
+export const KEY_SEP = KEY_SEP_CHAR;
+
+/** (rootPath, relPath) を一意キーに変換する。 */
 export const dirKey = (rootPath: string, relPath: string): string =>
   `${rootPath}${KEY_SEP}${relPath}`;
+
+/** dirKey を分解する。不正な key (sep 無し / 空 root) は null。 */
+export function splitKey(key: string): { rootPath: string; relPath: string } | null {
+  const sep = key.indexOf(KEY_SEP);
+  if (sep <= 0) return null;
+  return { rootPath: key.slice(0, sep), relPath: key.slice(sep + 1) };
+}
 
 export interface DirState {
   loading: boolean;
@@ -54,9 +79,11 @@ export interface FileTreeStateValue {
   /** 与えられた roots について、直下と展開済み配下を再ロードする */
   refreshAll: (roots: string[]) => void;
   /**
-   * 現在 mount されている FileTreePanel の roots を Provider に伝えて、
-   * 不要 entry を prune する trigger にする。Sidebar と FileTreeCard の双方が
-   * 自分の roots を渡し、Provider は和集合に対して prune する。
+   * 現在 mount されている FileTreePanel の roots を Provider に伝える。
+   * 補助情報 (Sidebar / Canvas のどこで FileTreePanel が描画されているか) として記録するが、
+   * prune の真理値は `settings.workspaceFolders + lastOpenedRoot` であり、ここの登録だけで
+   * は expanded を prune しない (Canvas の payload で limited extraRoots が来ると sidebar
+   * の保存値を消してしまうため)。
    */
   registerRoots: (instanceId: string, roots: string[]) => void;
   /** unmount 時に呼ぶ。当該 instance の roots を解除する */
@@ -65,7 +92,9 @@ export interface FileTreeStateValue {
 
 const FileTreeStateContext = createContext<FileTreeStateValue | null>(null);
 
-/** files.list を同時に何本までに絞るか (Issue #273 #4: I/O storm 対策)。 */
+/** files.list を同時に何本までに絞るか (Issue #273 #4: I/O storm 対策)。
+ *  4 は SSD / 一般的な user machine で「逐次キューよりは並列度を取りつつ、
+ *  HDD のシーク負荷で詰まらない」中庸値。設定化は別 issue 候補。 */
 const MAX_CONCURRENT_LOADS = 4;
 
 interface QueuedLoad {
@@ -73,57 +102,154 @@ interface QueuedLoad {
   run: () => Promise<void>;
 }
 
-export function FileTreeStateProvider({ children }: { children: ReactNode }): JSX.Element {
-  const { settings, update } = useSettings();
-
-  // 初期値は settings からの復元。lazy 初期化で mount 時の値だけ採用 (以後は内部 state 単独管理)。
-  const [expanded, setExpanded] = useState<Set<string>>(() => {
-    const set = new Set<string>();
-    const map = settings.fileTreeExpanded ?? {};
-    for (const [root, rels] of Object.entries(map)) {
-      if (typeof root !== 'string' || !root) continue;
-      if (!Array.isArray(rels)) continue;
-      for (const rel of rels) {
-        if (typeof rel !== 'string') continue;
-        set.add(dirKey(root, rel));
-      }
+/** settings.fileTreeExpanded (Record<root, rels[]>) を NUL 区切り Set に展開する。 */
+function deserializeExpanded(map: Record<string, string[]> | undefined): Set<string> {
+  const set = new Set<string>();
+  if (!map) return set;
+  for (const [root, rels] of Object.entries(map)) {
+    if (typeof root !== 'string' || !root) continue;
+    if (!Array.isArray(rels)) continue;
+    for (const rel of rels) {
+      if (typeof rel !== 'string') continue;
+      set.add(dirKey(root, rel));
     }
-    return set;
-  });
-  const [collapsedRoots, setCollapsedRoots] = useState<Set<string>>(
-    () => new Set(settings.fileTreeCollapsedRoots ?? [])
-  );
+  }
+  return set;
+}
+
+/** Set<key> を settings 保存形式 (Record<root, rels[]>) にシリアライズする。 */
+function serializeExpanded(set: Set<string>): Record<string, string[]> {
+  const map: Record<string, string[]> = {};
+  for (const key of set) {
+    const split = splitKey(key);
+    if (!split) continue;
+    (map[split.rootPath] ??= []).push(split.relPath);
+  }
+  return map;
+}
+
+export function FileTreeStateProvider({ children }: { children: ReactNode }): JSX.Element {
+  // settings の他フィールド (テーマ / フォント等) の変化で Provider が re-render しない
+  // ように、必要なフィールドだけ細粒度 selector で購読する。
+  const settingsLoading = useSettingsLoading();
+  const persistedExpanded = useSettingsValue('fileTreeExpanded');
+  const persistedCollapsedRoots = useSettingsValue('fileTreeCollapsedRoots');
+  const lastOpenedRoot = useSettingsValue('lastOpenedRoot');
+  const claudeCwd = useSettingsValue('claudeCwd');
+  const workspaceFolders = useSettingsValue('workspaceFolders');
+  const { update } = useSettingsActions();
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [collapsedRoots, setCollapsedRoots] = useState<Set<string>>(new Set());
   const [dirs, setDirs] = useState<Map<string, DirState>>(new Map());
 
-  // mount 中の FileTreePanel ごとの roots を集約して prune に使う。
+  // Issue #273 自己レビュー C1/C2: SettingsProvider は `useState(DEFAULT_SETTINGS)` で
+  // 起動し、`window.api.settings.load()` を await して非同期で hydrate する。よって
+  // FileTreeStateProvider の useState lazy 初期化は「settings 未ロードの空値」を採用
+  // してしまう。それで persist effect が即発火するとディスク上の保存値を空で上書き
+  // するので、`loading=false` になってから一度だけ state を hydrate する + hydrate 前は
+  // persist を完全に skip する。
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (settingsLoading || hydratedRef.current) return;
+    hydratedRef.current = true;
+    setExpanded(deserializeExpanded(persistedExpanded));
+    setCollapsedRoots(new Set(persistedCollapsedRoots ?? []));
+  }, [settingsLoading, persistedExpanded, persistedCollapsedRoots]);
+
+  // mount 中の FileTreePanel ごとの roots を集約 (補助情報。prune 判定には使わない)。
   const [activeRootsByInstance, setActiveRootsByInstance] = useState<Map<string, string[]>>(
     new Map()
   );
 
   // updater 内副作用の代わりに effect で persist する (Issue #273 #2)。
   // settings-context 内で 200ms debounce + atomic_write が走るので、ここでは debounce 不要。
-  // 初期復元で expanded が変わっても update が呼ばれるが、settings との等価性比較は context 側。
+  // hydrate 完了前は skip して空値による上書きを防ぐ (自己レビュー C1)。
   useEffect(() => {
-    const map: Record<string, string[]> = {};
-    for (const key of expanded) {
-      const sep = key.indexOf(KEY_SEP);
-      if (sep <= 0) continue;
-      const root = key.slice(0, sep);
-      const rel = key.slice(sep + 1);
-      (map[root] ??= []).push(rel);
-    }
+    if (!hydratedRef.current) return;
     void update({
-      fileTreeExpanded: map,
+      fileTreeExpanded: serializeExpanded(expanded),
       fileTreeCollapsedRoots: Array.from(collapsedRoots)
     });
   }, [expanded, collapsedRoots, update]);
 
-  // I/O キュー: 並列度を MAX_CONCURRENT_LOADS に制限する。
-  // queue は ref で持つ (state にすると各 enqueue が re-render を誘発する)。
-  // pendingKeys で重複 enqueue を防ぐ (同 key を 2 回 loadDir しても無駄)。
+  // Issue #273 #3: prune の真理値は `settings.workspaceFolders + lastOpenedRoot/claudeCwd`。
+  // 自己レビュー W1: registerRoots 経由で取った instance roots は Canvas で限定 payload
+  // (例: payload.extraRoots) を持たれた場合に sidebar の保存値まで prune してしまうので、
+  // prune の決定打にはしない。settings 由来の workspace truth に含まれないものだけ prune。
+  const canonicalRoots = useMemo(() => {
+    const set = new Set<string>();
+    if (lastOpenedRoot) set.add(lastOpenedRoot);
+    if (claudeCwd) set.add(claudeCwd);
+    if (Array.isArray(workspaceFolders)) {
+      for (const r of workspaceFolders) {
+        if (typeof r === 'string' && r) set.add(r);
+      }
+    }
+    return set;
+  }, [lastOpenedRoot, claudeCwd, workspaceFolders]);
+
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    if (canonicalRoots.size === 0) return;
+
+    setExpanded((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const key of prev) {
+        const split = splitKey(key);
+        if (!split) {
+          next.delete(key);
+          changed = true;
+          continue;
+        }
+        if (!canonicalRoots.has(split.rootPath)) {
+          next.delete(key);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+
+    setCollapsedRoots((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const root of prev) {
+        if (!canonicalRoots.has(root)) {
+          next.delete(root);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+
+    // dirs キャッシュも canonical に含まれない root のものは purge (memory leak 防止)。
+    setDirs((prev) => {
+      let changed = false;
+      const next = new Map(prev);
+      for (const key of prev.keys()) {
+        const split = splitKey(key);
+        if (!split) {
+          next.delete(key);
+          changed = true;
+          continue;
+        }
+        if (!canonicalRoots.has(split.rootPath)) {
+          next.delete(key);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [canonicalRoots]);
+
+  // I/O キュー: 並列度を MAX_CONCURRENT_LOADS に制限する (Issue #273 #4)。
+  // queue は ref で持つ (state にすると enqueue ごとに re-render が起きる)。
+  // 自己レビュー W3: pending 中の Promise を Map に保持し、同 key の重複 loadDir 呼び出し
+  // でも同じ Promise を返す (semantics 統一)。
   const queueRef = useRef<QueuedLoad[]>([]);
   const activeRef = useRef(0);
-  const pendingKeysRef = useRef<Set<string>>(new Set());
+  const pendingPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
 
   const drainQueue = useCallback(() => {
     while (activeRef.current < MAX_CONCURRENT_LOADS && queueRef.current.length > 0) {
@@ -133,16 +259,31 @@ export function FileTreeStateProvider({ children }: { children: ReactNode }): JS
       void item
         .run()
         .finally(() => {
-          pendingKeysRef.current.delete(item.key);
+          pendingPromisesRef.current.delete(item.key);
           activeRef.current -= 1;
           drainQueue();
         });
     }
   }, []);
 
+  /**
+   * loadDir 失敗時に該当 key を expanded から除去する。
+   * orphan dir (削除された / 移動した) を起動時の I/O storm として再試行し続けないための
+   * lazy prune 戦略 (Issue #273 #3 の lazy 部分)。dirs キャッシュ側にエラー DirState は
+   * 残しておくので、UI には「— (空)」相当の error 表示が出る。
+   */
+  const pruneOnLoadFailure = useCallback((key: string) => {
+    setExpanded((prev) => {
+      if (!prev.has(key)) return prev;
+      const next = new Set(prev);
+      next.delete(key);
+      return next;
+    });
+  }, []);
+
   const loadDir = useCallback(
-    async (rootPath: string, relPath: string): Promise<void> => {
-      if (!rootPath) return;
+    (rootPath: string, relPath: string): Promise<void> => {
+      if (!rootPath) return Promise.resolve();
       if (!window.api.files) {
         setDirs((prev) => {
           const next = new Map(prev);
@@ -153,14 +294,13 @@ export function FileTreeStateProvider({ children }: { children: ReactNode }): JS
           });
           return next;
         });
-        return;
+        return Promise.resolve();
       }
       const key = dirKey(rootPath, relPath);
-      // 既に同 key が queue に入っているか実行中なら enqueue しない (重複 IPC 抑制)。
-      if (pendingKeysRef.current.has(key)) return;
-      pendingKeysRef.current.add(key);
+      const existing = pendingPromisesRef.current.get(key);
+      if (existing) return existing;
 
-      return new Promise<void>((resolve) => {
+      const promise = new Promise<void>((resolve) => {
         queueRef.current.push({
           key,
           run: async () => {
@@ -184,15 +324,7 @@ export function FileTreeStateProvider({ children }: { children: ReactNode }): JS
                 });
                 return next;
               });
-              // Issue #273 #3 (lazy prune): list 失敗 = orphan dir 候補。expanded から除去。
-              if (!res.ok) {
-                setExpanded((prev) => {
-                  if (!prev.has(key)) return prev;
-                  const next = new Set(prev);
-                  next.delete(key);
-                  return next;
-                });
-              }
+              if (!res.ok) pruneOnLoadFailure(key);
             } catch (err) {
               setDirs((prev) => {
                 const next = new Map(prev);
@@ -203,13 +335,7 @@ export function FileTreeStateProvider({ children }: { children: ReactNode }): JS
                 });
                 return next;
               });
-              // catch 経路でも prune する (rootPath が無効な絶対パス等)。
-              setExpanded((prev) => {
-                if (!prev.has(key)) return prev;
-                const next = new Set(prev);
-                next.delete(key);
-                return next;
-              });
+              pruneOnLoadFailure(key);
             } finally {
               resolve();
             }
@@ -217,33 +343,37 @@ export function FileTreeStateProvider({ children }: { children: ReactNode }): JS
         });
         drainQueue();
       });
+      pendingPromisesRef.current.set(key, promise);
+      return promise;
     },
-    [drainQueue]
+    [drainQueue, pruneOnLoadFailure]
   );
+
+  // 自己レビュー N1 / W1 / A3: setState updater 内で wasOpen を判定して loadDir 必要性を
+  // 確定する (closure stale を排除)。dirs.has は呼び出し時 closure でも実害なし
+  // (load の重複は pendingPromisesRef で抑止される)。
+  const dirsRef = useRef(dirs);
+  dirsRef.current = dirs;
 
   const toggleDir = useCallback(
     (rootPath: string, relPath: string) => {
       const key = dirKey(rootPath, relPath);
-      // setState updater 内では副作用を呼ばず、純粋に state を更新する (Issue #273 #2)。
-      // 永続化は上の useEffect が expanded の変化を観測して 1 度だけ走る。
+      let nowOpened = false;
       setExpanded((prev) => {
         const next = new Set(prev);
-        const wasOpen = next.has(key);
-        if (wasOpen) next.delete(key);
-        else next.add(key);
+        if (next.has(key)) {
+          next.delete(key);
+        } else {
+          next.add(key);
+          nowOpened = true;
+        }
         return next;
       });
-      // expanded が新規追加された (= wasOpen が false → 新たに展開) ときだけ loadDir。
-      // setState の prev を読まないと wasOpen を判定できないので、ここでは expanded から
-      // 直接読む (closure の expanded は前回 render の値だが、判定は「未キャッシュなら load」
-      // に倒すので問題ない)。
-      const isAlreadyCached = dirs.has(key);
-      const wasOpen = expanded.has(key);
-      if (!wasOpen && !isAlreadyCached) {
+      if (nowOpened && !dirsRef.current.has(key)) {
         void loadDir(rootPath, relPath);
       }
     },
-    [expanded, dirs, loadDir]
+    [loadDir]
   );
 
   const toggleRoot = useCallback((rootPath: string) => {
@@ -255,28 +385,30 @@ export function FileTreeStateProvider({ children }: { children: ReactNode }): JS
     });
   }, []);
 
+  // 自己レビュー: refreshAll 内で expanded を closure 経由で見ると stale なので、
+  // ref 経由で最新値を読む。
+  const expandedRef = useRef(expanded);
+  expandedRef.current = expanded;
+
   const refreshAll = useCallback(
     (roots: string[]) => {
       for (const root of roots) {
         void loadDir(root, '');
       }
-      for (const key of expanded) {
-        const sep = key.indexOf(KEY_SEP);
-        if (sep <= 0) continue;
-        const rootPath = key.slice(0, sep);
-        const relPath = key.slice(sep + 1);
-        if (rootPath && roots.includes(rootPath)) {
-          void loadDir(rootPath, relPath);
+      for (const key of expandedRef.current) {
+        const split = splitKey(key);
+        if (!split) continue;
+        if (split.rootPath && roots.includes(split.rootPath)) {
+          void loadDir(split.rootPath, split.relPath);
         }
       }
     },
-    [expanded, loadDir]
+    [loadDir]
   );
 
   const registerRoots = useCallback((instanceId: string, roots: string[]) => {
     setActiveRootsByInstance((prev) => {
       const existing = prev.get(instanceId);
-      // identity 比較で同じなら更新しない (再 render 抑制)。
       if (
         existing &&
         existing.length === roots.length &&
@@ -299,50 +431,10 @@ export function FileTreeStateProvider({ children }: { children: ReactNode }): JS
     });
   }, []);
 
-  // Issue #273 #3: prune. 全 instance の roots 和集合に含まれない entry を expanded から除去。
-  // どの instance も mount されていない (= ファイルツリー UI 非表示) ときは prune しない
-  // (起動初期で root が無いまま expanded を空にしてしまうのを避ける)。
-  useEffect(() => {
-    if (activeRootsByInstance.size === 0) return;
-    const allRoots = new Set<string>();
-    for (const list of activeRootsByInstance.values()) {
-      for (const r of list) {
-        if (r) allRoots.add(r);
-      }
-    }
-    if (allRoots.size === 0) return;
-
-    setExpanded((prev) => {
-      let changed = false;
-      const next = new Set(prev);
-      for (const key of prev) {
-        const sep = key.indexOf(KEY_SEP);
-        if (sep <= 0) {
-          next.delete(key);
-          changed = true;
-          continue;
-        }
-        const root = key.slice(0, sep);
-        if (!allRoots.has(root)) {
-          next.delete(key);
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
-
-    setCollapsedRoots((prev) => {
-      let changed = false;
-      const next = new Set(prev);
-      for (const root of prev) {
-        if (!allRoots.has(root)) {
-          next.delete(root);
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
-  }, [activeRootsByInstance]);
+  // activeRootsByInstance 自体は API 互換のため残すが、現状 prune には使わない
+  // (canonical roots を真理値にした自己レビュー W1 への対応)。将来 UI で
+  // 「現在マウント中のパネルだけ描画」等の判定に使えるよう露出だけしておく。
+  void activeRootsByInstance;
 
   const value = useMemo<FileTreeStateValue>(
     () => ({

--- a/src/renderer/src/lib/filetree-state-context.tsx
+++ b/src/renderer/src/lib/filetree-state-context.tsx
@@ -1,0 +1,385 @@
+/**
+ * FileTreeStateContext — ファイルツリーの展開/折り畳み状態とディレクトリキャッシュを
+ * アプリ全体で共有する Provider。
+ *
+ * Issue #273 で指摘された次の 4 件への対応:
+ *   1. Sidebar と Canvas (FileTreeCard) の同時 mount で `update({ fileTreeExpanded })` が
+ *      お互いの古い state で last-writer-wins 上書きする問題 → 共有 Context にして単一参照に。
+ *   2. setState updater 内で `onPersistState` を呼んでいた副作用混在 → effect で expanded/
+ *      collapsedRoots の変化に追従して persist する。React Strict Mode / concurrent rendering
+ *      で updater が複数回実行されても副作用が二重発火しない。
+ *   3. 存在しない root / orphan dir の prune 未実装 → mount 時に現在の roots に含まれない
+ *      entry を expanded から除去。`loadDir` 失敗時にもそのキーを expanded から除去 (lazy)。
+ *   4. 復元時の I/O storm → `loadDir` を最大 4 並列の queue で発火し、CLI の files.list が
+ *      同時多発するのを防ぐ。
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode
+} from 'react';
+import type { FileNode } from '../../../types/shared';
+import { useSettings } from './settings-context';
+
+const KEY_SEP = '\0';
+
+/** (rootPath, relPath) を一意キーに変換する。Map のキーにする。 */
+export const dirKey = (rootPath: string, relPath: string): string =>
+  `${rootPath}${KEY_SEP}${relPath}`;
+
+export interface DirState {
+  loading: boolean;
+  error: string | null;
+  entries: FileNode[];
+}
+
+export interface FileTreeStateValue {
+  /** 現在の展開済みディレクトリ集合 (NUL 区切りキー) */
+  expanded: Set<string>;
+  /** 折り畳み済みのルート (絶対パス) 集合 */
+  collapsedRoots: Set<string>;
+  /** ルート配下を含むすべてのディレクトリのキャッシュ */
+  dirs: Map<string, DirState>;
+  /** ディレクトリ展開状態のトグル。`isDir=false` のときは no-op (FileNode を直接渡す側でガード) */
+  toggleDir: (rootPath: string, relPath: string) => void;
+  /** ルート (workspace folder) の折り畳み状態のトグル */
+  toggleRoot: (rootPath: string) => void;
+  /** files.list を発火してキャッシュを更新する。並列数は内部 queue で制限 */
+  loadDir: (rootPath: string, relPath: string) => Promise<void>;
+  /** 与えられた roots について、直下と展開済み配下を再ロードする */
+  refreshAll: (roots: string[]) => void;
+  /**
+   * 現在 mount されている FileTreePanel の roots を Provider に伝えて、
+   * 不要 entry を prune する trigger にする。Sidebar と FileTreeCard の双方が
+   * 自分の roots を渡し、Provider は和集合に対して prune する。
+   */
+  registerRoots: (instanceId: string, roots: string[]) => void;
+  /** unmount 時に呼ぶ。当該 instance の roots を解除する */
+  unregisterRoots: (instanceId: string) => void;
+}
+
+const FileTreeStateContext = createContext<FileTreeStateValue | null>(null);
+
+/** files.list を同時に何本までに絞るか (Issue #273 #4: I/O storm 対策)。 */
+const MAX_CONCURRENT_LOADS = 4;
+
+interface QueuedLoad {
+  key: string;
+  run: () => Promise<void>;
+}
+
+export function FileTreeStateProvider({ children }: { children: ReactNode }): JSX.Element {
+  const { settings, update } = useSettings();
+
+  // 初期値は settings からの復元。lazy 初期化で mount 時の値だけ採用 (以後は内部 state 単独管理)。
+  const [expanded, setExpanded] = useState<Set<string>>(() => {
+    const set = new Set<string>();
+    const map = settings.fileTreeExpanded ?? {};
+    for (const [root, rels] of Object.entries(map)) {
+      if (typeof root !== 'string' || !root) continue;
+      if (!Array.isArray(rels)) continue;
+      for (const rel of rels) {
+        if (typeof rel !== 'string') continue;
+        set.add(dirKey(root, rel));
+      }
+    }
+    return set;
+  });
+  const [collapsedRoots, setCollapsedRoots] = useState<Set<string>>(
+    () => new Set(settings.fileTreeCollapsedRoots ?? [])
+  );
+  const [dirs, setDirs] = useState<Map<string, DirState>>(new Map());
+
+  // mount 中の FileTreePanel ごとの roots を集約して prune に使う。
+  const [activeRootsByInstance, setActiveRootsByInstance] = useState<Map<string, string[]>>(
+    new Map()
+  );
+
+  // updater 内副作用の代わりに effect で persist する (Issue #273 #2)。
+  // settings-context 内で 200ms debounce + atomic_write が走るので、ここでは debounce 不要。
+  // 初期復元で expanded が変わっても update が呼ばれるが、settings との等価性比較は context 側。
+  useEffect(() => {
+    const map: Record<string, string[]> = {};
+    for (const key of expanded) {
+      const sep = key.indexOf(KEY_SEP);
+      if (sep <= 0) continue;
+      const root = key.slice(0, sep);
+      const rel = key.slice(sep + 1);
+      (map[root] ??= []).push(rel);
+    }
+    void update({
+      fileTreeExpanded: map,
+      fileTreeCollapsedRoots: Array.from(collapsedRoots)
+    });
+  }, [expanded, collapsedRoots, update]);
+
+  // I/O キュー: 並列度を MAX_CONCURRENT_LOADS に制限する。
+  // queue は ref で持つ (state にすると各 enqueue が re-render を誘発する)。
+  // pendingKeys で重複 enqueue を防ぐ (同 key を 2 回 loadDir しても無駄)。
+  const queueRef = useRef<QueuedLoad[]>([]);
+  const activeRef = useRef(0);
+  const pendingKeysRef = useRef<Set<string>>(new Set());
+
+  const drainQueue = useCallback(() => {
+    while (activeRef.current < MAX_CONCURRENT_LOADS && queueRef.current.length > 0) {
+      const item = queueRef.current.shift();
+      if (!item) break;
+      activeRef.current += 1;
+      void item
+        .run()
+        .finally(() => {
+          pendingKeysRef.current.delete(item.key);
+          activeRef.current -= 1;
+          drainQueue();
+        });
+    }
+  }, []);
+
+  const loadDir = useCallback(
+    async (rootPath: string, relPath: string): Promise<void> => {
+      if (!rootPath) return;
+      if (!window.api.files) {
+        setDirs((prev) => {
+          const next = new Map(prev);
+          next.set(dirKey(rootPath, relPath), {
+            loading: false,
+            error: 'アプリを再起動してください（preload 更新のため）',
+            entries: []
+          });
+          return next;
+        });
+        return;
+      }
+      const key = dirKey(rootPath, relPath);
+      // 既に同 key が queue に入っているか実行中なら enqueue しない (重複 IPC 抑制)。
+      if (pendingKeysRef.current.has(key)) return;
+      pendingKeysRef.current.add(key);
+
+      return new Promise<void>((resolve) => {
+        queueRef.current.push({
+          key,
+          run: async () => {
+            setDirs((prev) => {
+              const next = new Map(prev);
+              next.set(key, {
+                loading: true,
+                error: null,
+                entries: prev.get(key)?.entries ?? []
+              });
+              return next;
+            });
+            try {
+              const res = await window.api.files.list(rootPath, relPath);
+              setDirs((prev) => {
+                const next = new Map(prev);
+                next.set(key, {
+                  loading: false,
+                  error: res.ok ? null : res.error ?? 'error',
+                  entries: res.entries
+                });
+                return next;
+              });
+              // Issue #273 #3 (lazy prune): list 失敗 = orphan dir 候補。expanded から除去。
+              if (!res.ok) {
+                setExpanded((prev) => {
+                  if (!prev.has(key)) return prev;
+                  const next = new Set(prev);
+                  next.delete(key);
+                  return next;
+                });
+              }
+            } catch (err) {
+              setDirs((prev) => {
+                const next = new Map(prev);
+                next.set(key, {
+                  loading: false,
+                  error: String(err),
+                  entries: []
+                });
+                return next;
+              });
+              // catch 経路でも prune する (rootPath が無効な絶対パス等)。
+              setExpanded((prev) => {
+                if (!prev.has(key)) return prev;
+                const next = new Set(prev);
+                next.delete(key);
+                return next;
+              });
+            } finally {
+              resolve();
+            }
+          }
+        });
+        drainQueue();
+      });
+    },
+    [drainQueue]
+  );
+
+  const toggleDir = useCallback(
+    (rootPath: string, relPath: string) => {
+      const key = dirKey(rootPath, relPath);
+      // setState updater 内では副作用を呼ばず、純粋に state を更新する (Issue #273 #2)。
+      // 永続化は上の useEffect が expanded の変化を観測して 1 度だけ走る。
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        const wasOpen = next.has(key);
+        if (wasOpen) next.delete(key);
+        else next.add(key);
+        return next;
+      });
+      // expanded が新規追加された (= wasOpen が false → 新たに展開) ときだけ loadDir。
+      // setState の prev を読まないと wasOpen を判定できないので、ここでは expanded から
+      // 直接読む (closure の expanded は前回 render の値だが、判定は「未キャッシュなら load」
+      // に倒すので問題ない)。
+      const isAlreadyCached = dirs.has(key);
+      const wasOpen = expanded.has(key);
+      if (!wasOpen && !isAlreadyCached) {
+        void loadDir(rootPath, relPath);
+      }
+    },
+    [expanded, dirs, loadDir]
+  );
+
+  const toggleRoot = useCallback((rootPath: string) => {
+    setCollapsedRoots((prev) => {
+      const next = new Set(prev);
+      if (next.has(rootPath)) next.delete(rootPath);
+      else next.add(rootPath);
+      return next;
+    });
+  }, []);
+
+  const refreshAll = useCallback(
+    (roots: string[]) => {
+      for (const root of roots) {
+        void loadDir(root, '');
+      }
+      for (const key of expanded) {
+        const sep = key.indexOf(KEY_SEP);
+        if (sep <= 0) continue;
+        const rootPath = key.slice(0, sep);
+        const relPath = key.slice(sep + 1);
+        if (rootPath && roots.includes(rootPath)) {
+          void loadDir(rootPath, relPath);
+        }
+      }
+    },
+    [expanded, loadDir]
+  );
+
+  const registerRoots = useCallback((instanceId: string, roots: string[]) => {
+    setActiveRootsByInstance((prev) => {
+      const existing = prev.get(instanceId);
+      // identity 比較で同じなら更新しない (再 render 抑制)。
+      if (
+        existing &&
+        existing.length === roots.length &&
+        existing.every((r, i) => r === roots[i])
+      ) {
+        return prev;
+      }
+      const next = new Map(prev);
+      next.set(instanceId, roots);
+      return next;
+    });
+  }, []);
+
+  const unregisterRoots = useCallback((instanceId: string) => {
+    setActiveRootsByInstance((prev) => {
+      if (!prev.has(instanceId)) return prev;
+      const next = new Map(prev);
+      next.delete(instanceId);
+      return next;
+    });
+  }, []);
+
+  // Issue #273 #3: prune. 全 instance の roots 和集合に含まれない entry を expanded から除去。
+  // どの instance も mount されていない (= ファイルツリー UI 非表示) ときは prune しない
+  // (起動初期で root が無いまま expanded を空にしてしまうのを避ける)。
+  useEffect(() => {
+    if (activeRootsByInstance.size === 0) return;
+    const allRoots = new Set<string>();
+    for (const list of activeRootsByInstance.values()) {
+      for (const r of list) {
+        if (r) allRoots.add(r);
+      }
+    }
+    if (allRoots.size === 0) return;
+
+    setExpanded((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const key of prev) {
+        const sep = key.indexOf(KEY_SEP);
+        if (sep <= 0) {
+          next.delete(key);
+          changed = true;
+          continue;
+        }
+        const root = key.slice(0, sep);
+        if (!allRoots.has(root)) {
+          next.delete(key);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+
+    setCollapsedRoots((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const root of prev) {
+        if (!allRoots.has(root)) {
+          next.delete(root);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [activeRootsByInstance]);
+
+  const value = useMemo<FileTreeStateValue>(
+    () => ({
+      expanded,
+      collapsedRoots,
+      dirs,
+      toggleDir,
+      toggleRoot,
+      loadDir,
+      refreshAll,
+      registerRoots,
+      unregisterRoots
+    }),
+    [
+      expanded,
+      collapsedRoots,
+      dirs,
+      toggleDir,
+      toggleRoot,
+      loadDir,
+      refreshAll,
+      registerRoots,
+      unregisterRoots
+    ]
+  );
+
+  return (
+    <FileTreeStateContext.Provider value={value}>{children}</FileTreeStateContext.Provider>
+  );
+}
+
+export function useFileTreeState(): FileTreeStateValue {
+  const ctx = useContext(FileTreeStateContext);
+  if (!ctx) {
+    throw new Error(
+      'useFileTreeState は FileTreeStateProvider の子孫で呼び出してください'
+    );
+  }
+  return ctx;
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -25,6 +25,7 @@ import { useT } from './lib/i18n';
 import { SettingsProvider } from './lib/settings-context';
 import { ToastProvider } from './lib/toast-context';
 import { RoleProfilesProvider } from './lib/role-profiles-context';
+import { FileTreeStateProvider } from './lib/filetree-state-context';
 import { useUiStore } from './stores/ui';
 import { webviewZoom } from './lib/webview-zoom';
 import './index.css';
@@ -228,7 +229,9 @@ ReactDOM.createRoot(rootEl).render(
       <SettingsProvider>
         <ToastProvider>
           <RoleProfilesProvider>
-            <Root />
+            <FileTreeStateProvider>
+              <Root />
+            </FileTreeStateProvider>
           </RoleProfilesProvider>
         </ToastProvider>
       </SettingsProvider>


### PR DESCRIPTION
## Summary
Issue #273 の 4 件の設計改善 (PR #264 / Closes #250 のクアドレビュー指摘) を一括対応する。

### 4 件の対応
1. **Sidebar / Canvas 同時 mount 時の last-writer-wins**
   - 新規 `FileTreeStateProvider` (`src/renderer/src/lib/filetree-state-context.tsx`) を main.tsx に追加し、`expanded` / `collapsedRoots` / `dirs` を全 consumer で共有する単一 source of truth に。Sidebar / FileTreeCard の永続化ロジックを削除。
2. **setState updater 内の onPersistState 副作用**
   - `toggleDir` / `toggleRoot` は state を純粋に変更するだけ。永続化は Provider 内 useEffect が `[expanded, collapsedRoots]` を観測。React StrictMode / concurrent rendering で updater が複数回実行されても副作用が二重発火しない。
3. **存在しない root / orphan dir の prune**
   - `settings.workspaceFolders + lastOpenedRoot + claudeCwd` を canonical roots として、これに含まれない expanded / collapsedRoots / dirs entry を prune。`loadDir` 失敗時にも該当 entry を expanded から prune (lazy)。
4. **復元 effect の I/O storm**
   - Provider 内の concurrency-limited queue (`MAX_CONCURRENT_LOADS=4`) で `files.list` を発火。`pendingPromisesRef` で同 key の重複 `loadDir` を統一 Promise に。

### 自己レビュー反映 (Codex 不在のため Claude サブエージェント 3 視点で代替)
- 🟦 信頼性 / race: 🔴 critical 2 / 🟡 warning 3 / 🔵 nit 2
- 🟥 パフォーマンス: 🔴 critical 3 / 🟡 warning 4 / 🔵 nit 5
- 🟨 設計 / 規約: 🔴 critical 1 / 🟡 warning 7 / 🔵 nit 5

→ 第 2 コミット (`refactor(filetree): #273 self-review 指摘 9 件を反映`) で反映:

| 指摘 | 対応 |
|------|------|
| 🔴 hydration race (R-C1/C2) | `useSettingsLoading()` を見て hydrate 完了まで persist を skip + `hydratedRef` 完了直後に一度だけ state を hydrate する effect を追加。**Issue #250 の機能が cold start で消える critical regression を回避** |
| 🟡 prune 真理値 (R-W1) | registerRoots ではなく `settings.workspaceFolders + lastOpenedRoot + claudeCwd` を canonical roots として prune |
| 🟡 loadDir Promise semantics (R-W3) | `pendingPromisesRef` Map で重複呼び出しを統一 Promise に |
| 🟡 useSettings 全購読 (P-C1/D-A1) | `useSettingsActions` + `useSettingsValue` 細粒度 selector に分離 |
| 🟡 toggleDir closure stale (P-W1/R-N1/D-A3) | setState updater 内で `nowOpened` 捕捉に書き換え |
| 🟡 KEY_SEP / splitKey 一貫性 (P-W3/D-A5) | context から export して FileTreePanel の重複定義を解消 |
| 🔵 loadDir 失敗時 prune helper (D-A4) | `pruneOnLoadFailure(key)` に括り出し JSDoc 明記 |
| 🔵 dirs LRU on unregister (P-N1) | canonical roots に含まれない root の dirs entry も purge |
| 🔴 unit test 不足 (D-A6/A7) | vitest smoke test 6 ケース追加 (hydration / concurrency / dedup / lazy prune / dirKey / splitKey) |

### スコープ外 (別 issue 化候補)
- dirs を value から分離した zustand-style fine-grained subscription (P-C3/R-N2) — 構造変更が大きいためフォローアップ
- AppSettings 外部 reset の Provider 反映 (R-W2) — reset 検知 signature 追加が必要なので別 issue

Closes #273

## Test plan
- [x] `npm run typecheck` 通過
- [ ] CI: `npm test` で `filetree-state-context.test.tsx` 6 ケース通過
- [ ] 手動: 起動 → ファイルツリーで dir 展開 → 再起動 → **過去の保存値が消えていない** ことを確認 (regression check の核)
- [ ] 手動: IDE → Canvas モード切替で expanded / collapsedRoots が共有されている
- [ ] 手動: 既存 PR #264 の動作 (Sidebar 単独での展開状態永続化) に regression が無い
- [ ] 手動: 設定モーダルから設定 reset した後、ファイルツリーが想定通り動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZbPD1tz6utgZx6PNgeHh3)_