### PR TITLE
feat(window): #260 PR-1 — Tauri 透過 + Glass テーマで OS Acrylic/Vibrancy 導入

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -176,20 +176,32 @@ pub struct SetWindowEffectsResult {
 /// - Linux: 非対応 (no-op、ok=true / applied=false)
 /// 他テーマ (claude-dark / claude-light / dark / midnight / light) では effect を解除し、
 /// 通常の不透明背景に戻す。
+///
+/// 戻り値は `SetWindowEffectsResult` (Result でラップしない) — 自己レビュー D-3C。
+/// IPC 自体は失敗せず、OS 側の applied 状態は `applied` フィールドで返す方針。
 #[tauri::command]
 pub fn app_set_window_effects(
     window: tauri::WebviewWindow,
     theme: String,
-) -> Result<SetWindowEffectsResult, String> {
+) -> SetWindowEffectsResult {
     let is_glass = theme == "glass";
     apply_window_effects(&window, is_glass)
+}
+
+/// 起動時の初期適用 (`lib.rs` の `setup` から呼ぶ)。`#[tauri::command]` 関数を internal で
+/// 直接呼ぶと State 引数を取り始めた瞬間に破綻するため、純関数として `pub(crate)` で公開。
+pub(crate) fn apply_window_effects_for_startup(
+    window: &tauri::WebviewWindow,
+    is_glass: bool,
+) -> SetWindowEffectsResult {
+    apply_window_effects(window, is_glass)
 }
 
 #[cfg(target_os = "windows")]
 fn apply_window_effects(
     window: &tauri::WebviewWindow,
     is_glass: bool,
-) -> Result<SetWindowEffectsResult, String> {
+) -> SetWindowEffectsResult {
     use tauri::window::{Effect, EffectState, EffectsBuilder};
     if is_glass {
         let cfg = EffectsBuilder::new()
@@ -197,28 +209,38 @@ fn apply_window_effects(
             .state(EffectState::Active)
             .build();
         match window.set_effects(cfg) {
-            Ok(_) => Ok(SetWindowEffectsResult {
+            Ok(_) => SetWindowEffectsResult {
                 ok: true,
                 applied: true,
                 error: None,
-            }),
+            },
             Err(e) => {
-                tracing::warn!("[window_effects] set_effects(Acrylic) failed: {e}");
-                Ok(SetWindowEffectsResult {
+                tracing::warn!("[window-effects] set_effects(Acrylic) failed: {e}");
+                SetWindowEffectsResult {
                     ok: true,
                     applied: false,
                     error: Some(e.to_string()),
-                })
+                }
             }
         }
     } else {
         // 非 Glass テーマ: None を渡して effect を解除。
-        let _ = window.set_effects(None);
-        Ok(SetWindowEffectsResult {
-            ok: true,
-            applied: false,
-            error: None,
-        })
+        // 自己レビュー D-3B: 解除失敗時も warn + error に詰める (Glass→他テーマ復帰失敗の可視化)。
+        match window.set_effects(None) {
+            Ok(_) => SetWindowEffectsResult {
+                ok: true,
+                applied: false,
+                error: None,
+            },
+            Err(e) => {
+                tracing::warn!("[window-effects] set_effects(None) failed: {e}");
+                SetWindowEffectsResult {
+                    ok: true,
+                    applied: false,
+                    error: Some(e.to_string()),
+                }
+            }
+        }
     }
 }
 
@@ -226,34 +248,43 @@ fn apply_window_effects(
 fn apply_window_effects(
     window: &tauri::WebviewWindow,
     is_glass: bool,
-) -> Result<SetWindowEffectsResult, String> {
+) -> SetWindowEffectsResult {
     use tauri::window::{Effect, EffectsBuilder};
     if is_glass {
         let cfg = EffectsBuilder::new()
             .effect(Effect::UnderWindowBackground)
             .build();
         match window.set_effects(cfg) {
-            Ok(_) => Ok(SetWindowEffectsResult {
+            Ok(_) => SetWindowEffectsResult {
                 ok: true,
                 applied: true,
                 error: None,
-            }),
+            },
             Err(e) => {
-                tracing::warn!("[window_effects] set_effects(UnderWindowBackground) failed: {e}");
-                Ok(SetWindowEffectsResult {
+                tracing::warn!("[window-effects] set_effects(UnderWindowBackground) failed: {e}");
+                SetWindowEffectsResult {
                     ok: true,
                     applied: false,
                     error: Some(e.to_string()),
-                })
+                }
             }
         }
     } else {
-        let _ = window.set_effects(None);
-        Ok(SetWindowEffectsResult {
-            ok: true,
-            applied: false,
-            error: None,
-        })
+        match window.set_effects(None) {
+            Ok(_) => SetWindowEffectsResult {
+                ok: true,
+                applied: false,
+                error: None,
+            },
+            Err(e) => {
+                tracing::warn!("[window-effects] set_effects(None) failed: {e}");
+                SetWindowEffectsResult {
+                    ok: true,
+                    applied: false,
+                    error: Some(e.to_string()),
+                }
+            }
+        }
     }
 }
 
@@ -261,14 +292,14 @@ fn apply_window_effects(
 fn apply_window_effects(
     _window: &tauri::WebviewWindow,
     _is_glass: bool,
-) -> Result<SetWindowEffectsResult, String> {
+) -> SetWindowEffectsResult {
     // Linux 等は windowEffects 非対応 (Tauri 2 docs: "Linux: Unsupported")。
     // CSS backdrop-filter のみで擬似 Glass を維持する。
-    Ok(SetWindowEffectsResult {
+    SetWindowEffectsResult {
         ok: true,
         applied: false,
         error: None,
-    })
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -159,6 +159,118 @@ pub fn app_set_zoom_level(window: tauri::WebviewWindow, level: f64) -> Result<()
     Ok(())
 }
 
+#[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SetWindowEffectsResult {
+    pub ok: bool,
+    /// OS ネイティブ effect が実際に適用されたか。Linux 等の非対応プラットフォームや
+    /// 古い Windows ビルドでは false。renderer は CSS backdrop-filter フォールバックに
+    /// デグラデする判断材料として使う。
+    pub applied: bool,
+    pub error: Option<String>,
+}
+
+/// Issue #260 PR-1: テーマに応じて OS ネイティブの window effect を切り替える。
+/// - Windows: `glass` テーマで Acrylic (PowerShell の Windows Terminal 同等の動的ぼかし)
+/// - macOS: `glass` テーマで under-window vibrancy
+/// - Linux: 非対応 (no-op、ok=true / applied=false)
+/// 他テーマ (claude-dark / claude-light / dark / midnight / light) では effect を解除し、
+/// 通常の不透明背景に戻す。
+#[tauri::command]
+pub fn app_set_window_effects(
+    window: tauri::WebviewWindow,
+    theme: String,
+) -> Result<SetWindowEffectsResult, String> {
+    let is_glass = theme == "glass";
+    apply_window_effects(&window, is_glass)
+}
+
+#[cfg(target_os = "windows")]
+fn apply_window_effects(
+    window: &tauri::WebviewWindow,
+    is_glass: bool,
+) -> Result<SetWindowEffectsResult, String> {
+    use tauri::window::{Effect, EffectState, EffectsBuilder};
+    if is_glass {
+        let cfg = EffectsBuilder::new()
+            .effect(Effect::Acrylic)
+            .state(EffectState::Active)
+            .build();
+        match window.set_effects(cfg) {
+            Ok(_) => Ok(SetWindowEffectsResult {
+                ok: true,
+                applied: true,
+                error: None,
+            }),
+            Err(e) => {
+                tracing::warn!("[window_effects] set_effects(Acrylic) failed: {e}");
+                Ok(SetWindowEffectsResult {
+                    ok: true,
+                    applied: false,
+                    error: Some(e.to_string()),
+                })
+            }
+        }
+    } else {
+        // 非 Glass テーマ: None を渡して effect を解除。
+        let _ = window.set_effects(None);
+        Ok(SetWindowEffectsResult {
+            ok: true,
+            applied: false,
+            error: None,
+        })
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn apply_window_effects(
+    window: &tauri::WebviewWindow,
+    is_glass: bool,
+) -> Result<SetWindowEffectsResult, String> {
+    use tauri::window::{Effect, EffectsBuilder};
+    if is_glass {
+        let cfg = EffectsBuilder::new()
+            .effect(Effect::UnderWindowBackground)
+            .build();
+        match window.set_effects(cfg) {
+            Ok(_) => Ok(SetWindowEffectsResult {
+                ok: true,
+                applied: true,
+                error: None,
+            }),
+            Err(e) => {
+                tracing::warn!("[window_effects] set_effects(UnderWindowBackground) failed: {e}");
+                Ok(SetWindowEffectsResult {
+                    ok: true,
+                    applied: false,
+                    error: Some(e.to_string()),
+                })
+            }
+        }
+    } else {
+        let _ = window.set_effects(None);
+        Ok(SetWindowEffectsResult {
+            ok: true,
+            applied: false,
+            error: None,
+        })
+    }
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+fn apply_window_effects(
+    _window: &tauri::WebviewWindow,
+    _is_glass: bool,
+) -> Result<SetWindowEffectsResult, String> {
+    // Linux 等は windowEffects 非対応 (Tauri 2 docs: "Linux: Unsupported")。
+    // CSS backdrop-filter のみで擬似 Glass を維持する。
+    Ok(SetWindowEffectsResult {
+        ok: true,
+        applied: false,
+        error: None,
+    })
+}
+
 #[tauri::command]
 pub async fn app_setup_team_mcp(
     state: State<'_, AppState>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,7 @@ pub fn run() {
             commands::app::app_set_window_title,
             commands::app::app_check_claude,
             commands::app::app_set_zoom_level,
+            commands::app::app_set_window_effects,
             commands::app::app_setup_team_mcp,
             commands::app::app_cleanup_team_mcp,
             commands::app::app_get_team_file_path,
@@ -137,6 +138,9 @@ pub fn run() {
             });
 
             // Issue #29: settings.json の lastOpenedRoot から AppState.project_root を復元する。
+            // Issue #260 PR-1: 同じ settings 読み込みで `theme` も取り出し、glass テーマだったら
+            // 起動時に Acrylic / Vibrancy を初期適用する (renderer の applyTheme から再適用される
+            // までの空白で「透過 conf.json なのに effect 未適用 → 完全透明」になるのを防ぐ)。
             let app_handle_for_root = app.handle().clone();
             spawn_observed("settings_restore", async move {
                 let settings = commands::settings::settings_load().await;
@@ -158,6 +162,24 @@ pub fn run() {
                     let mut guard = state::lock_project_root_recover(&state.project_root);
                     *guard = Some(root.clone());
                     tracing::info!("[setup] project_root restored from settings: {root}");
+                }
+                // Issue #260: theme が glass なら初期 effect を適用。それ以外は何もしない
+                // (transparent: true の conf でも OS chrome の不透明背景は維持される)。
+                let theme = settings
+                    .get("theme")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                if theme == "glass" {
+                    if let Some(win) = app_handle_for_root.get_webview_window("main") {
+                        match commands::app::app_set_window_effects(win, theme.to_string()) {
+                            Ok(res) => tracing::info!(
+                                "[setup] window_effects (glass) applied={} error={:?}",
+                                res.applied,
+                                res.error
+                            ),
+                            Err(e) => tracing::warn!("[setup] window_effects failed: {e}"),
+                        }
+                    }
                 }
             });
             #[cfg(debug_assertions)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,22 +163,27 @@ pub fn run() {
                     *guard = Some(root.clone());
                     tracing::info!("[setup] project_root restored from settings: {root}");
                 }
-                // Issue #260: theme が glass なら初期 effect を適用。それ以外は何もしない
-                // (transparent: true の conf でも OS chrome の不透明背景は維持される)。
+                // Issue #260: theme が glass なら初期 effect を適用。
+                // - tauri.conf.json で `transparent: true` + `backgroundColor: "#171716"` に
+                //   なっており、起動瞬間は claude-dark の bg 相当の不透明色で覆われる。renderer
+                //   が body の `--bg` を rgba(0,0,0,0) に書き換えてから OS chrome 越しに透過する
+                //   ので、glass 以外のテーマで「OS 描画の背景がデスクトップ」になる起動 flash は
+                //   起こらない。
+                // - glass テーマは renderer のテーマ適用直後に Acrylic が乗るが、settings_load の
+                //   disk read を待つ僅かな時間だけ「不透明 #171716 の上に panel が薄く乗る」状態
+                //   になる。実機検証で気になるなら PR-2 でカスタム title bar 化と同時に再評価する。
                 let theme = settings
                     .get("theme")
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
                 if theme == "glass" {
                     if let Some(win) = app_handle_for_root.get_webview_window("main") {
-                        match commands::app::app_set_window_effects(win, theme.to_string()) {
-                            Ok(res) => tracing::info!(
-                                "[setup] window_effects (glass) applied={} error={:?}",
-                                res.applied,
-                                res.error
-                            ),
-                            Err(e) => tracing::warn!("[setup] window_effects failed: {e}"),
-                        }
+                        let res = commands::app::apply_window_effects_for_startup(&win, true);
+                        tracing::info!(
+                            "[setup] window-effects (glass) applied={} error={:?}",
+                            res.applied,
+                            res.error
+                        );
                     }
                 }
             });

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
         "resizable": true,
         "decorations": true,
         "transparent": true,
-        "backgroundColor": "#00000000",
+        "backgroundColor": "#171716",
         "fullscreen": false
       }
     ],

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,6 +19,8 @@
         "minHeight": 640,
         "resizable": true,
         "decorations": true,
+        "transparent": true,
+        "backgroundColor": "#00000000",
         "fullscreen": false
       }
     ],

--- a/src/renderer/src/lib/settings-context.tsx
+++ b/src/renderer/src/lib/settings-context.tsx
@@ -95,12 +95,22 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
   }, [commitState]);
 
   useEffect(() => {
+    // Issue #260 自己レビュー R-W1: settings load 完了前 (loadingState=true) は
+    // `DEFAULT_SETTINGS.theme = 'claude-dark'` で applyTheme が走ってしまい、Rust 側
+    // setup の `theme=='glass'` 初期適用と競合する。load 完了後の effect で「実際の
+    // ユーザー設定」が反映されるので、loading 中は CSS 変数の更新も IPC 発火も skip する。
+    if (loadingState) return;
     applyTheme(
       settingsState.theme,
       settingsState.uiFontFamily,
       settingsState.uiFontSize
     );
-  }, [settingsState.theme, settingsState.uiFontFamily, settingsState.uiFontSize]);
+  }, [
+    loadingState,
+    settingsState.theme,
+    settingsState.uiFontFamily,
+    settingsState.uiFontSize
+  ]);
 
   useEffect(() => {
     if (loadingState) return;

--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -20,6 +20,7 @@ import {
   type GitStatus,
   type RoleProfilesFile,
   type SessionInfo,
+  type SetWindowEffectsResult,
   type TeamHistoryEntry,
   type TerminalCreateOptions,
   type TerminalCreateResult,
@@ -152,6 +153,12 @@ export const api = {
     checkClaude: (command: string): Promise<ClaudeCheckResult> =>
       invoke('app_check_claude', { command }),
     setZoomLevel: (level: number): Promise<void> => invoke('app_set_zoom_level', { level }),
+    /**
+     * Issue #260 PR-1: テーマに応じて OS ネイティブの window effect (Windows: Acrylic /
+     * macOS: vibrancy) を切り替える。Linux 等は no-op (applied=false で返る)。
+     */
+    setWindowEffects: (theme: string): Promise<SetWindowEffectsResult> =>
+      invoke('app_set_window_effects', { theme }),
     setupTeamMcp: (
       projectRoot: string,
       teamId: string,

--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -24,7 +24,8 @@ import {
   type TeamHistoryEntry,
   type TerminalCreateOptions,
   type TerminalCreateResult,
-  type TerminalExitInfo
+  type TerminalExitInfo,
+  type ThemeName
 } from '../../../types/shared';
 
 /**
@@ -156,8 +157,9 @@ export const api = {
     /**
      * Issue #260 PR-1: テーマに応じて OS ネイティブの window effect (Windows: Acrylic /
      * macOS: vibrancy) を切り替える。Linux 等は no-op (applied=false で返る)。
+     * 引数を `ThemeName` に絞ることで誤った文字列での呼び出しをコンパイル時に弾く。
      */
-    setWindowEffects: (theme: string): Promise<SetWindowEffectsResult> =>
+    setWindowEffects: (theme: ThemeName): Promise<SetWindowEffectsResult> =>
       invoke('app_set_window_effects', { theme }),
     setupTeamMcp: (
       projectRoot: string,

--- a/src/renderer/src/lib/themes.ts
+++ b/src/renderer/src/lib/themes.ts
@@ -272,17 +272,66 @@ export function applyTheme(name: ThemeName, uiFontFamily: string, uiFontSize: nu
   root.style.setProperty('--radius-md', claudeTheme ? '14px' : '12px');
   root.style.setProperty('--radius-lg', claudeTheme ? '16px' : '16px');
   root.style.setProperty('--radius-xl', claudeTheme ? '20px' : '20px');
-  root.dataset.theme = name;
 
   // Issue #260 PR-1: テーマ切替時に OS ネイティブの window effect (Windows: Acrylic /
   // macOS: vibrancy) を切り替える。Linux や非対応環境では IPC が ok / applied=false を
   // 返すだけで失敗扱いにはしない。失敗時もログだけで続行 (CSS backdrop-filter で擬似
   // Glass を維持できる)。
-  if (typeof window !== 'undefined' && window.api?.app?.setWindowEffects) {
-    void window.api.app.setWindowEffects(name).catch((err) => {
-      console.warn('[theme] setWindowEffects failed:', err);
-    });
+  //
+  // 順序の意図 (UX レビュー U-4):
+  //   - **glass に移行**するときは IPC を **CSS データ属性更新の前に** 発火する。
+  //     `data-theme="glass"` を立てると `--bg` が rgba(0,0,0,0) になって window が
+  //     透けるが、その時点で OS Acrylic がまだ来ていないと一瞬デスクトップが見える。
+  //     IPC を先に出すことで OS 側の合成キックを少しでも早める。
+  //   - **glass から離脱**するときは CSS データ属性を先に更新する。`--bg` が不透明色
+  //     に切り替わった瞬間に画面は埋まり、effect 解除はその裏で進む (ユーザーには
+  //     見えない)。
+  //
+  // 注意 (UX レビュー): glass 以外のテーマは必ず不透明 (alpha=1) の bg / bgPanel を持つこと。
+  // tauri.conf.json で `transparent: true` のままなので、半透明 bg のテーマを増やすと
+  // OS 越しにデスクトップが透けてしまう。`THEMES` 定義を変更する PR では再確認すること。
+  const isGlass = name === 'glass';
+  if (isGlass) {
+    triggerSetWindowEffects(name);
+    root.dataset.theme = name;
+  } else {
+    root.dataset.theme = name;
+    triggerSetWindowEffects(name);
   }
+}
+
+/**
+ * Issue #260 自己レビュー R-W2: テーマ連打 (glass → dark → glass を高速切替) 時に
+ * `setWindowEffects` IPC が並列に in-flight になる問題への簡易シリアライズ。
+ * sequence 番号で「最後に発火した呼び出し」だけを正と扱い、それより古い結果は破棄する。
+ * 失敗ログも古い呼び出し由来のものは出さない (UI が既に次のテーマに進んでいるため)。
+ *
+ * 加えて renderer ルート (`<html>`) に `data-window-effect="native" | "fallback"` を
+ * 立てて、PR-3 以降の `.glass-surface` ユーティリティが OS 適用可否で表現を切替えら
+ * れるようにする (D-4B)。
+ */
+let windowEffectsSeq = 0;
+
+function triggerSetWindowEffects(name: ThemeName): void {
+  if (typeof window === 'undefined' || !window.api?.app?.setWindowEffects) return;
+  const my = ++windowEffectsSeq;
+  void window.api.app
+    .setWindowEffects(name)
+    .then((res) => {
+      if (my !== windowEffectsSeq) return;
+      const root = typeof document !== 'undefined' ? document.documentElement : null;
+      if (root) {
+        root.dataset.windowEffect = res.applied ? 'native' : 'fallback';
+      }
+    })
+    .catch((err) => {
+      if (my !== windowEffectsSeq) return;
+      console.warn('[theme] setWindowEffects failed:', err);
+      const root = typeof document !== 'undefined' ? document.documentElement : null;
+      if (root) {
+        root.dataset.windowEffect = 'fallback';
+      }
+    });
 }
 
 export function applyDensity(density: Density): void {

--- a/src/renderer/src/lib/themes.ts
+++ b/src/renderer/src/lib/themes.ts
@@ -273,6 +273,16 @@ export function applyTheme(name: ThemeName, uiFontFamily: string, uiFontSize: nu
   root.style.setProperty('--radius-lg', claudeTheme ? '16px' : '16px');
   root.style.setProperty('--radius-xl', claudeTheme ? '20px' : '20px');
   root.dataset.theme = name;
+
+  // Issue #260 PR-1: テーマ切替時に OS ネイティブの window effect (Windows: Acrylic /
+  // macOS: vibrancy) を切り替える。Linux や非対応環境では IPC が ok / applied=false を
+  // 返すだけで失敗扱いにはしない。失敗時もログだけで続行 (CSS backdrop-filter で擬似
+  // Glass を維持できる)。
+  if (typeof window !== 'undefined' && window.api?.app?.setWindowEffects) {
+    void window.api.app.setWindowEffects(name).catch((err) => {
+      console.warn('[theme] setWindowEffects failed:', err);
+    });
+  }
 }
 
 export function applyDensity(density: Density): void {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -442,3 +442,22 @@ export interface TerminalExitInfo {
   exitCode: number;
   signal?: number;
 }
+
+// ---------- Window Effects (Issue #260) ----------
+
+/**
+ * Issue #260 PR-1: テーマ別の OS ネイティブ window effect 適用結果。
+ * - Windows: Acrylic (PowerShell 同等の動的ぼかし)
+ * - macOS: vibrancy (under-window)
+ * - Linux: 非対応 (no-op、`applied=false` で返る)
+ */
+export interface SetWindowEffectsResult {
+  ok: boolean;
+  /**
+   * OS ネイティブ effect が実際に適用されたか。Linux 等の非対応プラットフォームや
+   * Windows 10 21H2 以前では false。renderer 側はこれを見て CSS backdrop-filter
+   * フォールバックの有無を判断する余地を持つ (現時点では CSS 側で常に効いている)。
+   */
+  applied: boolean;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
Issue #260 (Glass テーマで PowerShell 相当の Acrylic / Mica 体験) の **PR-1 (Phase 1)** を実装する。issue-planner の 4 PR 分割計画に従い、本 PR ではカスタムタイトルバー (PR-2)、`.glass-surface` ユーティリティ化 (PR-3)、色値再調整 (PR-4) は触らず、**Tauri 透過 + windowEffects API のみ** を導入する安全な刻み。

### 変更点
1. **`tauri.conf.json`**: `transparent: true`, `backgroundColor: "#171716"` (claude-dark bg) を追加。`decorations: true` は維持してネイティブ chrome を保つ。
2. **新規 IPC `app_set_window_effects(theme: ThemeName) -> SetWindowEffectsResult`**:
   - Windows: `tauri::window::Effect::Acrylic` + `EffectState::Active` (PowerShell 同等の動的ぼかし)
   - macOS: `Effect::UnderWindowBackground` (vibrancy)
   - Linux: no-op (Tauri 2 docs: "Linux: Unsupported")
   - 戻り値は `{ ok, applied, error? }` で OS 適用可否を renderer に返す
3. **起動時の初期適用 (`lib.rs` setup)**: settings.json から `theme=='glass'` を検出し、起動時に Acrylic を初期適用 (renderer の `applyTheme` 呼び出しまでの空白を埋める)
4. **`themes.ts:applyTheme` から IPC 呼び出し**: テーマ切替に追従。失敗は console.warn のみで続行。
5. **renderer ルート `data-window-effect="native|fallback"`**: OS 適用可否を CSS から参照可能にし、PR-3 の `.glass-surface` 化で fallback 経路を切替えるフックを残す。

### 自己レビュー (Codex 不在のため Claude サブエージェント 3 視点で代替)
- 🟦 信頼性 / race: 🔴 0 / 🟡 3 / 🔵 3
- 🟨 設計 / 規約: 🔴 0 / 🟡 6 / 🔵 5
- 🟧 UX / 視覚 regression: 🔴 1 / 🟡 2 / 🔵 1

→ 第 2 コミット (`refactor(window): #260 PR-1 self-review 指摘 10 件を反映`) で反映:

| 指摘 | 対応 |
|------|------|
| 🔴 **U-3 起動透過フラッシュ** | `backgroundColor` を `#00000000` → `#171716` |
| 🟡 R-W1 起動時 race | settings-context に `loadingState` ガード |
| 🟡 R-W2 テーマ連打 race | `windowEffectsSeq` で古い結果を破棄 |
| 🟡 D-3C 戻り値簡素化 | `Result<...>` → `SetWindowEffectsResult` 単独 |
| 🟡 D-3B set_effects(None) 失敗ログ | warn + error 詰め |
| 🟡 D-4A 引数型絞り | `theme: string` → `theme: ThemeName` |
| 🟡 D-4B `applied` 公開 | `<html data-window-effect="native|fallback">` |
| 🟡 D-5A 白フラッシュコメント | lib.rs に PR-2 で再評価メモ |
| 🟡 D-5B 不透明 `--bg` 契約 | themes.ts にコメント |
| 🟡 U-4 glass 移行順序 | glass 移行時のみ IPC を CSS 更新より先 |
| 🟡 D-2B/6B 内部呼び出し | `apply_window_effects_for_startup` を pub(crate) 化、tracing prefix を `[window-effects]` に統一 |

### スコープ外 (PR-2/3/4 で対応)
- カスタムタイトルバー (`decorations: false` + `WindowControls`)
- `.glass-surface` ユーティリティ化 + 既存 CSS リファクタ
- themes.ts glass の色値再調整 (Acrylic と二重ブラー回避)
- Linux fallback の調整
- 3 つの cfg 分岐の集約 (`Effect::Mica` 追加時に同時に)
- prefers-reduced-transparency / system theme listener (別 issue 候補)

Refs #260

## Test plan
- [x] `npm run typecheck` 通過
- [ ] CI: `cargo check` 通過 (Rust 側 windowEffects API 互換確認)
- [ ] 手動 (Windows 11): Glass テーマ選択 → 背後の Notepad 文字が透けて見える、ウィンドウドラッグで追従
- [ ] 手動 (Windows 11): Glass → claude-dark に切替 → 透過解除されて不透明背景に戻る
- [ ] 手動 (Windows 11): 起動時 (claude-dark) にデスクトップが透けて見えない (regression check)
- [ ] 手動 (macOS): Glass テーマで vibrancy が効く (under-window)
- [ ] 手動 (Linux): `applied=false` で fallback、CSS backdrop-filter のみで擬似 Glass 維持
- [ ] 手動 (regression): claude-dark / claude-light / dark / midnight / light で見た目変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZbPD1tz6utgZx6PNgeHh3)_