### PR TITLE
chore(release): bump version to 1.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5186,7 +5186,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.4.5"
+version = "1.4.6"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## Summary

v1.4.5 で発覚した #328 (Canvas モードの xterm 描画崩れ) の forward fix を含む patch リリース。

## CHANGELOG (v1.4.5 → v1.4.6)

### 🐛 Bug fixes (fix)

- **release バンドルでの Canvas モードのターミナル描画崩れを修正** (#328, #329)
  - release `csp` の `style-src-elem` に `'unsafe-inline'` を追加し dev とパリティを取った
  - xterm.js v6 が runtime に動的注入する scrollbar / dimensions / theme の `<style>` 要素が WebView2 で block されていた問題を解消

## v1.4.5 Draft Release との関係

v1.4.5 Draft Release は #328 のため Publish 保留中だった。
本 v1.4.6 forward fix で修正できたため、**v1.4.5 Draft は Publish せず、v1.4.6 を新規リリースする方針**。タグの作り直しを避けて updater の `latest.json` 整合性を保つ。

## Test plan

- [x] `bump-version.ps1` で 3 ファイル + Cargo.lock を 1.4.6 に同期
- [x] 書き換え後の整合性検証 (package.json / Cargo.toml / tauri.conf.json すべて 1.4.6 で一致)
- [ ] merge 後 `v1.4.6` タグ push で release.yml 発火を確認
- [ ] tauri-action の build 完了後、Windows NSIS で fresh install → Canvas terminal 描画が正常か確認
- [ ] Console に `style-src-elem` 違反が出ていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)