### PR TITLE
docs(skill): #295 vibeeditor SKILL.md に IPC event pre-subscribe パターンを追記

### DIFF
--- a/.claude/skills/vibeeditor/SKILL.md
+++ b/.claude/skills/vibeeditor/SKILL.md
@@ -83,7 +83,76 @@ npm run dev:vite     # レンダラーだけ vite で起動 (UI 単体確認用)
 5. 呼び出し側 React から `window.api.xxx(...)` で利用。
 6. `npm run typecheck` で両側の型整合を確認。
 
-イベント (Rust → Renderer の push) を足す場合は、`tauri::Manager::emit` + Renderer 側で `listen()`。tauri-api.ts に薄い subscribe ヘルパを足すと書き味が揃う。
+イベント push (Rust → Renderer) を足す場合は **「IPC event を足すレシピ」セクション** を参照。`subscribeEvent` (sync) は内部に listener 登録前 race を抱えるため、初期出力が重要なイベントでは `subscribeEventReady` (async) を使う。
+
+---
+
+## IPC event (Rust → Renderer push) を足すレシピ
+
+Issue #285 / PR #291 で「Rust 側 emit が listener 登録より早く走るとデータが drop される」 race を pre-subscribe パターンで解消した。同じ罠は IPC event を新規追加するたびに再発し得るので、ここで明文化する。
+
+### 1. event 名は `<領域>:<種別>:<id>` の `:` 区切り形式
+
+例: `terminal:data:{id}`、`terminal:exit:{id}`、`fs:changed:{path}`。`/` や `.` は使わず `:` で揃える。
+
+### 2. emit のタイミングを設計する
+
+Rust 側で `app.emit(event_name, payload)` を呼ぶタイミングが「receiver が listener を登録した後」であることを保証する責務は **caller 側にある**。create コマンド完了 → renderer が listener 登録、の順では create 直後に走る初期出力が drop され得る (PTY の CLI banner が消える、ファイル監視の初回イベントが届かない、等)。
+
+### 3. race を起こす時系列の判定
+
+| 状況 | 推奨 API | 理由 |
+|------|---------|------|
+| 初期出力が **重要** (banner / prompt / 初回スナップショット) | `subscribeEventReady` + **client-generated id 経路** | renderer が事前に id を作って `await listen()` してから create を呼べば post-subscribe race を完全排除できる |
+| 初期出力が **重要でない** / イベントが定期的に流れ続ける | `subscribeEvent` (sync) | listener 登録完了前の数十 ms は無視しても影響なし。書き心地優先 |
+| 補助: Rust 側で初回 flush を意図的に遅延 | batcher delay | 単独で race を完全排除はできない。pre-subscribe と併用する補助策 |
+
+### 4. tauri-api.ts に subscribe helper を足す
+
+```ts
+// 同期版 (post-subscribe race を許容するイベント用)
+function subscribeEvent<T>(event: string, cb: (payload: T) => void): () => void
+
+// async 版 (await で listener 登録完了を保証する。初期出力が重要なイベント用)
+async function subscribeEventReady<T>(event: string, cb: (payload: T) => void): Promise<() => void>
+```
+
+#### caller 側 (renderer) の責務
+
+- `subscribeEventReady` の **await pending 中に component が dispose** される race は helper 側では検知できない (cleanup 関数をまだ caller に返していないため)。await 解決直後に caller 側で disposed flag を再判定し、必要なら戻り値の cleanup を即呼ぶこと。
+- 参考実装: `src/renderer/src/lib/use-pty-session.ts` の pre-subscribe ブロック
+  ```ts
+  offData = await window.api.terminalEvents(id).onDataReady(handleData);
+  if (localDisposed || disposedRef.current) { unsubscribePtyListeners(); return; }
+  ```
+
+### 5. client-generated id 経路 (推奨)
+
+Rust 側 create コマンドが renderer から `id?: string` を受け取り、未指定なら UUID を生成する形にする。renderer は事前に id を生成して `subscribeEventReady` で listener を張り、await 完了後に create を呼ぶ。これで「create 直後の初回 emit を取り逃がす」 race が構造的に消える。
+
+```rust
+// src-tauri/src/commands/terminal.rs (例)
+#[tauri::command]
+async fn terminal_create(opts: TerminalCreateOptions) -> Result<String, String> {
+    let id = match opts.id.as_deref() {
+        Some(s) if state.pty_registry.get(s).is_none() => s.to_string(),
+        Some(_) => Uuid::new_v4().to_string(),  // 衝突時は再生成
+        None => Uuid::new_v4().to_string(),
+    };
+    // ...
+}
+```
+
+### 6. 既存の使い分け基準まとめ
+
+- **`subscribeEventReady` を使う**: PTY data / exit / sessionId 等、PTY create 直後の出力が重要な全てのイベント
+- **`subscribeEvent` で十分**: 設定変更通知 / アップデート進捗 / Toast 配信 等、post-subscribe race の影響が無いイベント
+
+迷ったら `subscribeEventReady` 側を採用する (「post-subscribe race を内包する API は構造的に Issue #285 を再生産する」)。
+
+### 関連
+- Issue #285: IDE 初回ターミナルが空白になる race
+- PR #291: pre-subscribe パターンで上記を解消
 
 ---
 
@@ -135,6 +204,20 @@ npm run dev:vite     # レンダラーだけ vite で起動 (UI 単体確認用)
 - **node-pty 系の electron-rebuild は不要** (portable-pty を使っているので)。Electron 文脈の解決策をそのまま持ち込まない。
 - **OS は Windows 11**。Rust 側のパス処理・改行・PTY 周りは Windows ネイティブを優先動作確認する。
 - **ショートカット**は CLAUDE.md の表が正。新しいショートカットを足したら `commands*` と CLAUDE.md の両方を更新する。
+
+---
+
+## 不変式 (壊さない約束)
+
+このリポジトリで **常に成り立っていてほしい性質**。レビューや実装中の自問はこの欄に照らす。
+
+- **shared.ts の型 ⇄ Rust struct ⇄ tauri-api.ts ラッパは常に同期している**。片側だけ変えない。
+- **Renderer は OS リソース (fs / 外部プロセス / network) に直接アクセスしない**。必ず Rust 側コマンド経由。
+- **設定の永続化は Rust 側 (`~/.vibe-editor/settings.json`) を Single Source of Truth とする**。renderer がローカル state にコピーを持つ場合、Rust 側を最新としてこれに合わせる。
+- **IPC event の listener 登録は emit より先に完了させる責務が caller 側にある**。初期出力が重要なイベントは `subscribeEventReady` + client-generated id 経路で pre-subscribe する (Issue #285 / PR #291)。
+- **`subscribeEventReady` は await 解決直後に caller 側で disposed 再判定を行う**。await pending 中の dispose は helper 側で検知できないため、caller 責務。
+- **Rust 側コマンドは `src-tauri/src/commands/<領域>.rs` に集約**し、別ファイルに散らさない。
+- **CSS は Tailwind を使わず `--*` カスタムプロパティ + 機能別 CSS** で完結させる。テーマ切替は `:root[data-theme="..."]` のみで成立すること。
 
 ---
 


### PR DESCRIPTION
## Summary

Issue #295 を実装。`.claude/skills/vibeeditor/SKILL.md` に IPC event の pre-subscribe パターンを明文化する。

PR #291 (Closes #285) で導入した pre-subscribe race 回避パターンが、将来 IPC event を新規追加するたびに再発し得る問題なので、SKILL.md に登録手順とガード規約として書き残す。

### 変更点
- **新セクション「IPC event (Rust → Renderer push) を足すレシピ」** を追加 (line ~85 付近)
  - event 名命名 (`<領域>:<種別>:<id>` の `:` 区切り)
  - emit タイミング設計の責務 (caller 側にある)
  - `subscribeEvent` (sync) vs `subscribeEventReady` (async) の使い分け基準を表で明記
  - tauri-api.ts に subscribe helper を足すパターン
  - **client-generated id 経路** (renderer が事前に id 生成 → `await listen()` → create 呼び出し) を推奨として明記
  - caller 側 (renderer) の責務: `subscribeEventReady` の await pending 中の dispose race ガード
- **新セクション「不変式」** を追加 (末尾に近い位置)
  - 「IPC event の listener 登録は emit より先に完了させる責務が caller 側にある」
  - 「`subscribeEventReady` は await 解決直後に caller 側で disposed 再判定」
  - 加えて shared.ts ⇄ Rust struct ⇄ tauri-api.ts の同期 / Renderer は OS リソース直アクセス禁止 / 設定 SSOT は Rust 側 / Tailwind 禁止 等、頻出の暗黙ルールも不変式として並列化
- 既存「新しい IPC コマンドを足すレシピ」末尾の 1 行 event 言及を新セクションへの導線に置換

### 受け入れ基準 (Issue #295)
- [x] `.claude/skills/vibeeditor/SKILL.md` に「IPC event を足すレシピ」セクションが存在
- [x] 既存の `subscribeEvent` / `subscribeEventReady` の使い分け基準が記述されている
- [x] Issue #285 と PR #291 への参照リンクが含まれている

実コード変更は伴わない (Issue #295 のスコープ通り)。subscribe API の構造リファクタは別 issue #294 で扱う。

Closes #295

## Test plan
- [x] `git diff main...HEAD` で `.claude/skills/vibeeditor/SKILL.md` のみが変更されていることを確認
- [x] 追加した「IPC event を足すレシピ」が #285 / #291 を参照している
- [x] 「不変式」セクションが本 PR で追加されている
- [ ] (bot レビュー) `vibe-editor-reviewer` の指摘を全件解消するまで自動 merge を待つ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012QQTY9wBDKP7wyt6gzpYFK)_