### PR TITLE
docs(readme): ヘッダーアイコンを現行ロゴに差し替え

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="build/icon.png" alt="vibe-editor" width="112" />
+<img src="src/renderer/public/vibe-editor.png" alt="vibe-editor" width="112" />
 
 # vibe-editor
 


### PR DESCRIPTION
## Summary
- README.md ヘッダー画像を `build/icon.png` (旧 serif-V) から `src/renderer/public/vibe-editor.png` (現行ロゴ) に変更

`build/icon.png` には Tauri の bundling 用に古いバージョンのアイコンが残っており、README に表示されていたのもそちらでした。リポジトリにある現行のロゴ画像を参照するように差し替えます。

## Test plan
- [ ] GitHub 上で README.md ヘッダー画像が新しいロゴに切り替わっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)