### PR TITLE
feat(pty): #293 PTY 数上限 + spawn レート制限を導入 (DoS 対策)

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -443,6 +443,20 @@ pub async fn terminal_create(
         }
     }
 
+    // Issue #293: 新規 spawn 経路は DoS ガードを通す。
+    // - 同時 PTY 数が `MAX_CONCURRENT_PTY` (=100) に達していたら拒否
+    // - `RATE_LIMIT_WINDOW` (=1s) 内に `MAX_PTY_SPAWNS_PER_WINDOW` (=10) 回以上 spawn 済なら拒否
+    // attach_if_exists で既存 PTY を再利用する経路は新規 spawn ではないので、ここに到達しない。
+    if let Err(gate_err) = state.pty_registry.try_reserve_spawn_slot() {
+        let msg = gate_err.message();
+        tracing::warn!("[terminal] spawn rejected by DoS gate: {msg}");
+        return Ok(TerminalCreateResult {
+            ok: false,
+            error: Some(msg),
+            ..Default::default()
+        });
+    }
+
     let (cwd, warning) =
         crate::pty::session::resolve_valid_cwd(&opts.cwd, opts.fallback_cwd.as_deref());
 

--- a/src-tauri/src/pty/registry.rs
+++ b/src-tauri/src/pty/registry.rs
@@ -4,8 +4,43 @@
 // TeamHub 側からは agent_id 経由で SessionHandle を引きたいので両方持つ。
 
 use crate::pty::session::SessionHandle;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::time::{Duration, Instant};
+
+/// Issue #293: 同時 PTY 数の上限。CLAUDE.md の「ターミナル最大 10 タブ」+ Canvas 上の
+/// agent ノード等を考慮しても十分余裕がある値として 100 を採用。renderer の暴走 / 悪意ある
+/// 連投で OS リソースを枯渇させない安全網。
+pub const MAX_CONCURRENT_PTY: usize = 100;
+
+/// Issue #293: spawn のレート制限。token bucket / leaky bucket の代替として、
+/// `RATE_LIMIT_WINDOW` 内に何回 spawn したかを VecDeque で数える単純な実装にする。
+/// 起動時に複数タブを並列復元するケース (~5-10 PTY) を誤検知しないため、上限は 10/sec。
+pub const MAX_PTY_SPAWNS_PER_WINDOW: usize = 10;
+pub const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(1);
+
+/// Issue #293: spawn ゲート判定の結果。caller (terminal_create) が renderer にエラー文字列を
+/// 返すために使う。
+#[derive(Debug, Clone, Copy)]
+pub enum SpawnGateError {
+    /// 同時 PTY 数が上限 (`MAX_CONCURRENT_PTY`) に達している
+    Capacity,
+    /// `RATE_LIMIT_WINDOW` 内の spawn 回数が `MAX_PTY_SPAWNS_PER_WINDOW` に達している
+    RateLimited,
+}
+
+impl SpawnGateError {
+    pub fn message(self) -> String {
+        match self {
+            Self::Capacity => format!(
+                "PTY count limit reached ({MAX_CONCURRENT_PTY}). Close some terminals before opening new ones."
+            ),
+            Self::RateLimited => format!(
+                "PTY spawn rate limit reached ({MAX_PTY_SPAWNS_PER_WINDOW} per {RATE_LIMIT_WINDOW:?}). Slow down terminal creation."
+            ),
+        }
+    }
+}
 
 /// Mutex が poison していたら warn ログを出し、data を取り出して処理を継続する。
 /// panic はしない (上位が IPC 層の場合 panic はプロセスごと吹き飛ばすため)。
@@ -69,6 +104,35 @@ struct Inner {
     /// Issue #271: HMR 経路で「同じ React mount identity の生存 PTY」を逆引きする index。
     /// agent_id を持たない Canvas TerminalCard / IDE タブも attach 対象にできる。
     by_session_key: HashMap<String, String>, // session_key → session_id
+    /// Issue #293: 直近の spawn 時刻 (`RATE_LIMIT_WINDOW` 内のもの)。
+    /// `try_reserve_spawn_slot` が pop_front + push_back で循環的に整理する。
+    spawn_history: VecDeque<Instant>,
+}
+
+/// Issue #293: spawn ゲート判定の pure 関数。`Inner` 全体を渡さずに、判定に必要な
+/// `by_id_len` と `spawn_history` だけを引数に取り、副作用は spawn_history の整理 +
+/// 許可時の push_back のみ。テストで時刻を注入して挙動を確定的に検証できる。
+fn gate_check_pure(
+    by_id_len: usize,
+    spawn_history: &mut VecDeque<Instant>,
+    now: Instant,
+) -> Result<(), SpawnGateError> {
+    if by_id_len >= MAX_CONCURRENT_PTY {
+        return Err(SpawnGateError::Capacity);
+    }
+    // window より古い spawn 履歴を捨てる
+    while let Some(&front) = spawn_history.front() {
+        if now.duration_since(front) >= RATE_LIMIT_WINDOW {
+            spawn_history.pop_front();
+        } else {
+            break;
+        }
+    }
+    if spawn_history.len() >= MAX_PTY_SPAWNS_PER_WINDOW {
+        return Err(SpawnGateError::RateLimited);
+    }
+    spawn_history.push_back(now);
+    Ok(())
 }
 
 #[derive(Default)]
@@ -79,6 +143,17 @@ pub struct SessionRegistry {
 impl SessionRegistry {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Issue #293: spawn 開始前に呼ぶ DoS ガード。同時 PTY 数の上限と spawn レートを
+    /// atomic に判定し、許可された場合のみ `spawn_history` に現在時刻を push する。
+    /// `terminal_create` は spawn (= portable-pty が子プロセスを起こす) より前に呼ぶこと。
+    ///
+    /// 拒否された場合 spawn_history は変更しない (試行回数では数えない)。
+    pub fn try_reserve_spawn_slot(&self) -> Result<(), SpawnGateError> {
+        let mut g = recover(self.inner.lock());
+        let by_id_len = g.by_id.len();
+        gate_check_pure(by_id_len, &mut g.spawn_history, Instant::now())
     }
 
     pub fn insert(&self, id: String, handle: SessionHandle) {
@@ -221,6 +296,100 @@ impl SessionRegistry {
 
     pub fn len(&self) -> usize {
         recover(self.inner.lock()).by_id.len()
+    }
+}
+
+#[cfg(test)]
+mod spawn_gate_tests {
+    //! Issue #293: `gate_check_pure` の純粋ロジックを検証する。実 PTY / SessionHandle を
+    //! 作らずに、capacity / rate limit / window 経過のすべての分岐を網羅する。
+    use super::*;
+
+    #[test]
+    fn approves_first_spawn_when_below_limits() {
+        let mut history = VecDeque::new();
+        let now = Instant::now();
+        assert!(gate_check_pure(0, &mut history, now).is_ok());
+        assert_eq!(history.len(), 1);
+    }
+
+    #[test]
+    fn allows_up_to_max_per_window_then_rate_limits() {
+        let mut history = VecDeque::new();
+        let base = Instant::now();
+        for i in 0..MAX_PTY_SPAWNS_PER_WINDOW {
+            let t = base + Duration::from_millis(i as u64 * 10);
+            assert!(
+                gate_check_pure(0, &mut history, t).is_ok(),
+                "{i} 回目は許可されるべき"
+            );
+        }
+        // 上限超え: rate limited
+        let t = base + Duration::from_millis(500);
+        assert!(matches!(
+            gate_check_pure(0, &mut history, t).unwrap_err(),
+            SpawnGateError::RateLimited
+        ));
+        // window 経過後は再度許可される (古い履歴が pop される)
+        let later = base + RATE_LIMIT_WINDOW + Duration::from_millis(10);
+        assert!(gate_check_pure(0, &mut history, later).is_ok());
+    }
+
+    #[test]
+    fn rejects_when_pty_count_at_capacity() {
+        let mut history = VecDeque::new();
+        let now = Instant::now();
+        assert!(matches!(
+            gate_check_pure(MAX_CONCURRENT_PTY, &mut history, now).unwrap_err(),
+            SpawnGateError::Capacity
+        ));
+        // capacity 拒否時は spawn_history を変更しない
+        assert_eq!(history.len(), 0);
+    }
+
+    #[test]
+    fn capacity_is_checked_before_rate_limit() {
+        // by_id_len 上限到達 + spawn_history も上限到達 → capacity が先に報告される
+        let mut history = VecDeque::new();
+        let base = Instant::now();
+        for i in 0..MAX_PTY_SPAWNS_PER_WINDOW {
+            history.push_back(base + Duration::from_millis(i as u64));
+        }
+        let now = base + Duration::from_millis(500);
+        assert!(matches!(
+            gate_check_pure(MAX_CONCURRENT_PTY, &mut history, now).unwrap_err(),
+            SpawnGateError::Capacity
+        ));
+    }
+
+    #[test]
+    fn old_history_entries_are_pruned() {
+        let mut history = VecDeque::new();
+        let base = Instant::now();
+        history.push_back(base);
+        history.push_back(base + Duration::from_millis(10));
+        // window より十分先で要求 → 古い履歴は pop_front される
+        let later = base + RATE_LIMIT_WINDOW + Duration::from_millis(100);
+        assert!(gate_check_pure(0, &mut history, later).is_ok());
+        // 新規 push_back の 1 件だけ残る
+        assert_eq!(history.len(), 1);
+    }
+
+    #[test]
+    fn rejection_does_not_modify_history() {
+        let mut history = VecDeque::new();
+        let base = Instant::now();
+        for i in 0..MAX_PTY_SPAWNS_PER_WINDOW {
+            history.push_back(base + Duration::from_millis(i as u64));
+        }
+        let len_before = history.len();
+        let now = base + Duration::from_millis(500);
+        assert!(gate_check_pure(0, &mut history, now).is_err());
+        assert_eq!(
+            history.len(),
+            len_before,
+            "拒否時は history を変更しない (試行回数では数えない)"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Issue #293 を実装。PR #291 (Closes #285) で renderer 由来 client-generated id 経路を増やしたことを踏まえ、PTY spawn の DoS ガードを入れる。

### 変更点

1. **同時 PTY 数の上限 (`MAX_CONCURRENT_PTY = 100`)** (`src-tauri/src/pty/registry.rs`)
   - CLAUDE.md の「ターミナル最大 10 タブ」+ Canvas 上の agent ノード等を考慮しても十分余裕がある値
   - 上限到達時は `SpawnGateError::Capacity` を返す
2. **spawn レート制限 (`MAX_PTY_SPAWNS_PER_WINDOW = 10` / `RATE_LIMIT_WINDOW = 1s`)**
   - `Inner` に `spawn_history: VecDeque<Instant>` を追加
   - 判定時に window より古い履歴を pop_front (容量無限肥大化を防ぐ)
   - 起動時の複数タブ並列復元 (~5-10 PTY) を誤検知しない範囲
3. **`SessionRegistry::try_reserve_spawn_slot()` を追加**
   - `terminal_create` の **新規 spawn 経路で spawn より前に呼ぶ** (attach_if_exists 経路は消費しない)
   - 拒否されたら `TerminalCreateResult { ok: false, error: ... }` を返す
4. **判定ロジックを `gate_check_pure(by_id_len, history, now)` に切り出し**
   - time injection で確定的にテスト可能にした
5. **ユニットテスト 6 件追加** (`spawn_gate_tests`):
   - capacity 未到達で 1 件目が許可される
   - window 内 max_per_window まで許可後、超過は RateLimited
   - capacity 到達で Capacity 拒否 (history 不変)
   - capacity と rate limit 同時到達時は Capacity が先に報告される
   - window 経過後の古い履歴は pop_front される
   - 拒否時は history を変更しない (試行回数では数えない)

### 設計判断

- **拒否時のメッセージは英語で返す**: `MAX_*` 数値を含む簡潔な文字列で、現状の renderer エラー表示にそのまま乗せる。i18n 化は将来 settings モーダル拡張時にまとめて行う想定。
- **agent_id 単位の上限はスコープ外**: Issue #42 で「同 agent_id 再 spawn 時に旧 PTY を kill する」既存挙動 (registry.insert) があり、agent_id ごとに 1 PTY 制限は構造的に保証されている。本 PR では追加処理しない。

### スコープ外 (issue 通り)

- TOCTOU の atomic 化 → #292 で別途対応済 (既に PR #299 で投稿)
- 上限値を設定モーダル UI で露出 / 切替 → 別 issue 候補
- DoS 以外のセキュリティ強化 (signature 検証等)

### 受け入れ基準 (Issue #293)

- [x] 同時 PTY 数の上限 (100)
- [x] レート制限 (10 PTY / 1 秒)
- [x] 拒否時に renderer に明確なエラーメッセージを返す

Closes #293

## Test plan

- [x] `npm run typecheck` 通過
- [ ] CI: `cargo check --manifest-path src-tauri/Cargo.toml` 通過 (sandbox では gdk-3.0 系 system lib 不在のためローカル実行不可)
- [ ] CI: `cargo test --manifest-path src-tauri/Cargo.toml -p vibe-editor pty::registry::spawn_gate_tests` (新規 6 件 + 既存 attach_lookup_tests 5 件 が PASS)
- [ ] 手動 (Windows 11): 通常のターミナル開き (~5 タブ並列復元) で誤検知しない
- [ ] 手動 (Windows 11): 1 秒以内に 11 回連続で `terminal.create` を呼ぶスクリプトでレート制限が発火する
- [ ] 手動: 100 PTY を超えて開こうとするとキャパシティエラーで拒否される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012QQTY9wBDKP7wyt6gzpYFK)_