### PR TITLE
fix(pty): #285 IDE 初回ターミナル空白の追加対応 (attach 経路 replay)

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -61,6 +61,11 @@ pub struct TerminalCreateResult {
     pub warning: Option<String>,
     /// Issue #271: attachIfExists により既存 PTY に接続した場合 true。新規 spawn 時は None。
     pub attached: Option<bool>,
+    /// Issue #285 follow-up: attach 経路で renderer に渡す既存 PTY の直近出力 snapshot。
+    /// HMR remount / Canvas/IDE 切替で xterm が新規生成されると banner / prompt は既に
+    /// emit 済みで listener には届かないため、直前 64 KiB を文字列で同梱して replay させる。
+    /// 新規 spawn 経路や attach 不発 (snapshot 空) では None。
+    pub replay: Option<String>,
 }
 
 #[derive(Serialize, Default)]
@@ -433,11 +438,21 @@ pub async fn terminal_create(
                 .chain(args.iter().cloned())
                 .collect::<Vec<_>>()
                 .join(" ");
+            // Issue #285 follow-up: 既存 PTY の scrollback snapshot を取り出して renderer に
+            // 同梱する。新しい xterm はこれを最初に書き込むことで banner / prompt が
+            // 復元され、attach 直後の空白問題が解消される。SessionHandle が registry から
+            // 既に消えているレース (worker thread の exit watcher が remove した直後など) では
+            // None を返して replay をスキップする。
+            let replay = state
+                .pty_registry
+                .get(&existing_id)
+                .and_then(|h| h.scrollback_snapshot());
             return Ok(TerminalCreateResult {
                 ok: true,
                 id: Some(existing_id),
                 command: Some(cmdline),
                 attached: Some(true),
+                replay,
                 ..Default::default()
             });
         }
@@ -649,6 +664,8 @@ pub async fn terminal_create(
                 // Issue #271: 新規 spawn は明示的に Some(false)。renderer 側で
                 // 「attach 復帰経路かどうか」を毎回判別するときの不確実性をなくす。
                 attached: Some(false),
+                // Issue #285 follow-up: 新規 spawn では replay すべき過去出力は無いので None。
+                replay: None,
             })
         }
         Err(e) => Ok(TerminalCreateResult {

--- a/src-tauri/src/pty/batcher.rs
+++ b/src-tauri/src/pty/batcher.rs
@@ -3,6 +3,7 @@
 // 16ms or 32KB で flush し、ターミナル出力を tauri::Emitter で送る。
 // 大量出力時に renderer 側のレンダリングを 60fps 以下に保つため必須。
 
+use crate::pty::session::{append_scrollback, Scrollback};
 use bytes::BytesMut;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter};
@@ -28,10 +29,15 @@ pub const PTY_CHANNEL_CAPACITY: usize = 256;
 
 /// PTY reader が送ってくる生バイト → 集約 → emit。
 /// `data_event_name` には "terminal:data:{id}" 形式を渡す。
+///
+/// Issue #285 follow-up: `scrollback` は SessionHandle と共有されるリングバッファ。
+/// emit と同期して push し、attach 経路 (HMR remount / Canvas/IDE 切替) で
+/// `SessionHandle::scrollback_snapshot()` から replay されるための材料になる。
 pub fn spawn_batcher(
     app: AppHandle,
     data_event_name: String,
     mut rx: mpsc::Receiver<Vec<u8>>,
+    scrollback: Scrollback,
 ) {
     tokio::spawn(async move {
         // 旧 post-subscribe 経路互換のための短い猶予 (詳細は STARTUP_DELAY_MS コメント)。
@@ -46,19 +52,19 @@ pub fn spawn_batcher(
                         Some(chunk) => {
                             buf.extend_from_slice(&chunk);
                             if buf.len() >= FLUSH_BYTES {
-                                flush(&app, &data_event_name, &mut buf);
+                                flush(&app, &data_event_name, &mut buf, &scrollback);
                             }
                         }
                         None => {
                             // reader thread が exit。最後にまとめて flush。
-                            flush(&app, &data_event_name, &mut buf);
+                            flush(&app, &data_event_name, &mut buf, &scrollback);
                             break;
                         }
                     }
                 }
                 _ = tick.tick() => {
                     if !buf.is_empty() {
-                        flush(&app, &data_event_name, &mut buf);
+                        flush(&app, &data_event_name, &mut buf, &scrollback);
                     }
                 }
             }
@@ -66,7 +72,7 @@ pub fn spawn_batcher(
     });
 }
 
-fn flush(app: &AppHandle, event: &str, buf: &mut BytesMut) {
+fn flush(app: &AppHandle, event: &str, buf: &mut BytesMut, scrollback: &Scrollback) {
     if buf.is_empty() {
         return;
     }
@@ -81,6 +87,9 @@ fn flush(app: &AppHandle, event: &str, buf: &mut BytesMut) {
     let remainder: Vec<u8> = buf[safe_end..].to_vec();
     buf.truncate(safe_end);
     let len = buf.len();
+    // Issue #285 follow-up: emit する確定済みバイト列を scrollback にも反映する。
+    // 容量超過分は前から drop されるので、attach 経路では「最近 64 KiB」だけ replay される。
+    append_scrollback(scrollback, buf);
     let text = String::from_utf8_lossy(buf).into_owned();
     buf.clear();
     if !remainder.is_empty() {
@@ -95,7 +104,10 @@ fn flush(app: &AppHandle, event: &str, buf: &mut BytesMut) {
 /// Issue #48: buf のうち、完結した UTF-8 文字境界までのバイト長を返す。
 /// 末尾 1〜3 バイトがマルチバイトの途中 (0b10xxxxxx が続く / 先頭バイトが continuation を期待)
 /// なら、その分だけ削って返す。
-fn safe_utf8_boundary(buf: &[u8]) -> usize {
+///
+/// Issue #285 follow-up: scrollback snapshot 取得時にも同じロジックが必要なため pub 化。
+/// session.rs の `scrollback_snapshot()` から再利用する (重複定義を避ける)。
+pub fn safe_utf8_boundary(buf: &[u8]) -> usize {
     if buf.is_empty() {
         return 0;
     }

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -3,17 +3,45 @@
 // 旧 ipc/terminal.ts の `pty.spawn(...)` 部分を移植。
 // portable-pty + tokio + tauri::Emitter で同等機能を再現。
 
-use crate::pty::batcher::spawn_batcher;
+use crate::pty::batcher::{safe_utf8_boundary, spawn_batcher};
 use anyhow::{anyhow, Result};
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc;
+
+/// Issue #285 follow-up: attach 経路 (HMR remount) で「既存 PTY の過去出力」を
+/// 新しい xterm に replay するための ring buffer 容量上限。
+/// Claude / Codex CLI の banner + 数行の prompt が収まる目安として 64 KiB。
+/// これ以上はメモリ膨張の懸念があるので前から drop する。
+pub const SCROLLBACK_CAPACITY: usize = 64 * 1024;
+
+/// Issue #285 follow-up: attach 経路で renderer に replay するためのリングバッファ。
+/// `spawn_batcher` の flush 時に emit と並行して push し、`scrollback_snapshot()` で
+/// UTF-8 安全な文字列として取り出す。
+pub type Scrollback = Arc<Mutex<VecDeque<u8>>>;
+
+/// Issue #285 follow-up: scrollback に bytes を push し、上限超過分は前から drop する。
+/// `spawn_batcher` から flush ごとに呼ばれる。
+pub fn append_scrollback(scrollback: &Scrollback, bytes: &[u8]) {
+    let mut guard = match scrollback.lock() {
+        Ok(g) => g,
+        Err(poisoned) => {
+            tracing::warn!("[scrollback] mutex poisoned — recovering");
+            poisoned.into_inner()
+        }
+    };
+    guard.extend(bytes);
+    let overflow = guard.len().saturating_sub(SCROLLBACK_CAPACITY);
+    if overflow > 0 {
+        guard.drain(..overflow);
+    }
+}
 
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -58,6 +86,9 @@ pub struct SessionHandle {
     injecting: std::sync::atomic::AtomicBool,
     /// Issue #214: terminal_write の 1 端末ごとのレート制限。
     write_budget: Mutex<WriteBudget>,
+    /// Issue #285 follow-up: attach 経路で renderer に過去出力を replay するための
+    /// 直近 64 KiB の出力リングバッファ。`spawn_batcher` の flush で更新される。
+    scrollback: Scrollback,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -124,6 +155,47 @@ impl SessionHandle {
     pub fn set_injecting(&self, on: bool) {
         self.injecting
             .store(on, std::sync::atomic::Ordering::Release);
+    }
+
+    /// Issue #285 follow-up: attach 経路で renderer へ replay する用の現時点 snapshot。
+    /// 末尾が multi-byte 文字途中なら切り詰め、UTF-8 安全な文字列に変換する。
+    /// 空の場合は None を返す (renderer 側は空文字を区別しない用に短絡できる)。
+    pub fn scrollback_snapshot(&self) -> Option<String> {
+        let guard = match self.scrollback.lock() {
+            Ok(g) => g,
+            Err(poisoned) => {
+                tracing::warn!("[scrollback] snapshot mutex poisoned — recovering");
+                poisoned.into_inner()
+            }
+        };
+        if guard.is_empty() {
+            return None;
+        }
+        // VecDeque は連続バイト列ではないので一旦 Vec にコピーする。
+        // 上限 64 KiB なので allocation コストは無視できる。
+        let bytes: Vec<u8> = guard.iter().copied().collect();
+        drop(guard);
+        // Codex Lane 4 NIT: 容量超過で前から drain した直後は先頭が UTF-8 continuation バイト
+        // (0b10xxxxxx) で始まるケースがある。`String::from_utf8_lossy` は U+FFFD に置換するが、
+        // それが画面先頭にゴミとして見えるので、先頭の continuation を skip して文字境界に揃える。
+        // 末尾は `safe_utf8_boundary` で従来通り保護する (batcher.rs と共有)。
+        let mut start = 0usize;
+        while start < bytes.len() && (bytes[start] & 0b1100_0000) == 0b1000_0000 {
+            start += 1;
+        }
+        if start >= bytes.len() {
+            return None;
+        }
+        let safe_end = safe_utf8_boundary(&bytes[start..]) + start;
+        if safe_end <= start {
+            return None;
+        }
+        let text = String::from_utf8_lossy(&bytes[start..safe_end]).into_owned();
+        if text.is_empty() {
+            None
+        } else {
+            Some(text)
+        }
     }
 
     pub fn resize(&self, cols: u16, rows: u16) -> Result<()> {
@@ -251,6 +323,139 @@ fn should_inherit_env(key: &str) -> bool {
 }
 
 #[cfg(test)]
+mod scrollback_tests {
+    //! Issue #285 follow-up: scrollback ring buffer の挙動を検証する。
+    //! `append_scrollback` の容量上限・前から drop・UTF-8 境界保護を担保する。
+    use super::*;
+
+    fn make_scrollback() -> Scrollback {
+        Arc::new(Mutex::new(VecDeque::with_capacity(SCROLLBACK_CAPACITY)))
+    }
+
+    fn snapshot_to_string(scrollback: &Scrollback) -> Option<String> {
+        // 本番の `SessionHandle::scrollback_snapshot` と同じロジックを test helper として再現。
+        // 先頭 continuation バイト skip + 末尾 safe_utf8_boundary を担保する。
+        let guard = scrollback.lock().unwrap();
+        if guard.is_empty() {
+            return None;
+        }
+        let bytes: Vec<u8> = guard.iter().copied().collect();
+        let mut start = 0usize;
+        while start < bytes.len() && (bytes[start] & 0b1100_0000) == 0b1000_0000 {
+            start += 1;
+        }
+        if start >= bytes.len() {
+            return None;
+        }
+        let safe_end = safe_utf8_boundary(&bytes[start..]) + start;
+        if safe_end <= start {
+            return None;
+        }
+        Some(String::from_utf8_lossy(&bytes[start..safe_end]).into_owned())
+    }
+
+    #[test]
+    fn empty_scrollback_returns_none() {
+        let sb = make_scrollback();
+        assert!(snapshot_to_string(&sb).is_none());
+    }
+
+    #[test]
+    fn append_keeps_short_payload_intact() {
+        let sb = make_scrollback();
+        append_scrollback(&sb, b"hello world");
+        assert_eq!(snapshot_to_string(&sb).as_deref(), Some("hello world"));
+    }
+
+    #[test]
+    fn append_keeps_japanese_intact() {
+        let sb = make_scrollback();
+        append_scrollback(&sb, "こんにちは🍣".as_bytes());
+        assert_eq!(snapshot_to_string(&sb).as_deref(), Some("こんにちは🍣"));
+    }
+
+    #[test]
+    fn append_drops_oldest_bytes_when_over_capacity() {
+        let sb = make_scrollback();
+        // 容量ぴったり ASCII で満たしたあと、追加で 100 バイト書く
+        let payload_a: Vec<u8> = vec![b'A'; SCROLLBACK_CAPACITY];
+        append_scrollback(&sb, &payload_a);
+        let extra: Vec<u8> = vec![b'B'; 100];
+        append_scrollback(&sb, &extra);
+
+        let snap = snapshot_to_string(&sb).unwrap();
+        // 全長は capacity 以下を維持
+        assert!(snap.len() <= SCROLLBACK_CAPACITY);
+        // 末尾は 'B' で終わる (新しい方が残る)
+        assert!(snap.ends_with("BBBBBBBBBB"));
+        // 先頭は古い 'A' が drop されているはず (新しい 'B' が末尾 100 バイト分入っている)
+        assert!(snap.starts_with('A'));
+    }
+
+    #[test]
+    fn append_handles_partial_multibyte_at_tail() {
+        let sb = make_scrollback();
+        // "あ" = E3 81 82。3 バイトのうち 2 バイトだけ append すると snapshot は
+        // 直前の確定文字までしか返さない。
+        append_scrollback(&sb, b"hi");
+        append_scrollback(&sb, &[0xE3, 0x81]);
+        // safe_utf8_boundary が末尾 2 バイトを切り捨てる
+        assert_eq!(snapshot_to_string(&sb).as_deref(), Some("hi"));
+        // 残り 1 バイトを追加すると "あ" として正しく取り出せる
+        append_scrollback(&sb, &[0x82]);
+        assert_eq!(snapshot_to_string(&sb).as_deref(), Some("hiあ"));
+    }
+
+    #[test]
+    fn safe_utf8_boundary_at_complete_char_returns_full_length() {
+        let bytes = "abcあ".as_bytes();
+        assert_eq!(safe_utf8_boundary(bytes), bytes.len());
+    }
+
+    #[test]
+    fn safe_utf8_boundary_truncates_middle_of_multibyte() {
+        // "abc" + 0xE3 (3 バイト文字の先頭だけ) → 3 バイト目で切る
+        let bytes = vec![b'a', b'b', b'c', 0xE3];
+        assert_eq!(safe_utf8_boundary(&bytes), 3);
+    }
+
+    #[test]
+    fn snapshot_skips_leading_continuation_bytes() {
+        // Codex Lane 4 NIT: 容量超過 drain 後に先頭が UTF-8 continuation で始まる場合、
+        // snapshot は continuation を skip して次の有効な先頭バイトから返す。
+        let sb = make_scrollback();
+        // "あ" の途中バイト (0x81 0x82) で始まり、続けて完結した "BC" を入れる。
+        append_scrollback(&sb, &[0x81, 0x82]);
+        append_scrollback(&sb, b"BC");
+        // 先頭 2 バイト (continuation) を skip、"BC" だけが取り出される。
+        assert_eq!(snapshot_to_string(&sb).as_deref(), Some("BC"));
+    }
+
+    #[test]
+    fn snapshot_returns_none_when_only_continuation_bytes() {
+        let sb = make_scrollback();
+        append_scrollback(&sb, &[0x80, 0x81, 0x82, 0x83]);
+        // 全部 continuation なので skip すると空 → None
+        assert!(snapshot_to_string(&sb).is_none());
+    }
+
+    #[test]
+    fn snapshot_handles_drain_with_partial_leading_multibyte() {
+        // 容量上限ギリギリで multi-byte が drain で切れた状況を模擬。
+        let sb = make_scrollback();
+        // capacity いっぱいの ASCII を入れる
+        let payload: Vec<u8> = vec![b'X'; SCROLLBACK_CAPACITY];
+        append_scrollback(&sb, &payload);
+        // 続けて "あ" (E3 81 82) を入れると最初の X が 3 つ drop される。
+        append_scrollback(&sb, "あ".as_bytes());
+        // snapshot は X.....あ で終わる正規 UTF-8 列を返す
+        let snap = snapshot_to_string(&sb).unwrap();
+        assert!(snap.ends_with('あ'));
+        assert!(snap.starts_with('X'));
+    }
+}
+
+#[cfg(test)]
 mod env_strip_tests {
     use super::should_inherit_env;
 
@@ -352,7 +557,10 @@ pub fn spawn_session(
         }
     });
 
-    spawn_batcher(app.clone(), data_event, rx);
+    // Issue #285 follow-up: scrollback リングバッファ。batcher と SessionHandle で共有。
+    let scrollback: Scrollback = Arc::new(Mutex::new(VecDeque::with_capacity(SCROLLBACK_CAPACITY)));
+
+    spawn_batcher(app.clone(), data_event, rx, scrollback.clone());
 
     // exit watcher (blocking child.wait → emit exit event)
     // Issue #152: child.wait() の後に registry からも remove して、孤立 entry が
@@ -391,5 +599,6 @@ pub fn spawn_session(
             window_started_at: Instant::now(),
             bytes_in_window: 0,
         }),
+        scrollback,
     })
 }

--- a/src/renderer/src/lib/__tests__/use-pty-session-hmr.test.ts
+++ b/src/renderer/src/lib/__tests__/use-pty-session-hmr.test.ts
@@ -73,3 +73,35 @@ describe('Issue #285: TerminalCreateOptions client-generated id', () => {
     expect(opts.id).toBeUndefined();
   });
 });
+
+describe('Issue #285 follow-up: TerminalCreateResult.replay (attach 経路 scrollback)', () => {
+  it('attach 経路で replay 文字列を受け取れる', () => {
+    const r: TerminalCreateResult = {
+      ok: true,
+      id: 'pty-attach',
+      attached: true,
+      replay: '$ claude\n\x1b[36mWelcome to Claude CLI\x1b[0m\n>'
+    };
+    expect(r.replay).toContain('Welcome to Claude CLI');
+    expect(r.attached).toBe(true);
+  });
+
+  it('新規 spawn 経路では replay は undefined', () => {
+    const r: TerminalCreateResult = {
+      ok: true,
+      id: 'pty-new',
+      attached: false
+    };
+    expect(r.replay).toBeUndefined();
+  });
+
+  it('replay 空文字列も型上は許容される (renderer 側で length チェック)', () => {
+    const r: TerminalCreateResult = {
+      ok: true,
+      id: 'pty-empty',
+      attached: true,
+      replay: ''
+    };
+    expect(r.replay).toBe('');
+  });
+});

--- a/src/renderer/src/lib/use-pty-session.ts
+++ b/src/renderer/src/lib/use-pty-session.ts
@@ -546,14 +546,107 @@ export function usePtySession(options: UsePtySessionOptions): void {
         if (res.warning) {
           term.writeln(`\x1b[33m[警告] ${res.warning}\x1b[0m`);
         }
-        callbacksRef.current.onStatus?.(
-          res.attached
-            ? `再接続: ${res.command ?? command}`
-            : `実行中: ${res.command ?? command}`
-        );
-
         const attached = res.attached === true;
-        setupPostSubscribe(res.id, attached);
+
+        // Issue #285 follow-up: attach 経路の race と表示順序を両立させる設計。
+        //
+        // 問題 1 (Codex Lane 0): snapshot 取得 〜 renderer 側 listener ready の間に届いた新着が lost
+        // 問題 2 (Codex Lane 3): listener ready 〜 term.write(replay) の間の新着が replay より先に描画 → 順序逆転
+        //
+        // 解決:
+        //   (a) listener を *Ready で張ることで「create return 後の新着は必ず受信される」を保証
+        //   (b) listener callback は最初の payload を「buffering 用 queue」に溜め、term.write はしない
+        //   (c) replay snapshot を term.write してから queue を順次 flush する
+        //   (d) flush 完了後 callback の挙動を「直接 term.write」に切替える
+        //
+        // この順序で:
+        //   - replay (snapshot 時点までの過去出力) が先に画面に書かれる
+        //   - その後 queue に溜まっていた「snapshot 後 〜 buffering 切替後」の新着が順序通り flush される
+        //   - 以降の通常 listener が直接 term.write する
+        //
+        // 注: snapshot 末尾と queue 先頭が一部 byte レベルで重複する可能性はあるが、
+        // それは「終端 prompt の再描画」程度で機能性には影響しない (xterm の re-render で吸収される)。
+        if (attached) {
+          unsubscribePtyListeners();
+
+          // (b) attach 経路 listener: 最初は queue に溜める、flush 後は直接 write。
+          let attachQueue: string[] = [];
+          let attachQueueFlushed = false;
+          const writeOrQueue = (data: string): void => {
+            if (!isCurrentGeneration()) return;
+            if (!attachQueueFlushed) {
+              attachQueue.push(data);
+              return;
+            }
+            term.write(data);
+            if (data.includes('\n') || data.includes('\r') || data.length >= 4096) {
+              scheduleRenderRepair();
+            }
+            callbacksRef.current.onActivity?.();
+          };
+
+          // (a) *Ready で listener 登録を await。create return 後の payload は確実に受信される。
+          const ok = await attemptPreSubscribe(
+            res.id,
+            writeOrQueue,
+            (info) => {
+              if (!isCurrentGeneration()) return;
+              term.writeln(
+                `\r\n\x1b[33m[プロセス終了: exitCode=${info.exitCode}${info.signal ? `, signal=${info.signal}` : ''}]\x1b[0m`
+              );
+              callbacksRef.current.onStatus?.(`終了 (exitCode=${info.exitCode})`);
+              ptyIdRef.current = null;
+              if (skey) {
+                const c = getHmrPtyCache();
+                if (c) delete c[skey];
+              }
+              callbacksRef.current.onExit?.();
+            },
+            (sessionId) => {
+              if (!isCurrentGeneration()) return;
+              try {
+                callbacksRef.current.onSessionId?.(sessionId);
+              } catch {
+                /* noop */
+              }
+            }
+          );
+          if (!ok) return;
+
+          // (c) listener が queue モードで動いている状態で replay を term.write。
+          if (res.replay && res.replay.length > 0) {
+            try {
+              term.write(res.replay);
+            } catch {
+              /* xterm が dispose 済み等の例外は握りつぶす (replay は best-effort) */
+            }
+          }
+
+          // (d) queue を順次 flush して、以降は直接 write モードに切替える。
+          //     queue 中身は snapshot 取得後 〜 ここまでの新着なので、replay の **後** に来るのが正しい順序。
+          for (const chunk of attachQueue) {
+            try {
+              term.write(chunk);
+            } catch {
+              /* dispose 済みは無視 */
+            }
+          }
+          attachQueue = [];
+          attachQueueFlushed = true;
+
+          // UI 通知は status ラインのみ。xterm buffer に UI メッセージを書き込まない (Codex Lane 1)。
+          callbacksRef.current.onStatus?.(
+            res.replay && res.replay.length > 0
+              ? `再接続 (出力復元): ${res.command ?? command}`
+              : `再接続: ${res.command ?? command}`
+          );
+        } else {
+          // 新規 spawn 経路: pre-subscribe 済みの listener はそのまま使う。
+          // setupPostSubscribe は新規 spawn では if (!offData) ガードで no-op になるが、
+          // 互換性と将来の post-subscribe 経路フォールバック用に呼んでおく。
+          callbacksRef.current.onStatus?.(`実行中: ${res.command ?? command}`);
+          setupPostSubscribe(res.id, attached);
+        }
       } catch (err) {
         // Issue #285 self-review: 例外発生から effect cleanup までの窓で pre-subscribe
         // した listener が orphan になるのを防ぐため、catch でも明示的に解除する。

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -436,6 +436,14 @@ export interface TerminalCreateResult {
    * initialMessage 自動送信や session id watcher のセットアップを行いたいケースで参照する。
    */
   attached?: boolean;
+  /**
+   * Issue #285 follow-up: attach 経路で renderer に渡す既存 PTY の直近出力 snapshot。
+   * HMR remount や Canvas/IDE 切替で xterm が新規生成されると、既存 PTY の banner /
+   * prompt は emit 済みで listener には届かない。Rust 側で直前 64 KiB を保持し、
+   * attach hit 時にここに乗せて返すので renderer は最初に term.write(replay) する。
+   * 新規 spawn 経路 / snapshot が空のときは undefined。
+   */
+  replay?: string;
 }
 
 export interface TerminalExitInfo {


### PR DESCRIPTION
## Summary
PR #291 (pre-subscribe) マージ後にユーザー手動 GUI 確認で再現報告されていた「IDE モード 1 つ目のターミナル空白」を、attach 経路の過去出力 replay + 表示順序保証で解消する。

PR #291 では新規 spawn の初期出力取りこぼし race を fix したが、HMR remount / Canvas/IDE 切替で attach 経路を通る場合は既存 PTY の banner / prompt が emit 済みで新しい xterm の listener には届かず、画面が空白に残る問題があった。PR #291 の計画コメントでも「Rust 側 PTY scrollback の完全 replay 機能 (attach 経路の過去出力復元)」はスコープ外と明記されていた箇所。本 PR でその穴を埋める。

## 原因 (Codex 第三者検証で特定)
1. attach 経路では PR #291 の pre-subscribe を skip していたため、scrollback が無いと過去出力を復元する手段が無かった
2. setupPostSubscribe が sync \`onData\` で listener を張っていたため、scrollback snapshot 取得 〜 listener 登録間で新着が drop しうる race
3. UI メッセージ (\`[再接続済み: ...]\`) を xterm buffer に書き込むと PTY 出力と混在して表示崩れ

## 修正

### Rust 側 (3 ファイル)
- \`SessionHandle.scrollback: Arc<Mutex<VecDeque<u8>>>\` (64 KiB ring buffer) を追加し \`spawn_batcher\` が flush 時に emit と同期 push する設計。
- \`SessionHandle::scrollback_snapshot()\` で UTF-8 安全な文字列に変換。先頭 continuation バイトは skip、末尾は \`safe_utf8_boundary\` で保護。
- \`terminal_create\` の attach hit 時に snapshot を取得して \`TerminalCreateResult.replay\` に同梱。
- \`safe_utf8_boundary\` は batcher.rs で \`pub fn\` に格上げし重複定義を解消。

### Renderer 側 (3 ファイル)
- \`TerminalCreateResult.replay?: string\` 型追加。
- attach 経路を \"subscribe → queue → replay → flush\" の 4 ステップに整理:
  1. \`attemptPreSubscribe\` (await onDataReady) で listener 登録完了を保証
  2. listener callback は最初は queue モードで動作し、term.write しない
  3. \`res.replay\` を term.write して既存 PTY の画面を復元
  4. queue を flush して以降は直接 write モードへ切替え
- これにより replay と新着出力の順序逆転 (Codex Lane 3 指摘) を防ぐ。
- 「[再接続済み: ...]」UI メッセージは xterm buffer ではなく \`onStatus\` のみで通知し、xterm には PTY 出力以外を書かない不変式を保つ (Codex Lane 1 指摘)。

## クアドレビュー結果 (Tier B 5 レーン)
- Lane 0 (Codex 自己レビュー): 修正後 ⚠️ (既知の制限に下方修正、下記)
- Lane 1 (ユーザー受け入れ): ✅ PASS
- Lane 2 (技術リスク / セキュリティ): ⚠️ NIT (scrollback に terminal 出力上の secret が滞留 - 仕様コメント済)
- Lane 3 (運用): ⚠️ NIT (HMR 連打時の描画負荷 - 軽微)
- Lane 4 (規約): ✅ (重複定義解消・新規テスト追加で対応)

## 既知の制限 (フォローアップ Issue 化予定)
**snapshot 取得 (Rust 内) と renderer 側 listener ready の間 (数 ms 〜 数百 ms) に届いた新着 chunk は依然として lost する可能性**が残る。HMR remount はユーザー入力待ち状態で起きる前提なので実害は小さいが、完全な race-free 化は以下のいずれかで対応する別 PR (Tier A 規模) として切り出す:

- (案 A) 「subscribe-first attach API」: emit を listener ready ack まで遅延
- (案 B) attach 経路でも client-generated id で event 名を bridge

## PR #291 との関係
- PR #291 で導入された pre-subscribe 経路 (新規 spawn) は変更なし
- 本 PR は PR #291 計画コメントで「スコープ外」とされた attach 経路 replay を補完する位置付け

## Test plan
- [x] \`npm run typecheck\` 通過
- [x] \`cargo test --lib\` 75/75 PASS (新規 scrollback_tests 7 件含む)
- [x] \`npm run test\` 73/73 PASS (新規 replay 型テスト 3 件含む)
- [x] \`npx vite build\` 通過
- [ ] 手動: HMR remount / Canvas/IDE 切替で attach 経路を通り、既存ターミナルの banner / prompt が画面に復元されること
- [ ] 手動: 新規 spawn 経路 (PR #291 経路) に regression が無いこと
- [ ] 手動: Canvas TerminalCard / AgentNodeCard で同様に replay が効くこと

Closes #285