### PR TITLE
fix: planned issues #324 #325 #326 #327 をまとめて修正

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1652,6 +1652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4121,6 +4127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4258,6 +4270,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "image",
  "jni",
  "libc",
@@ -4952,6 +4965,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5211,6 +5237,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uuid",
  "which",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 # --- Tauri core ---
-tauri = { version = "2", features = ["tray-icon", "image-png", "image-ico"] }
+tauri = { version = "2", features = ["tray-icon", "image-png", "image-ico", "protocol-asset"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-updater = "2"
@@ -37,6 +37,10 @@ notify = "8"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Issue #326: 設定モーダルからログを閲覧できるように、stderr に加えて
+# ~/.vibe-editor/logs/vibe-editor.log にも書き出す。non_blocking で I/O を
+# 別スレッドへ逃がし、never 戦略 (1 ファイル無回転) でシンプルに保つ。
+tracing-appender = "0.2"
 
 # --- misc ---
 once_cell = "1"

--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -1,0 +1,114 @@
+// logs.* command — 設定モーダルからログを閲覧する用 (Issue #326)
+//
+// `~/.vibe-editor/logs/vibe-editor.log` の末尾だけを UTF-8 で読み出して renderer に返す。
+// ログファイル自体は `lib.rs` の `init_logging()` 内で tracing-appender が書き出している。
+
+use serde::Serialize;
+use std::path::PathBuf;
+use tokio::fs;
+
+/// `~/.vibe-editor/logs/` ディレクトリ
+pub fn log_dir() -> PathBuf {
+    let home = dirs::home_dir().unwrap_or_default();
+    home.join(".vibe-editor").join("logs")
+}
+
+/// ログファイル本体のパス
+pub fn log_file_path() -> PathBuf {
+    log_dir().join("vibe-editor.log")
+}
+
+/// renderer に返す read_log_tail 応答。serde が camelCase に変換する。
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadLogTailResponse {
+    /// ログ末尾の UTF-8 文字列。ファイル先頭から読んだ場合 truncated=false。
+    pub content: String,
+    /// 表示用の絶対パス
+    pub path: String,
+    /// max_bytes でクリップしたか (= ログがそれ以上長い)
+    pub truncated: bool,
+    /// ファイルが存在しない / size=0 のとき true。content は空。
+    pub empty: bool,
+}
+
+/// ログファイル末尾の最大 `max_bytes` バイトを UTF-8 lossy で読む。
+///
+/// - max_bytes=0 や指定なしは 256KB にデフォルト。
+/// - ファイルが存在しない場合は empty=true で空文字列を返す (エラーにはしない)。
+/// - ログは tracing-appender が UTF-8 で書いているので lossy decode で十分。
+#[tauri::command]
+pub async fn logs_read_tail(max_bytes: Option<u64>) -> Result<ReadLogTailResponse, String> {
+    const DEFAULT_MAX: u64 = 256 * 1024;
+    let cap = max_bytes.filter(|n| *n > 0).unwrap_or(DEFAULT_MAX);
+    let path = log_file_path();
+    let path_str = path.to_string_lossy().to_string();
+
+    // metadata 取得 (ファイル不在は empty=true で正常終了)
+    let meta = match fs::metadata(&path).await {
+        Ok(m) => m,
+        Err(_) => {
+            return Ok(ReadLogTailResponse {
+                content: String::new(),
+                path: path_str,
+                truncated: false,
+                empty: true,
+            });
+        }
+    };
+    let size = meta.len();
+    if size == 0 {
+        return Ok(ReadLogTailResponse {
+            content: String::new(),
+            path: path_str,
+            truncated: false,
+            empty: true,
+        });
+    }
+
+    let bytes = if size <= cap {
+        // 全部読める
+        fs::read(&path).await.map_err(|e| e.to_string())?
+    } else {
+        // 末尾だけ読む
+        use tokio::io::{AsyncReadExt, AsyncSeekExt, SeekFrom};
+        let mut f = fs::File::open(&path).await.map_err(|e| e.to_string())?;
+        f.seek(SeekFrom::End(-(cap as i64)))
+            .await
+            .map_err(|e| e.to_string())?;
+        let mut buf = Vec::with_capacity(cap as usize);
+        f.take(cap).read_to_end(&mut buf).await.map_err(|e| e.to_string())?;
+        buf
+    };
+
+    // 行頭が途中切れになっていたら捨てる (見栄え)
+    let mut content = String::from_utf8_lossy(&bytes).to_string();
+    if size > cap {
+        if let Some(idx) = content.find('\n') {
+            content = content[idx + 1..].to_string();
+        }
+    }
+
+    Ok(ReadLogTailResponse {
+        content,
+        path: path_str,
+        truncated: size > cap,
+        empty: false,
+    })
+}
+
+/// ログディレクトリを OS のファイルマネージャで開く。
+/// tauri-plugin-opener を使用 (lib.rs で plugin 登録済み)。
+#[tauri::command]
+pub async fn logs_open_dir(app: tauri::AppHandle) -> Result<(), String> {
+    use tauri_plugin_opener::OpenerExt;
+    let dir = log_dir();
+    // ディレクトリが無ければ best-effort で作成 (初回起動直後対策)
+    if let Err(e) = fs::create_dir_all(&dir).await {
+        tracing::warn!("[logs] mkdir failed: {e}");
+    }
+    let path_str = dir.to_string_lossy().to_string();
+    app.opener()
+        .open_path(path_str, None::<&str>)
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod dialog;
 pub mod files;
 pub mod fs_watch;
 pub mod git;
+pub mod logs;
 pub mod role_profiles;
 pub mod sessions;
 pub mod settings;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,13 +15,38 @@ use tauri::Manager;
 #[allow(unused_imports)]
 use tracing::info;
 
+/// Issue #326: tracing を stderr + ファイル両方に書き出す。
+/// ファイルは `~/.vibe-editor/logs/vibe-editor.log` (1 ファイル無回転、tracing-appender::never)。
+/// 設定モーダルからこのファイルを読み返してエラーログを GUI 上で確認できる。
+fn init_logging() {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("vibe_editor_lib=debug,info"));
+
+    let log_dir = commands::logs::log_dir();
+    let _ = std::fs::create_dir_all(&log_dir); // best-effort
+    let file_appender = tracing_appender::rolling::never(log_dir, "vibe-editor.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+    // WorkerGuard はプロセス終了まで保持する必要があるため leak で 'static 化する。
+    // 1 度だけの起動コストで、メモリリークも 1 件のみ (許容)。
+    Box::leak(Box::new(guard));
+
+    let stderr_layer = fmt::layer().with_writer(std::io::stderr);
+    let file_layer = fmt::layer().with_writer(non_blocking).with_ansi(false);
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(stderr_layer)
+        .with(file_layer)
+        .init();
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            std::env::var("RUST_LOG").unwrap_or_else(|_| "vibe_editor_lib=debug,info".into()),
-        )
-        .init();
+    init_logging();
 
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
@@ -83,6 +108,9 @@ pub fn run() {
             // ---- role profiles ----
             commands::role_profiles::role_profiles_load,
             commands::role_profiles::role_profiles_save,
+            // ---- logs (Issue #326) ----
+            commands::logs::logs_read_tail,
+            commands::logs::logs_open_dir,
             // ---- terminal ----
             commands::terminal::terminal_create,
             commands::terminal::terminal_write,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,20 @@
     ],
     "security": {
       "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'wasm-unsafe-eval' blob:; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://github.com https://api.github.com; worker-src 'self' blob:; frame-src 'none'; object-src 'none'",
-      "devCsp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'wasm-unsafe-eval' blob:; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://localhost:5173 http://localhost:5173 https://github.com https://api.github.com; worker-src 'self' blob:; frame-src 'none'; object-src 'none'"
+      "devCsp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'wasm-unsafe-eval' blob:; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://localhost:5173 http://localhost:5173 https://github.com https://api.github.com; worker-src 'self' blob:; frame-src 'none'; object-src 'none'",
+      "assetProtocol": {
+        "enable": true,
+        "scope": [
+          "**/*.png",
+          "**/*.jpg",
+          "**/*.jpeg",
+          "**/*.gif",
+          "**/*.webp",
+          "**/*.avif",
+          "**/*.bmp",
+          "**/*.ico"
+        ]
+      }
     },
     "trayIcon": {
       "iconPath": "icons/icon.png",

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2256,6 +2256,9 @@ export function App(): JSX.Element {
             <div className="pane">
               <EditorView
                 path={activeEditorTab.relPath}
+                /* Issue #325: 画像ファイルを開いたとき ImagePreview で convertFileSrc を呼べるように
+                   projectRoot (= ワークスペース絶対パス) を渡す。 */
+                projectRoot={activeEditorTab.rootPath}
                 content={activeEditorTab.content}
                 dirty={activeEditorTab.content !== activeEditorTab.originalContent}
                 isBinary={activeEditorTab.isBinary}

--- a/src/renderer/src/components/EditorView.tsx
+++ b/src/renderer/src/components/EditorView.tsx
@@ -6,9 +6,15 @@ import { detectLanguage } from '../lib/language';
 import { useMonacoTheme, useSettings } from '../lib/settings-context';
 import { useT } from '../lib/i18n';
 import { MarkdownPreview } from './MarkdownPreview';
+import { ImagePreview } from './ImagePreview';
 
 interface EditorViewProps {
   path: string;
+  /**
+   * Issue #325: ImagePreview に絶対パスを渡すために必要。
+   * 未指定なら画像ファイルでも従来どおり binary プレースホルダにフォールバックする。
+   */
+  projectRoot?: string;
   content: string;
   dirty: boolean;
   isBinary: boolean;
@@ -22,8 +28,20 @@ interface EditorViewProps {
   onSave: () => void;
 }
 
+/**
+ * Issue #325: relPath を projectRoot に結合して OS 絶対パスを作る。
+ * convertFileSrc は forward slash でも動作するため `/` で統一し、
+ * 重複区切りやバックスラッシュは正規化する。
+ */
+function joinAbsolutePath(projectRoot: string, relPath: string): string {
+  const root = projectRoot.replace(/[\\/]+$/, '');
+  const rel = relPath.replace(/^[\\/]+/, '').replace(/\\/g, '/');
+  return `${root}/${rel}`;
+}
+
 export function EditorView({
   path,
+  projectRoot,
   content,
   dirty,
   isBinary,
@@ -41,6 +59,27 @@ export function EditorView({
   // 早期 return より後で useState すると Rules of Hooks 違反になるので、
   // フックは全て先頭で呼ぶ。
   const [previewMode, setPreviewMode] = useState<boolean>(true);
+
+  // Issue #325: 画像言語にマップされる拡張子は loading / isBinary より優先して
+  // ImagePreview に流す。binary プレースホルダではなく実際の画像を表示する。
+  const language = detectLanguage(path);
+  const isImage = language === 'image';
+
+  if (isImage && projectRoot) {
+    return (
+      <div className="diffview">
+        <div className="diffview__header">
+          <span className="diffview__path">{path}</span>
+        </div>
+        <div className="diffview__editor">
+          <ImagePreview
+            absolutePath={joinAbsolutePath(projectRoot, path)}
+            relativePath={path}
+          />
+        </div>
+      </div>
+    );
+  }
 
   if (loading) {
     return (
@@ -70,7 +109,6 @@ export function EditorView({
     );
   }
 
-  const language = detectLanguage(path);
   const isMarkdown = language === 'markdown';
   const showPreview = isMarkdown && previewMode;
 

--- a/src/renderer/src/components/ImagePreview.tsx
+++ b/src/renderer/src/components/ImagePreview.tsx
@@ -1,0 +1,61 @@
+/**
+ * ImagePreview — Canvas / IDE で画像ファイルをプレビューするコンポーネント。
+ *
+ * Issue #325: ファイルツリーから png/jpg/gif/webp 等を開いたとき、Monaco の
+ * binary プレースホルダではなく実際の画像を表示する。Tauri v2 の asset プロトコル
+ * (convertFileSrc) で `asset://` URL を生成して <img> に渡す。
+ *
+ * dev:vite 直接アクセス (Tauri ランタイム不在) では convertFileSrc が機能しないため、
+ * その場合は静的なフォールバックメッセージを出す。
+ */
+import { useMemo, useState } from 'react';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { isTauri } from '../lib/tauri-api';
+
+interface ImagePreviewProps {
+  /** OS 絶対パス。convertFileSrc に渡される */
+  absolutePath: string;
+  /** ヘッダ表示用 (相対パス想定だが実装側で自由に決めて良い) */
+  relativePath: string;
+}
+
+export function ImagePreview({ absolutePath, relativePath }: ImagePreviewProps): JSX.Element {
+  const [errored, setErrored] = useState(false);
+  const tauri = isTauri();
+  const url = useMemo(() => {
+    if (!tauri) return '';
+    try {
+      return convertFileSrc(absolutePath);
+    } catch {
+      return '';
+    }
+  }, [absolutePath, tauri]);
+
+  if (!tauri) {
+    return (
+      <div className="image-preview">
+        <div className="image-preview__error">Image preview is unavailable in dev:vite mode.</div>
+      </div>
+    );
+  }
+
+  if (errored || !url) {
+    return (
+      <div className="image-preview">
+        <div className="image-preview__error">画像を表示できません: {relativePath}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="image-preview">
+      <img
+        className="image-preview__img"
+        src={url}
+        alt={relativePath}
+        onError={() => setErrored(true)}
+        draggable={false}
+      />
+    </div>
+  );
+}

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -7,6 +7,7 @@ import {
   Palette,
   Plug,
   Plus,
+  ScrollText,
   Search,
   Settings as SettingsIcon,
   Sparkles,
@@ -30,6 +31,7 @@ import { DensitySection } from './settings/DensitySection';
 import { CommandOptionsSection } from './settings/CommandOptionsSection';
 import { CustomAgentEditor } from './settings/CustomAgentEditor';
 import { McpSection } from './settings/McpSection';
+import { LogsSection } from './settings/LogsSection';
 
 interface SettingsModalProps {
   open: boolean;
@@ -72,7 +74,8 @@ const SECTION_ICON_TYPES: Record<string, LucideIcon> = {
   claude: Bot,
   codex: Code2,
   roles: Users,
-  mcp: Plug
+  mcp: Plug,
+  logs: ScrollText
 };
 function iconFor(id: SectionId): JSX.Element {
   const Icon =
@@ -92,7 +95,8 @@ const FIXED_LABELS_JA: Record<string, FixedLabelEntry> = {
   claude: { label: 'Claude Code', title: 'Claude Code', desc: '起動コマンドと引数' },
   codex: { label: 'Codex', title: 'Codex', desc: '起動コマンドと引数' },
   roles: { label: 'ロール定義', title: 'ロール定義', desc: 'チームメンバーの役割テンプレ' },
-  mcp: { label: 'MCP', title: 'MCP', desc: 'vibe-team MCP の導入方法' }
+  mcp: { label: 'MCP', title: 'MCP', desc: 'vibe-team MCP の導入方法' },
+  logs: { label: 'ログ', title: 'ログ', desc: 'アプリの実行ログを表示' }
 };
 const FIXED_LABELS_EN: Record<string, FixedLabelEntry> = {
   general: { label: 'General', title: 'General', desc: 'Language and density' },
@@ -101,7 +105,8 @@ const FIXED_LABELS_EN: Record<string, FixedLabelEntry> = {
   claude: { label: 'Claude Code', title: 'Claude Code', desc: 'Launch command and args' },
   codex: { label: 'Codex', title: 'Codex', desc: 'Launch command and args' },
   roles: { label: 'Role profiles', title: 'Role profiles', desc: 'Team member role templates' },
-  mcp: { label: 'MCP', title: 'MCP', desc: 'How to install vibe-team MCP' }
+  mcp: { label: 'MCP', title: 'MCP', desc: 'How to install vibe-team MCP' },
+  logs: { label: 'Logs', title: 'Logs', desc: 'View runtime logs from the app' }
 };
 
 /** 名前未設定のカスタムエージェントに使う fallback 文字列。
@@ -310,7 +315,10 @@ export function SettingsModal({
         // vibe-team MCP のセットアップ手順は「チーム」機能の一部なので同グループに収める。
         // 旧構成では MCP を独立グループにしていたが、グループラベル "MCP" と唯一の項目 "MCP" が
         // 同名で並び、サイドバー上で MCP が 2 行重複しているように見える UI バグを生んでいた。
-        { label: isJa ? 'チーム' : 'Team', items: ['roles', 'mcp'] }
+        { label: isJa ? 'チーム' : 'Team', items: ['roles', 'mcp'] },
+        // Issue #326: 「その他」グループにログビューアを置く。リリース後の bug 報告で
+        // 開発者ツールを開かずにユーザー側でエラーログを確認できるようにする。
+        { label: isJa ? 'その他' : 'Other', items: ['logs'] }
       ];
     },
     // deps は customAgents と同じく draft の生プロパティを直接参照する形で統一する。
@@ -474,6 +482,8 @@ export function SettingsModal({
         return <RoleProfilesSection />;
       case 'mcp':
         return <McpSection draft={draft} update={update} />;
+      case 'logs':
+        return <LogsSection />;
       default:
         if (id.startsWith('custom:')) {
           const a = customAgents.find((x) => `custom:${x.id}` === id);

--- a/src/renderer/src/components/canvas/cards/EditorCard.tsx
+++ b/src/renderer/src/components/canvas/cards/EditorCard.tsx
@@ -4,10 +4,11 @@
  * payload: { projectRoot, relPath }
  * 自前で files.read/write を呼び、dirty 管理 + Ctrl+S 保存。
  */
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import { CardFrame } from '../CardFrame';
 import { EditorView } from '../../EditorView';
+import { detectLanguage } from '../../../lib/language';
 
 interface EditorPayload {
   projectRoot: string;
@@ -18,6 +19,10 @@ function EditorCardImpl({ id, data }: NodeProps): JSX.Element {
   const payload = (data?.payload ?? {}) as EditorPayload;
   const { projectRoot, relPath } = payload;
   const title = (data?.title as string) ?? relPath ?? 'Editor';
+  const isImage = useMemo(
+    () => (relPath ? detectLanguage(relPath) === 'image' : false),
+    [relPath]
+  );
 
   const [content, setContent] = useState('');
   const [original, setOriginal] = useState('');
@@ -28,6 +33,12 @@ function EditorCardImpl({ id, data }: NodeProps): JSX.Element {
   useEffect(() => {
     let cancelled = false;
     if (!projectRoot || !relPath) {
+      setLoading(false);
+      return;
+    }
+    // Issue #325: 画像ファイルは files.read を呼ばず ImagePreview に委ねる。
+    // バイナリを丸ごと UTF-8 lossy で読むコストを避けるため早期 return する。
+    if (isImage) {
       setLoading(false);
       return;
     }
@@ -50,7 +61,7 @@ function EditorCardImpl({ id, data }: NodeProps): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [projectRoot, relPath]);
+  }, [projectRoot, relPath, isImage]);
 
   const dirty = content !== original;
 
@@ -67,9 +78,10 @@ function EditorCardImpl({ id, data }: NodeProps): JSX.Element {
   return (
     <>
       <Handle type="target" position={Position.Left} style={{ background: '#7a9eff' }} />
-      <CardFrame id={id} title={dirty ? `● ${title}` : title} accent="#7a9eff">
+      <CardFrame id={id} title={isImage ? title : dirty ? `● ${title}` : title} accent="#7a9eff">
         <EditorView
           path={relPath}
+          projectRoot={projectRoot}
           content={content}
           dirty={dirty}
           isBinary={isBinary}

--- a/src/renderer/src/components/canvas/cards/TerminalCard.tsx
+++ b/src/renderer/src/components/canvas/cards/TerminalCard.tsx
@@ -83,7 +83,15 @@ function TerminalCardImpl({ id, data }: NodeProps): JSX.Element {
     <>
       <Handle type="target" position={Position.Left} style={{ background: '#7a7afd' }} />
       <CardFrame id={id} title={title} minWidth={NODE_MIN_W} minHeight={NODE_MIN_H}>
-        <div className="canvas-terminal-card__term" ref={termContainerRef}>
+        {/* Issue #327: AgentNodeCard と同じく `nodrag nowheel` を付与する。
+            これが無いと React Flow がノード全体で pointerdown を奪い、xterm v6 の
+            custom scrollbar thumb をマウスでドラッグできない (= ホイールは効くが
+            scrollbar が掴めない) 状態になる。Claude 側は Spawn Team 経由で
+            AgentNodeCard に乗るため既に nodrag があったが、Codex 等を「Terminal」
+            カードとして直接立ち上げると TerminalCard 経由で出るためここで揃える。
+            nowheel は AgentNodeCard と対称にし、wheel イベントを React Flow の
+            zoom/pan に奪わせない。xterm.js への wheel 配送は内部処理で完結する。 */}
+        <div className="nodrag nowheel canvas-terminal-card__term" ref={termContainerRef}>
           <TerminalView
             ref={ref}
             // Issue #271: HMR remount で同じ PTY へ再 bind するための論理キー。

--- a/src/renderer/src/components/settings/LogsSection.tsx
+++ b/src/renderer/src/components/settings/LogsSection.tsx
@@ -1,0 +1,128 @@
+/**
+ * LogsSection — Issue #326
+ *
+ * 設定モーダル内に「ログ」セクションを追加し、`~/.vibe-editor/logs/vibe-editor.log`
+ * の末尾を GUI 上で閲覧できるようにする。
+ *
+ * 機能 (MVP):
+ *   - リフレッシュボタンで末尾 256KB を再取得
+ *   - レベルフィルタ (ALL / ERROR / WARN / INFO)
+ *   - ログフォルダを OS ファイルマネージャで開く
+ *   - ログパスの表示
+ *
+ * 自動 tail / 全文検索 / 行番号表示は Phase 2 に分離する。
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { FolderOpen, RefreshCw } from 'lucide-react';
+import type { ReadLogTailResponse } from '../../../../types/shared';
+import { useT } from '../../lib/i18n';
+
+type LevelFilter = 'all' | 'error' | 'warn' | 'info';
+
+const LEVEL_REGEX: Record<Exclude<LevelFilter, 'all'>, RegExp> = {
+  // tracing-subscriber fmt の標準フォーマットは `2026-04-29T12:34:56.789Z  ERROR ...`
+  // のように LEVEL が大文字で出るので大文字 / 大小無視の両対応で抽出する。
+  error: /\bERROR\b/i,
+  warn: /\bWARN\b/i,
+  info: /\bINFO\b/i
+};
+
+function filterLines(content: string, filter: LevelFilter): string {
+  if (filter === 'all') return content;
+  const re = LEVEL_REGEX[filter];
+  return content
+    .split(/\r?\n/)
+    .filter((line) => re.test(line))
+    .join('\n');
+}
+
+export function LogsSection(): JSX.Element {
+  const t = useT();
+  const [resp, setResp] = useState<ReadLogTailResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<LevelFilter>('all');
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await window.api.logs.readTail();
+      setResp(r);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleOpenDir = useCallback(async () => {
+    try {
+      await window.api.logs.openDir();
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  const filtered = useMemo(
+    () => (resp ? filterLines(resp.content, filter) : ''),
+    [resp, filter]
+  );
+
+  return (
+    <section className="modal__section logs-section">
+      <h3>{t('settings.logs.title')}</h3>
+      <p className="modal__note">{t('settings.logs.desc')}</p>
+
+      <div className="logs-section__toolbar">
+        <button
+          type="button"
+          className="toolbar__btn"
+          onClick={() => void refresh()}
+          disabled={loading}
+        >
+          <RefreshCw size={13} strokeWidth={2} />
+          {t('settings.logs.refresh')}
+        </button>
+        <button type="button" className="toolbar__btn" onClick={() => void handleOpenDir()}>
+          <FolderOpen size={13} strokeWidth={2} />
+          {t('settings.logs.openDir')}
+        </button>
+        <label className="logs-section__filter">
+          <span>{t('settings.logs.levelFilter')}</span>
+          <select value={filter} onChange={(e) => setFilter(e.target.value as LevelFilter)}>
+            <option value="all">{t('settings.logs.level.all')}</option>
+            <option value="error">ERROR</option>
+            <option value="warn">WARN</option>
+            <option value="info">INFO</option>
+          </select>
+        </label>
+      </div>
+
+      {resp && (
+        <div className="logs-section__path" title={resp.path}>
+          {resp.path}
+          {resp.truncated && ` — ${t('settings.logs.truncated')}`}
+        </div>
+      )}
+
+      {error && (
+        <div className="modal__note logs-section__error">{error}</div>
+      )}
+
+      <pre className="logs-section__view">
+        {loading
+          ? t('settings.logs.loading')
+          : !resp || resp.empty
+            ? t('settings.logs.empty')
+            : filtered.length === 0
+              ? t('settings.logs.noMatch')
+              : filtered}
+      </pre>
+    </section>
+  );
+}

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -303,6 +303,19 @@ const ja: Dict = {
   'settings.apply': '適用して保存',
   'settings.custom': '（カスタム）',
 
+  // ---------- Settings: Logs (Issue #326) ----------
+  'settings.logs.title': 'ログ',
+  'settings.logs.desc':
+    'アプリの実行ログ (~/.vibe-editor/logs/vibe-editor.log) の末尾を表示します。バグ報告にはこのログを添付してください。',
+  'settings.logs.refresh': '再読み込み',
+  'settings.logs.openDir': 'ログフォルダを開く',
+  'settings.logs.levelFilter': 'レベル',
+  'settings.logs.level.all': 'すべて',
+  'settings.logs.loading': '読み込み中…',
+  'settings.logs.empty': 'ログはまだありません。',
+  'settings.logs.noMatch': '選択したレベルに該当するログがありません。',
+  'settings.logs.truncated': '末尾のみ表示中',
+
   // ---------- Toast ----------
   'toast.reviewRequested': '差分レビューを依頼: {path}',
   'toast.pathCopied': 'パスをクリップボードにコピー',
@@ -761,6 +774,19 @@ const en: Dict = {
   'settings.cancel': 'Cancel',
   'settings.apply': 'Apply & save',
   'settings.custom': '(custom)',
+
+  // ---------- Settings: Logs (Issue #326) ----------
+  'settings.logs.title': 'Logs',
+  'settings.logs.desc':
+    'Tail of the app runtime log (~/.vibe-editor/logs/vibe-editor.log). Attach this when filing a bug report.',
+  'settings.logs.refresh': 'Refresh',
+  'settings.logs.openDir': 'Open log folder',
+  'settings.logs.levelFilter': 'Level',
+  'settings.logs.level.all': 'All',
+  'settings.logs.loading': 'Loading…',
+  'settings.logs.empty': 'No logs yet.',
+  'settings.logs.noMatch': 'No log lines match the selected level.',
+  'settings.logs.truncated': 'tail only',
 
   // ---------- Toast ----------
   'toast.reviewRequested': 'Review requested: {path}',

--- a/src/renderer/src/lib/language.ts
+++ b/src/renderer/src/lib/language.ts
@@ -43,7 +43,18 @@ const EXT_MAP: Record<string, string> = {
   cc: 'cpp',
   lua: 'lua',
   sql: 'sql',
-  dockerfile: 'dockerfile'
+  dockerfile: 'dockerfile',
+  // Issue #325: 画像ファイルは Monaco のテキスト編集ではなく ImagePreview で表示する。
+  // svg は既存どおり 'xml' を維持してテキスト編集できるようにしておく (将来必要なら
+  // 切替トグルで両対応にする想定)。
+  png: 'image',
+  jpg: 'image',
+  jpeg: 'image',
+  gif: 'image',
+  webp: 'image',
+  avif: 'image',
+  bmp: 'image',
+  ico: 'image'
 };
 
 export function detectLanguage(path: string): string {

--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -18,6 +18,7 @@ import {
   type FileWriteResult,
   type GitDiffResult,
   type GitStatus,
+  type ReadLogTailResponse,
   type RoleProfilesFile,
   type SessionInfo,
   type SetWindowEffectsResult,
@@ -224,6 +225,16 @@ export const api = {
   roleProfiles: {
     load: (): Promise<RoleProfilesFile | null> => invoke('role_profiles_load'),
     save: (file: RoleProfilesFile): Promise<void> => invoke('role_profiles_save', { file })
+  },
+
+  /** Issue #326: 設定モーダルからログを表示する用。
+   *  Rust 側で stderr と並行して `~/.vibe-editor/logs/vibe-editor.log` に書き出している。 */
+  logs: {
+    /** ログファイル末尾の最大 maxBytes バイトを返す。省略時は 256KB。 */
+    readTail: (maxBytes?: number): Promise<ReadLogTailResponse> =>
+      invoke('logs_read_tail', { maxBytes }),
+    /** ログ格納ディレクトリを OS のファイルマネージャで開く。 */
+    openDir: (): Promise<void> => invoke('logs_open_dir')
   },
 
   terminal: {

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -40,6 +40,7 @@ import './styles/components/canvas.css';
 import './styles/components/claude-patterns.css';
 import './styles/components/shell.css';
 import './styles/components/tweaks.css';
+import './styles/components/image-preview.css';
 
 const rootEl = document.getElementById('root');
 if (!rootEl) throw new Error('#root が見つかりません');

--- a/src/renderer/src/styles/components/image-preview.css
+++ b/src/renderer/src/styles/components/image-preview.css
@@ -1,0 +1,35 @@
+/* Issue #325: ファイルツリーから png/jpg 等を開いたときの画像プレビュー。
+ * EditorView の `.diffview__editor` 内にマウントされるので、親と同じ高さに広がるよう
+ * width/height: 100% を取り、画像は縦横どちらも収まるよう object-fit: contain で縮小する。 */
+.image-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-panel);
+  overflow: hidden;
+}
+
+.image-preview__img {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  /* チェッカー透過背景: 透過 PNG の透過領域を視認しやすくする */
+  background-image:
+    linear-gradient(45deg, rgba(255, 255, 255, 0.04) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(255, 255, 255, 0.04) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(255, 255, 255, 0.04) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(255, 255, 255, 0.04) 75%);
+  background-size: 16px 16px;
+  background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+}
+
+.image-preview__error {
+  color: var(--text-muted, var(--fg-muted));
+  font-size: 13px;
+  padding: 16px;
+  text-align: center;
+}

--- a/src/renderer/src/styles/components/menu.css
+++ b/src/renderer/src/styles/components/menu.css
@@ -22,6 +22,20 @@
   box-shadow: var(--shadow-popover);
 }
 
+/* Issue #324: ContextMenu は createPortal(document.body) されるため、親パネルの
+ * Glass 背景越しに浮くと「親 backdrop-filter の milky 状態の上に不透明色」と
+ * なってコントラストが落ちる。Glass テーマ時は半透明 + 自前 backdrop-filter で
+ * 独立レイヤとして立たせ、視認性を確保する。
+ * セレクタは :root[data-theme='glass'] でルート起点にすることで Portal 経由でも
+ * 確実にマッチする。 */
+:root[data-theme='glass'] .context-menu {
+  background: rgba(31, 31, 30, 0.92);
+  -webkit-backdrop-filter: blur(12px) saturate(140%);
+  backdrop-filter: blur(12px) saturate(140%);
+  border-color: var(--glass-border);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45), var(--glass-highlight);
+}
+
 .app-menu__dropdown,
 .user-menu__dropdown {
   opacity: 0;

--- a/src/renderer/src/styles/components/modal.css
+++ b/src/renderer/src/styles/components/modal.css
@@ -506,6 +506,63 @@
   margin-bottom: 4px;
 }
 
+/* ---------- Settings: Logs viewer (Issue #326) ---------- */
+.logs-section__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 0 10px;
+}
+
+.logs-section__filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-left: auto;
+}
+
+.logs-section__filter select {
+  height: 28px;
+  padding: 0 6px;
+  background: var(--bg-panel);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  font: inherit;
+}
+
+.logs-section__path {
+  font-family: var(--mono-font, monospace);
+  font-size: 11px;
+  color: var(--text-mute, var(--text-dim));
+  margin-bottom: 8px;
+  word-break: break-all;
+}
+
+.logs-section__error {
+  color: var(--danger, #e16868);
+}
+
+.logs-section__view {
+  margin: 0;
+  padding: 12px;
+  height: 360px;
+  max-height: 60vh;
+  overflow: auto;
+  font-family: var(--mono-font, monospace);
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--text);
+  background: var(--bg-sidebar, var(--bg));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .modal--settings .modal__label {
   gap: 6px;
 }

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -204,6 +204,21 @@ export interface GitDiffResult {
   modified: string;
 }
 
+/**
+ * Issue #326: 設定モーダルのログビューア用。Rust 側 `logs_read_tail` の応答に対応。
+ * 構造体は `src-tauri/src/commands/logs.rs` の `ReadLogTailResponse` と一致させる。
+ */
+export interface ReadLogTailResponse {
+  /** ログ末尾の文字列。`empty=true` のとき空文字列 */
+  content: string;
+  /** ログファイルの絶対パス (表示用) */
+  path: string;
+  /** maxBytes でクリップしたか (= ファイルがそれ以上長い) */
+  truncated: boolean;
+  /** ファイル不在 / size=0 のとき true */
+  empty: boolean;
+}
+
 export interface SessionInfo {
   id: string;
   path: string;

--- a/tasks/issue-326/plan.md
+++ b/tasks/issue-326/plan.md
@@ -1,0 +1,46 @@
+## 実装計画
+
+### ゴール
+設定モーダルに「ログ」セクションを追加し、`~/.vibe-editor/logs/vibe-editor.log` の内容 (Rust 側 tracing が出力するエラー / 警告 / IPC ログ) を GUI 上で閲覧できるようにする。最低限「最新行を表示・リフレッシュ・レベルフィルタ・ログフォルダを開く」ができる状態を done とする。
+
+### 影響範囲 / 触るファイル
+- `src/types/shared.ts` — `ReadLogTailRequest` / `ReadLogTailResponse` 型を追加 (max_bytes / lines / 取得結果)
+- `src-tauri/src/commands/settings.rs` (または新規 `src-tauri/src/commands/logs.rs`) — `read_log_tail` / `open_log_dir` の Tauri コマンドを追加。ログパスは既存の `~/.vibe-editor/logs/vibe-editor.log` を再利用
+- `src-tauri/src/commands/mod.rs` — 新規モジュール宣言 (新規ファイルにする場合)
+- `src-tauri/src/lib.rs` — `invoke_handler!` に新コマンドを登録
+- `src/renderer/src/lib/tauri-api.ts` — `readLogTail` / `openLogDir` ラッパーを追加
+- `src/renderer/src/components/settings/LogsSection.tsx` (新規) — ログビューア UI (textarea/pre + フィルタ + リフレッシュ + フォルダを開くボタン)
+- `src/renderer/src/components/SettingsModal.tsx` — `SECTION_ICON_TYPES` / `FIXED_LABELS_JA` / `FIXED_LABELS_EN` / `groupsRaw` / `renderSection` の 5 箇所に `logs` を追加
+- `src/renderer/src/styles/components/settings.css` (該当ファイル名は実装時に確認) — ログ表示用のモノスペース / 背景 / overflow スタイル
+- (任意) `src/renderer/src/lib/i18n.ts` — 「ログ」「リフレッシュ」「レベル」「フォルダを開く」の文言を ja/en で追加
+
+### 実装ステップ
+- [ ] Step 1: Rust 側に `read_log_tail(max_bytes: u64) -> { content: String, path: String, truncated: bool }` を実装。ファイル末尾から最大 256KB を UTF-8 lossy で読む (CP932 混入には `encoding_rs` を使うが、tracing 出力は UTF-8 なので通常は不要)
+- [ ] Step 2: Rust 側に `open_log_dir()` を実装 — Tauri の `opener` プラグイン (既に依存に入っているか要確認) で `~/.vibe-editor/logs/` をエクスプローラ等で開く
+- [ ] Step 3: `tauri-ipc-commands` skill の 5 点同期チェック — `shared.ts` 型 / `commands/<領域>.rs` 構造体 (`#[serde(rename_all = "camelCase")]`) / `mod.rs` モジュール宣言 / `lib.rs` の `invoke_handler!` 登録 / `tauri-api.ts` ラッパー の同期
+- [ ] Step 4: `LogsSection.tsx` を作成。最低限の UI は (a) `<pre>` でテール表示、(b) リフレッシュボタン、(c) ログレベル絞り込みセレクト (ALL / ERROR / WARN / INFO)、(d) ログフォルダを開くボタン、(e) ログパス表示
+- [ ] Step 5: `SettingsModal.tsx` の 5 箇所に `logs` を追加。アイコンは lucide-react の `FileText` か `ScrollText` を採用。グループは「その他」相当 (既存にあれば流用、無ければ MCP / roles と同じ「チーム」グループに混ぜず別グループ「ログ」を新設するか検討)
+- [ ] Step 6: i18n 文言 (ja/en) を `i18n.ts` に追記
+- [ ] Step 7: 表示時のサイズ上限 (例: 直近 1000 行) と自動更新 (5 秒ポーリング or 手動のみ) を最終決定して実装。MVP は手動リフレッシュのみで OK
+- [ ] Step 8: パフォーマンス確認 — ログが数 MB に成長しても固まらないか (末尾だけ読む実装になっているか)
+
+### 検証方法
+- `npm run typecheck` が通る
+- `npm run build` が通る (Tauri ビルド)
+- `npm run dev` で起動 → 設定モーダル → 「ログ」セクションで `~/.vibe-editor/logs/vibe-editor.log` の末尾が表示される
+- リフレッシュボタンで再読込される
+- 「フォルダを開く」でエクスプローラ / Finder が開く
+- レベルフィルタで ERROR のみ抽出できる
+- ログファイルが存在しない / 空のときも例外を出さず空表示になる
+
+### リスク・代替案
+- リスク: ログにユーザのファイルパス等 PII が含まれる可能性 → 既に `util/log_redact.rs` でホームディレクトリは `~` に置換済みなので踏襲する。それ以外の機微情報が混入していないかを確認
+- リスク: 巨大ログ (数十 MB) を全文読み込むと固まる → 末尾 N バイトのみ読む実装で回避
+- 代替案 1: 最初は MVP として「リフレッシュボタン + 末尾 256KB 表示」のみ実装し、自動 tail / 検索 / 追従は後続 issue に切り出す (推奨)
+- 代替案 2: `tauri-plugin-log` 導入で Rust→Renderer のリアルタイムストリームを構築する案もあるが、依存追加が大きくなるので今回は見送る
+
+### 想定 PR 構成
+- branch: `feat/issue-326-settings-logs-viewer`
+- commit 粒度: 2 commit に分割推奨。(1) Rust IPC + 型同期、(2) 設定モーダル UI 追加 + i18n
+- PR title 案: `feat(settings): #326 設定モーダルにログビューアセクションを追加`
+- 本文に `Closes #326` を含める

--- a/tasks/issue-327/plan.md
+++ b/tasks/issue-327/plan.md
@@ -1,0 +1,36 @@
+## 実装計画
+
+### ゴール
+Canvas モードで Codex 側のターミナルカードでも、スクロールバー (xterm の vertical scrollbar thumb) をマウスで掴んでドラッグできる状態にする。Claude 側と同じ操作感に揃える。マウスホイールでのスクロールは現状維持。
+
+### 影響範囲 / 触るファイル
+- `src/renderer/src/components/canvas/cards/TerminalCard.tsx` — terminal wrapper に `nodrag` (および必要なら `nowheel`) クラスを付与し、xterm DOM 上でのドラッグを React Flow が奪わないようにする
+- `src/renderer/src/components/canvas/cards/AgentNodeCard.tsx` — Codex がこちら側で描画されているケースのため、`canvas-agent-card__term` 配下で scrollbar 領域に `nodrag` が確実に効いているか再点検 (現状の `nodrag` 付与位置がスクロールバー DOM までカバーしているかを確認し、必要なら xterm の `.xterm-scrollable-element > .scrollbar.vertical` まで継承させる)
+- `src/renderer/src/styles/components/canvas.css` — `pointer-events: auto !important` の対象セレクタを TerminalCard 配下にも揃える (現状 614 行付近の上書きが AgentNodeCard 寄りなら、TerminalCard 用の `.canvas-terminal-card__term .xterm-scrollable-element > .scrollbar.vertical` も追加)
+- (該当時) `src/renderer/src/components/canvas/CardFrame.tsx` — `onPointerDown` の `stopPropagation` がスクロールバー drag を妨げていないか確認し、scrollbar 領域では伝播させるよう調整
+
+### 実装ステップ
+- [ ] Step 1: 再現確認 — Canvas モードで Claude / Codex 両方を起動し、スクロールバー thumb のドラッグ可否を実機検証 (どちらが TerminalCard / AgentNodeCard で描画されているかを DevTools で特定する。仮説では Codex が TerminalCard 経由)
+- [ ] Step 2: 原因切り分け — DevTools の Event Listeners で xterm scrollbar の `pointerdown` を確認し、React Flow の drag handler が先に capture していないか / `pointer-events: none` がかかっていないかを判定
+- [ ] Step 3: 修正方針 A — TerminalCard 側の terminal wrapper に `nodrag` クラスを付与 (1 行追加)。これだけで解消すればここで止める
+- [ ] Step 4: 修正方針 B (A で不十分なら) — `canvas.css` 側のセレクタを TerminalCard まで拡張 (`pointer-events: auto !important` を統一)
+- [ ] Step 5: 修正方針 C (それでも不十分なら) — `CardFrame` の `onPointerDown` で `target.closest('.scrollbar.vertical, .xterm-scrollable-element')` のときだけ `stopPropagation` をスキップ
+- [ ] Step 6: Claude / Codex / カスタムエージェント / 通常 Terminal カード の 4 系統で回帰確認
+
+### 検証方法
+- `npm run typecheck` が通る
+- `npm run dev` で起動し、Canvas モードに切替 → Claude / Codex / Terminal カードを並べて全て立ち上げ、scrollbar thumb をマウスでドラッグできることを目視確認
+- マウスホイールスクロールが従来通り効く (regression なし)
+- カードを通常通りドラッグで移動できる (scrollbar 領域以外は drag が React Flow に届く)
+- 通常 IDE モードの Terminal タブでも regression が無い
+
+### リスク・代替案
+- リスク: `nodrag` を広く当てすぎるとカード本体のドラッグ移動が効かなくなる。あくまで scrollbar / xterm-scrollable-element 配下に限定する
+- リスク: `pointer-events: auto !important` を強める方向は、別の overlay (`Handle` 等) との重なりを潰す可能性があるので影響範囲を最小化する
+- 代替案: xterm の `scrollbar` を OS ネイティブに切り替える方向はライブラリ仕様上難しいので採用しない
+
+### 想定 PR 構成
+- branch: `fix/issue-327-codex-terminal-scrollbar`
+- commit 粒度: 1 commit (Step 3 の最小修正で済む想定。Step 4/5 が必要になったら 2〜3 commit に分割)
+- PR title 案: `fix(canvas): #327 Codex ターミナルでスクロールバーをマウス操作できない問題を修正`
+- 本文に `Closes #327` を含める


### PR DESCRIPTION
## Summary
4 件の planned issue を 1 commit / issue で 1 PR にバンドル (memory: PR bundling for issue sweeps)。

| Issue | type | 概要 |
|---|---|---|
| #324 | fix(menu) | Glass テーマで ContextMenu が透けすぎる問題を修正 |
| #325 | feat(editor) | ファイルツリーから png 等の画像ファイルをプレビュー |
| #327 | fix(canvas) | Codex ターミナルでスクロールバーをマウス操作できない問題を修正 |
| #326 | feat(settings) | 設定モーダルにログビューアセクションを追加 |

### #324: Glass ContextMenu
`createPortal(document.body)` 経由のメニューに Glass テーマ専用の半透明 + `backdrop-filter` を当てて視認性を確保。

### #325: 画像プレビュー
- `language.ts` に png/jpg/jpeg/gif/webp/avif/bmp/ico を `'image'` でマップ (svg は xml 維持)
- `ImagePreview.tsx` を新規作成。Tauri ランタイム検出 + `convertFileSrc` + onError fallback
- `EditorView` に `projectRoot` prop を追加し、画像言語のときは `ImagePreview` に委ねる
- `tauri.conf.json` の `assetProtocol` に画像拡張子限定 scope を追加
- Cargo の `tauri` features に `protocol-asset` を追加

### #327: Codex scrollbar
`TerminalCard` の terminal wrapper に `nodrag nowheel` を付与。`AgentNodeCard` 側は元々付いていたが TerminalCard 側にだけ抜けていたため、Codex を Terminal カードとして直接立ち上げたケースで scrollbar が掴めなかった。

### #326: ログビューア
- Rust 側に `tracing-appender` を追加し、stderr + `~/.vibe-editor/logs/vibe-editor.log` の二系統書き出しに再編
- `commands/logs.rs` に `logs_read_tail` / `logs_open_dir` IPC を追加 (末尾 256KB を seek で読む)
- `LogsSection.tsx` を新規作成 (リフレッシュ / レベルフィルタ / フォルダを開く)
- `SettingsModal` の 5 箇所 (`SECTION_ICON_TYPES` / `FIXED_LABELS_(JA|EN)` / `groupsRaw` / `renderSection`) に `logs` を同期追加
- ja/en の i18n キーを追加

## Test plan
- [ ] `npm run typecheck` ✅ パス済み
- [ ] `cargo check --lib` ✅ パス済み
- [ ] Glass テーマでファイルツリー右クリック → メニューが視認可能か手動確認 (#324)
- [ ] png / jpg / gif / webp をファイルツリーから開いて表示確認 (#325)
- [ ] Codex を Terminal カードで立ち上げて scrollbar thumb をマウスでドラッグできるか確認 (#327)
- [ ] 設定 → ログ で末尾が表示される / リフレッシュ / レベルフィルタ / フォルダを開くが動作するか確認 (#326)

Closes #324
Closes #325
Closes #326
Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)