### PR TITLE
fix(canvas): Canvas の xterm 文字色を修正

### DIFF
--- a/src/renderer/src/lib/__tests__/xterm-theme.test.ts
+++ b/src/renderer/src/lib/__tests__/xterm-theme.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { buildXtermTheme } from '../xterm-theme';
+import { THEMES } from '../themes';
+
+describe('buildXtermTheme', () => {
+  it('既定では WebGL 向けに背景を透過する', () => {
+    expect(buildXtermTheme('claude-dark').background).toBe('rgba(0, 0, 0, 0)');
+    expect(buildXtermTheme('dark').background).toBe('rgba(0, 0, 0, 0)');
+    expect(buildXtermTheme('light').background).toBe('rgba(0, 0, 0, 0)');
+  });
+
+  it('DOM renderer 向けには非 glass テーマの実背景色を渡せる', () => {
+    expect(buildXtermTheme('claude-dark', { transparentBackground: false }).background)
+      .toBe(THEMES['claude-dark'].bg);
+    expect(buildXtermTheme('dark', { transparentBackground: false }).background)
+      .toBe(THEMES.dark.bg);
+    expect(buildXtermTheme('light', { transparentBackground: false }).background)
+      .toBe(THEMES.light.bg);
+  });
+
+  it('glass は DOM renderer 向けでも透過背景を維持する', () => {
+    expect(buildXtermTheme('glass', { transparentBackground: false }).background)
+      .toBe('rgba(0, 0, 0, 0)');
+  });
+
+  it('foreground はテーマの text 色に揃える', () => {
+    expect(buildXtermTheme('claude-dark').foreground).toBe(THEMES['claude-dark'].text);
+    expect(buildXtermTheme('light').foreground).toBe(THEMES.light.text);
+  });
+});

--- a/src/renderer/src/lib/use-xterm-instance.ts
+++ b/src/renderer/src/lib/use-xterm-instance.ts
@@ -32,6 +32,11 @@ function wheelEventToLineDelta(event: WheelEvent, rows: number): number {
   return event.deltaY / WHEEL_PIXEL_PER_LINE;
 }
 
+function shouldUseTransparentXtermBackground(theme: AppSettings['theme'], disableWebgl: boolean): boolean {
+  // WebGL は Issue #333 回避のため透過必須。glass は DOM renderer でも透過を維持する。
+  return !disableWebgl || theme === 'glass';
+}
+
 /*
  * Issue #126: Chromium の active WebGL context 上限は通常 16 (実装依存だが Tauri/WebView2
  * でも同等)。MAX_TERMINALS=30 のうち 16 個目以降の WebGL 作成が成功しても、新しい context
@@ -142,8 +147,8 @@ export function useXtermInstance(
       letterSpacing: 0,
       cursorBlink: true,
       allowProposedApi: true,
-      // glass テーマで xterm キャンバスを透過させるために必要 (Issue #89)。
-      // 他テーマでも不透明色を渡しているので挙動は変わらない。
+      // glass テーマと WebGL 経路で xterm 背景を透過させるために必要 (Issue #89/#333)。
+      // Canvas の DOM renderer では非 glass テーマのみ実背景色を渡し、文字色の同化を避ける (#343)。
       allowTransparency: true,
       // Block Elements (U+2580-U+259F) と Box Drawing (U+2500-U+257F) を
       // フォントから取らず WebGL/Canvas renderer 内蔵のベクター描画でラスタライズする。
@@ -156,7 +161,9 @@ export function useXtermInstance(
       // CJK や全角記号など、セル幅を超える glyph をセル内に縮小して描画する。
       // ASCII art に CJK が混じった場合の桁ズレを防ぐ。
       rescaleOverlappingGlyphs: true,
-      theme: buildXtermTheme(initial.theme),
+      theme: buildXtermTheme(initial.theme, {
+        transparentBackground: shouldUseTransparentXtermBackground(initial.theme, disableWebgl)
+      }),
       scrollback: SCROLLBACK_LINES,
       convertEol: false
     });
@@ -266,7 +273,9 @@ export function useXtermInstance(
       settings.terminalFontFamily || settings.editorFontFamily
     );
     term.options.fontSize = settings.terminalFontSize;
-    term.options.theme = buildXtermTheme(settings.theme);
+    term.options.theme = buildXtermTheme(settings.theme, {
+      transparentBackground: shouldUseTransparentXtermBackground(settings.theme, disableWebgl)
+    });
     // Issue #123: WebGL renderer はグリフをテクスチャアトラスにキャッシュするため、
     // fontFamily/fontSize を切り替えても古いフォントの glyph が描画され続けることがある。
     // clearTextureAtlas() で強制的にアトラスを破棄して新フォントで再ラスタライズさせる。
@@ -288,7 +297,13 @@ export function useXtermInstance(
         // fit は container 不在 / Terminal dispose 直後で例外を投げ得る (無視で安全)
       }
     });
-  }, [settings.theme, settings.terminalFontFamily, settings.editorFontFamily, settings.terminalFontSize]);
+  }, [
+    settings.theme,
+    settings.terminalFontFamily,
+    settings.editorFontFamily,
+    settings.terminalFontSize,
+    disableWebgl
+  ]);
 
   return { containerRef, termRef, fitRef };
 }

--- a/src/renderer/src/lib/xterm-theme.ts
+++ b/src/renderer/src/lib/xterm-theme.ts
@@ -2,23 +2,39 @@ import type { ITheme } from '@xterm/xterm';
 import type { ThemeName } from '../../../types/shared';
 import { THEMES } from './themes';
 
+interface BuildXtermThemeOptions {
+  /**
+   * true のとき xterm 側の背景を透過し、CSS 側の `.xterm-viewport`
+   * 背景に委譲する。WebGL renderer では Issue #333 の回避に必要。
+   */
+  transparentBackground?: boolean;
+}
+
 /**
  * アプリのテーマ名から xterm.js 用の `ITheme` を構築する。
  * 既存テーマにフォールバック (`dark`) を入れて undefined を返さないようにする。
  * 'light' テーマのみ選択色を明るい青にする (他は VS Code 風の濃紺)。
  *
- * 背景色は **全テーマで透過** (`rgba(0,0,0,0)`) を渡し、見た目の背景は
- * `.xterm-viewport` 側の CSS `background-color: var(--bg)` が担う (Issue #333)。
+ * WebGL renderer では背景色を透過 (`rgba(0,0,0,0)`) にして、見た目の背景は
+ * `.xterm-viewport` 側の CSS `background-color: var(--bg)` に委譲する (Issue #333)。
  * glass テーマで導入した `allowTransparency: true` (Issue #89) は常時 ON で、
  * xterm v6 の WebGL renderer は `allowTransparency: true` + opaque
  * `theme.background` の組み合わせで cell background fill が glyph layer に被さって
  * 文字が見えなくなる経路がある (Chromium / GPU 依存)。glass 以外のテーマで
- * 文字が消える #333 の症状は、xterm 側の bg を常に透過にして CSS に背景を
- * 委譲することで根本的に解消する (glass と同じ描画経路に統一)。
+ * 文字が消える #333 の症状は、WebGL 経路の xterm 側 bg を透過にして CSS に背景を
+ * 委譲することで根本的に解消する。
+ *
+ * 一方、Canvas モードは `disableWebgl=true` で DOM renderer を使う。DOM renderer では
+ * transparent bg + CSS bg の組み合わせで foreground が背景に同化する経路があるため、
+ * Issue #343 では非 glass テーマのみ xterm 側にも実背景色を渡す。
  */
-export function buildXtermTheme(themeName: ThemeName): ITheme {
+export function buildXtermTheme(
+  themeName: ThemeName,
+  options: BuildXtermThemeOptions = {}
+): ITheme {
   const themeVars = THEMES[themeName] ?? THEMES.dark;
   const isLight = themeName === 'light';
+  const transparentBackground = options.transparentBackground ?? true;
   /*
    * ANSI パレット (yellow/red 系) を xterm デフォルトの彩度高めの値から
    * 目に優しいパステル調へ上書き。デフォルトの yellow (#e5e510) は
@@ -27,7 +43,7 @@ export function buildXtermTheme(themeName: ThemeName): ITheme {
    */
   const isLightSurface = isLight;
   return {
-    background: 'rgba(0, 0, 0, 0)',
+    background: transparentBackground ? 'rgba(0, 0, 0, 0)' : themeVars.bg,
     foreground: themeVars.text,
     cursor: themeVars.text,
     cursorAccent: themeVars.bg,


### PR DESCRIPTION
## Summary
- Canvas の DOM renderer では非 glass テーマの xterm 背景に実テーマ背景色を渡すように変更
- IDE/WebGL 経路では Issue #333 対策の transparent background を維持
- `buildXtermTheme()` の背景モードをテストで固定

Closes #343

## Test plan
- [x] `npm run typecheck`
- [x] `npm test -- xterm-theme`
- [x] `git diff --check`
- [ ] `npm test` 全体: 77 tests passed だが、既存の jsdom 環境エラー (`HTMLCanvasElement.prototype.getContext` / `window.api.app.setZoomLevel`) が未処理エラーとして検出され終了コード 1
- [ ] 手動確認: `npm run dev` で Canvas の Claude/Codex 表示確認
