### PR TITLE
fix(canvas): #320 Spawn Team caret popover の TabBtn 未定義を修正

### DIFF
--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -151,6 +151,7 @@ export function CanvasLayout(): JSX.Element {
   const availableUpdate = useUiStore((s) => s.availableUpdate);
   const { showToast, dismissToast } = useToast();
   const [spawnOpen, setSpawnOpen] = useState(false);
+  const [tab, setTab] = useState<'preset' | 'recent'>('preset');
   const [addCardOpen, setAddCardOpen] = useState(false);
   const [recent, setRecent] = useState<TeamHistoryEntry[]>([]);
   const [sidebarView, setSidebarView] = useState<SidebarView>('files');
@@ -795,6 +796,27 @@ function AgentBadge({ label, color }: { label: string; color: string }): JSX.Ele
     >
       {label}
     </span>
+  );
+}
+
+function TabBtn({
+  active,
+  onClick,
+  children
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`canvas-popover__tab${active ? ' canvas-popover__tab--active' : ''}`}
+      aria-pressed={active}
+    >
+      {children}
+    </button>
   );
 }
 

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -261,6 +261,70 @@
   width: 340px;
 }
 
+.canvas-popover__tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--surface-panel);
+  border-bottom: 1px solid var(--border);
+}
+
+.canvas-popover__tab {
+  flex: 1;
+  min-width: 0;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 0 8px;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--fg-muted);
+  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  cursor: pointer;
+  transition:
+    background-color var(--dur-fast, 180ms) var(--ease-standard),
+    border-color var(--dur-fast, 180ms) var(--ease-standard),
+    color var(--dur-fast, 180ms) var(--ease-standard);
+}
+
+.canvas-popover__tab:hover {
+  color: var(--fg);
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+}
+
+.canvas-popover__tab:focus-visible {
+  outline: none;
+  border-color: var(--claude-brand, var(--accent));
+  box-shadow: 0 0 0 2px var(--surface-active);
+}
+
+.canvas-popover__tab--active {
+  color: var(--fg);
+  background: var(--surface-active);
+  border-color: var(--claude-brand, var(--accent));
+}
+
+.canvas-popover__tab-badge {
+  min-width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--bg);
+  background: var(--claude-brand, var(--accent));
+  border-radius: 999px;
+}
+
 .canvas-popover__item {
   width: 100%;
   display: flex;


### PR DESCRIPTION
Closes #320

## Summary
- `CanvasLayout.tsx` で参照されていた `tab` / `setTab` state が未宣言だった問題を修正
- 同ファイルで使用されていた未定義のローカルコンポーネント `TabBtn` を追加（既存 `AddItem` と同じローカル関数コンポーネント形式）
- `canvas-popover__tabs` / `__tab` / `__tab--active` / `__tab-badge` 用 CSS をテーマ変数のみで追加（Glass テーマ等を壊さず、追加の `glass-surface` クラスも不要）

## Root Cause
Canvas モードで「チーム起動」横の caret ↓ をクリックすると `setSpawnOpen(true)` で popover が開くが、その中で参照される `tab` / `setTab` / `TabBtn` の宣言が漏れており `ReferenceError: TabBtn is not defined` で ErrorBoundary が発火していた。

## Verification
- [x] `npm run typecheck` PASS
- [ ] `npm run dev` で起動し、Canvas モードのヘッダー「チーム起動」横の caret ↓ をクリック
- [ ] popover が描画される（ErrorBoundary が出ない）
- [ ] `Preset` / `最近使ったチーム` タブを切り替えられる
- [ ] アクティブタブのスタイル / hover / focus-visible が崩れていない

## Implementation Plan
詳細は Issue #320 の Codex 計画コメント（`## 実装計画 (Codex Plan)`）を参照。

## Risk
- 影響範囲: Canvas モードの Spawn Team caret popover のみ
- フィーチャーフラグ: 不要（既存機能の修復）
- ロールバック: 1 コミットの `git revert` で戻せる

🤖 Generated with [Claude Code](https://claude.com/claude-code)