### PR TITLE
fix(csp): #328 release csp の style-src-elem に 'unsafe-inline' を追加

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'wasm-unsafe-eval' blob:; style-src 'self'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://github.com https://api.github.com; worker-src 'self' blob:; frame-src 'none'; object-src 'none'",
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'wasm-unsafe-eval' blob:; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://github.com https://api.github.com; worker-src 'self' blob:; frame-src 'none'; object-src 'none'",
       "devCsp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'wasm-unsafe-eval' blob:; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://localhost:5173 http://localhost:5173 https://github.com https://api.github.com; worker-src 'self' blob:; frame-src 'none'; object-src 'none'"
     },
     "trayIcon": {


### PR DESCRIPTION
## Summary

- v1.4.5 release バンドル (NSIS) で **Canvas モードのターミナル (xterm.js v6) が崩れる** 回帰 (#328) の first-pass 修正。
- `src-tauri/tauri.conf.json` の release `csp` の `style-src-elem 'self'` を `style-src-elem 'self' 'unsafe-inline'` に変更し、dev `devCsp` とパリティを取る。

## 背景

`@xterm/xterm` v6 のランタイムは scrollbar / dimensions / theme などの **必須レイアウト CSS を `document.createElement("style") + appendChild` で動的注入**する (`node_modules/@xterm/xterm/lib/xterm.js` 内 4 箇所で確認済み)。

release `csp` には `style-src-elem 'self'` しか無く `'unsafe-inline'` が許可されていないため、これらの inline `<style>` 要素は WebView2 で block される。一方 dev `devCsp` は同位置に `'unsafe-inline'` を持つため通る。

→ 「同一コミット (`ec8add0`) で `npm run dev` は正常、release NSIS だけ崩れる」という唯一の機能差を直接説明できる差分なので、最初に潰す。

## 変更内容

```diff
- "csp": "...; style-src 'self'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; ..."
+ "csp": "...; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; ..."
```

1 行 / 1 ファイルのみ。`devCsp` 側は元から `'unsafe-inline'` 入り。

## セキュリティ影響

- `style-src-attr 'unsafe-inline'` は元々許可されており、style 系の inline は実質的に既に広く許容されていた。本変更による実害の増加は限定的。
- 恒久的には xterm 側を fork して nonce 対応 / 自前 stylesheet 注入に切り替える選択肢があるが、本 PR の scope 外。

## CSP 単独原因か?

調査の結果、**CSP は v1.4.0 から不変**であり、xterm@^6.0.0 も v1.4.0 から導入済み。したがって厳密には「v1.4.5 で初めて発生した新規 regression」ではなく、「v1.4.0 以来の release 専用の long-standing bug が今回顕在化した」可能性が高い。

本パッチで Canvas terminal の崩れが直れば CSP が主因と確定。直らない場合は、v1.4.5 で導入された Canvas terminal 実装変更 (#287 / #289 の custom scrollbar / wheel) や window 条件 (#297 / #302 の transparent / decorations) の追加修正が必要。

## Test plan

- [ ] `npm run typecheck` PASS (確認済み)
- [ ] release ビルド (`cargo tauri build`) を作成し、NSIS インストール後の Canvas モード terminal 描画を確認
- [ ] `Ctrl+Shift+I` で Console を開き `Refused to apply inline style ... style-src-elem` 違反が消えていることを確認
- [ ] dev (`npm run dev`) で従来挙動が維持されていることを確認

## v1.4.5 Draft Release の扱い

- 本 PR が merge されたら `v1.4.6` として forward fix を切る方針 (タグの作り直しを避けて auto-updater `latest.json` 整合性を維持)
- v1.4.5 Draft は引き続き Publish 保留

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)