### PR TITLE
feat(window): #260 PR-2 — カスタムタイトルバー (decorations: false + WindowControls)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
         "minWidth": 1100,
         "minHeight": 640,
         "resizable": true,
-        "decorations": true,
+        "decorations": false,
         "transparent": true,
         "backgroundColor": "#171716",
         "fullscreen": false

--- a/src/renderer/src/components/shell/Topbar.tsx
+++ b/src/renderer/src/components/shell/Topbar.tsx
@@ -10,6 +10,7 @@ import {
 import { useT } from '../../lib/i18n';
 import { useUiStore } from '../../stores/ui';
 import type { AvailableUpdateInfo } from '../../lib/updater-check';
+import { WindowControls } from './WindowControls';
 
 interface TopbarProps {
   projectRoot: string;
@@ -144,6 +145,9 @@ export function Topbar({
       <div className="topbar__user" aria-label="user">
         {userInitial.slice(0, 1).toUpperCase()}
       </div>
+
+      {/* Issue #260 PR-2: カスタムタイトルバーのウィンドウ制御 (decorations: false の代替) */}
+      <WindowControls />
     </div>
   );
 }

--- a/src/renderer/src/components/shell/WindowControls.tsx
+++ b/src/renderer/src/components/shell/WindowControls.tsx
@@ -1,0 +1,96 @@
+/**
+ * Issue #260 PR-2: カスタムタイトルバー用のウィンドウ制御ボタン
+ * (最小化 / 最大化・復元 / 閉じる)。
+ *
+ * `decorations: false` でネイティブ chrome を外した代わりに、Tauri 2 の
+ * `getCurrentWindow()` API を呼んでウィンドウ操作を行う。`-webkit-app-region: drag`
+ * のドラッグ可能領域に置かれるので、ボタン側は `no-drag` を CSS で当てる。
+ */
+import { useEffect, useState } from 'react';
+import { Minus, Square, Copy, X } from 'lucide-react';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { useT } from '../../lib/i18n';
+
+export function WindowControls(): JSX.Element {
+  const t = useT();
+  const [isMaximized, setIsMaximized] = useState(false);
+
+  useEffect(() => {
+    const win = getCurrentWindow();
+    let unlisten: (() => void) | undefined;
+    let disposed = false;
+    void (async () => {
+      try {
+        const initial = await win.isMaximized();
+        if (!disposed) setIsMaximized(initial);
+        // Tauri 2: onResized は最大化/復元/手動 resize 全てで発火する。
+        unlisten = await win.onResized(async () => {
+          try {
+            const next = await win.isMaximized();
+            if (!disposed) setIsMaximized(next);
+          } catch {
+            /* swallow */
+          }
+        });
+      } catch (err) {
+        // dev-mode で window API が解決できない等の場合は静かに諦める
+        // (titlebar UI は無効化されるが致命的ではない)
+        console.warn('[window-controls] init failed:', err);
+      }
+    })();
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
+
+  const handleMinimize = (): void => {
+    void getCurrentWindow().minimize();
+  };
+  const handleToggleMaximize = (): void => {
+    void getCurrentWindow().toggleMaximize();
+  };
+  const handleClose = (): void => {
+    void getCurrentWindow().close();
+  };
+
+  return (
+    <div className="window-controls" role="group" aria-label="Window controls">
+      <button
+        type="button"
+        className="window-controls__btn window-controls__btn--minimize"
+        onClick={handleMinimize}
+        title={t('windowControls.minimize')}
+        aria-label={t('windowControls.minimize')}
+      >
+        <Minus size={12} strokeWidth={2} />
+      </button>
+      <button
+        type="button"
+        className="window-controls__btn window-controls__btn--maximize"
+        onClick={handleToggleMaximize}
+        title={
+          isMaximized ? t('windowControls.restore') : t('windowControls.maximize')
+        }
+        aria-label={
+          isMaximized ? t('windowControls.restore') : t('windowControls.maximize')
+        }
+      >
+        {isMaximized ? (
+          <Copy size={11} strokeWidth={2} />
+        ) : (
+          <Square size={11} strokeWidth={2} />
+        )}
+      </button>
+      <button
+        type="button"
+        className="window-controls__btn window-controls__btn--close"
+        onClick={handleClose}
+        title={t('windowControls.close')}
+        aria-label={t('windowControls.close')}
+      >
+        <X size={13} strokeWidth={2} />
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -16,6 +16,12 @@ const ja: Dict = {
   'toolbar.palette.title': 'コマンドパレット (Ctrl+Shift+P)',
   'toolbar.settings.title': '設定 (Ctrl+,)',
 
+  // ---------- Window controls (Issue #260 PR-2: カスタムタイトルバー) ----------
+  'windowControls.minimize': '最小化',
+  'windowControls.maximize': '最大化',
+  'windowControls.restore': '元のサイズに戻す',
+  'windowControls.close': '閉じる',
+
   // ---------- Topbar (redesign shell) ----------
   'topbar.searchHint': 'コマンドを検索…',
   'topbar.mode.canvas': 'Canvas',
@@ -467,6 +473,12 @@ const en: Dict = {
   'toolbar.restart.title': 'Restart app',
   'toolbar.palette.title': 'Command palette (Ctrl+Shift+P)',
   'toolbar.settings.title': 'Settings (Ctrl+,)',
+
+  // ---------- Window controls (Issue #260 PR-2: custom titlebar) ----------
+  'windowControls.minimize': 'Minimize',
+  'windowControls.maximize': 'Maximize',
+  'windowControls.restore': 'Restore',
+  'windowControls.close': 'Close',
 
   // ---------- Topbar (redesign shell) ----------
   'topbar.searchHint': 'Search commands…',

--- a/src/renderer/src/styles/components/shell.css
+++ b/src/renderer/src/styles/components/shell.css
@@ -386,6 +386,53 @@
   flex-shrink: 0;
 }
 
+/* ==================== WINDOW CONTROLS (Issue #260 PR-2) ==================== */
+/* `decorations: false` でネイティブ chrome を外した代わりのカスタムボタン群。
+   .topbar の右端に座り、`-webkit-app-region: drag` の親領域から自身は no-drag に
+   抜けることでクリック可能を保つ。 */
+.window-controls {
+  -webkit-app-region: no-drag;
+  display: flex;
+  align-items: center;
+  margin-left: 8px;
+  gap: 0;
+  flex-shrink: 0;
+  /* Topbar の左 padding (16px) と視覚バランスを揃え、右端まで密着させる */
+  margin-right: -18px;
+  height: 100%;
+}
+
+.window-controls__btn {
+  -webkit-app-region: no-drag;
+  width: 46px;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition:
+    background 120ms var(--ease-out),
+    color 120ms var(--ease-out);
+}
+
+.window-controls__btn:hover {
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  color: var(--text);
+}
+
+.window-controls__btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -3px;
+}
+
+/* Close ボタンだけ Windows 11 / VS Code 流儀で hover 時に赤背景 + 白文字 */
+.window-controls__btn--close:hover {
+  background: #e81123;
+  color: #ffffff;
+}
+
 /* ==================== LEFT RAIL ==================== */
 .rail {
   width: var(--shell-rail);


### PR DESCRIPTION
## Summary

Issue #260 の 4-PR 計画のうち **PR-2: カスタムタイトルバー**。

PR-1 (#297) で `transparent: true` + windowEffects (Acrylic / vibrancy) を入れた状態でも、ネイティブ chrome 自体は透過しない (DWM 仕様)。`decorations: false` にしてネイティブ chrome を外し、自前のタイトルバーで置き換えることで初めて Glass の見え味が完成する。

### 変更点

1. **`tauri.conf.json`**: `decorations: true` → `false`
2. **`WindowControls` コンポーネント新設** (`src/renderer/src/components/shell/WindowControls.tsx`)
   - 最小化 / 最大化・復元 / 閉じる の 3 ボタン
   - `@tauri-apps/api/window` の `getCurrentWindow().minimize() / toggleMaximize() / close()`
   - `onResized` listen で max 状態を追従し、最大化時アイコンを Square → Copy に切替
   - dispose ガード (`disposed` flag) で unmount 後の setState を防止
3. **`Topbar` の右端に `<WindowControls />` を挿入**
   - `.topbar` 自体が `-webkit-app-region: drag` 領域なので、WindowControls 側は CSS で `no-drag` を強制
4. **CSS** (`shell.css`): `.window-controls` + 3 種のボタン
   - hover で `color-mix(text 8%)` の薄い背景
   - `focus-visible` で accent アウトライン
   - close ボタンだけ Windows 11 / VS Code 流儀で hover 時 `#e81123` 赤背景
   - Topbar の右 padding を打ち消して右端に密着させる
5. **i18n キー** (`windowControls.{minimize,maximize,restore,close}`) を ja/en 両方に追加

### スコープ外 (PR-3 / PR-4 で対応予定)

- `.glass-surface` ユーティリティクラス化 (#89 Phase 2 の積み残し) → PR-3
- themes.ts glass の色値再調整 (Acrylic との二重ブラー回避) → PR-4
- xterm.js の `allowTransparency: true` + `theme.background: rgba(0,0,0,0)` → PR-4
- macOS 用の `titleBarStyle: 'overlay'` でトラフィックライトを浮かせる経路 (本 PR では macOS でも custom WindowControls を表示する単純構成)
- Linux fallback 調整 (decorations: false が機能しない WM 上の挙動)

### プラットフォーム差異の注意

- **Windows 11**: `decorations: false` + Acrylic で PowerShell 同等の Glass 体験になる想定
- **macOS**: トラフィックライトが消えるので custom WindowControls がメインの操作系。Vibrancy は引き続き効く
- **Linux**: WM 次第。`decorations: false` を解釈しない WM では既存通りの装飾が残る場合あり (PR-1 の `applied=false` 経路と整合)

### 受け入れ基準 (Issue #260 のうち PR-2 範囲)

- [x] `decorations: false` でネイティブ chrome を外す
- [x] カスタムタイトルバー (close / minimize / maximize) を実装
- [x] `-webkit-app-region: drag` 領域 + 個別ボタンの no-drag 切り抜き
- [ ] Glass テーマ色値再調整 → PR-4
- [ ] xterm.js の `allowTransparency` → PR-3 / PR-4 で扱う

Refs #260 (PR-2)

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm test` 通過 (10 files, 70 tests, 全 PASS)
- [ ] 手動 (Windows 11): デコレーション無し + Acrylic でデスクトップ壁紙が透けて見え、custom titlebar から最小化 / 最大化 / 復元 / 閉じるが正常動作
- [ ] 手動 (Windows 11): Topbar 上部のドラッグ領域でウィンドウ移動できる
- [ ] 手動 (macOS): トラフィックライトが消え、custom WindowControls が main 操作系として機能する
- [ ] 手動 (regression): claude-dark / claude-light / dark / midnight / light でも custom titlebar が表示される (= Glass テーマ専用ではないこと)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012QQTY9wBDKP7wyt6gzpYFK)_