### PR TITLE
feat(theme): #260 PR-3 — .glass-surface ユーティリティクラスを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Tauri ベースの Claude Code / Codex 専用エディタ (v1.4.x)
 - コンポーネントは `src/renderer/src/components/` に配置
 - Rust の IPC コマンドは `src-tauri/src/commands/` にまとめる
 - 型定義は `src/types/` に集約 (Rust 側は serde で camelCase へマッピング)
+- **Glass テーマ対応**: 新規パネル / surface 系コンポーネントのルート要素には `glass-surface` クラスを付与する (Issue #260 PR-3)。Glass テーマ時のみ自動で `backdrop-filter` が当たり、他テーマでは no-op。`tokens.css` 側で完結するので index.css の `[data-theme='glass']` ホワイトリスト追記は不要。
 - スタイリング: `src/renderer/src/styles/components/` に機能別 CSS を配置 + CSS 変数でテーマ切替
 
 ## よく使うコマンド

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -270,6 +270,28 @@ samp,
   --glass-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
+/*
+ * Issue #260 PR-3: `.glass-surface` ユーティリティクラス。
+ *
+ * 新規パネル / surface コンポーネントは ルート要素の className に `glass-surface` を
+ * 付与するだけで、Glass テーマ時に自動的に backdrop-filter (blur + saturate) が
+ * 適用される。Glass 以外のテーマでは何もしないので、付け得 (no-op)。
+ *
+ * 旧来の index.css 側 `[data-theme='glass'] .toolbar, .sidebar, ...` ホワイトリスト
+ * 方式は、既存パネル互換のため当面残す。新規追加分は本ユーティリティで完結させる。
+ *
+ * 使い方:
+ *   <div className="my-panel glass-surface">...</div>
+ *
+ * 注意: backdrop-filter は新しい stacking context を作るので、`position: relative`
+ * と組み合わせると z-index が新規にスコープされる。modal/popover の上に重ねる
+ * 場合は親側の overflow と z-index を要確認。
+ */
+[data-theme='glass'] .glass-surface {
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+}
+
 :root[data-theme='light'],
 :root[data-theme='claude-light'] {
   color-scheme: light;


### PR DESCRIPTION
## Summary

Issue #260 の Phase 3 (sub-task B `.glass-surface` ユーティリティクラス化) 対応。

PR-1 (#297) で Tauri ウィンドウ透過 + OS Acrylic/Vibrancy が、PR-2 (#302) でカスタムタイトルバーが入った。本 PR-3 は、新規パネルが Glass テーマに対して **オプトインで backdrop-filter を受け取れる** ユーティリティクラスを足す。

### 変更内容

| ファイル | 変更 |
|---------|------|
| `src/renderer/src/styles/tokens.css` | `[data-theme='glass'] .glass-surface { backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate)); }` を追加 |
| `CLAUDE.md` | 「Glass テーマ対応」のコーディング規約を追記 (新規 surface 系コンポーネントは `glass-surface` className を付与する) |

### 設計判断: 既存ホワイトリストとの併存

`index.css` の `[data-theme="glass"] .toolbar, .sidebar, ...` ホワイトリスト (~22 selector) は **保持** する。

理由:
- 既存パネルへの一括 className 追加 (~10-15 ファイル touch + 視覚 regression) はリスクが高い
- 本 PR は **オプトインの additive 機能** に絞り、既存挙動への影響をゼロにする
- 将来的に `glass-surface` を各パネルに追加していけば、ホワイトリストを段階的に縮小できる

### 互換性

- 既存テーマ (`claude-dark` / `claude-light` / `dark` / `midnight` / `light` / `glass`) の見た目に影響なし
- `glass-surface` を付けていないコンポーネントは現状維持
- `glass-surface` を付けたコンポーネントは Glass テーマ時のみ blur が当たる (他テーマでは no-op)

## Test plan

- [x] `npm run typecheck` → green
- [x] `npm run build:vite` → green
- [x] `tokens.css` の追加ルールが Glass 以外のテーマでは適用されない (selector が `[data-theme='glass'] .glass-surface` 限定)
- [ ] 手動確認 (vibe-editor-reviewer 自動マージ後 staging 環境で実施)
  - 既存 Glass テーマの全パネル (Topbar / Sidebar / Rail / StatusBar / 等) で見た目に変化がないこと
  - 試しに `<div className="glass-surface">test</div>` を作って Glass テーマで blur されること

Refs #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011vfqvbri8gEoJiPgG31NzW)_