### PR TITLE
fix(canvas): #312 Canvas モードに WindowControls を追加

### DIFF
--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -34,6 +34,7 @@ import type {
 import { Canvas } from '../components/canvas/Canvas';
 import { CanvasSidebar } from '../components/canvas/CanvasSidebar';
 import { Rail } from '../components/shell/Rail';
+import { WindowControls } from '../components/shell/WindowControls';
 import type { SidebarView } from '../components/Sidebar';
 import { SettingsModal } from '../components/SettingsModal';
 import { useT } from '../lib/i18n';
@@ -689,6 +690,7 @@ export function CanvasLayout(): JSX.Element {
           <Layout size={13} strokeWidth={1.8} />
           IDE
         </button>
+        <WindowControls />
       </header>
       <div className="canvas-layout__body">
         <Rail


### PR DESCRIPTION
## Summary
- `CanvasLayout.tsx` に `WindowControls` を import し、`canvas-header` 末尾（IDE モード切替ボタンの後）に `<WindowControls />` を配置
- これにより Canvas モードでも最小化 / 最大化 / 閉じるボタンが画面右上に表示される

## 背景
#307 / PR #308 で IDE モード（`Topbar`）の WindowControls は機能するようになったが、Canvas モードは独自の `canvas-header` を使っており **そもそも `WindowControls` が配置されていない** ため、ウィンドウを閉じる手段が `Alt+F4` か IDE モードに戻るしかない状態だった。バッチ完了後の手動 GUI 確認で発覚（#310 と同根）。

## 補足
- CSS の `.window-controls { app-region: no-drag; }` は #307 で `shell.css` に導入済（class 名共有のため追加変更不要）
- 1 ファイル / 2 行追加の最小差分

## Test plan
- [ ] Canvas モード（Ctrl+Shift+M）で右上に最小化 / 最大化 / 閉じるボタンが表示
- [ ] 各ボタンが個別動作（最小化 / 最大化 / 閉じる）
- [ ] ボタンクリックが drag に奪われない
- [ ] IDE モードの挙動が #307 から退行していない
- [ ] `npm run typecheck` 通過

Closes #312