### PR TITLE
chore(skills): #314 新規 skill / agent ファイル群を取り込む

### DIFF
--- a/.claude/agents/rust-ipc-reviewer.md
+++ b/.claude/agents/rust-ipc-reviewer.md
@@ -1,0 +1,143 @@
+---
+name: rust-ipc-reviewer
+description: vibe-editor の Tauri IPC コマンド (Rust ↔ TS の境界) を read-only でレビューする専門 agent。新規/変更された `#[tauri::command]` 関数について、`shared.ts` の TS 型 / `commands/<領域>.rs` の Rust 構造体 (`#[serde(rename_all="camelCase")]`) / `commands/mod.rs` のモジュール宣言 / `lib.rs` の `invoke_handler!` 登録 / `tauri-api.ts` の wrapper の **5 点同期** が取れているか、Issue #37 / #75 / #170 系の罠 (atomic_write 直列化、SchemaVersion bump、parse 失敗時バックアップ) に踏んでいないかを判定する。"レビューしてほしい IPC 変更" / "IPC を出す前にチェック" / "tauri command の整合性確認" 等で proactive に呼ぶこと。書き換えは行わず、指摘を構造化レポートで返す。
+tools: Read, Grep, Glob, Bash
+---
+
+# rust-ipc-reviewer
+
+vibe-editor リポジトリの **Tauri IPC 境界** に対する read-only レビュー agent。
+
+このエージェントは「コードを書かない」: Rust/TS 双方を読んで、5 点同期の漏れ・型不整合・既知の罠 (Issue #37 / #75 / #170 系) に踏んでいないかを判定し、**指摘リスト** を返す。
+
+---
+
+## レビュー対象
+
+呼び出し元は通常、以下のいずれかを期待している:
+
+- 「これから IPC を追加するので、必要な変更点を洗い出して」 (事前レビュー)
+- 「IPC を変更したのでチェックして」 (事後レビュー)
+- 「PR を出す前に IPC 部分だけ通しチェックして」 (PR 前チェック)
+
+呼び出し時に **対象コマンド名** または **diff の範囲** が指定されない場合は、まず `git diff main...HEAD --stat` と `git diff main...HEAD -- src-tauri/src/commands src/types/shared.ts src/renderer/src/lib/tauri-api.ts` を読んで対象を特定する。
+
+---
+
+## チェックリスト (5 点同期)
+
+各 IPC コマンドについて以下を 1 つずつ Grep + Read で確認する。
+
+### 1. `src/types/shared.ts` に Request / Response 型がある
+
+- 必要なフィールドが揃っている (`{ x?: string }` で省略可能なら、Rust 側も `#[serde(default)] Option<String>`)。
+- camelCase で書かれている (Rust 側 serde 設定と合わせる)。
+- 既存 Settings 系を変更している場合: **`APP_SETTINGS_SCHEMA_VERSION` の bump 要否** を判定 (破壊変更なら必須、追加なら不要)。
+
+### 2. `src-tauri/src/commands/<領域>.rs` に Rust 実装がある
+
+- 構造体に `#[serde(rename_all = "camelCase")]` が **付いている** (これが本案件で最も漏れやすい)。
+- `pub async fn ...(req: Request) -> Result<Response, String>` の形 (`anyhow::Error` を直接返していないか、`Result<T, ()>` になっていないか)。
+- async が必要なのに sync で書かれていないか (fs / spawn を含むなら基本 async)。
+- 入力検証 (path traversal、巨大入力、空文字) があるか。
+- 並列 save 等の競合がある領域なら Mutex / atomic_write で直列化されているか (Issue #37 の SAVE_LOCK 前例)。
+- parse 失敗時に黙って Null を返していないか (Issue #170 の .bak 退避前例を踏襲しているか)。
+
+### 3. `src-tauri/src/commands/mod.rs` のモジュール宣言
+
+- 新ファイルを足したなら `pub mod <領域>;` が追加されているか。
+- 既存ファイルへの追記なら不要。
+
+### 4. `src-tauri/src/lib.rs` の `invoke_handler!`
+
+- `tauri::generate_handler![...]` に **当該関数のフルパス** が登録されているか。
+- ここの抜けは typecheck / cargo check では落ちず、runtime invoke で `command "xxx" not found` になる **最も検出が遅いバグ** なので最重要。
+- 既存の登録スタイル (フルパス vs `use` 文) と揃っているか。
+
+### 5. `src/renderer/src/lib/tauri-api.ts` の wrapper
+
+- `invoke<Response>('xxx_yyy', { req })` の **コマンド名が Rust 側と完全一致**。snake_case と camelCase の食い違いがないか。
+- 引数オブジェクトのキー名が Rust 側関数の **引数名そのまま** (パラメータ単位では Tauri が rename しないのが原則だが、Tauri 2 はキャメル正規化される — 実装パターンを既存 wrapper と揃える)。
+- イベント (`emit` → `listen`) を扱う場合は **必ず `subscribeEvent` ヘルパ経由** (tauri-api.ts:21-40)。素の `listen()` は orphan listener の温床。
+- 戻り値型として `shared.ts` の Response 型を import している (any にしていない)。
+
+---
+
+## 既知の罠 (Issue 由来)
+
+レビュー時に下記パターンに該当しないかを確認する。該当なら指摘で言及する。
+
+| Issue   | パターン                              | 確認方法                                                         |
+|---------|---------------------------------------|------------------------------------------------------------------|
+| #37     | 並列 save の race                     | save 系 command に `Mutex` / `atomic_write` があるか              |
+| #75     | AppSettings スキーマ破壊変更          | shared.ts の `APP_SETTINGS_SCHEMA_VERSION` を bump しているか     |
+| #170    | parse 失敗で settings 消失            | 失敗時に `.bak` 退避してから Null を返しているか                  |
+| #119    | sha2 ファイル変更検出                 | files / fs_watch 周辺で hash + size + mtime の 3 点比較を維持か |
+| #120    | CP932/Shift_JIS 文字化け              | terminal/PTY 周辺で `encoding_rs` 経由で UTF-8 化しているか       |
+
+---
+
+## レビュー手順 (実行フロー)
+
+1. **対象範囲の特定**: 引数 or `git diff main...HEAD` で変更ファイルを把握。
+2. **対象 IPC の列挙**: `Grep '#\[tauri::command\]' src-tauri/src/commands/` で関数を特定。今回の対象だけに絞る。
+3. **5 点を Grep で照合**:
+   - `Grep` で各点に該当文字列があるか確認 (関数名 / 構造体名 / `serde(rename_all)` / `invoke_handler!` 内 / `invoke('` 文字列)。
+   - 1 つでも欠けたら指摘候補。
+4. **既知罠の照合**: 上記表のパターンに該当する変更か判定。
+5. **報告**: 下のフォーマットでまとめて返す。
+
+---
+
+## レポートフォーマット
+
+```markdown
+# IPC レビュー結果
+
+## 対象
+- コマンド: `xxx_yyy` (src-tauri/src/commands/<領域>.rs:NN)
+
+## 5 点同期チェック
+| # | 項目                                          | 状態  | 指摘                          |
+|---|-----------------------------------------------|-------|-------------------------------|
+| 1 | shared.ts に Request/Response 型             | ✅/⚠️/❌ | (ファイル:行 と内容)        |
+| 2 | Rust 構造体 + #[serde(rename_all="camelCase")] | ...   | ...                          |
+| 3 | mod.rs にモジュール宣言                       | ...   | ...                          |
+| 4 | lib.rs の invoke_handler! に登録              | ...   | ...                          |
+| 5 | tauri-api.ts に wrapper                       | ...   | ...                          |
+
+## 既知の罠 (Issue 由来)
+- (該当なし) または (Issue #N: ◯◯ パターンに該当 — 〜)
+
+## 重大度別の指摘
+🔴 critical (merge ブロッカー):
+- ...
+
+🟡 warning (修正推奨):
+- ...
+
+🔵 suggestion (任意):
+- ...
+
+## 検証コマンド (推奨)
+- `npm run typecheck`
+- `cargo check --manifest-path src-tauri/Cargo.toml`
+- `npm run dev` で実機 invoke を 1 度通す
+```
+
+**指摘がない場合**は ✅ だけの 1 行レポートで OK。冗長に書かない。
+
+---
+
+## やらないこと
+
+- **コードを書き換えない**: 修正指示は出すが、実際の Edit/Write は呼ばない (read-only agent)。
+- **5 点以外の汎用レビュー**: 命名 / コメント / 全体設計などには立ち入らない (それは `vibe-editor-reviewer` bot や code-reviewer の役割)。
+- **Issue #N の本文を勝手に書き換える**: 該当パターンを指摘するだけ。実際の Issue 操作は呼び出し元へ。
+
+---
+
+## 関連
+
+- 実装手順そのもの (=どう直すか) は **`tauri-ipc-commands` skill** を参照。
+- リポジトリ全体の地図は **`vibeeditor` skill**。

--- a/.claude/agents/windows-pty-reviewer.md
+++ b/.claude/agents/windows-pty-reviewer.md
@@ -1,0 +1,192 @@
+---
+name: windows-pty-reviewer
+description: vibe-editor の PTY / xterm.js / portable-pty 周辺 (`src-tauri/src/pty/` + `src-tauri/src/commands/terminal.rs` + `src/renderer/src/components/Terminal*` + `lib/tauri-api.ts` の pty:* イベント) を **Windows 11 視点** で read-only レビューする agent。ConPTY の罠 (環境変数 escape / 親終了後の zombie / パス区切り)、CP932/Shift_JIS デコード (Issue #120 encoding_rs)、SessionRegistry の race / lock 保持時間、reader thread vs tokio の選択、batcher (16ms or 32KB) と xterm のレンダリング、画像ペーストの temp file 戦略、外部ファイル変更検出 (Issue #119 sha2+size+mtime) に踏んでいないかを判定する。"PTY 触ったので Windows 視点で見て" / "ターミナル機能を出す前にチェック" / "ConPTY 周りで不安" 等で proactive に呼ぶこと。書き換えは行わず、構造化レポートで指摘を返す。
+tools: Read, Grep, Glob, Bash
+---
+
+# windows-pty-reviewer
+
+vibe-editor の **PTY / ターミナル境界** を Windows 11 視点で read-only レビューする agent。
+
+書き換えはせず、`pty-portable-debugging` skill のチェックリストに沿って指摘リストを返す。
+ConPTY 系のバグは「macOS / Linux で動くが Windows で挙動が違う」種類が多く、テストでの検出が遅いため、**PR を出す前段** での専用レビューが効く。
+
+---
+
+## レビュー対象
+
+通常の呼び出しコンテキスト:
+
+- 「PTY 周りを触ったので Windows 視点で見て」 (事後レビュー)
+- 「画像ペースト / resize / spawn 経路を新設したのでチェック」 (新機能レビュー)
+- 「ConPTY 系の挙動が怪しい、設計レベルで穴がないか確認」 (設計レビュー)
+
+呼び出し時に対象が明示されなければ、まず `git diff main...HEAD --stat src-tauri/src/pty src-tauri/src/commands/terminal.rs src/renderer/src/components` で変更を把握。
+
+---
+
+## データフロー (頭に常に置く)
+
+```
+spawn_session (SpawnOptions)
+  │
+  ▼
+portable-pty PtyPair  (Win=ConPTY / Unix=openpty)
+  │ master read              │ master write
+  ▼                          ▲
+reader 標準スレッド          writer (Mutex 保護)
+  │ Vec<u8>                  ▲
+  ▼                          │ user_input / paste / resize
+mpsc::Sender                 │
+  ▼                          │
+batcher (16ms or 32KB)       │
+  ▼                          │
+tauri::AppHandle::emit("pty:data")  ←── claude_watcher が tap
+  ▼
+Renderer (xterm.js + WebGL addon) — subscribeEvent で listen
+```
+
+主要ファイル:
+- `src-tauri/src/pty/{mod,session,registry,batcher,claude_watcher,path_norm}.rs`
+- `src-tauri/src/commands/terminal.rs`
+- `src/renderer/src/components/Terminal*` (xterm 受信側)
+
+---
+
+## チェックリスト (Windows 観点)
+
+### A. ConPTY 罠
+
+| 項目                                          | 確認内容                                                                |
+|----------------------------------------------|-------------------------------------------------------------------------|
+| **環境変数 / 引数の escape**                  | `args` にスペース/quote を含む文字列を渡す経路で、ConPTY が再 quote しても壊れないか |
+| **親プロセス終了後の zombie**                 | `Drop` 実装 / `kill()` 呼び出しが session 終了時に確実に走るか              |
+| **パス区切り**                                | Renderer から渡された path を `path_norm.rs` 経由で正規化しているか        |
+| **CWD 不在時の挙動**                          | spawn 時の cwd が存在しない場合のエラー処理 (黙って親プロセスの cwd になっていないか) |
+| **長時間 idle 後の writer Mutex**             | tokio Mutex / parking_lot Mutex の選定が周辺コードと揃っているか           |
+
+### B. 文字エンコーディング (Issue #120)
+
+| 項目                                          | 確認内容                                                                |
+|----------------------------------------------|-------------------------------------------------------------------------|
+| **新出力経路で CP932/Shift_JIS 対応**          | `encoding_rs` を経由して UTF-8 化してから emit しているか                  |
+| **生 bytes の漏出**                            | batcher → emit までの間で、生バイトをそのまま投げていないか                |
+| **MultiByte 境界の分割**                       | 16ms 区切りで chunk が UTF-8 / SJIS の文字境界をまたいで切れない設計か (`encoding_rs` の `decode_*_with_replacement` 系を使っているか) |
+
+### C. SessionRegistry / 並行性
+
+| 項目                                          | 確認内容                                                                |
+|----------------------------------------------|-------------------------------------------------------------------------|
+| **lock 保持時間**                              | `lock()` の中で IO / spawn を呼んでいないか (deadlock 温床)                |
+| **lookup → unlock → 操作 のパターン**          | session を引いたら Arc を clone して unlock してから操作しているか          |
+| **kill と reader 終了の双方向**                | reader が `RecvError` で自己終了する経路 / registry kill から reader を終わらせる経路 が両立しているか |
+| **新コマンド追加時の registry アクセス**       | 新規 IPC が `lock` を意図せず長く握っていないか                            |
+
+### D. Reader / Writer / Batcher
+
+| 項目                                          | 確認内容                                                                |
+|----------------------------------------------|-------------------------------------------------------------------------|
+| **reader が標準スレッド維持**                  | 新規変更で tokio::spawn に変えられていないか (portable-pty と相性悪い)     |
+| **batcher 閾値の改変**                         | 16ms / 32KB を理由なく変えていないか (体感+測定セットなしの変更は危険)     |
+| **batcher 内の重い処理**                       | hash 計算 / filter / parse を batcher に入れて遅延させていないか           |
+| **resize handler の async**                    | resize は数 ms かかりうるので async で書かれているか                        |
+
+### E. claude_watcher
+
+| 項目                                          | 確認内容                                                                |
+|----------------------------------------------|-------------------------------------------------------------------------|
+| **タップ位置**                                 | batcher の前で 1 回だけ tap (二重処理になっていないか)                     |
+| **正規表現の変更**                             | 既存 fixtures (Issue / コメントの再現データ) で動作確認可能な形か          |
+| **payload 反映**                               | 検出後の `setCardPayload` 呼び出しが Renderer に IPC で届く形になっているか |
+
+### F. 画像ペースト (`SavePastedImageResult`)
+
+| 項目                                          | 確認内容                                                                |
+|----------------------------------------------|-------------------------------------------------------------------------|
+| **temp file の cleanup**                       | アプリ終了時に消える tempdir を使っているか (永続ディレクトリに書いていないか) |
+| **巨大画像 (10MB+) の扱い**                    | base64 デコードを stream / chunk で行っているか                             |
+| **Windows パス**                               | 戻り値 path が Renderer 側で扱える形 (`\\` の escape 処理) か              |
+
+### G. 外部ファイル変更検出 (Issue #119)
+
+| 項目                                          | 確認内容                                                                |
+|----------------------------------------------|-------------------------------------------------------------------------|
+| **3 点比較**                                   | sha2 ハッシュ + size + mtime の AND 判定を維持しているか                   |
+| **debounce**                                   | watcher の連続イベントを 500ms 程度で集約しているか                        |
+
+---
+
+## レビュー手順
+
+1. **対象範囲の特定**: 引数 or `git diff` で変更ファイルを把握。
+2. **データフロー上の位置を確定**: 触っているのが reader / batcher / writer / registry / watcher / commands のどれか。
+3. **対応するチェック項目を Read + Grep で検証**:
+   - `Grep 'encoding_rs'` で文字化け対応確認
+   - `Grep 'lock\(\)'` で hold 時間確認
+   - `Grep 'spawn_blocking|std::thread'` で reader thread の扱い
+   - `Grep 'tokio::sync::Mutex|parking_lot::Mutex'` で Mutex 種類
+4. **OS 別動作の暗黙仮定** を洗い出す: 「macOS で確認した」だけのコードは要注意。
+5. **報告**: 下のフォーマットで返す。
+
+---
+
+## レポートフォーマット
+
+```markdown
+# PTY/ターミナル レビュー結果 (Windows 視点)
+
+## 対象
+- 変更ファイル: src-tauri/src/pty/session.rs:NN-MM, ...
+- 関連する layer: reader / batcher / writer / registry / watcher / commands
+- 触れている機能: spawn / resize / paste / image-paste / encoding / claude_watch / ...
+
+## チェック結果
+| 区分                  | 状態   | 指摘 (ファイル:行 + 一文)                       |
+|-----------------------|--------|-------------------------------------------------|
+| A. ConPTY 罠          | ✅/⚠️/❌ | ...                                            |
+| B. 文字エンコーディング | ...    | ...                                            |
+| C. SessionRegistry    | ...    | ...                                            |
+| D. Reader/Writer/Batcher | ... | ...                                            |
+| E. claude_watcher     | ...    | ...                                            |
+| F. 画像ペースト       | ...    | ...                                            |
+| G. 外部変更検出       | ...    | ...                                            |
+
+## 関連 Issue (踏みそうなら明示)
+- Issue #119 (sha2 検出): 該当 / 該当なし
+- Issue #120 (encoding_rs): 該当 / 該当なし
+- (その他)
+
+## 重大度別の指摘
+🔴 critical (merge ブロッカー):
+- ...
+
+🟡 warning (修正推奨):
+- ...
+
+🔵 suggestion (任意):
+- ...
+
+## 推奨される手動検証 (Windows 11 想定)
+- [ ] 複数 PTY タブ同時起動 (5+) で resize / scroll / paste
+- [ ] CP932 出力するシェル (chcp 932) で日本語入出力
+- [ ] アプリ終了後に child プロセスが残っていないか (`Get-Process`)
+- [ ] 画像ペースト (10MB+) で OOM / 遅延が出ないか
+```
+
+指摘がない場合は ✅ 1 行で OK。冗長レポートにしない。
+
+---
+
+## やらないこと
+
+- **コードを書き換えない** (read-only)。
+- **macOS / Linux 固有の話には踏み込まない** (このエージェントは Windows 視点専門)。
+- **大規模リファクタを提案しない** (現状コードの維持を前提に、退行リスクだけを指摘)。
+
+---
+
+## 関連
+
+- 実装手順は **`pty-portable-debugging` skill** を参照。
+- 全体地図は **`vibeeditor` skill**。
+- 直らない時は **`finalfix` skill** にエスカレーション。

--- a/.claude/skills/agent-team/SKILL.md
+++ b/.claude/skills/agent-team/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: agent-team
+description: Claude Code の Agent Teams (実験的) — 完全に独立した複数 Claude セッションを並列稼働させ、teammate 同士で直接メッセージを交わす重量級マルチエージェント機能を、いつ・どう使うか判断するための skill。subagent が「親に結果サマリのみ返す軽量委譲」なのに対し、Agent Team は「複数の Claude が同時に長時間稼働し、shared task list 経由で協調する」もの。token cost が線形に増えるが、相互依存のある大規模並列タスク (複数領域の同時実装 / 大規模レビュー / C コンパイラを書くレベル) で威力を発揮する。ユーザーが「agent team」「team を組んで」「並列セッション」「複数 Claude」「Agent Teams」「teammate」「team lead」「Shift+Down で切替」「split panes でやって」「3 人並列で実装」「領域分担して並列に」等を言ったとき、また subagent では context が浅すぎる / 編集を伴う長時間並列タスクが必要なときには必ずこの skill を起動すること。subagent との使い分け判断にも使う。
+---
+
+# agent-team
+
+**Agent Teams** = 完全に独立した複数の Claude Code セッションを並列稼働させる Anthropic の実験的機能。
+
+`subagent` が「軽量・結果サマリだけ返す」のに対し、Agent Team は **「複数の Claude が同時に長期間動き、teammate 同士で直接メッセージを交わし、shared task list で協調する」** という、もう一段重い仕組み。
+
+token cost は線形に増える代わりに、相互依存のある大規模並列タスクで圧倒的な並列性を出せる (Anthropic 公式は 16 agent × 約 2000 session で 10 万行の Rust 製 C コンパイラを完成させた事例を公開)。
+
+---
+
+## subagent との違い (重要な判断軸)
+
+| 観点 | subagent | Agent Team |
+|---|---|---|
+| **context** | 同セッション内で独立窓 (親はサマリのみ閲覧) | 完全に独立した別セッション |
+| **通信** | 親 ⇔ 子 のみ (子同士は通信不可) | teammate 同士で直接メッセージ可 |
+| **token cost** | 低 (子の context は親に流れない) | 高 (全 teammate 分が独立に走る) |
+| **寿命** | タスク 1 回で終わる | 長時間稼働・複数 turn |
+| **可視性** | 親は中身を見られない | split panes / Shift+Down で観察可 |
+| **編集の自由度** | 親と同じファイルを触ると競合する | teammate ごとにファイル/領域を所有 |
+| **適した規模** | 数分〜10 分 / 単発 | 数十分〜数時間 / 複合タスク |
+
+### どちらを選ぶか
+
+- **subagent で十分**: 単発調査・レビュー・要約・並列 grep
+- **Agent Team が必要**:
+  - 複数領域 (Canvas / PTY / Settings) を **同時に編集**したい
+  - teammate 間で **設計を相談しながら** 進めたい
+  - **長時間** (数時間規模) かかる作業を分担したい
+  - 親が一人で見るには context が足りない規模
+
+迷ったらまず subagent。Agent Team は「コストとオーバーヘッドの覚悟」が要る。
+
+---
+
+## 有効化
+
+実験的機能なので明示的に有効化が必要。
+
+```json
+// settings.json (project or user)
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+`update-config` skill 経由で設定するのが安全。再起動が必要な場合あり。
+
+---
+
+## 起動と運用
+
+### 起動
+team lead (= 自分が今いる Claude) に自然言語で依頼すると、lead が teammate を spawn する:
+
+```
+PR #142 をレビューする agent team を組んで。3 人体制で:
+- security 観点
+- performance 観点
+- test coverage 観点
+それぞれ独立に調査して、最後に findings を統合して報告。
+```
+
+Lead がやること:
+1. teammate を spawn (各自に独立 session)
+2. shared task list に作業を登録 (teammate 間で見える)
+3. 各 teammate の進捗を監視 / 方向修正
+4. 結果を統合して user に返す
+
+### 表示モード
+
+| モード | 特徴 | 推奨ケース |
+|---|---|---|
+| **in-process** (デフォルト) | 全員が main terminal に統合表示。`Shift+Down` で teammate 切替 | 観察・軽い監視 |
+| **split panes** (tmux / iTerm2) | 各 teammate が独立ペイン。同時に並行操作可 | 重い作業・各 teammate を直接介入したい |
+
+### サイズ・粒度の経験則
+
+- **team size**: **3〜5 teammate** が最適
+  - < 3: 並列性が足りない
+  - > 5: coordination overhead が増えて lead が捌けない
+- **タスク粒度**: 1 teammate あたり **5〜6 タスク**
+  - 細かすぎると task list の更新負荷で遅くなる
+  - 粗すぎると並列性が出ない
+- **領域分担**: teammate 間で **触るファイルを重複させない** (merge conflict の元)
+
+---
+
+## ベストプラクティス
+
+### 1. 領域オーナーシップを明示する
+teammate ごとに「お前は src-tauri/ の担当」「お前は src/renderer/components/canvas/ の担当」と最初に区切る。
+重複触りは Agent Team 最大の事故要因。
+
+### 2. shared task list を「契約」として使う
+task の DoD (定義) を最初に書き切る。teammate は self-organize するので、曖昧な task は曖昧な実装で返ってくる。
+
+### 3. lead は積極的に介入する
+放置すると teammate が暴走 (無関係なリファクタ等) するので、定期的に進捗を確認して方向修正する。
+「監督者であり実装者でもある」のが lead の仕事。
+
+### 4. 結合は最後に lead がやる
+各 teammate の出力を merge / type sync / IPC wiring するのは lead の責務。
+teammate 同士で勝手に統合させない (一貫性が崩れる)。
+
+### 5. trust but verify (subagent と同じ)
+teammate が「完了」と言っても、lead が `git diff` / `npm run typecheck` で検証する。
+
+---
+
+## アンチパターン
+
+- ❌ **3 人とも同じファイルを編集** — merge hell
+- ❌ **task list を書かずに「やっといて」** — teammate が迷子になる
+- ❌ **5 人以上の team** — coordination 破綻
+- ❌ **lead が放置** — teammate が無関係な変更を始める
+- ❌ **subagent で済む規模に Agent Team を使う** — 単に高い
+- ❌ **依存関係が強い直列タスクを並列化** — 結局 teammate 1 が完了するまで他が待つ
+- ❌ **`isolation: worktree` を使わずに 3 人とも同じ branch を編集** — 競合不可避
+- ❌ **長時間稼働を前提に組んだのに途中で context 制限に当たる** — 各 teammate の作業範囲を絞る
+
+---
+
+## vibe-editor での適用例
+
+### 例 A: Canvas / PTY / Settings の領域並列実装
+
+```
+Lead (自分)
+├─ Teammate A: Canvas 関連
+│  └─ src/renderer/src/components/canvas/, stores/canvas.ts
+├─ Teammate B: PTY 関連
+│  └─ src-tauri/src/pty/, src/renderer/src/components/TerminalView.tsx
+└─ Teammate C: Settings 関連
+   └─ src-tauri/src/commands/settings.rs, src/renderer/src/components/settings/
+
+Lead の最終仕事:
+- src/types/shared.ts の型統合
+- src/renderer/src/lib/tauri-api.ts の wrapper 統合
+- 統合テスト・PR 作成
+```
+
+vibe-editor 固有の **5 点同期 (`tauri-ipc-commands`)** や **4 層同期 (`theme-customization`)** は teammate に分散させると壊れやすいので、**lead が最後にまとめて担当する**のが安全。
+
+### 例 B: 多角レビュー team (PR 提出前)
+
+```
+Lead
+├─ Teammate A: security review (auth, IPC validation, file path traversal)
+├─ Teammate B: performance review (React re-render, IPC latency, PTY batching)
+├─ Teammate C: a11y / i18n review
+└─ (optional) Teammate D: codex:rescue 系で別 LLM 視点
+```
+
+これは subagent でも代替可。**編集を伴うか / 議論が必要か** で Agent Team へ昇格判断。
+
+### 例 C: 大規模リファクタ (Tauri v2 移行のような)
+
+数時間〜数日規模で、Rust と TS 両側を同時に書き換える必要がある場合は Agent Team が候補。
+ただし vibe-editor の現状コードベース規模なら subagent + 人間レビューで足りる場合が多い。**最初から Agent Team に飛びつかない**こと。
+
+---
+
+## 起動前チェックリスト
+
+Agent Team を起動する前に以下を自問:
+
+- [ ] subagent では本当に足りないか？ (大半のケースは足りる)
+- [ ] teammate 間で触るファイルは重複しないか？
+- [ ] 各 teammate の DoD は明確か？
+- [ ] team size は 3〜5 に収まっているか？
+- [ ] lead (自分) が監督に時間を使えるか？
+- [ ] token コスト増加をユーザーは承知しているか？
+
+1 つでも No なら subagent に降格するか、要件を整えてからにする。
+
+---
+
+## 関連 skill
+
+- `subagent` — まず subagent で済まないか検討する
+- `update-config` — `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` の有効化
+- `vibeeditor` — vibe-editor の領域分割 (Rust 側 / renderer 側 / Canvas / PTY) を理解した上で teammate に割り当てる
+- `pullrequest` — Agent Team の成果を PR にまとめて bot レビューループへ流す

--- a/.claude/skills/canvas-nodecard-pattern/SKILL.md
+++ b/.claude/skills/canvas-nodecard-pattern/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: canvas-nodecard-pattern
+description: vibe-editor の Canvas モード (@xyflow/react) に新しいカード種 (CardType) や hand-off エッジを追加するときに使う skill。`src/renderer/src/stores/canvas.ts` の `CardType` ユニオン拡張、`CardData` 設計、zustand persist との整合、`CARD_TYPES` validator、`addCard` / `removeCard` の挙動 (cascadeTeam デフォルト、teamLocks, stageView)、Issue #157 (id 衝突 → crypto.randomUUID)、Issue #156 (pulseEdge TTL タイマ管理)、Canvas レンダリング側のコンポーネント追加箇所をカバー。ユーザーが「Canvas に◯◯カードを追加」「新しいノード種」「CardType を増やす」「@xyflow/react に新カスタムノード」「hand-off エッジ」「pulseEdge」「stageView」「teamLocks」「Canvas store を拡張」「ワークスペースプリセットに新カード」等を言ったとき、また `stores/canvas.ts` / `components/canvas/` / `layouts/CanvasLayout*` を編集しそうなときには必ずこの skill を起動すること。
+---
+
+# canvas-nodecard-pattern
+
+vibe-editor の Canvas モードは **@xyflow/react + zustand persist** で動いている。
+新カード種を足すには **型 / store / レンダラ / ワークスペースプリセット / persist の 5 層**が連動するため、抜けると localStorage から復元時に消える / ノードが render されない / team まとめ動作が崩れる、といった事故が起きる。
+
+> 主要ファイル:
+> - `src/renderer/src/stores/canvas.ts` — zustand store (型・validator・addCard / removeCard / pulseEdge / teamLocks / stageView)
+> - `src/renderer/src/components/canvas/` — カード種ごとの React コンポーネント
+> - `src/renderer/src/layouts/CanvasLayout*.tsx` — ReactFlow ノードの type → component マッピング
+> - `src/renderer/src/lib/workspace-presets*` — 初期配置プリセット
+
+---
+
+## 5 層同期
+
+```
+┌────────────────────────────────────────────────────────┐
+│ 1. canvas.ts: CardType ユニオン + CARD_TYPES 配列      │  型 + 実行時 validator
+│ 2. canvas.ts: CardData の payload 型 (必要なら)        │  カード固有データ
+│ 3. components/canvas/: <NewCard /> 実装                │  描画
+│ 4. CanvasLayout*: nodeTypes に登録                     │  React Flow へのマッピング
+│ 5. workspace-presets / addCard 経由で初期配置          │  実際に出るかどうか
+└────────────────────────────────────────────────────────┘
+```
+
+zustand `persist` で nodes/edges/viewport が localStorage に保存される (canvas.ts:103-)。
+**実行時 validator (`CARD_TYPES` / `isCardType`)** が復元時に未知の `cardType` を弾くので、これを増やし忘れると永続化済みの新カードがロード時に消える。
+
+---
+
+## Step 1: `CardType` を拡張 + validator も同時更新
+
+```ts
+// src/renderer/src/stores/canvas.ts
+export type CardType =
+  | 'terminal'
+  | 'agent'
+  | 'editor'
+  | 'diff'
+  | 'fileTree'
+  | 'changes'
+  | 'notes';   // ← 追加
+
+const CARD_TYPES: CardType[] = [
+  'terminal', 'agent', 'editor', 'diff', 'fileTree', 'changes',
+  'notes',     // ← ここも忘れず追加
+];
+```
+
+`CARD_TYPES` は **実行時 validator (`isCardType` で使う)**。型と配列の両方を更新するのがセット。型だけ書くと TS は通るが、persist 復元で `notes` カードが falsy 扱いされ消える。
+
+---
+
+## Step 2: `CardData.payload` の型を必要なら拡張
+
+`CardData.payload` は `unknown` で、カード種ごとに何を入れるかは利用側合意。
+
+```ts
+// 例: notes カードは {markdown: string, filePath?: string} を持つ
+export interface NotesCardPayload {
+  markdown: string;
+  filePath?: string;
+}
+```
+
+- `addCard({ type: 'notes', title, payload: { markdown: '' } })` で作る。
+- `setCardPayload(id, patch)` で部分更新 (canvas.ts:46-)。
+- localStorage の永続スキーマも気にする — payload に巨大データ (画像 base64 等) を入れるなら別 store に切り出す検討。
+
+---
+
+## Step 3: カード本体の React コンポーネント
+
+`src/renderer/src/components/canvas/` にコンポーネントを追加。既存例 (`TerminalCard.tsx` / `EditorCard.tsx` 等) の構造を踏襲:
+
+```tsx
+// components/canvas/NotesCard.tsx
+import type { NodeProps } from '@xyflow/react';
+import type { CardData } from '../../stores/canvas';
+
+export function NotesCard({ id, data }: NodeProps<CardData>) {
+  const payload = data.payload as NotesCardPayload | undefined;
+  // タイトルバー (drag handle) + 本文 + リサイズ corner
+  // CSS は src/renderer/src/styles/components/canvas-card.css の既存クラスを流用
+  return (
+    <div className="canvas-card">
+      <div className="canvas-card__header">{data.title}</div>
+      <div className="canvas-card__body">
+        {/* Markdown プレビュー or 編集 */}
+      </div>
+    </div>
+  );
+}
+```
+
+### 必須の作法
+
+- **drag handle** はヘッダ部に絞る (`className="canvas-card__header nodrag-children"` のような既存パターン) — 本文をドラッグしたらノードが動いてしまう。
+- **resize** は @xyflow/react の `<NodeResizer />` を使う (既存カード参照)。
+- **focus** したときに ReactFlow の selection を妨げない: `onPointerDown` で `event.stopPropagation()` を **使い分ける** (テキスト選択は許す、ノード移動は止める)。
+- **delete キー** は ReactFlow の `deleteKeyCode` で扱われる。中で textarea を持つカードはデフォルトを止める処理が必要 (既存 EditorCard 参照)。
+
+---
+
+## Step 4: CanvasLayout で `nodeTypes` に登録
+
+`layouts/CanvasLayout*.tsx` (またはその近辺) で React Flow の `nodeTypes` マップに追加:
+
+```tsx
+import { NotesCard } from '../components/canvas/NotesCard';
+
+const nodeTypes = {
+  terminal: TerminalCard,
+  agent: AgentCard,
+  editor: EditorCard,
+  diff: DiffCard,
+  fileTree: FileTreeCard,
+  changes: ChangesCard,
+  notes: NotesCard,   // ← 追加
+};
+```
+
+> ノードの `type` は zustand 側 `cardType` と **同じキー**にする (=React Flow のノード type と CardType が 1:1)。
+
+---
+
+## Step 5: 初期配置 / プリセット / コマンドパレット
+
+新カードを「ユーザーが追加できる」ようにするには、最低 1 経路を用意:
+
+- **コマンドパレット**: `lib/commands*` に「Notes カードを追加」を登録 → `useCanvasStore.getState().addCard({ type: 'notes', title: '...' })` を呼ぶ。
+- **ワークスペースプリセット**: `lib/workspace-presets*` のプリセット定義に追加 → `addCards([...])` で複数を 1 トランザクションで配置。
+- **コンテキストメニュー / ボタン**: 既存 UI に追加導線がある場合のみ。
+
+i18n (タイトル表示) が必要なら `lib/i18n*` に翻訳キーも追加。
+
+---
+
+## teamLocks / stageView との整合
+
+カードが **チーム単位で動く** かどうかを決める:
+
+- `teamLocks[teamId]` が `true` (デフォルト) なら、同じ teamId のカードがまとまって動く。
+- `removeCard(id)` のデフォルトは **`cascadeTeam: true`** (canvas.ts:38-41) — × ボタンで「チーム全員消す」が起きるので、新カードが team 所属する場合は確認ダイアログ等を入れる。
+- 「1 枚だけ消したい」UI (例: `team_dismiss` で 1 名解雇) は `removeCard(id, { cascadeTeam: false })` で呼ぶ。
+
+stageView (`'stage' | 'list' | 'focus'`) の各表示モードで、新カードが正しくレイアウトされるか確認。`focus` モードは選択カードだけ拡大表示するので新カードが落ちないかチェック。
+
+---
+
+## pulseEdge (一時 hand-off エッジ)
+
+別エージェント間の「一時的な可視化」用エッジを足す場合は `pulseEdge(edge, ttlMs)` を使う。
+**直接 `edges` を append しない** — Issue #156 の TTL タイマ管理 (canvas.ts:94-101) を経由しないと、タイマがリークする。
+
+```ts
+useCanvasStore.getState().pulseEdge({
+  id: `pulse-${from}-${to}`,
+  source: from,
+  target: to,
+  animated: true,
+  // ...
+}, 1500);
+```
+
+同じ `edge.id` への連続 pulse は古い timer を clear して上書きされる (canvas.ts:97-100)。
+
+---
+
+## ID 衝突 (Issue #157) を踏まないために
+
+`addCard` 内の `newId(prefix)` は `crypto.randomUUID()` ベース (canvas.ts:86-92)。
+**自前で `Date.now() + counter` を組み立てない** — リロード後の counter リセットで衝突する歴史的バグ (Issue #157)。
+
+---
+
+## Step 6: 検証
+
+```bash
+npm run typecheck
+npm run dev
+```
+
+実機:
+
+1. コマンドパレットから新カードを追加。
+2. 位置を動かす / リサイズ / 内容入力。
+3. **アプリ再起動** → カードが localStorage から復元されるか (`CARD_TYPES` 漏れていると復元時に消える)。
+4. team locked の他カードと一緒に動くか / 単独で動かす UI もあるか。
+5. `clear()` で全消去後、addCards 経由のプリセットで一括配置。
+6. stageView を `stage` / `list` / `focus` に切替えて新カードが破綻しないか。
+7. delete キー / × ボタン / `removeCard(.., {cascadeTeam: false})` の挙動確認。
+
+---
+
+## やってはいけないこと
+
+- **`CardType` 型だけ追加して `CARD_TYPES` 配列を放置**: persist 復元で消える silent バグ。
+- **`edges` を直接書き換える hand-off**: TTL リークで再描画が止まる (Issue #156)。
+- **id を自前で組み立てる**: `crypto.randomUUID()` ベース (`newId`) を使う (Issue #157)。
+- **巨大な payload を `CardData.payload` に詰める**: localStorage の容量が逼迫する (画像は別 store / 別永続化に切り出す)。
+- **`removeCard(id)` を「1 枚だけ消したい」用途で呼ぶ**: cascadeTeam: true がデフォルトなのでチーム全滅する。`{ cascadeTeam: false }` を明示する。
+- **新カードの drag handle を本文全体にする**: 中で text 選択ができなくなる。
+
+---
+
+## 関連 skill
+
+- 全体の地図 → **`vibeeditor`** skill
+- TeamHub / マルチエージェント coordination → **`vibe-team`** skill
+- カード見た目を Claude.ai 風に → **`claude-design`** skill

--- a/.claude/skills/issue-plan/SKILL.md
+++ b/.claude/skills/issue-plan/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: issue-plan
+description: vibe-editor の GitHub Issue を読んで実装計画を立て、`planned` ラベルを付けて計画を Markdown コメントとして issue に投稿する skill。実装そのものは行わず「計画立案 + ラベル付与 + 計画コメント投稿」までで 1 つのワークフローとして完結させる。ユーザーが「issue の計画を立てて」「issue を読んで plan して」「実装計画を issue に書いて」「planned ラベルを付けて」「plan タグを付けて」「issue #N の計画」「この issue どう実装する？」「先に計画だけ書いて」「issue にプラン残して」「実装方針を issue にまとめて」等を言ったとき、また `gh issue view` した直後に「これの計画を残しておきたい」と言ったときには必ずこの skill を起動すること。issue-first ワークフロー (Issue → branch → PR) のうち branch を切る前段階の「計画フェーズ」を担うので、修正に着手する前のステップとして頻繁に呼ばれる想定。
+---
+
+# issue-plan
+
+vibe-editor の Issue に対して **「読む → 調査する → 計画を立てる → planned ラベルを付ける → 計画コメントを投稿する」** までを一気通貫で行う skill。
+
+実装 (= branch を切ってコードを書く) は **行わない**。この skill のゴールは「issue 単体を見れば、どう実装するつもりかが第三者にも分かる状態」を作ることまで。実装フェーズに入るときは別途 `vibeeditor` skill / 通常の編集フローに引き継ぐ。
+
+---
+
+## 全体フロー
+
+```
+[1] 入力 (issue 番号 or URL) を受け取る
+      ↓
+[2] gh で issue 本体 + 既存コメント + ラベルを取得
+      ↓
+[3] 既に planned が付いていないかチェック (ガード)
+      ↓
+[4] リポジトリを探索して関連ファイル・現状動作を把握
+      ↓
+[5] 計画 Markdown を作成
+      ↓
+[6] planned ラベルが無ければ作成 → issue に付与
+      ↓
+[7] 計画 Markdown を issue コメントとして投稿
+      ↓
+[8] 「次は実装フェーズ。branch を切って良いか？」とユーザーに確認して終了
+```
+
+---
+
+## Step 1: 入力の正規化
+
+ユーザーから受け取る入力は次のいずれかの形:
+
+- 数値のみ: `123`
+- `#123`
+- 完全 URL: `https://github.com/<owner>/<repo>/issues/123`
+
+いずれの場合も最終的に `<num>` (整数) に正規化して以降使う。URL なら数字部分を抜き出す。`gh` は現在のリポジトリを自動で見るので、`<owner>/<repo>` の指定は不要。
+
+複数 issue を一度に渡された場合は、**1 件ずつ順番に** この skill のフローを回すこと。バッチ処理してはいけない (各 issue ごとに独立した調査・計画が要る)。
+
+---
+
+## Step 2: issue の取得
+
+並列でまとめて取得して良い:
+
+```bash
+gh issue view <num> --json number,title,body,labels,state,author,comments,url
+```
+
+取得した内容を頭に入れる。特に注目するのは:
+
+- `title` / `body` — 何が問題か / 何を作りたいか
+- `labels` — `bug` / `enhancement` / `refactor` / `area:*` の組合せ
+- `comments` — 議論の経緯。途中で要件がアップデートされていることが多い
+- `state` — `closed` だったら原則 plan しない (ユーザーに確認)
+
+---
+
+## Step 3: 重複ガード (planned が既に付いているか)
+
+`labels` の配列に `planned` が含まれていたら、いきなり計画を投稿してはいけない。
+
+ユーザーに次の 3 択を確認する:
+
+1. **既存計画が古いので上書き的に新しい計画を追記する** (推奨)
+2. **既存計画で十分なので何もしない** (中断)
+3. **既存計画コメントを編集する** (該当コメントの URL/ID を特定して `gh issue comment <id> --edit-last` 等で対応)
+
+ユーザーが明示しない限り、勝手に既存コメントを削除・編集しない。**追記が安全側のデフォルト**。
+
+---
+
+## Step 4: リポジトリ探索
+
+issue 本文だけでは実装計画は立てられない。必ず関連箇所のコードを読むこと。
+範囲が広い・どこから手を付けるか不明なときは `Agent` (subagent_type: `Explore`) に任せると速い。
+
+最低限の調査チェックリスト:
+
+- [ ] issue で言及されているファイル / 機能名を Grep / Glob で実在確認
+- [ ] 関連する Rust 側コマンド (`src-tauri/src/commands/`) と TS 側 (`src/renderer/`) の対応関係
+- [ ] 触る予定のファイルが他のどこから参照されているか (影響範囲)
+- [ ] 既存テスト (`*.test.ts` 等) があるか、無いなら追加すべきか
+- [ ] 同じ領域で過去にどんな PR / commit があったか (`git log -- <path>`)
+
+vibe-editor 固有の同期ポイント (5 点同期 / 4 層同期 / 2 ファイル同期) に該当する変更なら、必ず該当 skill (`tauri-ipc-commands` / `theme-customization` / `monaco-language-setup` / `canvas-nodecard-pattern` 等) の手順を **計画段階で参照** し、そのチェックリストを実装ステップに落とすこと。これを忘れると「実装中に skill を見ても遅い」状態になる。
+
+---
+
+## Step 5: 計画 Markdown を作る
+
+以下のテンプレートを **そのままの見出し構成** で埋める。
+ファイル化する場合は `tasks/issue-<num>/plan.md` を推奨 (リポジトリの慣例に合う) が、`gh issue comment --body-file` の入力にできれば一時ファイルでも OK。
+
+```markdown
+## 実装計画
+
+### ゴール
+<この issue を closed にする条件を 1〜3 行で。曖昧な「改善する」ではなく、
+ユーザーから見て何が変わるか / どうなれば done かを書く>
+
+### 影響範囲 / 触るファイル
+- `path/to/file.ts` — どう変える
+- `src-tauri/src/commands/foo.rs` — どう変える
+- (新規追加するファイルは `(新規)` を末尾に)
+
+### 実装ステップ
+- [ ] Step 1: <最小の動く塊。まずここまでで commit できる粒度>
+- [ ] Step 2: <次の塊>
+- [ ] Step 3: ...
+- [ ] (該当時) `tauri-ipc-commands` skill の 5 点同期チェック
+- [ ] (該当時) `theme-customization` skill の 4 層同期チェック
+- [ ] テスト追加 / 既存テスト更新
+
+### 検証方法
+- `npm run typecheck` が通る
+- `npm run build` が通る (Tauri ビルドが必要なら明記)
+- 手動テスト: <再現手順 / 期待する挙動>
+- (該当時) `npm test` / vitest の対象テスト名
+
+### リスク・代替案
+- リスク: <壊れそうな箇所 / regression が出そうな機能>
+- 代替案: <別アプローチがあれば 1 行で。なければ「特になし」>
+
+### 想定 PR 構成
+- branch: `<type>/issue-<num>-<short-slug>`
+- commit 粒度: <1 commit で済むか / Step ごとに分けるか>
+- PR title 案: `<type>(<scope>): <要約>`  (Conventional Commits)
+- 本文に `Closes #<num>` を含める
+```
+
+埋めるときの原則:
+
+- **過剰に詳細にしない**。シニアが見て「方針は分かる、あとは書ける」レベルで止める。コードのフルコピーや関数の完成形を計画に書かない (実装フェーズで書けば良い)
+- **不確実な箇所は明記する**。「ここは実装してみないと分からない」「A 案 / B 案で迷っている」は隠さず書く。後で議論しやすい
+- **vibe-editor の規約に反する計画にしない**: main 直 push 禁止 / branch 必須 / PR 経由 / Conventional Commits / ラベル付き Issue。これらが満たされる前提で書く
+
+---
+
+## Step 6: planned ラベルの付与
+
+### 6-1. ラベルの存在確認
+
+```bash
+gh label list --json name --jq '.[] | select(.name=="planned")'
+```
+
+何も返ってこなかったら作成:
+
+```bash
+gh label create planned \
+  --color BFD4F2 \
+  --description "実装計画 (plan) を issue に記載済み"
+```
+
+色 `BFD4F2` は淡いブルー。既存の領域系ラベルとぶつかりにくい。
+
+### 6-2. issue に付与
+
+```bash
+gh issue edit <num> --add-label planned
+```
+
+既に付いていた場合 (Step 3 で追記合意済みのケース) は no-op で OK。
+
+---
+
+## Step 7: 計画コメントを投稿
+
+`gh issue comment` は `--body` に直接渡すと改行・引用符のエスケープで事故るので、**必ずファイル経由**:
+
+```bash
+gh issue comment <num> --body-file <plan-path>.md
+```
+
+投稿後、コメント URL を控えてユーザーに見せる:
+
+```bash
+gh issue view <num> --json comments --jq '.comments[-1].url'
+```
+
+---
+
+## Step 8: 引き継ぎ
+
+最後にユーザーへ次のアクションを 1 行で提示:
+
+> 計画を issue #N にコメントしました (URL: ...)。実装フェーズに進む場合は branch `<type>/issue-N-<slug>` を切って `vibeeditor` skill のフローで進めます。続行しますか？
+
+ここで **勝手に branch を切らない**。この skill のスコープは計画までで、実装は別フェーズ。ユーザーが Yes と言って初めて次に進む。
+
+---
+
+## やってはいけないこと (anti-patterns)
+
+- ❌ 計画コメントを投稿せずに即 branch 切ってコードを書き始める (skill のゴールを逸脱)
+- ❌ issue 本文を書き換える (`gh issue edit --body`) — 元の報告内容は保全する
+- ❌ 既存の `planned` コメントを断りなく上書き / 削除する
+- ❌ ラベルが無いからといって `planned` 以外のラベルまで勝手に整理する (ラベル管理は `label-and-issue-workflow` skill のスコープ)
+- ❌ コードの完成形を計画に貼り付けて長大化させる (PR でやれば良い)
+- ❌ closed issue に断りなく plan を投稿する
+
+---
+
+## 参考: 関連 skill
+
+- `vibeeditor` — 実装フェーズに入ったら必ず参照
+- `pullrequest` — 実装が済んだら PR → bot レビュー → merge まで持っていく
+- `label-and-issue-workflow` — そもそも issue 起票時にラベルが付いていない場合
+- `tauri-ipc-commands` / `theme-customization` / `monaco-language-setup` / `canvas-nodecard-pattern` / `pty-portable-debugging` — 計画段階で該当領域なら必ず読む

--- a/.claude/skills/monaco-language-setup/SKILL.md
+++ b/.claude/skills/monaco-language-setup/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: monaco-language-setup
+description: vibe-editor の Monaco エディタに新言語サポート (シンタックスハイライト) を追加するときに使う skill。`src/renderer/src/lib/monaco-setup.ts` の selective import (`monaco-editor/esm/vs/basic-languages/<lang>/<lang>.contribution`) と `src/renderer/src/lib/language.ts` の `EXT_MAP` (拡張子 → Monaco 言語 ID) を **2 ファイル同期**で追加する手順、basic-languages に entry が無い言語の代替策 (Issue #77 の TOML→ini 流用)、worker の有無、bundle サイズへの影響、検証手順をまとめる。ユーザーが「言語サポートを追加」「Monaco に◯◯言語を足して」「シンタックスハイライト」「拡張子マッピング」「.◯◯ ファイルが plaintext 表示になる」「TOML / Zig / Nim のハイライト」「basic-languages の◯◯」「language.ts」「monaco-setup.ts」等を言ったとき、また `monaco-setup.ts` / `language.ts` を編集しそうなときには必ずこの skill を起動すること。
+---
+
+# monaco-language-setup
+
+vibe-editor の Monaco は **selective import** 戦略 (バンドル肥大化防止のため、basic-languages を 1 つずつ import する)。
+新言語を足すには **monaco-setup.ts と language.ts の 2 ファイル同期**が必要。
+
+> 現状 27 言語が登録済み (monaco-setup.ts:14-42)。
+> 「シンタックスハイライトのみ」 = `basic-languages/<lang>/<lang>.contribution`。**language worker (TS の型チェック等) は登録していない**ので軽量。
+
+---
+
+## 2 ファイル同期
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ 1. monaco-setup.ts: import '<lang>/<lang>.contribution'    │  Monaco に言語を登録
+│ 2. language.ts: EXT_MAP['<ext>'] = '<lang>'               │  拡張子 → Monaco 言語 ID
+└────────────────────────────────────────────────────────────┘
+```
+
+両方書かないと:
+
+- 1 だけ → 言語は知っているが拡張子から引けない (`detectLanguage()` が plaintext 返す)。
+- 2 だけ → 拡張子 → 言語 ID は引けるが Monaco がその ID を知らないので結局 plaintext 描画。
+
+---
+
+## Step 1: 該当言語が basic-languages にあるか確認
+
+[monaco-editor の basic-languages](https://github.com/microsoft/monaco-editor/tree/main/src/basic-languages) で対応言語を確認する。**バージョン依存**で増減するので、リポジトリの monaco-editor の実物を見る:
+
+```bash
+ls node_modules/monaco-editor/esm/vs/basic-languages
+```
+
+ある場合 → Step 2 へ。ない場合 → Step 1.5 (代替策) へ。
+
+### Step 1.5: 無い場合の代替策
+
+| 状況                               | 対応                                                                  |
+|------------------------------------|-----------------------------------------------------------------------|
+| 上位互換の言語が basic-languages にある | その ID で代替 (例 Issue #77: `toml` → `ini` で流用、語彙の上位互換)  |
+| 似た構文の別言語で代替              | 例: Zig は明確な entry が無いので `cpp` で当てる (golf 的だが妥当)    |
+| Monarch tokenizer を自作           | `monaco.languages.register({ id: 'mylang' })` + `setMonarchTokensProvider` を monaco-setup.ts に追加。重いので慎重に |
+| basic-languages 以外の Monaco 純正 | (json / typescript-language-features 等は worker 同梱で重い)。基本やらない |
+
+代替策を取るなら `language.ts` の該当行に **必ずコメントで「なぜ ◯◯ に流用したか」を残す** (Issue #77 の前例参照)。
+
+---
+
+## Step 2: `monaco-setup.ts` に import を追加
+
+`src/renderer/src/lib/monaco-setup.ts` の既存 import 群 (14〜42 行目) に 1 行追加。**アルファベット順 / 既存の並びの慣例に合わせる** (途中で並びが乱れていればその場の慣例に従う)。
+
+```ts
+// 例: zig を追加 (basic-languages にあると仮定)
+import 'monaco-editor/esm/vs/basic-languages/zig/zig.contribution';
+```
+
+### import path の罠
+
+- 必ず `.../basic-languages/<id>/<id>.contribution` の形 — `.contribution` を忘れると言語が登録されない。
+- `id` は monaco の言語 ID と完全一致。`csharp` (× `c-sharp`)、`cpp` (× `c++`)、`shell` (× `bash`) などケアフル。**フォルダ名 = 拡張子 .contribution 名**。
+- 既存例:
+  - `dockerfile` ← Dockerfile
+  - `ini` ← .ini と TOML 流用 (Issue #77)
+  - `shell` ← sh / bash / zsh
+
+### json と c の例外
+
+`monaco-setup.ts:39-42` のコメントが正:
+
+> json と c は monaco-editor v0.55 の basic-languages に entry が無い (json は language/json の worker 同梱版のみ、c は cpp に統合済み)。
+
+→ json は `EXT_MAP['json'] = 'json'` で Monaco の組込が拾う、c は `EXT_MAP['c'] = 'c'` で `cpp` contribution が拾う、という **暗黙の流用**。新言語を足すときも同じパターンが使えないか先に確認する。
+
+---
+
+## Step 3: `language.ts` の `EXT_MAP` に拡張子を追加
+
+`src/renderer/src/lib/language.ts` (~5 行目から始まる `EXT_MAP`) に追加。
+
+```ts
+const EXT_MAP: Record<string, string> = {
+  // ...
+  zig: 'zig',  // ← 拡張子 → Monaco 言語 ID
+  // 拡張子が複数あるなら全部書く
+  zigon: 'zig',
+};
+```
+
+### キーの正規化
+
+- **すべて小文字**で書く (`detectLanguage()` 内で toLowerCase 済み)。
+- ドット (`.`) は付けない (`'.zig'` は誤り、`'zig'` が正)。
+- ファイル名そのもので判別する特殊ケース (Dockerfile / Makefile) は `language.ts:51-52` のように関数本体で個別ハンドル — `EXT_MAP` に入れない。
+
+---
+
+## Step 4: 検証
+
+```bash
+npm run typecheck
+npm run dev
+```
+
+実機で:
+
+1. 該当拡張子のファイルをエディタで開き、シンタックスハイライトが効いているか確認。
+2. ファイル名タブにある「言語表示」(あれば) が想定 ID か。
+3. キーワードや文字列のトークン化が崩れていないか (Monarch のバージョン違いで稀に色が抜ける)。
+4. ファイルツリーから該当ファイルが普通に開けるか (どのコンポーネントもリーク的に変わっていないか)。
+
+`detectLanguage('foo.zig')` を Console から呼んで `'zig'` が返るかも見ると確実:
+
+```ts
+import { detectLanguage } from './lib/language';
+detectLanguage('foo.zig'); // => 'zig'
+```
+
+---
+
+## バンドルサイズへの影響
+
+basic-languages の 1 言語 import は概ね 5〜30 KB (gzip 後)。
+27 言語登録済みでも language worker を入れていないため十分軽い。
+
+ただし **Monarch tokenizer 自作** (Step 1.5 の最終手段) は数十 KB 級になりうるため、必要性をユーザーに確認してから着手する。
+
+---
+
+## やってはいけないこと
+
+- **`monaco-editor` 全体を import する**: `import * as monaco from 'monaco-editor'` ではなく `'monaco-editor/esm/vs/editor/editor.api'` を使う (monaco-setup.ts:7)。前者は worker 含めバンドルが膨れる。
+- **language worker を新規追加する**: 軽量重視のため避ける (monaco-setup.ts のコメント参照)。worker が必要な機能 (TS の型チェック等) を入れたいときは別途相談。
+- **`EXT_MAP` の値に存在しない言語 ID を書く**: Monaco が `Cannot register language` 警告を出して plaintext にフォールバックする。
+- **basic-languages のフォルダ名を勝手に推測する**: `node_modules/monaco-editor/esm/vs/basic-languages/` を ls で確認してから書く。
+- **既存の TOML→ini 代替を消す**: Issue #77 の判断記録なので、TOML 専用 contribution が出るまで触らない。
+
+---
+
+## 関連 skill
+
+- 全体の地図 → **`vibeeditor`** skill
+- 配色 (Monaco テーマ) → **`theme-customization`** skill

--- a/.claude/skills/pty-portable-debugging/SKILL.md
+++ b/.claude/skills/pty-portable-debugging/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: pty-portable-debugging
+description: vibe-editor の PTY (`src-tauri/src/pty/`, portable-pty + xterm.js) のデバッグ・拡張時に必ず使う skill。reader thread / mpsc / batcher (16ms or 32KB) / tauri emit のデータフロー、Windows ConPTY の罠 (環境変数 escape / 親プロセス終了後の zombie / パス区切り)、文字化け対策 (CP932 / Shift_JIS encoding_rs, Issue #120)、外部ファイル変更検出 (sha2 + size + mtime, Issue #119)、SessionRegistry の race condition、resize / kill / writer Mutex の使い分け、claude_watcher (claude session 検出)、画像ペースト (`SavePastedImageResult`) のフロー、xterm 側 deadlock の見分け方をカバー。ユーザーが「ターミナルが固まる」「PTY がハング」「ConPTY」「portable-pty」「Shift_JIS / CP932 文字化け」「外部変更検出が効かない」「resize で落ちる」「画像ペーストが動かない」「Claude セッションが検出されない」「session registry」「batcher」「pty:data event」「writer Mutex」等を言ったとき、また `src-tauri/src/pty/` を触りそうなときには必ずこの skill を起動すること。
+---
+
+# pty-portable-debugging
+
+vibe-editor のターミナル基盤 (`src-tauri/src/pty/`) は **portable-pty + 自前 batcher + Tauri emit** という 3 層構造で、Windows / Unix 双方の罠を内部で吸収している。
+このレイヤを触る作業 (新機能追加 / デバッグ / 退行修正) はミスのコストが大きいので、必ずこの skill のチェックリストに沿う。
+
+---
+
+## データフロー (これを最初に頭に入れる)
+
+```
+                       (1) spawn_session(SpawnOptions)
+                              │
+                              ▼
+     ┌────────────────────────────────┐
+     │ portable-pty PtyPair (Windows  │
+     │ は ConPTY、Unix は openpty)     │
+     └──────┬───────────────────┬─────┘
+            │ master read       │ master write
+            ▼                   ▲
+   ┌──────────────────┐   ┌──────────────────────┐
+   │ reader 標準スレ │   │ writer (Mutex 保護) │ ← user_input / paste
+   │ ブロッキング read│   └──────────────────────┘
+   └────┬─────────────┘
+        │ Vec<u8>
+        ▼
+   mpsc::Sender<...>
+        ▼
+   ┌──────────────────────────┐
+   │ batcher (16ms or 32KB)   │  ← Issue #119 の hash 計算もここ近辺
+   └────┬─────────────────────┘
+        │ chunked Vec<u8>
+        ▼
+   tauri::AppHandle::emit("pty:data", ...)
+        ▼
+   Renderer (xterm.js) — UnlistenFn で購読
+```
+
+主要ファイル:
+
+- `src-tauri/src/pty/session.rs` — spawn / lifecycle (SpawnOptions / UserWriteOutcome)
+- `src-tauri/src/pty/registry.rs` — SessionRegistry (AppState 経由で共有)
+- `src-tauri/src/pty/batcher.rs` — 出力束ね (16ms / 32KB)
+- `src-tauri/src/pty/claude_watcher.rs` — Claude Code の session id 検出 (resume 用)
+- `src-tauri/src/pty/path_norm.rs` — Windows パス正規化
+- `src-tauri/src/commands/terminal.rs` — IPC handler (create / write / resize / kill / paste image)
+
+---
+
+## 触る前に読むべき場所 (順番)
+
+1. `src-tauri/src/pty/mod.rs` の冒頭コメント (設計概要)。
+2. 該当機能の既存 IPC handler (`commands/terminal.rs`)。
+3. `pty/session.rs` の `spawn_session` 周辺 (lifecycle 全部)。
+4. `pty/batcher.rs` (出力タイミング — UI のチラつきや遅延報告はだいたいここ)。
+
+---
+
+## Windows ConPTY の主要な罠
+
+### 1. 環境変数 / 引数の escape
+
+ConPTY (Windows) と Unix PTY で **引数 / 環境変数の解釈が違う**。
+特に `args` にスペースを含む文字列を渡すとき、Windows は内部で再 quote される — 既に quote 済みだと double quote になって壊れる。
+
+→ 既存実装 (`session.rs` の `SpawnOptions`) で吸収しているが、新しい spawn パターンを足すなら **Windows 実機でテスト必須**。
+
+### 2. 親プロセス終了後の zombie
+
+WebView 強制終了 / アプリ kill 時に PTY child が孤立する場合がある。
+ConPTY job object でグループ kill するか、`Drop` で `kill()` を確実に呼ぶ実装が `session.rs` にあるはず。新 spawn パターンを足すなら **`drop` 時の kill 経路** を必ず動作確認する。
+
+### 3. パス区切り
+
+Windows: `\` / Unix: `/`。`pty/path_norm.rs` が正規化を吸収。
+新たに「Renderer から渡された path」を spawn 引数に使うなら **path_norm 経由**。
+
+### 4. CP932 / Shift_JIS 文字化け (Issue #120)
+
+Windows のコンソールはロケールによって CP932 / Shift_JIS で出力する場合がある。
+`encoding_rs` でデコードしてから xterm に送る実装が入っている。
+
+新出力経路 (例: 別プロセスをラップ) を足すときも **encoding_rs を経由**して UTF-8 化する。
+**生 bytes をそのまま emit すると mojibake が xterm に届く**。
+
+---
+
+## reader / writer / batcher の使い分け
+
+### reader
+
+- **標準スレッド (std::thread)** で動かす — tokio の async read は portable-pty の master reader と相性が悪い (ブロッキング read が tokio scheduler を詰まらせる)。
+- 読んだ bytes は `mpsc::Sender` で batcher に送る。
+
+### writer
+
+- **`Arc<Mutex<...>>`** で保護 — 複数経路 (user_input / paste / resize) から書き込まれる可能性がある。
+- async から呼ぶなら `tokio::sync::Mutex`、sync から呼ぶなら `parking_lot::Mutex`。**実装の流儀に合わせる**。
+
+### batcher
+
+- **16ms or 32KB に達したら emit** する設計。低遅延と CPU 負荷のバランス点。
+- 値を変えるなら **Renderer 側 xterm の rendering FPS** との兼ね合いを見る (体感での確認必須)。
+- batcher 内で hash 計算や filter を入れると遅延が伸びる — そういう加工は Renderer 側でやるのが基本。
+
+---
+
+## SessionRegistry の race condition
+
+`pty/registry.rs` の SessionRegistry は AppState 経由で共有される。
+**create / kill / lookup が並行する**ため、ロック順序を間違えると deadlock する。
+
+注意:
+
+- `lock()` は **必ず短時間**。spawn / IO の最中にロックを握り続けない。
+- session 削除と reader thread 終了は **どちらが先でも安全に**。reader が `RecvError` を見たら自分で片付ける、registry kill が来たらマスターを drop して reader を終わらせる、両経路を許容する設計。
+- 新コマンドを足すなら `lock` の hold 時間を最小化する (lookup → clone Arc → unlock の順)。
+
+---
+
+## claude_watcher (Claude Code の session id 検出)
+
+`pty/claude_watcher.rs` は xterm 出力をスキャンして「`Claude Code session: xxxxx` のようなマーカーを拾い、Canvas の `payload.resumeSessionId` に書き込む」役割。
+
+- 出力ストリームを **重複処理しない**: batcher の前で 1 回だけ tap する。
+- 検出後は zustand の `setCardPayload` (canvas.ts:46) を IPC 経由でトリガーする。
+- 正規表現を変えたら **既存 fixtures (CHANGELOG / issue にスクリーンショットあり)** で再現テストする。
+
+---
+
+## 画像ペースト (`SavePastedImageResult`)
+
+Renderer が clipboard から base64 画像を渡す → Rust 側 `commands/terminal.rs` の handler で temp file に保存 → ファイルパスを返す → Renderer 側で xterm に「`@/path/to/temp.png`」を挿入する流れ。
+
+罠:
+
+- temp file の cleanup は **アプリ終了時にも消える** ように tempdir の中に書く。
+- 巨大画像 (10MB 超) はメモリで base64 デコードすると重い。stream で書く。
+- Windows のパス区切りに注意 (Renderer 側で `\` を扱える形に正規化)。
+
+---
+
+## 外部ファイル変更検出 (Issue #119)
+
+`commands/files.rs` (または近辺) で sha2 ハッシュ + size + mtime の 3 点比較で外部変更を検出している。
+
+- ハッシュだけ / mtime だけ では誤検出が多い。**3 点 AND** で「変わった可能性」、ハッシュ一致なら「同一」、ハッシュ不一致なら「変わった」を確定。
+- watcher (`fs_watch.rs`) 通知と組み合わせる場合、debounce を 500ms 程度入れる (保存中の連続イベントで誤発火を抑える)。
+
+---
+
+## デバッグの第一手 (順序固定)
+
+ターミナル絡みでバグが報告されたとき:
+
+1. **再現条件を狭める**: OS (Win/macOS/Linux)、shell、入力サイズ、文字種 (ASCII か日本語か絵文字か)、resize の有無、画像ペーストの有無。
+2. **どの層のバグか切り分け**:
+   - `tracing::info!` を spawn / read / batcher / emit / xterm 受信 の各点に仕込む。
+   - bytes 数が合わないなら reader / batcher のバグ。
+   - bytes は届いてるが画面が壊れているなら xterm レンダリング / encoding (CP932) のバグ。
+   - resize 後に黙る → SessionRegistry / writer Mutex / ConPTY resize のバグ。
+3. **再現プロジェクト最小化**: `examples/` 相当に持っていく — フルアプリで再現させない。
+4. **Windows / Unix 両方で再現**するか確認 (片方だけなら ConPTY / openpty 差を疑う)。
+
+---
+
+## 検証
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo clippy --manifest-path src-tauri/Cargo.toml
+npm run typecheck
+npm run dev
+```
+
+実機:
+
+- `cargo tauri dev` で起動 → 複数 PTY タブ同時運用 → resize / paste / 巨大ログ流入 / Ctrl+C → アプリ終了。child が zombie 化していないか (`Get-Process` / `tasklist` で確認)。
+- 文字化けは **CP932 出力するコマンド** (`echo こんにちは` を chcp 932 のシェルで) で再現テスト。
+
+---
+
+## やってはいけないこと
+
+- **reader を tokio で書き直す**: portable-pty の API と相性が悪い。標準スレッドのまま。
+- **batcher の閾値を雰囲気で変える**: 体感とテストデータ両方で確認してから。
+- **registry のロックを長時間保持する**: 即 deadlock の温床。
+- **path をそのまま spawn args に渡す**: `path_norm` を必ず通す。
+- **生 bytes を emit する**: `encoding_rs` を経由して UTF-8 化してから。
+- **resize handler を sync で書く**: ConPTY の resize は数 ms かかることがあり UI を詰まらせる。
+
+---
+
+## 関連 skill
+
+- 全体の地図 / IPC レシピ → **`vibeeditor`** skill
+- 新 IPC コマンドを足す → **`tauri-ipc-commands`** skill
+- どうしても直らない時 → **`finalfix`** skill (Explore で並列調査して仮説 5 個から)

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: subagent
+description: Claude Code の subagent (Task / Agent tool による子エージェント委譲) を「いつ・どう使うか」を判断し、適切な subagent_type で起動して並列に作業させるための skill。メインの context window を圧迫せず、調査・探索・並列レビュー・独立タスクを子エージェントに任せて高速化するために使う。ユーザーが「subagent で調べて」「並列に調査して」「Explore で探して」「並列でやって」「context 汚したくない」「複数同時に走らせて」「sub agent」「サブエージェント」「Task tool」「Agent tool」「並列レビュー」「3 つ同時に」等を言ったとき、また自分が広範囲な調査・複数の独立タスク・別 context が欲しいタスクを行おうとしているときには必ずこの skill を起動して subagent 起動を検討すること。並列調査・探索・レビューを sequential にやろうとしているときの「気付き skill」としても機能する。
+---
+
+# subagent
+
+Claude Code の **subagent** = `Agent` tool / `Task` tool で起動できる子エージェント。
+「メインの context を汚さず、独立した context window で作業させる」のが本質。
+親には **結果サマリのみ** が返るので、大量ログ・grep 結果・ファイル中身が main を圧迫しない。
+
+この skill は「subagent を呼ぶべきか / どう呼ぶか / どう書くか」の判断 skill。
+
+---
+
+## いつ subagent を使うか
+
+### 強く推奨 (積極的に並列化)
+- **広範な調査** — 「この機能どこで使われてる？」「依存関係は？」「過去の実装は？」など 3 query 以上必要なもの → `Explore`
+- **複数の独立タスク** — 同時に違うファイル/領域を触る作業 → 並列 `general-purpose` × N
+- **別視点の検証** — レビュー / 第二意見 / 設計レビュー → `Plan` や独立 `general-purpose`
+- **ノイズの多い結果** — log 解析・大量の grep 結果・長い transcript の要約 → `general-purpose`
+
+### 不要 (直接やった方が速い)
+- 場所が分かっている 1 ファイルを読む → `Read`
+- 既知 symbol の grep → `Grep`
+- 1 〜 2 query で済む確認
+- 既に context にある情報を再確認するだけ
+
+### 微妙 (判断ポイント)
+- 中規模調査 (3〜5 query) → 自分でやって良いが、結果が長文ログを伴うなら subagent
+- ユーザーへ即返答が要る対話 → subagent は遅延が出るので避ける
+
+---
+
+## ビルトイン subagent の使い分け
+
+| subagent_type | 用途 | 強み | 注意 |
+|---|---|---|---|
+| `Explore` | コード探索専用 (read-only) | 速い・探索に特化 | 全文読まない (excerpt のみ) → 設計レビュー不可 |
+| `general-purpose` | 何でも屋 | フル tool 利用可・編集も可 | 重い・トークン消費 |
+| `Plan` | 実装計画立案 | アーキ視点で plan を返す | 編集はしない |
+| `statusline-setup` | ステータスライン設定専用 | — | — |
+| `claude-code-guide` | Claude Code 公式仕様の Q&A | docs / web 参照 | 限定用途 |
+| `codex:rescue` | 別 LLM (GPT-5 系) で裏取り | 視点の多様化 | コスト高 |
+
+**迷ったら**: 探索 = `Explore` / 計画 = `Plan` / 編集を伴う作業 = `general-purpose`。
+
+---
+
+## 起動方法 (`Agent` tool)
+
+```
+Agent({
+  description: "Branch ship-readiness audit",   // 3〜5 語
+  subagent_type: "general-purpose",              // 省略時は general-purpose
+  prompt: "<self-contained な指示>",
+  run_in_background: false                       // 並列に他の作業を進めたいなら true
+})
+```
+
+### 並列起動
+
+**同じメッセージ内で複数の `Agent` 呼び出しを並べる** と並列実行される。
+直列に呼ぶと意味がない (1 個ずつ待つことになる)。
+
+```
+1 メッセージ内で:
+  Agent(security-review)
+  Agent(performance-review)
+  Agent(test-coverage-review)
+→ 3 つ同時に走る
+```
+
+### isolation: "worktree"
+
+副作用のあるタスク (ファイル編集・git 操作) を試したいけど main の作業を汚したくない場合、
+`isolation: "worktree"` を渡すと一時 git worktree で作業させられる。変更が無ければ自動 cleanup。
+
+---
+
+## prompt の書き方 (重要)
+
+subagent は **親の会話履歴を一切見ていない**。
+「さっき調べた件」「上で出てきたあの関数」では伝わらない。**self-contained に書く**。
+
+### 良い prompt のチェックリスト
+- [ ] **目的**: 何を達成したいか (1〜2 文)
+- [ ] **背景**: なぜこのタスクが必要か / これまでに何を試したか / 何を除外済みか
+- [ ] **入力**: 関連ファイルパス・symbol 名・URL を明示
+- [ ] **求める出力の形**: 「200 字以内のサマリ」「punch list」「修正パッチ」等
+- [ ] **判断材料**: 細かい手順より「考えるべき問い」を渡す (前提が間違っていれば手順は無意味)
+
+### Bad
+```
+prompt: "this を調査して"
+prompt: "Canvas を直して"
+prompt: "テストを書いて"
+```
+→ 浅い・的外れな結果が返る。
+
+### Good
+```
+prompt: "Canvas モードで card 削除時に edge が残る issue #123 の調査。
+src/renderer/src/stores/canvas.ts の removeCard を中心に、
+removeNode と edges の連動が正しく行われているか確認してほしい。
+@xyflow/react の getConnectedEdges が呼ばれているか、
+zustand persist の migration で古い orphan edge が残っていないかも見てほしい。
+報告は: 原因の仮説 (複数可) / 触るべきファイル / 修正方針案、を 300 字以内で。"
+```
+
+### 「research か write か」を明示する
+subagent は user の意図を知らないので、
+
+- 「**調査だけ**してほしい (write しないで)」
+- 「**実装まで**してほしい」
+- 「**plan だけ**返して」
+
+を prompt 冒頭で明示する。曖昧だと subagent が勝手に編集してしまうことがある。
+
+---
+
+## アンチパターン
+
+- ❌ **3 query で済む調査に Explore を呼ぶ** — オーバーヘッドの方が大きい
+- ❌ **既に subagent が走っている query を自分でも grep する** — 二重作業
+- ❌ **subagent の自己申告を盲信** — 「修正完了」と言われても **diff を確認**する (Trust but verify)
+- ❌ **prompt に「上記を踏まえて」と書く** — 上記が見えていない
+- ❌ **直列に 5 個 Agent を呼ぶ** — 並列にできるなら 1 メッセージにまとめる
+- ❌ **Explore に編集を期待する** — read-only。書きたいなら general-purpose
+- ❌ **巨大な context を渡そうとする** — prompt は要点のみ。子側で必要なら自分で読ませる
+
+---
+
+## Trust but verify の実践
+
+子から「fix した」「test 通った」と返ってきたら、
+
+1. `git diff` で実際の変更を見る
+2. `npm run typecheck` / `npm run build` を自分で叩く
+3. 子が触ったと主張するファイルを `Read` で確認
+
+特に編集系 subagent は楽観的な report をしがち。**親が最終責任**。
+
+---
+
+## vibe-editor での実用パターン
+
+### パターン A: 並列調査 (Issue 起票前)
+```
+Agent(Explore, "issue #N の関連コードを src-tauri 側から探索")
+Agent(Explore, "同じ issue の renderer 側 (src/renderer/) から探索")
+→ 両側を並列に把握 → 自分で統合
+```
+
+### パターン B: 並列レビュー (PR 出す前)
+```
+Agent(general-purpose, "security 観点でレビュー")
+Agent(general-purpose, "performance 観点でレビュー")
+Agent(codex:rescue, "別 LLM で第二意見")
+→ 3 つ並走 → 親で統合判断
+```
+
+### パターン C: 大量ログの要約
+PTY のクラッシュ調査などで `cargo run` の出力が長くなりそうなとき、
+親が直接 stdout を浴びるとすぐ context が埋まる。
+→ `general-purpose` に「実行して原因仮説 5 行で返して」と委譲。
+
+### パターン D: Plan → Implement の分離
+```
+Agent(Plan, "issue #N の実装計画を立案")
+→ 計画レビュー → 親が実装 (or 別 Agent に渡す)
+```
+
+vibe-editor では **`issue-plan` skill** がこの Plan フェーズを担うので、組み合わせると効率的。
+
+---
+
+## 関連 skill
+
+- `agent-team` — 完全独立セッションで teammate 同士が通信し合うレベルの並列化が必要な場合
+- `vibeeditor` — vibe-editor でコードを書く前に必ず参照
+- `finalfix` — 詰んだバグで重量級調査が必要なときに subagent を組み合わせる

--- a/.claude/skills/tauri-ipc-commands/SKILL.md
+++ b/.claude/skills/tauri-ipc-commands/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: tauri-ipc-commands
+description: vibe-editor で新しい Tauri IPC コマンド (Rust → Renderer) を追加・変更するときに必ず使うチェックリスト skill。`src/types/shared.ts` の型・`src-tauri/src/commands/<領域>.rs` の Rust 構造体 (`#[serde(rename_all = "camelCase")]`)・`src-tauri/src/commands/mod.rs` のモジュール宣言・`src-tauri/src/lib.rs` の `invoke_handler!` 登録・`src/renderer/src/lib/tauri-api.ts` の wrapper の **5 点同期** が外れると runtime エラーや silent 失敗を起こすため、必ずこの skill の手順で進める。ユーザーが「IPC を足す」「invoke を追加」「tauri command を新規」「Rust から呼べるように」「shared.ts に型を足して」「window.api.◯◯ を追加」「Rust ↔ TS の型同期」「emit / listen を追加」「PTY コマンドを追加」「git コマンドを追加」「settings に保存項目を追加」等を言ったとき、また `#[tauri::command]` を新規に書きそうなとき、`commands/<領域>.rs` を編集するときには必ずこの skill を起動すること。
+---
+
+# tauri-ipc-commands
+
+vibe-editor で「Rust 側の機能を Renderer から呼べるようにする」ときの **5 点同期チェックリスト**。
+1 か所でも漏れると、`window.api.xxx is not a function` / `invoke "xxx" not found` / camelCase ⇄ snake_case の型不一致 / runtime エラーが発生する。
+
+> 既存コマンドは `src-tauri/src/commands/{app,git,terminal,settings,dialog,sessions,team_history,files,fs_watch,atomic_write,role_profiles,vibe_team_skill}.rs`。
+> Renderer 側ラッパは `src/renderer/src/lib/tauri-api.ts`。
+> 型は `src/types/shared.ts`。
+
+---
+
+## 5 点同期 (どれも必須)
+
+```
+┌──────────────────────────────────────────┐
+│ 1. src/types/shared.ts                  │  TS 型 (Request / Response, camelCase)
+│ 2. src-tauri/src/commands/<領域>.rs     │  Rust 構造体 + #[tauri::command]
+│ 3. src-tauri/src/commands/mod.rs        │  pub mod 宣言 (新ファイルを足したとき)
+│ 4. src-tauri/src/lib.rs                 │  invoke_handler! に function 名を登録
+│ 5. src/renderer/src/lib/tauri-api.ts    │  invoke('xxx', { ... }) wrapper
+└──────────────────────────────────────────┘
+```
+
+**この順番で書くと最後に typecheck で必ず噛み合う**。逆順に書くと型不一致を検出するタイミングが遅れる。
+
+---
+
+## Step 1: `src/types/shared.ts` に Request / Response 型を追加
+
+camelCase で書く (Rust 側で `#[serde(rename_all = "camelCase")]` するので、TS 側は素直な camelCase)。
+
+```ts
+// 例: ファイルのハッシュを取得する hashFile コマンド
+export interface HashFileRequest {
+  path: string;
+  /** sha256 / md5。省略時は sha256 */
+  algorithm?: 'sha256' | 'md5';
+}
+
+export interface HashFileResult {
+  hash: string;
+  byteLen: number;
+  modifiedMs: number;
+}
+```
+
+### 既存型の流用判断
+
+- `path` 系は string で書く (Rust 側で `PathBuf` に from する)。
+- 「成功 or エラー文字列」は `Result<T, String>` (= TS では throw に化ける) で表す。`{ ok: boolean, ... }` 形式は新規で増やさず、既存の慣例に合わせる。
+- バイナリは `Vec<u8>` ↔ `number[]` ではなく **base64 文字列** で渡す (`SavePastedImageResult` など先例あり)。
+
+---
+
+## Step 2: Rust 側 `commands/<領域>.rs` に handler を実装
+
+### 構造体は必ず `#[serde(rename_all = "camelCase")]`
+
+`commands/mod.rs` の冒頭コメントで明文化されている厳守ルール。
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HashFileRequest {
+    pub path: String,
+    #[serde(default)]
+    pub algorithm: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HashFileResult {
+    pub hash: String,
+    pub byte_len: u64,
+    pub modified_ms: i64,
+}
+```
+
+### 関数シグネチャの流儀
+
+```rust
+#[tauri::command]
+pub async fn hash_file(req: HashFileRequest) -> Result<HashFileResult, String> {
+    // 1. 入力検証 (path traversal / 空文字 / 巨大ファイルへの対処)
+    // 2. tokio::fs で非同期読み込み (sync な std::fs はメインスレッドで使わない)
+    // 3. エラーは map_err(|e| e.to_string()) で String 化
+    let bytes = tokio::fs::read(&req.path).await.map_err(|e| e.to_string())?;
+    // ...
+    Ok(HashFileResult { /* ... */ })
+}
+```
+
+### コマンド名の慣習
+
+- snake_case (`hash_file`、`team_history_list`、`session_resume`)。
+- 領域 prefix を付ける (`settings_*` / `git_*` / `team_history_*` / `pty_*`)。`mod.rs` の `ping` のような無 prefix は基本やらない。
+- AppState (グローバル) を触るなら `tauri::State<'_, AppState>` を引数に。`src-tauri/src/state.rs` 参照。
+
+### よくある罠
+
+- **path 引数を引数 1 個で書きたい誘惑**: `pub async fn hash_file(path: String)` は動くが、後で第 2 引数を増やす際に破壊変更になる。最初から Request 構造体で受ける。
+- **同期 IO を `#[tauri::command] pub fn` (非 async) で書く**: メインスレッドをブロックすると UI が固まる。read/write が絡むなら基本 `async`。
+- **`Result<T, anyhow::Error>` を直接返す**: serde で死ぬ。必ず `Result<T, String>` に揃える。
+- **`#[serde(rename_all = "camelCase")]` 漏れ**: 一見動くが、フィールドが `byte_len` のままだと TS 側 `byteLen` と噛み合わず `undefined`。
+
+---
+
+## Step 3: `commands/mod.rs` への登録 (新ファイルを作ったときのみ)
+
+```rust
+// 例: commands/hashing.rs を新規作成したら
+pub mod hashing;
+```
+
+既存ファイル (`files.rs` など) に追加するなら Step 3 は不要。
+
+---
+
+## Step 4: `src-tauri/src/lib.rs` の `invoke_handler!` に登録
+
+`tauri::generate_handler![...]` の **すべての** 関数を列挙する場所がある。**忘れると invoke 時に `command "xxx" not found` で失敗する**。
+
+```rust
+.invoke_handler(tauri::generate_handler![
+    commands::ping,
+    commands::settings::settings_load,
+    commands::settings::settings_save,
+    // ...
+    commands::hashing::hash_file,   // ← 追加
+])
+```
+
+> ファイル全体を grep して既存登録の流儀 (フルパス vs `use` 文) に合わせる。途中で書式を変えない。
+
+---
+
+## Step 5: `tauri-api.ts` に wrapper を追加
+
+```ts
+import type { HashFileRequest, HashFileResult } from '../../../types/shared';
+
+export const api = {
+  // ...
+  hashFile(req: HashFileRequest): Promise<HashFileResult> {
+    return invoke<HashFileResult>('hash_file', { req });
+  },
+};
+```
+
+### 引数の渡し方の罠
+
+- Tauri は **`invoke('cmd', { 引数名: 値 })` の形** で渡す。Rust 側のパラメータ名と完全一致させる。
+- Rust 側 `pub async fn hash_file(req: HashFileRequest)` なら TS 側は `{ req }`。
+- パラメータ名が **camelCase でも snake_case でも、Rust 側の引数名そのまま** を使う (Tauri はここだけ rename しない)。
+  - 例: Rust 側 `pub async fn x(some_arg: String)` → TS 側 `{ someArg }` で動く (Tauri 2 はパラメータ名は camelCase 化される)。**ただし型と関数名のときは別** — フィールドは `#[serde(rename_all="camelCase")]` で camelCase。
+  - 不安なら最初に `tracing::info!` でログを仕込んで実機で受信値を確認する。
+
+### イベント (Rust → Renderer push) の場合
+
+```rust
+// Rust 側
+app_handle.emit("pty:data", PtyDataEvent { session_id, chunk })?;
+```
+
+```ts
+// Renderer 側 (tauri-api.ts に subscribe ヘルパを足す)
+onPtyData(cb: (e: PtyDataEvent) => void): () => void {
+  return subscribeEvent<PtyDataEvent>('pty:data', cb);
+}
+```
+
+`subscribeEvent` (tauri-api.ts:21-40) は **早期 cleanup の orphan 対策**を含む既存ヘルパ。**直接 `listen()` を呼ばない** — ここを通すこと。
+
+---
+
+## Step 6: 検証
+
+```bash
+npm run typecheck
+cargo check --manifest-path src-tauri/Cargo.toml
+```
+
+両方通らないと噛み合いが取れていない。さらに `npm run dev` で実機起動して、
+
+- `tracing::info!` のログが Tauri DevTools 側 console に出るか
+- 戻り値が JS 側で **camelCase で受け取れているか** (フィールド名を `console.log` で確認)
+- エラー時の `Promise.reject(string)` が catch で拾えるか
+
+を 1 度だけ手動確認する (CLAUDE.md「動作の証明」原則)。
+
+---
+
+## やってはいけないこと
+
+- **5 点のうち 1〜2 点だけ書いて typecheck も通したつもりで終える**: invoke_handler! 登録漏れは typecheck では落ちず、起動後 invoke で初めて落ちる。**必ず実機で 1 度呼ぶ**。
+- **`#[serde(rename_all = "camelCase")]` を省略**: silent に `undefined` 化して原因不明バグになる。
+- **`Result<T, anyhow::Error>` を返す**: 必ず `Result<T, String>` に変換する。
+- **`subscribeEvent` を経由せず素の `listen()` を呼ぶ**: 早期 cleanup で orphan listener が残る。
+- **既存コマンドの引数を破壊変更する**: 永続化された値 (settings.json の旧スキーマ) と齟齬が出る。Issue #75 の `APP_SETTINGS_SCHEMA_VERSION` に倣って migration を書く。
+
+---
+
+## 既存実装の参照先 (作業前にチラ見すると速い)
+
+- 単純な save/load 例: `src-tauri/src/commands/settings.rs` (atomic_write + Mutex 直列化)
+- async + 戻り値構造体例: `src-tauri/src/commands/git.rs`
+- イベント emit + State 共有例: `src-tauri/src/commands/terminal.rs` + `src-tauri/src/pty/`
+- Mutex 連携 / 並列直列化の罠: settings.rs の SAVE_LOCK (Issue #37)
+- Parse 失敗時のバックアップ戦略: settings.rs settings_load (Issue #170)
+
+---
+
+## 関連 skill
+
+- 全体の地図と厳守ワークフロー → **`vibeeditor`** skill
+- PR を出すフェーズ → **`pullrequest`** skill
+- 設定永続化スキーマを変えるなら → `APP_SETTINGS_SCHEMA_VERSION` の bump も忘れず (vibeeditor 参照)

--- a/.claude/skills/test-setup-vitest/SKILL.md
+++ b/.claude/skills/test-setup-vitest/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: test-setup-vitest
+description: vibe-editor (Tauri 2 + Vite 8 + React 19 + TypeScript 6) にゼロから Vitest + @testing-library/react + Tauri モック を導入し、Renderer 側のユニットテスト基盤を作るための skill。renderer 側 React コンポーネントのテスト・zustand store のテスト・`@tauri-apps/api/core` の `invoke()` モック・`@xyflow/react` Canvas テストの注意点・`monaco-editor` の jsdom スタブ・`xterm.js` のテスト除外戦略・Rust 側 `cargo test` の規約 (`#[tokio::test]` 等) の組み合わせをガイドする。`disable-model-invocation: true` (= 一度導入したら Claude が自動起動はしない、ユーザーが `/test-setup-vitest` で明示起動)。ユーザーが「テストを入れたい」「Vitest を導入」「テスト環境を整える」「unit test 基盤」「TDD したい」「invoke をモックしたい」「テストフレームワークなくて困る」「テストの書き方の規約」等を言ったときに使う。
+disable-model-invocation: true
+---
+
+# test-setup-vitest
+
+vibe-editor (Tauri 2 + Vite 8 + React 19 + TS 6) に **テスト基盤を一から導入** するときに通すスキル。
+Tauri アプリのテストには「Renderer 側 (Vitest)」と「Rust 側 (cargo test)」の 2 系統があり、どちらをどこまでやるかを判断するところから始める。
+
+> **このスキルは `disable-model-invocation: true`** = 一度入れたら Claude は自動起動しない。
+> 必要時にユーザーが `/test-setup-vitest` で明示起動する。
+
+---
+
+## 範囲とスコープ判断
+
+vibe-editor で最初に入れる価値があるのは **下記の 3 層** に限る。E2E は重いので後回し:
+
+| 層                          | テスト基盤                       | テスト対象例                                              |
+|-----------------------------|----------------------------------|-----------------------------------------------------------|
+| Renderer ロジック層         | **Vitest + node 環境**           | zustand store (`canvas.ts` の addCard / pulseEdge 等), `lib/language.ts` の detectLanguage, `lib/themes.ts` の整合性 |
+| Renderer UI 層              | **Vitest + jsdom + RTL**         | 純粋な React コンポーネント (Monaco / xterm を含まないもの) |
+| Rust 側ロジック層           | **`cargo test`**                 | `commands/atomic_write.rs` / `pty/path_norm.rs` / `commands/files.rs` 等 |
+
+**最初に入れない (理由付き)**:
+
+- **Monaco を含むコンポーネント** — DOM API が jsdom に揃わないことが多く、unit テストが脆い。手動確認 + Playwright (将来) に回す。
+- **xterm.js を含むコンポーネント** — WebGL addon (`@xterm/addon-webgl`) が jsdom で動かない。除外。
+- **PTY 統合テスト** — portable-pty を CI で動かすのは面倒。Rust の lib 関数だけ `#[tokio::test]` で。
+- **E2E (Playwright + tauri-driver)** — セットアップ重く、安定運用にはノウハウが要る。基盤が育ってから別スキル化。
+
+---
+
+## Phase 1: 依存追加
+
+```bash
+# Renderer 側 (Vitest + RTL + jsdom)
+npm install -D vitest @vitest/ui @testing-library/react @testing-library/jest-dom @testing-library/user-event jsdom
+
+# (任意) happy-dom を jsdom の代替に。RTL が動けばどちらでも可。
+# npm install -D happy-dom
+```
+
+> **TypeScript 6 + React 19 + Vite 8** という最先端構成なので、各バージョンの最新 stable を使う。
+> 古いブログのバージョン指定 (`vitest@1.x` 等) を鵜呑みにしない — 最新の peerDependencies を確認。
+
+`package.json` に scripts 追加:
+
+```jsonc
+{
+  "scripts": {
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest run --coverage"
+  }
+}
+```
+
+`coverage` を使うなら `npm install -D @vitest/coverage-v8` も。
+
+---
+
+## Phase 2: Vitest 設定
+
+`vite.config.ts` に test セクションを足す (Vite と Vitest を 1 ファイルで共有するのが Vite 8 系の流儀):
+
+```ts
+// vite.config.ts (既存に追記)
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  // ... 既存設定
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/renderer/src/test-setup.ts'],
+    // Tauri 関連と OS 依存テストは scope を絞る
+    include: ['src/renderer/src/**/*.{test,spec}.{ts,tsx}'],
+    // monaco / xterm を含むコンポーネントは初期は exclude
+    exclude: [
+      'src/renderer/src/components/**/{EditorView,Terminal*,DiffViewer*}.test.{ts,tsx}',
+      'node_modules',
+      'src-tauri',
+      'dist',
+    ],
+    // Tauri モックを物理的に解決させる
+    alias: {
+      '@tauri-apps/api/core': new URL('./src/renderer/src/test-mocks/tauri-core.ts', import.meta.url).pathname,
+      '@tauri-apps/api/event': new URL('./src/renderer/src/test-mocks/tauri-event.ts', import.meta.url).pathname,
+    },
+  },
+});
+```
+
+> `import.meta.url` でのパス解決は ESM 前提。CommonJS 構成なら `path.resolve(__dirname, ...)`。
+
+---
+
+## Phase 3: setupFile と Tauri モック
+
+### `src/renderer/src/test-setup.ts`
+
+```ts
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// React Testing Library の cleanup
+afterEach(() => cleanup());
+
+// jsdom に無い API のスタブ (必要に応じて足す)
+// crypto.randomUUID は zustand canvas.ts で使われている (Issue #157)
+if (typeof globalThis.crypto?.randomUUID !== 'function') {
+  Object.defineProperty(globalThis.crypto, 'randomUUID', {
+    value: () => `test-${Math.random().toString(36).slice(2, 12)}`,
+  });
+}
+
+// matchMedia: テーマ切替 / レイアウトクエリで触る
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+
+// ResizeObserver: Monaco / xyflow が触るが、これらは exclude しているので軽い stub で十分
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  // @ts-expect-error: テスト stub
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+```
+
+### `src/renderer/src/test-mocks/tauri-core.ts`
+
+```ts
+// @tauri-apps/api/core の invoke() を制御可能なモックに置換する。
+// テスト側からハンドラを登録できるようにして、各テストで個別の戻り値を割り当てる。
+
+type InvokeHandler = (args: unknown) => unknown | Promise<unknown>;
+
+const handlers = new Map<string, InvokeHandler>();
+
+export function invoke<T = unknown>(cmd: string, args?: unknown): Promise<T> {
+  const h = handlers.get(cmd);
+  if (!h) {
+    return Promise.reject(new Error(`[mock] invoke "${cmd}" not registered`));
+  }
+  return Promise.resolve(h(args)).then((v) => v as T);
+}
+
+// テスト用ヘルパ — テストファイルの beforeEach で呼ぶ
+export const __mock = {
+  set(cmd: string, handler: InvokeHandler) {
+    handlers.set(cmd, handler);
+  },
+  reset() {
+    handlers.clear();
+  },
+};
+```
+
+### `src/renderer/src/test-mocks/tauri-event.ts`
+
+```ts
+// @tauri-apps/api/event の listen() を、emit ヘルパで発火可能なモックに。
+type Listener = (e: { payload: unknown }) => void;
+
+const listeners = new Map<string, Set<Listener>>();
+
+export type UnlistenFn = () => void;
+
+export function listen<T = unknown>(
+  event: string,
+  cb: (e: { payload: T }) => void,
+): Promise<UnlistenFn> {
+  const set = listeners.get(event) ?? new Set();
+  set.add(cb as Listener);
+  listeners.set(event, set);
+  return Promise.resolve(() => {
+    set.delete(cb as Listener);
+  });
+}
+
+// テスト用ヘルパ — テスト側から push を発火する
+export const __event = {
+  emit(event: string, payload: unknown) {
+    const set = listeners.get(event);
+    if (!set) return;
+    for (const cb of set) cb({ payload });
+  },
+  reset() {
+    listeners.clear();
+  },
+};
+```
+
+---
+
+## Phase 4: 最初の 3 本のテスト (お手本)
+
+ここから先は **既存ファイルに対する最小サンプル** を 3 本書いて、書き味を確かめる。
+
+### 4.1 純粋関数: `lib/language.ts`
+
+```ts
+// src/renderer/src/lib/language.test.ts
+import { describe, it, expect } from 'vitest';
+import { detectLanguage } from './language';
+
+describe('detectLanguage', () => {
+  it('拡張子から Monaco 言語 ID を返す', () => {
+    expect(detectLanguage('foo.ts')).toBe('typescript');
+    expect(detectLanguage('foo.rs')).toBe('rust');
+    expect(detectLanguage('foo.toml')).toBe('ini'); // Issue #77 の代替
+  });
+  it('Dockerfile はファイル名で特殊判定', () => {
+    expect(detectLanguage('path/Dockerfile')).toBe('dockerfile');
+  });
+  it('未知の拡張子は plaintext', () => {
+    expect(detectLanguage('foo.unknown')).toBe('plaintext');
+  });
+  it('拡張子なしは plaintext', () => {
+    expect(detectLanguage('LICENSE')).toBe('plaintext');
+  });
+});
+```
+
+### 4.2 zustand store: `stores/canvas.ts`
+
+```ts
+// src/renderer/src/stores/canvas.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCanvasStore } from './canvas';
+
+describe('canvas store', () => {
+  beforeEach(() => {
+    useCanvasStore.getState().clear();
+  });
+
+  it('addCard はノード id を返す', () => {
+    const id = useCanvasStore.getState().addCard({ type: 'editor', title: 'X' });
+    expect(id).toMatch(/^editor-/);
+    expect(useCanvasStore.getState().nodes).toHaveLength(1);
+  });
+
+  it('removeCard はデフォルトでチームを cascade で消す', () => {
+    const a = useCanvasStore.getState().addCard({ type: 'agent', title: 'A' });
+    // ... 同じ teamId を持たせる payload で 2 枚目を追加するセットアップ
+    useCanvasStore.getState().removeCard(a);
+    expect(useCanvasStore.getState().nodes).toHaveLength(0);
+  });
+
+  it('removeCard({cascadeTeam:false}) は 1 枚だけ消す', () => {
+    const a = useCanvasStore.getState().addCard({ type: 'agent', title: 'A' });
+    useCanvasStore.getState().removeCard(a, { cascadeTeam: false });
+    expect(useCanvasStore.getState().nodes).toHaveLength(0);
+  });
+});
+```
+
+### 4.3 IPC を伴う React コンポーネント (Tauri モック使用)
+
+```tsx
+// src/renderer/src/components/SomePanel.test.tsx
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// vite alias 経由で test-mocks/tauri-core.ts が解決される
+import { __mock } from '@tauri-apps/api/core';
+import { SomePanel } from './SomePanel';
+
+describe('<SomePanel />', () => {
+  beforeEach(() => __mock.reset());
+
+  it('保存ボタンで settings_save が呼ばれる', async () => {
+    let receivedArgs: unknown = null;
+    __mock.set('settings_save', (args) => {
+      receivedArgs = args;
+      return null;
+    });
+    const user = userEvent.setup();
+    render(<SomePanel />);
+    await user.click(screen.getByRole('button', { name: /保存/ }));
+    await waitFor(() => expect(receivedArgs).not.toBeNull());
+  });
+});
+```
+
+---
+
+## Phase 5: Rust 側のテスト規約
+
+`src-tauri/Cargo.toml` の `[dev-dependencies]` に必要なら追加:
+
+```toml
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tempfile = "3"
+```
+
+純粋関数 / I/O を伴う関数のテスト例:
+
+```rust
+// src-tauri/src/commands/atomic_write.rs (末尾に)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn write_then_read_round_trip() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("a.json");
+        atomic_write(&p, b"{}").await.unwrap();
+        let v = tokio::fs::read(&p).await.unwrap();
+        assert_eq!(v, b"{}");
+    }
+}
+```
+
+実行:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+> **PTY / portable-pty 統合テストはここで書かない**。OS 依存が強く CI で安定しないため、別フェーズで Playwright + tauri-driver 環境を立てる時にまとめる。
+
+---
+
+## Phase 6: CI への組み込み
+
+`.github/workflows/ci.yml` に test ジョブを追加:
+
+```yaml
+- run: npm ci
+- run: npm run typecheck
+- run: npm run test:run
+- run: cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+> Renderer テストだけ Linux runner (軽い)、Rust テストは matrix の中で 1 OS だけ走らせる、で OK。
+> Windows 固有 (PTY 系) はそもそも除外している前提なのでクロス OS は不要。
+
+---
+
+## Phase 7: テスト規約 (これだけ守る)
+
+- ファイル配置: テスト対象と **同じフォルダ** に `<name>.test.ts(x)`。`__tests__/` フォルダは作らない。
+- テスト名: `describe('<対象>', ...)` + `it('<期待される振る舞い>', ...)` の日本語 OK。
+- 1 テスト 1 アサーション原則は **しない** (関連アサーションはまとめて 1 テスト)。
+- IPC モックは **必ず `beforeEach(() => __mock.reset())`** で初期化 (テスト間の状態漏れ防止)。
+- グローバル状態 (zustand) は **必ず `beforeEach(() => store.getState().clear())`** で初期化。
+- スナップショットテストは原則使わない (壊れたときに直さず雑に更新する事故が多い)。
+
+---
+
+## やってはいけないこと
+
+- **Monaco / xterm を含むコンポーネントを最初から入れる**: jsdom で挙動が揃わず、テストが flaky になり開発体験が悪化する。明示的に exclude 済 (Phase 2)。
+- **PTY を unit test で動かす**: ConPTY / openpty は CI で安定しない。Rust 側 `path_norm.rs` のような純粋関数だけ。
+- **Tauri モックを scattered で書く**: `vite.config.ts` の `alias` で 1 か所に集約 (Phase 2)。
+- **古いブログを参考にバージョンを固定する**: TS 6 / React 19 / Vite 8 は最新 stable に追従する前提。peerDependencies で確認。
+- **E2E (Playwright + tauri-driver) を一気に入れる**: 別スキル化が筋。基盤が安定するまで保留。
+
+---
+
+## 完了判定 (このスキルが言う「終わった」)
+
+1. `npm run test:run` が **0 ファイル / 0 テスト** ではなく、Phase 4 のサンプル 3 本以上が緑で通る。
+2. `cargo test --manifest-path src-tauri/Cargo.toml` で 1 つ以上の lib テストが緑。
+3. `npm run typecheck` が通る (テストファイルも含めて)。
+4. `.github/workflows/ci.yml` に test step が追加され、Actions の最新 run が緑。
+5. CLAUDE.md の「実装済み機能」末尾に **「テスト基盤 (Vitest + cargo test)」** の 1 行を足す (将来の自分が忘れないため)。
+
+ここまで揃ったら **issue を 1 件起こして PR にする** (`label-and-issue-workflow` skill 経由でラベル付け、`pullrequest` skill 経由で merge まで)。導入そのものを 1 PR で完結させ、テストの追加は **別 PR** で積み上げる。
+
+---
+
+## 関連 skill
+
+- IPC 関連の関数をテストするときの境界 → **`tauri-ipc-commands`** skill
+- PTY のテスト戦略 (このスキルが回避している部分) → **`pty-portable-debugging`** skill
+- 完了後の PR を出す → **`pullrequest`** skill
+- 全体地図 → **`vibeeditor`** skill

--- a/.claude/skills/theme-customization/SKILL.md
+++ b/.claude/skills/theme-customization/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: theme-customization
+description: vibe-editor で新しいテーマ (claude-dark / claude-light / dark / light / midnight / glass のような色プリセット) を追加・既存テーマの色を調整するときに必ず使う 4 層同期 skill。`src/types/shared.ts` の `ThemeName` ユニオン、`src/renderer/src/lib/themes.ts` の `THEMES` オブジェクトと `ThemeVars` インターフェイス、`src/renderer/src/styles/tokens.css` の CSS 変数、`src/renderer/src/lib/monaco-setup.ts` の Monaco カスタムテーマ定義 (`claude-dark` / `claude-light` 等) — これらが 1 つでもズレるとテーマ切替で undefined フォールバックや配色崩れが起きる。ユーザーが「テーマを追加」「新しいテーマ」「カラースキーム」「テーマの色を変更」「Claude.ai 風の◯◯テーマ」「accent カラーを変えて」「dark テーマの bg を◯◯に」「Monaco の配色を調整」「tokens.css に変数を足して」「テーマトークンを追加」等を言ったとき、また `themes.ts` / `tokens.css` / `monaco-setup.ts` を編集しそうなときには必ずこの skill を起動すること。
+---
+
+# theme-customization
+
+vibe-editor のテーマシステムは **CSS 変数 + zustand 設定 + Monaco custom theme** の 3 系統が連動して動く。
+新テーマ追加・色調整は **4 層を必ず同期** させる必要があり、どれか 1 つを忘れるとテーマ切替時に色が崩れる。
+
+> デザイン上の色決定 (Claude.ai 風 / Linear 風など) は **`claude-design`** skill 側に集約されている。
+> この skill は「決まった色をコードに正しく落とす」ための実装手順。
+
+---
+
+## 4 層の関係
+
+```
+┌────────────────────────────────────────────┐
+│ 1. shared.ts: ThemeName ユニオン            │  型定義 (TS / Rust 両用)
+│ 2. themes.ts: THEMES{ name: ThemeVars }     │  色トークン (TS から CSS 変数を流し込む)
+│ 3. tokens.css: :root[data-theme="..."] {…}  │  CSS 側で参照する変数群
+│ 4. monaco-setup.ts: monaco.editor.defineTheme│  Monaco エディタ専用カスタム配色
+└────────────────────────────────────────────┘
+```
+
+`ThemeVars` (themes.ts:3-25) のフィールドが UI 全体で参照される CSS 変数の真実の出所。
+`tokens.css` は CSS 側のフォールバック / 互換 / 派生変数を定義する場所で、テーマごとに値が直接書かれているわけではない (ほとんどは themes.ts の値が `useEffect` で `document.documentElement.style.setProperty` される)。
+
+---
+
+## Step 1: `shared.ts` の `ThemeName` を拡張
+
+```ts
+// src/types/shared.ts
+export type ThemeName =
+  | 'claude-dark'
+  | 'claude-light'
+  | 'dark'
+  | 'light'
+  | 'midnight'
+  | 'glass'
+  | 'sunset';   // ← 新テーマを追加
+```
+
+これを足すと、`AppSettings.theme` の型もこの新名を受け付けるようになる。
+`APP_SETTINGS_SCHEMA_VERSION` (shared.ts) は **既存値の意味を変えるなら** bump、追加だけなら不要。
+
+---
+
+## Step 2: `themes.ts` の `THEMES` に新エントリを追加
+
+`ThemeVars` の **全フィールドを埋める**。省略すると undefined が CSS 変数に流れて崩れる。
+
+```ts
+// src/renderer/src/lib/themes.ts
+export const THEMES: Record<ThemeName, ThemeVars> = {
+  // 既存…
+  sunset: {
+    bg: '#1a0f0a',
+    bgPanel: '#241511',
+    bgSidebar: '#140a07',
+    bgToolbar: 'rgba(26, 15, 10, 0.62)',
+    bgElev: '#2e1a14',
+    border: 'rgba(255, 200, 160, 0.10)',
+    borderStrong: 'rgba(255, 200, 160, 0.18)',
+    bgHover: 'rgba(255, 200, 160, 0.06)',
+    bgActive: 'rgba(255, 140, 60, 0.16)',
+    accent: '#ff7a3c',
+    accentHover: '#ff9259',
+    accentSoft: '#ffa978',
+    accentTint: 'rgba(255, 122, 60, 0.14)',
+    warning: '#f5a623',
+    warningHover: '#f7b955',
+    text: '#fff5ee',
+    textDim: '#d9c0b0',
+    textMute: '#a08573',
+    surfaceGlass: 'rgba(26, 15, 10, 0.62)',
+    focusRing: '0 0 0 3px rgba(255, 122, 60, 0.28)',
+    monacoTheme: 'vs-dark'   // または 'claude-dark' / 'claude-light' / 自作 ('sunset' を Step 4 で defineTheme)
+  },
+};
+```
+
+### `monacoTheme` の選び方
+
+| 値             | 何になるか                                 |
+|----------------|-------------------------------------------|
+| `'vs-dark'`    | Monaco 標準のダーク (黒背景)              |
+| `'vs'`         | Monaco 標準のライト (白背景)              |
+| `'hc-black'`   | ハイコントラストダーク                    |
+| `'claude-dark'` | monaco-setup.ts で定義済み (warm dark)   |
+| `'claude-light'`| monaco-setup.ts で定義済み (warm light)  |
+| 自作テーマ ID  | Step 4 で `monaco.editor.defineTheme()` を追加した上で指定 |
+
+新しい配色を細部まで合わせたいなら **自作テーマ ID** にして Step 4 を書く。流用で十分なら既存のいずれかを指定。
+
+---
+
+## Step 3: `tokens.css` に派生変数 / 互換変数があれば追加
+
+`tokens.css` (`src/renderer/src/styles/tokens.css`) は **CSS 側で参照されるトークン**を定義する場所。
+themes.ts から流し込まれる変数 (`--bg`, `--text`, `--accent` …) が主役だが、CSS 側だけで使う派生 (`--font-claude-response`, motion / shadow / radius など) も並んでいる。
+
+新テーマ追加で **新規変数を増やすケースは少ない** (themes.ts の `ThemeVars` を増やしたい場合のみ)。
+増やすときは:
+
+1. `ThemeVars` インターフェイス (themes.ts:3-25) にフィールドを追加。
+2. `THEMES` の **全テーマ** に値を埋める (TS strict なので忘れるとコンパイルエラー)。
+3. 流し込み箇所 (おそらく `SettingsContext` の `useEffect`) で `setProperty` が新フィールドを拾うか確認。
+4. CSS 側で `var(--newvar)` を参照する場所を追加。
+
+> **既存変数の値を変えるだけ**なら themes.ts のみ触れば十分。tokens.css は触らなくてよい。
+
+---
+
+## Step 4: Monaco カスタムテーマを足す (必要なら)
+
+`monaco-setup.ts` に既に `claude-dark` / `claude-light` の例がある (monaco-setup.ts:62-114)。新テーマを Monaco でも独自配色にしたければ追加:
+
+```ts
+// src/renderer/src/lib/monaco-setup.ts
+monaco.editor.defineTheme('sunset', {
+  base: 'vs-dark',
+  inherit: true,
+  rules: [],
+  colors: {
+    'editor.background': '#1a0f0a',
+    'editor.foreground': '#fff5ee',
+    'editor.lineHighlightBackground': '#241511',
+    'editorCursor.foreground': '#ff7a3c',
+    // ... claude-dark の例を踏襲
+    // diff: 10% tint で揃える (skill: claude-design セクション 6)
+    'diffEditor.insertedTextBackground': '#578a0019',
+    'diffEditor.removedTextBackground':  '#cf3a3a19',
+    'diffEditor.insertedLineBackground': '#578a000d',
+    'diffEditor.removedLineBackground':  '#cf3a3a0d',
+    'diffEditorGutter.insertedLineBackground': '#578a0033',
+    'diffEditorGutter.removedLineBackground':  '#cf3a3a33',
+  }
+});
+```
+
+そして Step 2 の `monacoTheme` を `'sunset'` に書き換える。
+**`ThemeVars.monacoTheme` の string union にも追加する**こと (themes.ts:24)。
+
+```ts
+monacoTheme: 'vs-dark' | 'vs' | 'hc-black' | 'claude-dark' | 'claude-light' | 'sunset';
+```
+
+---
+
+## Step 5: 設定 UI / コマンドパレットへの露出
+
+新テーマが選択肢として出るかは、設定モーダル (`components/settings/`) や CommandPalette (`lib/commands*`) のテーマ一覧定義による。
+
+- 設定モーダルでテーマプルダウンに自動列挙されているなら追加不要。`Object.keys(THEMES)` から派生していれば自動。
+- ハードコードされた配列があれば、その配列にも `sunset` を追加。
+- i18n が必要な表示名 (`「サンセット」`) があれば `lib/i18n*` に翻訳キーを足す。
+
+---
+
+## Step 6: 検証
+
+```bash
+npm run typecheck
+npm run dev
+```
+
+実機で:
+
+1. 設定モーダル → テーマで新テーマを選択。
+2. 全 UI が崩れていないか (左サイドバー、ツールバー、エディタ、Canvas、ターミナル、設定モーダル自身)。
+3. **Monaco エディタの背景** が想定通り (色が `vs-dark` のままなら Step 4 を飛ばしている)。
+4. 設定を再起動しても永続化されているか。
+5. 別テーマと往復してチラつき / 残留色が無いか。
+
+スクリーンショットで before/after 並べて自己レビューする (CLAUDE.md「動作の証明」原則)。
+
+---
+
+## よくある事故
+
+- **`monacoTheme` を `'vs-dark'` のままで Step 4 を書いた**: 自作テーマが認識されないので Step 2 の `monacoTheme` 書き換えを必ずセットで。
+- **`ThemeVars` のフィールドを 1 つだけ書き忘れた**: TS strict で落ちる。落ちなかったら Record 型が `Partial` になっていないか確認。
+- **alpha 付きカラー (`rgba(...)`) を `border` 系に入れ忘れた**: Linear/Raycast 風の薄ボーダーが破綻する。既存テーマ (claude-dark) の値を元に微調整する。
+- **claude-dark / claude-light の "Claude.ai 実測値" コメントを書き換えた**: あの値は Claude.ai 本家から取った値なので、別テーマを足す場合は **新エントリで** 書く (既存値は触らない)。
+- **`focusRing` を空文字にした**: a11y で focus が見えなくなる。最低限 `0 0 0 3px rgba(accent, 0.28)` 風の値を入れる。
+
+---
+
+## 関連 skill
+
+- 色パレット決定 / Claude.ai 風の表現意図 → **`claude-design`** skill
+- 全体の地図 → **`vibeeditor`** skill
+- 設定スキーマを破壊変更するなら → `APP_SETTINGS_SCHEMA_VERSION` を bump (vibeeditor 参照)


### PR DESCRIPTION
## Summary

- PR #270 (closed) に残っていた skill commit から、新規 skill / agent 11 ファイルだけを取り込む
- `.claude/skills/vibeeditor/SKILL.md` の変更は main 側の最新内容 (不変式 + IPC event pre-subscribe レシピ #285 / PR #291) を保つため除外
- 既存ファイルへの変更なし、純粋に新規追加のみ

## 取り込むファイル

- `.claude/agents/rust-ipc-reviewer.md`
- `.claude/agents/windows-pty-reviewer.md`
- `.claude/skills/agent-team/SKILL.md`
- `.claude/skills/canvas-nodecard-pattern/SKILL.md`
- `.claude/skills/issue-plan/SKILL.md`
- `.claude/skills/monaco-language-setup/SKILL.md`
- `.claude/skills/pty-portable-debugging/SKILL.md`
- `.claude/skills/subagent/SKILL.md`
- `.claude/skills/tauri-ipc-commands/SKILL.md`
- `.claude/skills/test-setup-vitest/SKILL.md`
- `.claude/skills/theme-customization/SKILL.md`

## Test plan

- [x] 純粋に新規ファイル追加のみ — 既存コードへの影響なし
- [x] `git diff main...HEAD --stat` で 11 files (+2315) のみが変更されていることを確認
- [ ] `.claude/` 配下の Markdown のみのため typecheck / build は対象外

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)