### PR TITLE
refactor(pty): #292 SessionRegistry の id 衝突チェックを atomic 化 (insert_if_absent)

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -497,20 +497,17 @@ pub async fn terminal_create(
     // Issue #285: renderer が指定した id があれば採用 (event 名 `terminal:data:{id}` に
     // 安全な文字種だけ通す)。`attach_if_exists` 経路は preflight で既に return 済みで、
     // ここに到達するのは「新規 spawn 経路」だけなので、両者は構造的に直交している。
-    // 不正値・未指定は UUID v4 にフォールバック。既存 PTY との衝突は実質起こらない
-    // (UUID v4 の 122-bit エントロピー) が、安全側で衝突時も UUID にフォールバックする。
-    // ※ 衝突は registry の lock を握らない get→ 採用→ insert の TOCTOU を含むため、
-    //   完全な atomic 化はフォローアップ issue 扱い (実害シナリオは UUID 衝突ほぼ皆無)。
-    let id = match opts.id.as_deref() {
+    // 不正値・未指定は UUID v4 にフォールバック。
+    //
+    // Issue #292: 衝突検出は registry の `insert_if_absent` に atomic で委ねる。
+    // 旧実装の preflight `state.pty_registry.get(s).is_some()` → spawn → insert は、
+    // 判定と挿入の間に Mutex を一度離すため TOCTOU race が残っていた (UUID v4 の
+    // 122-bit エントロピーで実発生確率はほぼ 0 だが構造的に穴)。renderer-supplied id の
+    // 形式バリデーションのみここで行い、registry 衝突確認は spawn 後の atomic 検出に任せる。
+    let initial_id = match opts.id.as_deref() {
         Some(s) if !is_valid_terminal_id(s) => {
             tracing::warn!(
                 "[terminal] renderer-supplied id rejected (invalid charset/length), falling back to UUID v4"
-            );
-            Uuid::new_v4().to_string()
-        }
-        Some(s) if state.pty_registry.get(s).is_some() => {
-            tracing::warn!(
-                "[terminal] renderer-supplied id {s} collides with existing PTY, falling back to UUID v4"
             );
             Uuid::new_v4().to_string()
         }
@@ -548,9 +545,45 @@ pub async fn terminal_create(
         role: opts.role,
     };
 
-    match spawn_session(app.clone(), id.clone(), spawn_opts, state.pty_registry.clone()) {
-        Ok(handle) => {
-            state.pty_registry.insert(id.clone(), handle);
+    // Issue #292: id 衝突時の retry 上限。実発生はほぼ皆無 (UUID v4 衝突は
+    // 122-bit エントロピー + 同時 spawn 競合) なので 3 回もあれば十分。
+    const MAX_ID_ATTEMPTS: usize = 3;
+    let mut id_candidate = initial_id;
+    let mut attempt = 0usize;
+    let adopt_id_result: Result<String, anyhow::Error> = loop {
+        attempt += 1;
+        match spawn_session(
+            app.clone(),
+            id_candidate.clone(),
+            spawn_opts.clone(),
+            state.pty_registry.clone(),
+        ) {
+            Ok(handle) => match state
+                .pty_registry
+                .insert_if_absent(id_candidate.clone(), handle)
+            {
+                Ok(()) => break Ok(id_candidate),
+                Err(returned_handle) => {
+                    let _ = returned_handle.kill();
+                    if attempt >= MAX_ID_ATTEMPTS {
+                        break Err(anyhow::anyhow!(
+                            "terminal_create failed: id collision persisted after {attempt} attempts"
+                        ));
+                    }
+                    tracing::warn!(
+                        "[terminal] id {id_candidate} collided in registry (attempt {attempt}/{MAX_ID_ATTEMPTS}), retrying with fresh UUID"
+                    );
+                    id_candidate = Uuid::new_v4().to_string();
+                }
+            },
+            Err(e) => break Err(e),
+        }
+    };
+
+    match adopt_id_result {
+        Ok(id) => {
+            // 後続処理: spawn_session の Ok 分岐内で行っていた処理を保持
+            // (id は registry に登録済み、retry を経た場合も Ok(()) 後の状態は insert と等価)。
 
             // Codex stability: 起動した PTY に「最初の user メッセージ」として instructions を注入する。
             // - 1.8 秒待ってから注入 (TUI の初期化 / banner 描画完了を待つ目安)。早すぎると Codex の入力欄が

--- a/src-tauri/src/pty/registry.rs
+++ b/src-tauri/src/pty/registry.rs
@@ -83,6 +83,32 @@ impl SessionRegistry {
 
     pub fn insert(&self, id: String, handle: SessionHandle) {
         let mut g = recover(self.inner.lock());
+        Self::insert_locked(&mut g, id, handle);
+    }
+
+    /// Issue #292: id 衝突を atomic に検出する insert。Mutex 1 回ロックの中で
+    /// `by_id.contains_key(&id)` の判定 → 採用 / 拒否を行うため、TOCTOU race で別スレッド
+    /// が同 id を先に挿入していても、後勝ち上書きにならない。
+    ///
+    /// 戻り値:
+    ///   - `Ok(())`: 採用された (id は registry に登録済み)
+    ///   - `Err(handle)`: 既存 PTY と id が衝突。caller の handle はそのまま返却される
+    ///     ので、caller 側で `handle.kill()` してから別 id で retry する責務がある。
+    pub fn insert_if_absent(
+        &self,
+        id: String,
+        handle: SessionHandle,
+    ) -> Result<(), SessionHandle> {
+        let mut g = recover(self.inner.lock());
+        if g.by_id.contains_key(&id) {
+            return Err(handle);
+        }
+        Self::insert_locked(&mut g, id, handle);
+        Ok(())
+    }
+
+    /// `insert` / `insert_if_absent` の共通ボディ。caller 側で Mutex を取った状態で呼ぶ。
+    fn insert_locked(g: &mut MutexGuard<'_, Inner>, id: String, handle: SessionHandle) {
         // Issue #42: 同じ agent_id で再 spawn されると、旧 session_id を by_agent が手放した後も
         // by_id に旧 SessionHandle が残り続け、以後 kill されない孤立 PTY になる。
         // insert 時点で同 agent_id の旧 session があれば、by_id から取り出して kill + drop する。

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -22,6 +22,7 @@ pub struct TerminalExitInfo {
     pub signal: Option<i32>,
 }
 
+#[derive(Clone)]
 pub struct SpawnOptions {
     pub command: String,
     pub args: Vec<String>,


### PR DESCRIPTION
## Summary

Issue #292 を実装。`SessionRegistry` の id 衝突チェックを atomic 化する。

旧実装の `terminal_create` は `state.pty_registry.get(s).is_some()` の preflight check と `state.pty_registry.insert(id, ...)` の間で Mutex を一度離していたため、TOCTOU race で別スレッドが同 id を先に挿入すると後勝ち上書きになっていた。実発生確率は UUID v4 の 122-bit エントロピーでほぼ 0 だが、structural な穴。

### 変更点

1. **`SessionRegistry::insert_if_absent(id, handle) -> Result<(), SessionHandle>`** (`src-tauri/src/pty/registry.rs`)
   - Mutex 1 ロック内で `by_id.contains_key(&id)` の判定 → 採用 / 拒否を行う atomic API
   - 衝突時は handle を caller にそのまま返却 → caller が `handle.kill()` してから別 id で retry する責務
2. **`insert` / `insert_if_absent` の共通ボディを `insert_locked(g, id, handle)` に切り出し**
   - caller 側で Mutex を取った状態で呼ぶ private fn
   - 挙動は旧 `insert` と完全に一致 (agent_id 衝突時の旧 PTY kill / session_key index 更新もそのまま)
3. **`SpawnOptions` に `#[derive(Clone)]`** (`src-tauri/src/pty/session.rs`)
   - retry 時に再 spawn するため
4. **`terminal_create` の id 採用ロジックを retry ループ化** (`src-tauri/src/commands/terminal.rs`)
   - 旧 preflight `state.pty_registry.get(s).is_some()` を削除
   - 新ループ: spawn → `insert_if_absent` → `Err` の場合 kill + UUID 再生成 + retry
   - retry 上限 3 回 (定数 `MAX_ID_ATTEMPTS`)
   - 最終的に衝突が解消できなかった場合は `TerminalCreateResult { ok: false, error: ... }` を返す
   - renderer-supplied id の charset / 長さバリデーションは引き続きここで実施

### スコープ外 (issue 通り)

- DoS 対策 (PTY 数上限 / レート制限) → #293 で別途
- 他の registry method (by_agent / by_session_key) の atomic 化 → 本 PR では扱わない

### 受け入れ基準 (Issue #292)

- [x] `SessionRegistry::insert_if_absent` が存在し、Mutex 1 ロック内で contains → 採用 / 拒否する
- [x] `terminal_create` が preflight check を撤廃し、`insert_if_absent` ベースに書き換わっている
- [x] retry 上限 (本 PR では 3 回) を持つ
- [x] 旧 `insert` の挙動 (agent_id 衝突 kill / session_key index 更新) が `insert_locked` 経由で完全に保持されている

Closes #292

## Test plan

- [x] `npm run typecheck` 通過 (TS 側に影響なし)
- [ ] CI: `cargo check --manifest-path src-tauri/Cargo.toml` 通過 (sandbox では gdk-3.0 系 system lib 不在のためローカル実行不可)
- [ ] CI: `cargo test --manifest-path src-tauri/Cargo.toml -p vibe-editor pty::registry` (既存の `attach_lookup_tests` が PASS することを確認)
- [ ] 手動 (Windows 11): ターミナル新規作成が正常に動く
- [ ] 手動 (Windows 11): HMR (renderer 再 mount) で同 id 経路が collision にならず attach 復帰する
- [ ] 手動 (Windows 11): `terminal:data:{id}` イベントが先頭出力 (banner / prompt) を取り逃がさない (Issue #285 の挙動が回帰していない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012QQTY9wBDKP7wyt6gzpYFK)_