### PR TITLE
perf(ci): #331 macOS リリースビルドを aarch64-apple-darwin only に変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@
 #
 # 成果物: tauri-apps/tauri-action が GitHub Release を draft で作成し、
 #   - Windows: .exe (NSIS インストーラ)
-#   - macOS:   .dmg (universal: x86_64 + aarch64)
+#   - macOS:   .dmg (Apple Silicon, aarch64)
 #   - Linux:   .AppImage / .deb
 # を upload する。確認後、Releases ページで手動 publish する。
 name: release
@@ -30,10 +30,10 @@ jobs:
       matrix:
         include:
           - platform: macos-latest
-            args: '--target universal-apple-darwin'
-            bundle_dir: 'src-tauri/target/universal-apple-darwin/release/bundle'
-            attest_subjects: 'src-tauri/target/universal-apple-darwin/release/bundle/dmg/**/*.dmg'
-            sbom_file: 'sbom-macos-universal.cdx.json'
+            args: '--target aarch64-apple-darwin'
+            bundle_dir: 'src-tauri/target/aarch64-apple-darwin/release/bundle'
+            attest_subjects: 'src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/**/*.dmg'
+            sbom_file: 'sbom-macos-aarch64.cdx.json'
           - platform: ubuntu-22.04
             args: ''
             bundle_dir: 'src-tauri/target/release/bundle'
@@ -62,9 +62,9 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master @ 2026-04-26
         with:
-          # macOS universal は両方の target を必要とする
+          # macOS は Apple Silicon (aarch64) のみビルドする
           toolchain: stable
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || '' }}
 
       - name: Rust cache
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
@@ -100,7 +100,7 @@ jobs:
             自動ビルド成果物。
 
             - Windows: `.exe` (NSIS インストーラ)
-            - macOS:   `.dmg` (Intel + Apple Silicon universal)
+            - macOS:   `.dmg` (Apple Silicon, aarch64)
             - Linux:   `.AppImage` / `.deb`
 
             動作確認後にこの draft を publish してください。


### PR DESCRIPTION
## Summary

- `release.yml` の macOS matrix を universal (x86_64 + aarch64) → **Apple Silicon (aarch64) only** に変更
- macOS job の cargo build 時間を約半分に短縮し、release 全体の wall-clock を短縮するのが目的

## 変更内容

| 項目 | before | after |
|---|---|---|
| `args` | `--target universal-apple-darwin` | `--target aarch64-apple-darwin` |
| `bundle_dir` | `.../universal-apple-darwin/...` | `.../aarch64-apple-darwin/...` |
| `attest_subjects` | universal path | aarch64 path |
| `sbom_file` | `sbom-macos-universal.cdx.json` | `sbom-macos-aarch64.cdx.json` |
| `dtolnay/rust-toolchain` の `targets` | `aarch64,x86_64-apple-darwin` | `aarch64-apple-darwin` のみ |
| ヘッダコメント / `releaseBody` | "universal: x86_64 + aarch64" / "Intel + Apple Silicon universal" | "Apple Silicon, aarch64" |

1 ファイル / 8 行差分のみ。Cargo.lock 変更なし、Rust / TS コードは無変更。

## トレードオフ

- **Intel Mac (x86_64) ユーザは v1.4.7 以降の自動アップデート対象外**
- 該当者は手動で旧バンドルを使い続けるか、aarch64 → Rosetta 2 起動でしのぐ
- 利用者構成的に Intel Mac 比率が極小と判断

## 期待効果

- macOS の cargo build を 2 アーキ cross-compile → 1 アーキに削減
- v1.4.5 / v1.4.6 release.yml の macOS job が最遅であれば、release 全体の所要時間も短縮される

## スコープ外

- rust-cache / npm cache は既に有効化済みなので追加変更なし
- Linux パッケージ形式 (AppImage / deb / rpm) の削減は本 PR では扱わない

## Test plan

- [ ] PR merge 後に `gh workflow run release.yml -r main` で手動 dispatch、もしくは v1.4.7 タグ push 時に macOS job が新パスでビルド成功することを確認
- [ ] macOS Draft Release に `aarch64-apple-darwin` 版 `.dmg` が attach されることを確認
- [ ] SBOM / attest が新 path で成功していることを確認

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)