### PR TITLE
fix(canvas): #310 Canvas モードの canvas-header にドラッグ領域を追加

### DIFF
--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -526,12 +526,12 @@ export function CanvasLayout(): JSX.Element {
       aria-hidden={!isCanvasActive}
     >
       <header className="canvas-header">
-        <span className="canvas-header__brand">
+        <span className="canvas-header__brand" data-tauri-drag-region>
           <MonitorSmartphone size={14} strokeWidth={1.75} />
           Canvas
         </span>
-        <span className="canvas-header__count">{formatCardCount(cardCount, settings.language)}</span>
-        <div className="canvas-header__spacer" />
+        <span className="canvas-header__count" data-tauri-drag-region>{formatCardCount(cardCount, settings.language)}</span>
+        <div className="canvas-header__spacer" data-tauri-drag-region />
 
         <div className="canvas-popover__wrap" ref={addPopoverRef}>
           <button

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -106,6 +106,18 @@
   z-index: 5;
 }
 
+/* Canvas モードのボタン類はドラッグ領域から除外（#307 と同じパターンを #310 で適用）。
+   shell.css の *[data-tauri-drag-region] { app-region: drag; } と組み合わせて、
+   canvas-header__brand / __count / __spacer は drag、ボタン類は no-drag にする。 */
+.canvas-btn,
+.canvas-btn-split,
+.canvas-btn-split__main,
+.canvas-btn-split__caret,
+.canvas-popover__wrap,
+.canvas-popover {
+  app-region: no-drag;
+}
+
 .canvas-header__brand {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- `CanvasLayout.tsx` の `canvas-header__brand` / `canvas-header__count` / `canvas-header__spacer` に `data-tauri-drag-region` を付与
- `canvas.css` に `canvas-btn` / `canvas-btn-split` / `canvas-popover__wrap` の `app-region: no-drag` を追加し、Canvas モードのボタン操作が drag に奪われないようにする

## 背景
#307 / PR #308 で IDE モード（`Topbar`）のドラッグ問題は修正済だが、Canvas モードは独自の `<header className="canvas-header">` を使っており `data-tauri-drag-region` が一切付与されていなかった。バッチ完了後のユーザー手動 GUI 確認で発覚。

## Test plan
- [ ] Canvas モード（Ctrl+Shift+M）で `canvas-header__brand` をドラッグしてウィンドウが動く
- [ ] Canvas モードで `canvas-header__spacer` をドラッグしてウィンドウが動く
- [ ] Canvas モードの Add / Spawn Team ボタンとそれらの popover が正常クリック可能（drag に奪われない）
- [ ] IDE モードの挙動が #307 から退行していない
- [ ] `npm run typecheck` 通過

Closes #310