### PR TITLE
fix(shell): #306 .status の box-sizing を border-box に変更しメインコンテンツ最下部の見切れを解消

### DIFF
--- a/src/renderer/src/styles/components/shell.css
+++ b/src/renderer/src/styles/components/shell.css
@@ -551,6 +551,7 @@
 
 /* ==================== STATUS BAR ==================== */
 .status {
+  box-sizing: border-box;
   height: var(--shell-status);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- `.status` セレクタに `box-sizing: border-box;` を追加し、`border-top: 1px` を含めて grid 行サイズ `var(--shell-status) = 30px` に収まるようにする
- #307 PR (#308) で導入された `.layout` の `--wf-*` 補正と組み合わせて、Windows 11 フレームレス最大化時のメインコンテンツ最下部数ピクセル見切れ問題を解消

## 補足
- 本 Issue の実装計画 Step 1-2（`.layout` の `--wf-*` 補正）は #307 PR (#308) で既に完了済
- 本 PR は計画 Step 3（`.status` box-sizing）のみを対象とする最小差分

## Test plan
- [ ] Windows 11 で長文 markdown 表示時、最下端スクロールでコンテンツ最終行が完全表示
- [ ] StatusBar の border-top が見切れずウィンドウ底辺と整合
- [ ] 通常表示・最大化・Snap 各状態で同様
- [ ] macOS / Ubuntu でレイアウト変化なし
- [ ] `npm run typecheck` 通過

Closes #306