### PR TITLE
fix(canvas): #318 Canvas drag region を IDE Topbar と同構造に揃える (2次対応)

### DIFF
--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -526,9 +526,9 @@ export function CanvasLayout(): JSX.Element {
       style={isCanvasActive ? undefined : { display: 'none' }}
       aria-hidden={!isCanvasActive}
     >
-      <header className="canvas-header">
+      <header className="canvas-header" data-tauri-drag-region>
         <span className="canvas-header__brand" data-tauri-drag-region>
-          <MonitorSmartphone size={14} strokeWidth={1.75} />
+          <MonitorSmartphone size={14} strokeWidth={1.75} data-tauri-drag-region />
           Canvas
         </span>
         <span className="canvas-header__count" data-tauri-drag-region>{formatCardCount(cardCount, settings.language)}</span>

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -95,6 +95,11 @@
 }
 
 /* ---------- top header ---------- */
+/* #318: IDE Topbar (.topbar) と同じ「親ヘッダー全体を drag、操作要素だけ no-drag」構造に揃える。
+   PR #311 の子要素のみ drag-region 付与は Tauri 公式の「直接ターゲット要件」を満たさず、
+   SVG が pointer target を奪うケースで drag が失敗していた。
+   `position: relative` は `z-index` を有効にするため、`-webkit-app-region` と `app-region`
+   は WebView2 / WebKit 両系統への互換のため両方併記する。 */
 .canvas-header {
   display: flex;
   align-items: center;
@@ -103,19 +108,26 @@
   padding: 0 14px;
   background: var(--bg-toolbar, var(--bg-panel));
   border-bottom: 1px solid var(--border);
+  position: relative;
   z-index: 5;
+  app-region: drag;
+  -webkit-app-region: drag;
 }
 
 /* Canvas モードのボタン類はドラッグ領域から除外（#307 と同じパターンを #310 で適用）。
-   shell.css の *[data-tauri-drag-region] { app-region: drag; } と組み合わせて、
-   canvas-header__brand / __count / __spacer は drag、ボタン類は no-drag にする。 */
+   #318 で .canvas-header 全体を drag 化したため、操作要素は明示的に no-drag にする必要がある。
+   shell.css:247-345 の IDE Topbar 側の no-drag リストと同じ安全策。
+   `app-region` と `-webkit-app-region` を両方併記して WebView2 / WebKit 両系統に対応。 */
 .canvas-btn,
 .canvas-btn-split,
 .canvas-btn-split__main,
 .canvas-btn-split__caret,
 .canvas-popover__wrap,
-.canvas-popover {
+.canvas-popover,
+.window-controls,
+.window-controls__btn {
   app-region: no-drag;
+  -webkit-app-region: no-drag;
 }
 
 .canvas-header__brand {
@@ -125,6 +137,12 @@
   font-weight: 600;
   font-size: 13px;
   letter-spacing: 0.2px;
+}
+
+/* #318: MonitorSmartphone SVG が pointer target を奪うのを CSS 側でも閉じる。
+   data-tauri-drag-region の直接付与と二重化し、Windows WebView2 の hit-testing 差を吸収する。 */
+.canvas-header__brand svg {
+  pointer-events: none;
 }
 
 .canvas-header__count {


### PR DESCRIPTION
## 概要

Issue #318 の Canvas モードでウィンドウドラッグが依然として動作しない問題を、
IDE Topbar (`.topbar`) と完全に同じ「親ヘッダー全体を drag、操作要素だけ no-drag」
構造に揃えることで恒久対応する。

PR #311 (1次対応) は子要素 (`__brand` / `__count` / `__spacer`) にのみ
`data-tauri-drag-region` を付与する形だったが、Tauri 公式仕様
（[Window Customization](https://tauri.app/ja/learn/window-customization/)）の
**「直接ターゲット要件」** を満たしておらず、`MonitorSmartphone` SVG が pointer target
を奪うケースで drag が失敗していた。

Closes #318

## 根本原因（Issue #318 計画コメントより）

| 仮説 | 判定 |
|---|---|
| H1: `.layout::before` が Canvas 上に被さる | 不成立（visibility: hidden） |
| **H2: SVG が pointer target を奪う** | **成立** |
| H3: `canvas-layout` の fixed + z-index 不整合 | 不成立 |
| H4: capability scope 不整合 | 不成立（既に capability 追加済み） |

確定原因 = **H2 + Canvas header 側の IDE Topbar との CSS 差分**。
Canvas 側は `.canvas-header` に `app-region: drag` がなく、IDE Topbar の
`shell.css:131-145` のような parent drag 構造になっていなかった。

## 変更内容

### `src/renderer/src/styles/components/canvas.css`

- `.canvas-header` に下記を追加:
  - `position: relative` (z-index を有効化)
  - `app-region: drag` + `-webkit-app-region: drag` (両系統併記で WebView2/WebKit 互換)
- no-drag リストを拡張:
  - `.window-controls` / `.window-controls__btn` を追加
  - 全要素に `-webkit-app-region: no-drag` も併記
- 新規ルール追加:
  - `.canvas-header__brand svg { pointer-events: none; }`
    （SVG が pointer target を奪うのを CSS でも閉じる二重化）

### `src/renderer/src/layouts/CanvasLayout.tsx`

- `<header className=\"canvas-header\">` に `data-tauri-drag-region` を直接付与
- `<MonitorSmartphone />` SVG にも `data-tauri-drag-region` を付与
  （Tauri 公式の直接ターゲット要件への準拠）

## PR #311 との関係（補正）

PR #311 では子要素 3 つだけに `data-tauri-drag-region` を付与したが、
Tauri 公式仕様で **「子要素にも個別に必要」** と明記されているうえ、SVG が
pointer target を奪う経路を塞いでいなかったため、再発した（Issue #318）。

本 PR は PR #311 を **revert せず追加拡張する形** で完全対応する。
PR #311 の `__brand` / `__count` / `__spacer` への drag-region 付与は維持し、
親 header と SVG にも drag-region を加え、CSS 側で `app-region: drag`
（IDE Topbar と同じ構造）を適用する。

## Tauri 公式仕様への準拠

参考: https://tauri.app/ja/learn/window-customization/

> `data-tauri-drag-region` は属性が **直接付与された要素** にのみ機能し、
> 子要素にも必要

本 PR は以下を直接ターゲットとして付与:
- `<header>` (canvas-header)
- `<span>` (canvas-header__brand)
- `<svg>` (MonitorSmartphone)
- `<span>` (canvas-header__count)
- `<div>` (canvas-header__spacer)

加えて CSS 側で `.canvas-header { app-region: drag; }` の parent drag を併用し、
IDE Topbar (`shell.css:131-145`) と完全に同じ構造に揃えた。

## 受け入れ基準（計画コメントより）

- [x] Canvas モードで `canvas-header__brand` の SVG 上からウィンドウをドラッグできる構造
- [x] Canvas モードで `canvas-header__count` からドラッグできる構造（PR #311 維持）
- [x] Canvas モードで `canvas-header__spacer` とヘッダー余白からドラッグできる構造
- [x] `Add` / `Spawn Team` / popover / `IDE` / WindowControls はクリック可能（no-drag）
- [x] IDE モードの Topbar drag 挙動に回帰なし（Topbar 側は無変更）
- [x] `npm run typecheck` PASS
- [x] `npm run build:vite` PASS

実機検証（Windows WebView2 / 最大化 / Snap / DPI 100% & 150%）は merge 後に実施予定。

## クアドレビュー (Tier B 5レーン)

- **Lane 0 (Codex 自己レビュー)**: 計画 Step 1-5 完全実装。Tauri 公式仕様準拠。
- **Lane 1 (ユーザー視点)**: 受け入れ基準 6/6 を構造的に満たす。実機検証は merge 後。
- **Lane 2 (技術リスク)**: CSS specificity 影響なし（追加のみ）。`-webkit-app-region` と
  `app-region` 両系統併記で cross-browser 安全。
- **Lane 3 (運用視点)**: 既存テーマ・density に影響なし（pointer-events / app-region のみ追加）。
  Glass テーマの backdrop-filter にも干渉しない。
- **Lane 4 (仕様準拠)**: Tauri 公式 Window Customization 直接ターゲット要件準拠。
  IDE Topbar (shell.css:131-145, 247-345) と同構造。

## ロールバック手順

PR を revert すれば PR #311 の状態に戻る（H2 問題は再発するが H1/H3/H4 起因では失敗しない）。