### PR TITLE
fix(terminal): #333 glass 以外で xterm 文字が消える問題を修正

### DIFF
--- a/src/renderer/src/lib/xterm-theme.ts
+++ b/src/renderer/src/lib/xterm-theme.ts
@@ -7,14 +7,18 @@ import { THEMES } from './themes';
  * 既存テーマにフォールバック (`dark`) を入れて undefined を返さないようにする。
  * 'light' テーマのみ選択色を明るい青にする (他は VS Code 風の濃紺)。
  *
- * glass テーマのときは xterm のキャンバス自体を透過にして、
- * 親要素側の `backdrop-filter` (Issue #89) が背景に抜けて見えるようにする。
- * 透過は `useXtermInstance` 側で `allowTransparency: true` を併せて指定する必要がある。
+ * 背景色は **全テーマで透過** (`rgba(0,0,0,0)`) を渡し、見た目の背景は
+ * `.xterm-viewport` 側の CSS `background-color: var(--bg)` が担う (Issue #333)。
+ * glass テーマで導入した `allowTransparency: true` (Issue #89) は常時 ON で、
+ * xterm v6 の WebGL renderer は `allowTransparency: true` + opaque
+ * `theme.background` の組み合わせで cell background fill が glyph layer に被さって
+ * 文字が見えなくなる経路がある (Chromium / GPU 依存)。glass 以外のテーマで
+ * 文字が消える #333 の症状は、xterm 側の bg を常に透過にして CSS に背景を
+ * 委譲することで根本的に解消する (glass と同じ描画経路に統一)。
  */
 export function buildXtermTheme(themeName: ThemeName): ITheme {
   const themeVars = THEMES[themeName] ?? THEMES.dark;
   const isLight = themeName === 'light';
-  const isGlass = themeName === 'glass';
   /*
    * ANSI パレット (yellow/red 系) を xterm デフォルトの彩度高めの値から
    * 目に優しいパステル調へ上書き。デフォルトの yellow (#e5e510) は
@@ -23,7 +27,7 @@ export function buildXtermTheme(themeName: ThemeName): ITheme {
    */
   const isLightSurface = isLight;
   return {
-    background: isGlass ? 'rgba(0, 0, 0, 0)' : themeVars.bg,
+    background: 'rgba(0, 0, 0, 0)',
     foreground: themeVars.text,
     cursor: themeVars.text,
     cursorAccent: themeVars.bg,


### PR DESCRIPTION
## Summary
- `buildXtermTheme()` の `theme.background` を **全テーマで `rgba(0,0,0,0)`** に統一。
- 背景の見た目は既に CSS 側で当たっている `.xterm-viewport { background-color: var(--bg) }` が担う。
- glass テーマは元からこの経路で動いており視覚的回帰なし、他テーマは glass と同じ描画経路に統一されて WebGL の文字消失バグを根治。

## 原因
`useXtermInstance` が Issue #89 以降 `allowTransparency: true` を **常時** 設定している。xterm v6 の WebGL renderer はこの状態で `theme.background` に opaque 色 (e.g. `#171716`) を渡されると、cell background fill が glyph layer に被さって文字が見えなくなる経路がある (Chromium / GPU 依存)。glass のときだけ bg が透過だったので glyph が見えていた。

## 修正
`src/renderer/src/lib/xterm-theme.ts`:
- `background: isGlass ? 'rgba(0,0,0,0)' : themeVars.bg` → `background: 'rgba(0,0,0,0)'`
- 不要になった `isGlass` ローカル変数を削除
- 上の意図を JSDoc にコメント (将来同じ罠に踏まないように)

## Test plan
- [ ] `claude-dark` で xterm 起動 → プロンプト / コマンド出力が読めること
- [ ] `claude-light` / `dark` / `midnight` / `light` で同上
- [ ] `glass` で従来通り OS Acrylic が透けつつ文字が読めること
- [ ] テーマ切替時に xterm の文字が一瞬消えたり残像が出たりしないこと
- [ ] Canvas モードの TerminalCard / AgentNodeCard でも上記が成立すること
- [x] `npm run typecheck` 通過

Closes #333