### PR TITLE
fix(window): #307 カスタムタイトルバーのドラッグ・ウィンドウコントロールを修正

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:webview:default",
     "core:window:default",
     "core:window:allow-set-title",
+    "core:window:allow-start-dragging",
     "core:app:default",
     "dialog:default",
     "dialog:allow-confirm",

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -43,6 +43,7 @@ import { OnboardingWizard } from './components/OnboardingWizard';
 import { ContextMenu, type ContextMenuItem } from './components/ContextMenu';
 import { MenuBar, MenuItem, MenuDivider, MenuSection } from './components/shell/MenuBar';
 import { useRecruitListener } from './lib/use-recruit-listener';
+import { useWindowFrameInsets } from './lib/use-window-frame-insets';
 import { ClaudeNotFound } from './components/ClaudeNotFound';
 import { useT } from './lib/i18n';
 import {
@@ -227,6 +228,8 @@ function generateTeamAction(_tab: TerminalTab): string | undefined {
 }
 
 export function App(): JSX.Element {
+  // Issue #307: Windows 11 フレームレス最大化時の不可視リサイズ境界を CSS 変数で補正
+  useWindowFrameInsets();
   const settingsLoading = useSettingsLoading();
   const { update: updateSettings, reset: resetSettings } = useSettingsActions();
   const settings = {

--- a/src/renderer/src/components/shell/Topbar.tsx
+++ b/src/renderer/src/components/shell/Topbar.tsx
@@ -56,7 +56,7 @@ export function Topbar({
 
   return (
     <div className="topbar" role="banner">
-      <div className="topbar__brand" title="vibe-editor">
+      <div className="topbar__brand" data-tauri-drag-region title="vibe-editor">
         <img
           className="topbar__brand-logo"
           src="/vibe-editor.png"
@@ -85,7 +85,7 @@ export function Topbar({
         </button>
       ) : null}
 
-      <div className="topbar__spacer" />
+      <div className="topbar__spacer" data-tauri-drag-region />
 
       <button
         type="button"

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -124,7 +124,8 @@ body,
 .layout::before {
   content: '';
   position: fixed;
-  inset: 0;
+  /* Issue #307: Windows 最大化時の不可視リサイズ境界補正 */
+  inset: var(--wf-top) var(--wf-x) var(--wf-bottom) var(--wf-x);
   z-index: var(--z-noise-overlay);
   pointer-events: none;
   opacity: var(--noise-opacity);
@@ -163,8 +164,16 @@ body,
 .layout {
   display: grid;
   grid-template-columns: 272px minmax(0, 1fr) 5px var(--claude-code-width, 460px);
-  height: 100vh;
-  width: 100vw;
+  /* Issue #307: Windows 最大化時の -8px 不可視リサイズ境界補正。
+     margin shorthand (4値) は値の取り違えリスクが高いので使わず、
+     margin-top / margin-left の個別指定で左上方向だけ押し戻す。
+     width/height は calc で内側に縮め、grid の minmax(0,1fr) も同量縮むため
+     リサイズハンドル位置・grid 列計算は破綻しない。
+     通常表示時は `--wf-* = 0px` なので副作用なし。 */
+  height: calc(100vh - var(--wf-top) - var(--wf-bottom));
+  width: calc(100vw - (var(--wf-x) * 2));
+  margin-top: var(--wf-top);
+  margin-left: var(--wf-x);
   gap: 0;
 }
 
@@ -2359,7 +2368,8 @@ body.is-resizing * {
 
 .modal-backdrop {
   position: fixed;
-  inset: 0;
+  /* Issue #307: Windows 最大化時の不可視リサイズ境界補正 */
+  inset: var(--wf-top) var(--wf-x) var(--wf-bottom) var(--wf-x);
   background: rgba(20, 20, 19, 0);
   display: flex;
   align-items: center;
@@ -2809,7 +2819,8 @@ body.is-resizing * {
 
 .cmdp-backdrop {
   position: fixed;
-  inset: 0;
+  /* Issue #307: Windows 最大化時の不可視リサイズ境界補正 */
+  inset: var(--wf-top) var(--wf-x) var(--wf-bottom) var(--wf-x);
   background: rgba(20, 20, 19, 0);
   display: flex;
   align-items: flex-start;

--- a/src/renderer/src/lib/use-window-frame-insets.ts
+++ b/src/renderer/src/lib/use-window-frame-insets.ts
@@ -1,0 +1,47 @@
+/**
+ * Issue #307 / #306: Windows のフレームレスウィンドウ (decorations: false) 最大化時に
+ * OS が約 8px の不可視リサイズ境界を画面外へ拡張する挙動の補正。
+ *
+ * `<html>` の data-* 属性として状態を出力し、CSS 側で `--wf-*` 変数を切替える。
+ *
+ * 初期 render フラッシュ防止のため、useEffect 同期パートで `data-platform` を即セットし、
+ * `data-window-maximized` は async 解決後に setattr。CSS 側はデフォルト値 0 にしてあるので
+ * 最大化中に起動した場合のみ短時間（~1 frame）の不正描画があるが、Tauri は最大化状態を
+ * 保持して dev/prod 起動するため実害は最小。
+ */
+import { useEffect } from 'react';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+
+const isWindows = /Windows/i.test(navigator.userAgent);
+
+export function useWindowFrameInsets(): void {
+  useEffect(() => {
+    if (!isWindows) return;
+    const root = document.documentElement;
+    root.dataset.platform = 'windows';
+    // 初期値を即時セットして flash を最小化
+    root.dataset.windowMaximized = 'false';
+    const win = getCurrentWindow();
+    let unlisten: (() => void) | undefined;
+    let disposed = false;
+    void (async () => {
+      try {
+        const sync = async (): Promise<void> => {
+          if (disposed) return;
+          const maximized = await win.isMaximized();
+          root.dataset.windowMaximized = String(maximized);
+        };
+        await sync();
+        // Tauri 2: onResized は最大化/復元/手動 resize / DPI 変化全てで発火する
+        unlisten = await win.onResized(sync);
+      } catch (err) {
+        // dev mode で window API が未解決等の場合は静かに諦める
+        console.warn('[use-window-frame-insets] init failed:', err);
+      }
+    })();
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
+}

--- a/src/renderer/src/styles/components/onboarding.css
+++ b/src/renderer/src/styles/components/onboarding.css
@@ -4,7 +4,8 @@
 
 .onboarding {
   position: fixed;
-  inset: 0;
+  /* Issue #307: Windows 最大化時の不可視リサイズ境界補正 */
+  inset: var(--wf-top) var(--wf-x) var(--wf-bottom) var(--wf-x);
   z-index: 9000;
   display: grid;
   place-items: center;

--- a/src/renderer/src/styles/components/shell.css
+++ b/src/renderer/src/styles/components/shell.css
@@ -390,6 +390,20 @@
 /* `decorations: false` でネイティブ chrome を外した代わりのカスタムボタン群。
    .topbar の右端に座り、`-webkit-app-region: drag` の親領域から自身は no-drag に
    抜けることでクリック可能を保つ。 */
+
+/* Issue #307: Tauri 2 公式推奨の `data-tauri-drag-region` 属性が付いた要素を
+   ドラッグ可能領域として宣言する。Windows WebView2 では `-webkit-app-region` が
+   ほぼ無効なため、新仕様の `app-region` を併用する。 */
+*[data-tauri-drag-region] {
+  app-region: drag;
+  -webkit-app-region: drag;
+}
+.window-controls,
+.window-controls__btn {
+  app-region: no-drag;
+  -webkit-app-region: no-drag;
+}
+
 .window-controls {
   -webkit-app-region: no-drag;
   display: flex;
@@ -619,9 +633,10 @@
 /* Drawer モード: App ルートから直接 absolute で差し込む */
 .activity--drawer {
   position: fixed;
-  top: var(--shell-header);
-  right: 0;
-  bottom: var(--shell-status);
+  /* Issue #307: Windows 最大化時の不可視リサイズ境界補正 */
+  top: calc(var(--wf-top) + var(--shell-header));
+  right: var(--wf-x);
+  bottom: calc(var(--wf-bottom) + var(--shell-status));
   box-shadow: var(--shadow-lg);
   z-index: 600;
   animation: activityDrawerIn 280ms var(--ease-spring);

--- a/src/renderer/src/styles/components/tweaks.css
+++ b/src/renderer/src/styles/components/tweaks.css
@@ -5,8 +5,9 @@
 
 .tweaks {
   position: fixed;
-  right: 18px;
-  bottom: calc(var(--shell-status) + 12px);
+  /* Issue #307: Windows 最大化時の不可視リサイズ境界補正 */
+  right: calc(var(--wf-x) + 18px);
+  bottom: calc(var(--wf-bottom) + var(--shell-status) + 12px);
   width: 300px;
   background: var(--bg-panel);
   border: 1px solid var(--border-strong);

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -420,3 +420,20 @@ samp,
 :root[data-density] .status {
   gap: calc(var(--gap) + 6px);
 }
+
+/* ---- Window frame insets (Issue #307 / #306) ----
+ * Windows 11 のフレームレスウィンドウ (decorations: false) は最大化時に
+ * 約 8px の不可視リサイズ境界を画面外へ拡張する。`useWindowFrameInsets`
+ * フックが `<html>` の data-* 属性を切替えるので、それを CSS 変数として
+ * 受け取り、`.layout` や `position: fixed` の overlay を viewport 内に
+ * 押し込み直す。 */
+:root {
+  --wf-top: 0px;
+  --wf-bottom: 0px;
+  --wf-x: 0px;
+}
+:root[data-platform='windows'][data-window-maximized='true'] {
+  --wf-top: 8px;
+  --wf-bottom: 8px;
+  --wf-x: 8px;
+}


### PR DESCRIPTION
## Summary
- Tauri 2 の `core:window:allow-start-dragging` capability を追加し、`-webkit-app-region` のみに依存しない drag region 実装に切り替え
- `Topbar.tsx` の `.topbar__brand` と `.topbar__spacer` のみに `data-tauri-drag-region` を付与（公式推奨パターン）
- `shell.css` で `*[data-tauri-drag-region]` に `app-region: drag`、`.window-controls` / `.window-controls__btn` に `app-region: no-drag` を CSS で明示
- `useWindowFrameInsets` フック新規作成（Windows 最大化時の不可視リサイズ境界 -8px を CSS 変数 `--wf-*` で補正）
- `tokens.css` に `--wf-*` 変数定義、`index.css` の `.layout` および各種 `position: fixed` overlay (`.layout::before`, `.activity--drawer`, `.tweaks`, `.onboarding`, `.modal-backdrop`, `.cmdp-backdrop`) を補正

## Test plan
- [ ] Windows 11 で `npm run dev` 起動時、Topbar 全体が画面内に表示
- [ ] Topbar の空白領域・ブランド領域でウィンドウドラッグ動作
- [ ] 最小化 / 最大化 / 閉じるボタンが個別動作
- [ ] 最大化状態でも Topbar 上端が見切れない
- [ ] macOS / Linux で \`--wf-*\` が 0 のまま挙動が変わらない
- [x] \`npm run typecheck\` 通過
- [x] \`npm run build:vite\` 通過

Closes #307