### PR TITLE
fix: open issues #336-#341 の 6 件をバンドル修正

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -59,8 +59,12 @@ pub struct AppUserInfo {
     pub webview_version: String,
 }
 
+// Issue #336: 全フィールドが現状未参照だが、renderer から `app_setup_team_mcp` に
+// 渡される情報のシグネチャを保つため struct ごと保持する。将来 MCP 設定生成や
+// telemetry で読み出しを再開する想定。
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
 pub struct TeamMcpMember {
     pub agent_id: String,
     pub role: String,

--- a/src-tauri/src/pty/registry.rs
+++ b/src-tauri/src/pty/registry.rs
@@ -156,11 +156,6 @@ impl SessionRegistry {
         gate_check_pure(by_id_len, &mut g.spawn_history, Instant::now())
     }
 
-    pub fn insert(&self, id: String, handle: SessionHandle) {
-        let mut g = recover(self.inner.lock());
-        Self::insert_locked(&mut g, id, handle);
-    }
-
     /// Issue #292: id 衝突を atomic に検出する insert。Mutex 1 回ロックの中で
     /// `by_id.contains_key(&id)` の判定 → 採用 / 拒否を行うため、TOCTOU race で別スレッド
     /// が同 id を先に挿入していても、後勝ち上書きにならない。
@@ -320,9 +315,6 @@ impl SessionRegistry {
         }
     }
 
-    pub fn len(&self) -> usize {
-        recover(self.inner.lock()).by_id.len()
-    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/team_hub/bridge.rs
+++ b/src-tauri/src/team_hub/bridge.rs
@@ -80,6 +80,32 @@ const BASE_RETRY_MS = 500;
 const MAX_RETRY_MS = 10000;
 let givenUp = false;
 
+// Issue #340: Hub の IDLE_TIMEOUT (300s) より十分短い間隔で no-op 通知を送り、
+// 正常稼働中の Leader が「データ無し」で切られて再接続を繰り返すのを防ぐ。
+const KEEPALIVE_INTERVAL_MS = 90 * 1000;
+let keepaliveTimer = null;
+function startKeepalive() {
+  stopKeepalive();
+  keepaliveTimer = setInterval(() => {
+    if (!socket || !connected || socket.destroyed) return;
+    try {
+      socket.write('{"jsonrpc":"2.0","method":"team-hub/keepalive"}\n');
+    } catch (e) {
+      // 書き込み失敗は onClose で拾う
+    }
+  }, KEEPALIVE_INTERVAL_MS);
+  // keepalive timer 単独で Node プロセスを生かさない (stdin 終了で素直に exit するため)
+  if (keepaliveTimer && typeof keepaliveTimer.unref === 'function') {
+    keepaliveTimer.unref();
+  }
+}
+function stopKeepalive() {
+  if (keepaliveTimer) {
+    clearInterval(keepaliveTimer);
+    keepaliveTimer = null;
+  }
+}
+
 function nextBackoffMs() {
   // 500ms → 1s → 2s → ... (cap 10s)
   const ms = Math.min(BASE_RETRY_MS * 2 ** retryCount, MAX_RETRY_MS);
@@ -107,6 +133,8 @@ function connect() {
     if (flushed || dropped) {
       process.stderr.write(`[team-bridge] flushed ${flushed} pending request(s), dropped ${dropped} stale\n`);
     }
+    // Issue #340: handshake 直後に keepalive を起動して Hub の idle drop を防ぐ。
+    startKeepalive();
   });
 
   let buf = '';
@@ -129,6 +157,8 @@ function connect() {
 
   const onClose = () => {
     connected = false;
+    // Issue #340: 切断時は keepalive を止める。次回 connect 成功時に再起動する。
+    stopKeepalive();
     try { socket && socket.destroy(); } catch {}
     socket = null;
     if (givenUp) return;

--- a/src-tauri/src/team_hub/bridge.rs
+++ b/src-tauri/src/team_hub/bridge.rs
@@ -24,15 +24,23 @@ const net = require('net');
 const SOCKET = process.env.VIBE_TEAM_SOCKET || '';
 const TOKEN = process.env.VIBE_TEAM_TOKEN || '';
 const TEAM_ID = process.env.VIBE_TEAM_ID || '';
-const ROLE = process.env.VIBE_TEAM_ROLE || 'unknown';
+// Issue #339: 既定値 'unknown' を撤廃する。これがあると env 未設定の bridge が空 handshake で
+// connect → Hub に reject → 即再接続のループになりログを汚染する。
+const ROLE = process.env.VIBE_TEAM_ROLE || '';
 const AGENT_ID = process.env.VIBE_AGENT_ID || '';
 
-// Issue #62: SOCKET / TOKEN が欠落しているときは、offline fallback で「繋がっているフリ」を
-// するのではなく、initialize を明示的にエラーで返すことで Claude / Codex が
-// vibe-team MCP を「失敗サーバ」として認識できるようにする (ユーザーが気付きやすい)。
-const MISSING_HUB_ENV = !SOCKET || !TOKEN;
+// Issue #62 / #339: env が 1 つでも欠けているなら connect しない。
+// 旧実装は SOCKET/TOKEN だけ判定していたため、TEAM_ID/ROLE/AGENT_ID 欠落で空 handshake
+// → Hub の `empty field` reject → 0.8 秒間隔の再接続ループが発生していた。
+const missingEnv = [];
+if (!SOCKET) missingEnv.push('VIBE_TEAM_SOCKET');
+if (!TOKEN) missingEnv.push('VIBE_TEAM_TOKEN');
+if (!TEAM_ID) missingEnv.push('VIBE_TEAM_ID');
+if (!ROLE) missingEnv.push('VIBE_TEAM_ROLE');
+if (!AGENT_ID) missingEnv.push('VIBE_AGENT_ID');
+const MISSING_HUB_ENV = missingEnv.length > 0;
 if (MISSING_HUB_ENV) {
-  process.stderr.write('[team-bridge] missing VIBE_TEAM_SOCKET or VIBE_TEAM_TOKEN — team tools disabled\n');
+  process.stderr.write('[team-bridge] missing env: ' + missingEnv.join(', ') + ' — team tools disabled\n');
 }
 
 function resolveConnectionTarget(raw) {
@@ -84,7 +92,8 @@ function connect() {
     const hello = JSON.stringify({ token: TOKEN, teamId: TEAM_ID, role: ROLE, agentId: AGENT_ID });
     socket.write(hello + '\n');
     connected = true;
-    retryCount = 0; // 成功したので backoff リセット
+    // Issue #339: retryCount は TCP 接続時ではなく Hub から最初のバイトを受信した時に
+    // リセットする。handshake reject 後の即再接続ループで backoff が常に 500ms に戻るのを防ぐ。
     // Issue #100: connect 完了で pending request を flush。
     // TTL 切れの pending は捨て、生きているものだけ送る。
     const now = Date.now();
@@ -101,7 +110,14 @@ function connect() {
   });
 
   let buf = '';
+  // Issue #339: socket ごとにフラグを持ち、同 socket での data 初回受信時のみ retryCount を
+  // リセットする。再接続で新しい socket になったらまた false スタート。
+  let resetOnFirstData = false;
   socket.on('data', (chunk) => {
+    if (!resetOnFirstData) {
+      retryCount = 0;
+      resetOnFirstData = true;
+    }
     buf += chunk.toString('utf-8');
     let nl;
     while ((nl = buf.indexOf('\n')) !== -1) {
@@ -181,7 +197,7 @@ function localFallback(req) {
   // 「失敗していること」を明示するため、id 付き request には error を返す。
   const { method, id } = req;
   const reason = MISSING_HUB_ENV
-    ? 'vibe-team bridge is not configured (VIBE_TEAM_SOCKET / VIBE_TEAM_TOKEN missing)'
+    ? 'vibe-team bridge is not configured (missing env: ' + missingEnv.join(', ') + ')'
     : 'vibe-team hub is unreachable (gave up reconnecting)';
   if (id !== undefined && id !== null) {
     return {

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -126,8 +126,6 @@ struct HubState {
     token: String,
     /// 書き出し済みの bridge スクリプトパス
     bridge_path: PathBuf,
-    /// agent_id → 現在進行中の inject タスク数 (cancel 用には含めない、レート制限用)
-    pending_injects: HashMap<String, usize>,
     /// agent_id → 待機中の recruit (handshake 完了で resolve)。
     /// Issue #122: team_id と role を保持して、同時 team_recruit の人数 / singleton 判定に
     /// pending を含められるようにする (旧実装は registry の handshake 済みだけを見ていたため
@@ -198,7 +196,6 @@ pub struct PendingRecruit {
 
 #[derive(Default, Clone)]
 pub struct TeamInfo {
-    pub id: String,
     pub name: String,
     pub messages: VecDeque<TeamMessage>,
     pub tasks: VecDeque<TeamTask>,
@@ -249,7 +246,6 @@ impl TeamHub {
                 endpoint: String::new(),
                 token: String::new(),
                 bridge_path: PathBuf::new(),
-                pending_injects: HashMap::new(),
                 pending_recruits: HashMap::new(),
                 agent_role_bindings: HashMap::new(),
                 role_profile_summary: Vec::new(),
@@ -579,10 +575,7 @@ impl TeamHub {
         let team = s
             .teams
             .entry(team_id.to_string())
-            .or_insert_with(|| TeamInfo {
-                id: team_id.to_string(),
-                ..Default::default()
-            });
+            .or_insert_with(TeamInfo::default);
         if !name.is_empty() {
             team.name = name.to_string();
         }

--- a/src-tauri/src/team_hub/protocol.rs
+++ b/src-tauri/src/team_hub/protocol.rs
@@ -53,6 +53,9 @@ pub async fn handle(hub: &TeamHub, ctx: &CallContext, req: &Value) -> Option<Val
             }
         })),
         "notifications/initialized" | "notifications/cancelled" => None,
+        // Issue #340: bridge → Hub への keepalive 通知。idle drop を防ぐためだけの no-op。
+        // 応答を返すと Claude / Codex の stdout を汚染するので、id 有無に関わらず None を返す。
+        "team-hub/keepalive" => None,
         "ping" => Some(json!({ "jsonrpc": "2.0", "id": id, "result": {} })),
         "tools/list" => Some(json!({
             "jsonrpc": "2.0",

--- a/src-tauri/src/team_hub/protocol.rs
+++ b/src-tauri/src/team_hub/protocol.rs
@@ -757,10 +757,7 @@ async fn team_send(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<Val
     let team = state
         .teams
         .entry(ctx.team_id.clone())
-        .or_insert_with(|| crate::team_hub::TeamInfo {
-            id: ctx.team_id.clone(),
-            ..Default::default()
-        });
+        .or_insert_with(crate::team_hub::TeamInfo::default);
     // Issue #115: messages.len()+1 だと履歴上限到達後に id が固定して衝突する。
     // 単調増加カウンタにすることで上限を超えても一意性を保つ。
     team.next_message_id = team.next_message_id.saturating_add(1);
@@ -905,10 +902,7 @@ async fn team_read(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<Val
     let team = state
         .teams
         .entry(ctx.team_id.clone())
-        .or_insert_with(|| crate::team_hub::TeamInfo {
-            id: ctx.team_id.clone(),
-            ..Default::default()
-        });
+        .or_insert_with(crate::team_hub::TeamInfo::default);
     let mut out = vec![];
     for m in team.messages.iter_mut() {
         // team_send 側の宛先解決と整合: "all" / role 名 case-insensitive / agent_id 完全一致を許容。
@@ -1022,10 +1016,7 @@ async fn team_assign_task(
         let team = state
             .teams
             .entry(ctx.team_id.clone())
-            .or_insert_with(|| crate::team_hub::TeamInfo {
-                id: ctx.team_id.clone(),
-                ..Default::default()
-            });
+            .or_insert_with(crate::team_hub::TeamInfo::default);
         // Issue #116: tasks.len()+1 だと履歴上限到達後に id が固定して衝突する。
         // 単調増加カウンタで一意性を保つ。
         team.next_task_id = team.next_task_id.saturating_add(1);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -240,6 +240,7 @@ export function App(): JSX.Element {
     recentProjects: useSettingsValue('recentProjects'),
     workspaceFolders: useSettingsValue('workspaceFolders'),
     claudeCodePanelWidth: useSettingsValue('claudeCodePanelWidth'),
+    sidebarWidth: useSettingsValue('sidebarWidth'),
     codexCommand: useSettingsValue('codexCommand'),
     codexArgs: useSettingsValue('codexArgs'),
     language: useSettingsValue('language'),
@@ -609,6 +610,12 @@ export function App(): JSX.Element {
   const MAX_PANEL = 900;
   const resizeDragRef = useRef<{ startX: number; startWidth: number } | null>(null);
 
+  // ---------- サイドバー リサイズ (Issue #337) ----------
+  const MIN_SIDEBAR = 200;
+  const MAX_SIDEBAR = 600;
+  const DEFAULT_SIDEBAR = 272;
+  const sidebarResizeDragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
   // 設定からの初期幅を CSS 変数に反映
   useEffect(() => {
     const w = Math.max(
@@ -617,6 +624,15 @@ export function App(): JSX.Element {
     );
     document.documentElement.style.setProperty('--claude-code-width', `${w}px`);
   }, [settings.claudeCodePanelWidth]);
+
+  // Issue #337: サイドバー幅を CSS 変数に反映
+  useEffect(() => {
+    const w = Math.max(
+      MIN_SIDEBAR,
+      Math.min(MAX_SIDEBAR, settings.sidebarWidth ?? DEFAULT_SIDEBAR)
+    );
+    document.documentElement.style.setProperty('--shell-sidebar-w', `${w}px`);
+  }, [settings.sidebarWidth]);
 
   const handleResizeStart = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -666,6 +682,58 @@ export function App(): JSX.Element {
     },
     [settings.claudeCodePanelWidth, updateSettings]
   );
+
+  // Issue #337: サイドバーと main の境界をドラッグして幅を調整する
+  const handleSidebarResizeStart = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const currentWidth = Math.max(
+        MIN_SIDEBAR,
+        Math.min(MAX_SIDEBAR, settings.sidebarWidth ?? DEFAULT_SIDEBAR)
+      );
+      sidebarResizeDragRef.current = {
+        startX: e.clientX,
+        startWidth: currentWidth
+      };
+      document.body.classList.add('is-resizing');
+      const handleEl = e.currentTarget;
+      handleEl.classList.add('is-dragging');
+
+      let latestWidth = currentWidth;
+
+      const onMove = (ev: MouseEvent): void => {
+        const drag = sidebarResizeDragRef.current;
+        if (!drag) return;
+        // 右へドラッグ = width 増える (claude-code-panel と方向が逆)
+        const dx = ev.clientX - drag.startX;
+        const next = Math.max(
+          MIN_SIDEBAR,
+          Math.min(MAX_SIDEBAR, drag.startWidth + dx)
+        );
+        latestWidth = next;
+        document.documentElement.style.setProperty('--shell-sidebar-w', `${next}px`);
+      };
+
+      const onUp = (): void => {
+        sidebarResizeDragRef.current = null;
+        document.body.classList.remove('is-resizing');
+        handleEl.classList.remove('is-dragging');
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        void updateSettings({ sidebarWidth: latestWidth });
+      };
+
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [settings.sidebarWidth, updateSettings]
+  );
+
+  // Issue #337: ダブルクリックで default 幅にリセット
+  const handleSidebarResizeDouble = useCallback(() => {
+    document.documentElement.style.setProperty('--shell-sidebar-w', `${DEFAULT_SIDEBAR}px`);
+    void updateSettings({ sidebarWidth: DEFAULT_SIDEBAR });
+  }, [updateSettings]);
 
   const dirtyEditorTabs = useMemo(
     () => editorTabs.filter((tab) => !tab.isBinary && tab.content !== tab.originalContent),
@@ -2240,6 +2308,15 @@ export function App(): JSX.Element {
         onResumeTeam={(entry) => void handleResumeTeam(entry)}
         onDeleteTeamHistory={(id) => void handleDeleteTeamHistory(id)}
         onOpenSettings={() => setSettingsOpen(true)}
+      />
+      {/* Issue #337: サイドバー幅調整ハンドル */}
+      <div
+        className="resize-handle resize-handle--sidebar"
+        onMouseDown={handleSidebarResizeStart}
+        onDoubleClick={handleSidebarResizeDouble}
+        title="ドラッグでサイドバー幅を調整 / ダブルクリックでリセット"
+        role="separator"
+        aria-orientation="vertical"
       />
       <main className="main">
         {tabs.length > 0 && (

--- a/src/renderer/src/components/TerminalView.tsx
+++ b/src/renderer/src/components/TerminalView.tsx
@@ -129,6 +129,10 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
     ref
   ): JSX.Element {
     const { settings } = useSettings();
+    // Issue #338: useTerminalClipboard が React Context を直接引かないように、言語の current を
+    // ref で渡す。settings 変化のたびに同期するので stale にならない。
+    const langRef = useRef(settings.language);
+    langRef.current = settings.language;
 
     // --- Terminal インスタンス ---
     const { containerRef, termRef, fitRef } = useXtermInstance(
@@ -220,7 +224,8 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
     useTerminalClipboard({
       termRef,
       containerRef,
-      writeToPty
+      writeToPty,
+      langRef
     });
 
     // --- ResizeObserver + 可視化時 re-fit (不変式 #5) ---

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
@@ -361,7 +361,9 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
             cwd={cwd}
             fallbackCwd={cwd}
             command={command}
-            args={payload.args ?? args}
+            // Issue #341: payload.args が空配列で永続化された場合に settings 由来の args が
+            // 潰れないようガード (`?? args` だと `[]` でも truthy 扱いで args が無視される)。
+            args={payload.args && payload.args.length > 0 ? payload.args : args}
             codexInstructions={codexInstructions}
             visible={true}
             teamId={payload.teamId}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -163,7 +163,8 @@ body,
 
 .layout {
   display: grid;
-  grid-template-columns: 272px minmax(0, 1fr) 5px var(--claude-code-width, 460px);
+  /* Issue #337: 旧 .layout も CSS 変数化 (実体は .layout--redesign に上書きされる) */
+  grid-template-columns: var(--shell-sidebar-w) minmax(0, 1fr) 5px var(--claude-code-width, 460px);
   /* Issue #307: Windows 最大化時の -8px 不可視リサイズ境界補正。
      margin shorthand (4値) は値の取り違えリスクが高いので使わず、
      margin-top / margin-left の個別指定で左上方向だけ押し戻す。
@@ -179,14 +180,16 @@ body,
 
 /* diff なし → メイン非表示、パネルがフル幅 */
 .layout--terminal-full {
-  grid-template-columns: 272px 0 0 minmax(0, 1fr);
+  grid-template-columns: var(--shell-sidebar-w) 0 0 minmax(0, 1fr);
 }
 
 .layout--terminal-full .main {
   display: none;
 }
 
-.layout--terminal-full .resize-handle {
+/* Issue #337: terminal-full は claude-code-panel 側のハンドルだけ畳む。
+   サイドバーハンドル (.resize-handle--sidebar) は terminal-full でも表示する。 */
+.layout--terminal-full .resize-handle:not(.resize-handle--sidebar) {
   display: none;
 }
 

--- a/src/renderer/src/lib/settings-context.tsx
+++ b/src/renderer/src/lib/settings-context.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
   useSyncExternalStore,
+  type Context,
   type ReactNode
 } from 'react';
 import { DEFAULT_SETTINGS, type AppSettings } from '../../../types/shared';
@@ -32,7 +33,30 @@ interface SettingsStore {
   reset: () => Promise<void>;
 }
 
-const SettingsContext = createContext<SettingsStore | null>(null);
+// Issue #338: HMR で settings-context.tsx が再評価されると SettingsContext インスタンスが
+// 作り直され、別 HMR boundary の consumer (i18n.ts → use-terminal-clipboard.ts 等) が旧
+// Context 参照を保持して `useContext` が null を返す → throw → fewer hooks chain。
+// これを防ぐため、Context インスタンスは globalThis に保存して identity を維持する。
+type SettingsContextSlot = Context<SettingsStore | null>;
+declare global {
+  // eslint-disable-next-line no-var
+  var __vibeSettingsContext: SettingsContextSlot | undefined;
+}
+const SettingsContext: SettingsContextSlot =
+  globalThis.__vibeSettingsContext ?? createContext<SettingsStore | null>(null);
+if (!globalThis.__vibeSettingsContext) {
+  globalThis.__vibeSettingsContext = SettingsContext;
+}
+
+// Issue #338: 自モジュールの HMR を受け入れて再評価伝播を止める。dev のみ有効。
+// production では import.meta.hot は undefined なので no-op。
+const __hot = (import.meta as unknown as { hot?: { accept: (cb?: () => void) => void } }).hot;
+if (__hot) {
+  __hot.accept(() => {
+    // 何もしない: Context 識別子は globalThis 経由で保たれているので、
+    // モジュール再評価しても provider/consumer は同じ Context を見る。
+  });
+}
 
 export function SettingsProvider({ children }: { children: ReactNode }): JSX.Element {
   const [settingsState, setSettingsState] = useState<AppSettings>(DEFAULT_SETTINGS);

--- a/src/renderer/src/lib/settings-migrate.ts
+++ b/src/renderer/src/lib/settings-migrate.ts
@@ -140,6 +140,16 @@ export function migrateSettings(raw: unknown): AppSettings {
     }
   }
 
+  // --- Version 6 → 7: サイドバー幅の永続化 (Issue #337) ---
+  if (version < 7) {
+    if (typeof data.sidebarWidth !== 'number' || !Number.isFinite(data.sidebarWidth)) {
+      data.sidebarWidth = DEFAULT_SETTINGS.sidebarWidth;
+    } else if ((data.sidebarWidth as number) < 100 || (data.sidebarWidth as number) > 1200) {
+      // 異常値 (負/巨大) は default に戻す。runtime clamp は別途 200..600 で行う。
+      data.sidebarWidth = DEFAULT_SETTINGS.sidebarWidth;
+    }
+  }
+
   data.schemaVersion = APP_SETTINGS_SCHEMA_VERSION;
   // 最終マージで欠損フィールドを DEFAULT_SETTINGS で埋める
   return { ...DEFAULT_SETTINGS, ...data } as AppSettings;

--- a/src/renderer/src/lib/use-terminal-clipboard.ts
+++ b/src/renderer/src/lib/use-terminal-clipboard.ts
@@ -2,7 +2,8 @@ import { useEffect, useRef } from 'react';
 import type { MutableRefObject, RefObject } from 'react';
 import type { Terminal } from '@xterm/xterm';
 import { insertPastedImageToPty } from './paste-image-client';
-import { useT } from './i18n';
+import { translate } from './i18n';
+import type { Language } from '../../../types/shared';
 
 /**
  * ターミナルのコピー＆ペースト制御を担当するフック。
@@ -22,16 +23,15 @@ export function useTerminalClipboard(options: {
   containerRef: RefObject<HTMLDivElement>;
   /** 文字列を pty に書き込むコールバック (pty id が無ければ no-op) */
   writeToPty: (text: string) => void | Promise<void>;
+  /** Issue #338: 言語の current を ref 経由で受け取る。
+   *  内部 hook が React Context を直接引くと HMR で Context 分裂時にクラッシュ連鎖するため、
+   *  caller 側で settings.language を ref に詰めて渡す。 */
+  langRef: MutableRefObject<Language>;
 }): void {
-  const { termRef, containerRef, writeToPty } = options;
+  const { termRef, containerRef, writeToPty, langRef } = options;
 
   const writeRef = useRef(writeToPty);
   writeRef.current = writeToPty;
-
-  // Issue #64: エラーラベルの i18n 化。effect の [] deps を保つため、最新 t を ref 経由で参照する。
-  const t = useT();
-  const tRef = useRef(t);
-  tRef.current = t;
 
   useEffect(() => {
     const term = termRef.current;
@@ -45,7 +45,7 @@ export function useTerminalClipboard(options: {
     const handleImageBlob = async (blob: Blob, mime: string): Promise<void> => {
       const res = await insertPastedImageToPty(blob, mime, (text) => writeRef.current(text));
       if (!res.ok) {
-        writeError(tRef.current('terminal.pasteImageFailed'), res.error);
+        writeError(translate(langRef.current, 'terminal.pasteImageFailed'), res.error);
       }
     };
 
@@ -120,7 +120,7 @@ export function useTerminalClipboard(options: {
       if (!blob) return;
 
       void handleImageBlob(blob, imageItem.type).catch((err) => {
-        writeError(tRef.current('terminal.pasteException'), String(err));
+        writeError(translate(langRef.current, 'terminal.pasteException'), String(err));
       });
     };
 

--- a/src/renderer/src/styles/components/shell.css
+++ b/src/renderer/src/styles/components/shell.css
@@ -838,9 +838,9 @@
 }
 
 /* ==================== LAYOUT INTEGRATION ==================== */
-/* Redesign shell は 3 段 x 5 列:
+/* Redesign shell は 3 段 x 6 列 (Issue #337):
  *   row 1: topbar (全幅)
- *   row 2: rail | sidebar | main | resize | panel
+ *   row 2: rail | sidebar | sidebar-handle | main | panel-handle | panel
  *   row 3: status (全幅)
  * 既存 .layout (index.css:102) のカラム定義を上書きする。
  * .layout--terminal-full との両立にも追加ルールで対応。
@@ -851,6 +851,7 @@
   grid-template-columns:
     var(--shell-rail)
     var(--shell-sidebar-w)
+    var(--shell-sidebar-handle)
     minmax(0, 1fr)
     5px
     var(--claude-code-width, 460px);
@@ -867,17 +868,21 @@
   grid-row: 2;
   grid-column: 2;
 }
-.layout.layout--redesign > .main {
+.layout.layout--redesign > .resize-handle--sidebar {
   grid-row: 2;
   grid-column: 3;
 }
-.layout.layout--redesign > .resize-handle {
+.layout.layout--redesign > .main {
   grid-row: 2;
   grid-column: 4;
 }
-.layout.layout--redesign > .claude-code-panel {
+.layout.layout--redesign > .resize-handle:not(.resize-handle--sidebar) {
   grid-row: 2;
   grid-column: 5;
+}
+.layout.layout--redesign > .claude-code-panel {
+  grid-row: 2;
+  grid-column: 6;
 }
 .layout.layout--redesign > .status {
   grid-row: 3;
@@ -889,16 +894,18 @@
   grid-template-columns:
     var(--shell-rail)
     var(--shell-sidebar-w)
+    var(--shell-sidebar-handle)
     0
     0
     minmax(0, 1fr);
 }
 
-/* Sidebar 折り畳み: column 2 を 0 幅にして main / panel を広げる。
+/* Sidebar 折り畳み: column 2 / 3 を 0 幅にして main / panel を広げる。
    .sidebar 自体は visibility:hidden で要素ライフサイクルを保ちつつ非表示にする。 */
 .layout.layout--redesign.layout--sidebar-collapsed {
   grid-template-columns:
     var(--shell-rail)
+    0
     0
     minmax(0, 1fr)
     5px
@@ -910,9 +917,14 @@
     0
     0
     0
+    0
     minmax(0, 1fr);
 }
 .layout.layout--redesign.layout--sidebar-collapsed > .sidebar {
+  visibility: hidden;
+  pointer-events: none;
+}
+.layout.layout--redesign.layout--sidebar-collapsed > .resize-handle--sidebar {
   visibility: hidden;
   pointer-events: none;
 }
@@ -923,6 +935,7 @@
     grid-template-columns:
       0
       var(--shell-sidebar-w)
+      var(--shell-sidebar-handle)
       minmax(0, 1fr)
       5px
       var(--claude-code-width, 460px);
@@ -934,6 +947,7 @@
     grid-template-columns:
       0
       var(--shell-sidebar-w)
+      var(--shell-sidebar-handle)
       0
       0
       minmax(0, 1fr);

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -73,6 +73,8 @@
   --toolbar-h: 40px;
   --shell-sidebar-w: 272px;
   --shell-sidebar-min: 248px;
+  /* Issue #337: サイドバーと main の間のリサイズハンドル幅 */
+  --shell-sidebar-handle: 5px;
   --shell-panel-w: var(--claude-code-width, 460px);
   --shell-panel-min: 320px;
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -13,7 +13,7 @@ export type Density = 'compact' | 'normal' | 'comfortable';
 export type Language = 'ja' | 'en';
 
 /** Issue #75: AppSettings の現在スキーマ。破壊変更時に上げる。 */
-export const APP_SETTINGS_SCHEMA_VERSION = 6;
+export const APP_SETTINGS_SCHEMA_VERSION = 7;
 
 /**
  * ユーザーが自由に追加できるエージェントの設定。
@@ -73,6 +73,11 @@ export interface AppSettings {
   workspaceFolders: string[];
   /** 右側 Claude Code パネルの幅 (px) */
   claudeCodePanelWidth: number;
+  /**
+   * Issue #337: 左サイドバーの幅 (px)。ドラッグハンドルでリサイズ可能。
+   * default 272, min 200, max 600。異常値は migrate / runtime clamp で 272 にリセット。
+   */
+  sidebarWidth: number;
   // ---------- Codex ----------
   codexCommand: string;
   codexArgs: string;
@@ -162,6 +167,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   recentProjects: [],
   workspaceFolders: [],
   claudeCodePanelWidth: 460,
+  sidebarWidth: 272,
   codexCommand: 'codex',
   codexArgs: '',
   notepad: '',


### PR DESCRIPTION
## Summary

直交する 6 件の planned issue を 1 PR / 1 commit per issue でバンドル修正。

- **#336** refactor(rust): dead_code warning 4 件を掃除
  TeamMcpMember に `#[allow(dead_code)]`、SessionRegistry の insert/len 削除、HubState.pending_injects 削除、TeamInfo.id 削除
- **#341** fix(canvas): チーム起動 leader に settings の起動引数が反映されない
  `payload.args` が空配列で永続化された場合に settings 由来の args が潰れないようガード (`?? args` だと `[]` でも truthy 扱いで args が無視される問題への防御)
- **#338** fix(hmr): TerminalView の Rendered fewer hooks (HMR Context 分裂)
  settings-context を globalThis singleton 化 + `import.meta.hot.accept` の self-handler、use-terminal-clipboard を `langRef` + `translate(lang, key)` で Context 非依存化
- **#339** fix(team-hub): 空 handshake (team="" role="unknown") で 0.8s 再接続ループ
  bridge.js の env 検証を 5 つ全項目に拡張 (VIBE_TEAM_ROLE 既定値 'unknown' 撤廃)、retryCount リセット位置を TCP 接続成功時 → socket data 初回受信時へ移動
- **#340** fix(team-hub): Leader が 5 分ごとに idle drop されるのを keepalive で防止
  protocol.rs に `team-hub/keepalive` notification (None 応答) を追加、bridge.js に 90 秒間隔の keepalive timer
- **#337** feat(shell): サイドバー幅をドラッグでリサイズ可能にして永続化
  AppSettings.sidebarWidth (default 272 / clamp 200-600) を追加し schemaVersion 6→7、shell.css の grid を 5 列 → 6 列 (sidebar-handle を間に挿入) に拡張

## 除外 issue

- **#342** vibe-team MCP: ワーカー応答が Leader に届かない + 再採用時 recruit timeout
  `fortress-review-required` (Tier A、設計レビュー必須) かつ routing 経路の特定調査が必要なため、本バンドルから除外。別 PR で対応予定。

- **#343** Canvas モードで claude-dark / dark / light テーマの xterm 文字色が背景と同化して視認できない (PR #334 後)
  作業中に dev で発見した別系統のバグ。本 PR の commit には含まず、Issue として登録のみ (本 PR に対する regression ではなく PR #334 起因の可能性)。

## Test plan

- [x] `npm run typecheck` 通過
- [x] `cargo check --lib` 通過 (warning 0)
- [x] `npm run dev` で IDE / Canvas 両モードを起動し動作確認
- [ ] サイドバー境界をドラッグして 200-600px でクランプ動作 / 設定永続化 / ダブルクリックでリセット
- [ ] Canvas モード「チーム起動」でリーダーターミナルに `settings.claudeArgs` が反映される
- [ ] HMR (TerminalView や i18n.ts を編集) でターミナルが落ちない
- [ ] `vibe-team` MCP 起動後 10 分以上アイドルでも `dropping idle client` が出ない
- [ ] 空 env で起動した bridge が `missing env:` を出して 0.8s ループしない

🤖 Generated with [Claude Code](https://claude.com/claude-code)