### PR TITLE
fix(canvas): #349 Canvas xterm の日本語文字の見た目を安定化

### DIFF
--- a/src/renderer/src/lib/use-xterm-instance.ts
+++ b/src/renderer/src/lib/use-xterm-instance.ts
@@ -62,6 +62,18 @@ const BOX_DRAWING_FALLBACKS = [
 ] as const;
 
 /**
+ * Issue #349: 日本語 (CJK) glyph を確実に持つ Windows OS フォント。ユーザー設定 fontFamily
+ * の chain (BoxDrawing fallback の後ろ、generic `monospace` の直前) に注入することで、
+ * 既定フォント `JetBrainsMono Nerd Font Mono` (latin-only webfont) や類似の CJK 非対応
+ * primary フォントを使っているときも、日本語が常に同じ Windows OS フォントから拾われ、
+ * Canvas 内 xterm DOM renderer の見た目が安定する (browser の monospace 降格に依らない)。
+ *
+ * 順序は `Yu Gothic UI` → `Meiryo` → `MS Gothic` の優先度で、Windows 10/11 のいずれかに
+ * 必ずどれかが存在するように冗長化している。
+ */
+const CJK_FALLBACKS = ["'Yu Gothic UI'", 'Meiryo', "'MS Gothic'"] as const;
+
+/**
  * ユーザー設定の fontFamily に、罫線/濃淡 glyph を確実に持つ Windows OS フォントを
  * fallback として注入する。
  *
@@ -94,6 +106,48 @@ function ensureBoxDrawingFallbacks(family: string): string {
     return `${m[1]}, ${missing.join(', ')}${m[2]}`;
   }
   return `${trimmed}, ${missing.join(', ')}, monospace`;
+}
+
+/**
+ * Issue #349: ユーザー設定の fontFamily に、日本語 (CJK) glyph を確実に持つ Windows OS
+ * フォントを fallback として注入する。
+ *
+ * 背景:
+ *   v1.4.x で既定 fontFamily を `JetBrainsMono Nerd Font Mono` (本体同梱、latin-only
+ *   webfont) に切り替えた (Issue #346 / PR #347)。Nerd Font の patched glyph には
+ *   ASCII + Powerline/Devicons は含まれるが、CJK Unified Ideographs (U+4E00-U+9FFF) や
+ *   Hiragana/Katakana は含まれない。chain に明示的な日本語フォントが無いと、Chromium の
+ *   monospace 降格が選ぶ OS フォントが環境依存で、Canvas 内 xterm の DOM renderer で
+ *   日本語が「少しずつ違う glyph」で描画される (見た目が崩れる)。
+ *
+ *   ここで `Yu Gothic UI` / `Meiryo` / `MS Gothic` を BoxDrawing fallback の後ろ、
+ *   generic `monospace` の直前に注入することで、Windows 環境で常に同じ glyph が拾われ
+ *   見た目を安定させる。primary font は preserve するので、ASCII / 罫線の見た目は変わらない
+ *   (CJK の範囲だけ後段の fallback が拾う)。既に chain に含まれているフォントは
+ *   重複追加しない (case-insensitive)。
+ */
+function ensureCjkFallbacks(family: string): string {
+  const trimmed = family.trim().replace(/,\s*$/, '');
+  if (!trimmed) return trimmed;
+  const lower = trimmed.toLowerCase();
+  const missing = CJK_FALLBACKS.filter((fb) => {
+    const name = fb.replace(/['"]/g, '').toLowerCase();
+    return !lower.includes(name);
+  });
+  if (missing.length === 0) return family;
+  const m = trimmed.match(/^(.*?)(\s*,\s*monospace\s*)$/i);
+  if (m) {
+    return `${m[1]}, ${missing.join(', ')}${m[2]}`;
+  }
+  return `${trimmed}, ${missing.join(', ')}, monospace`;
+}
+
+/**
+ * Issue #349: 安全のため必ず BoxDrawing → CJK の順で fallback を積む共通入口。
+ * 順序は Latin/罫線 (ASCII の見た目を崩さないよう前) → CJK → generic `monospace`。
+ */
+function applySafetyFallbacks(family: string): string {
+  return ensureCjkFallbacks(ensureBoxDrawingFallbacks(family));
 }
 
 /**
@@ -135,9 +189,11 @@ export function useXtermInstance(
     const initial = initialSettingsRef.current;
     const term = new Terminal({
       // ターミナル専用フォントを優先、未設定なら editor フォントに fallback。
-      // ensureBoxDrawingFallbacks: Canvas モードの DOM renderer で罫線/濃淡が崩れないよう
-      // 設定値に Cascadia Mono / Consolas / Lucida Console / Segoe UI Symbol を必ず含める。
-      fontFamily: ensureBoxDrawingFallbacks(initial.terminalFontFamily || initial.editorFontFamily),
+      // applySafetyFallbacks (Issue #261 + #349): Canvas モードの DOM renderer で罫線/濃淡が
+      // 崩れないよう Cascadia Mono / Consolas / Lucida Console / Segoe UI Symbol を、
+      // 日本語 glyph の見た目を安定させるため Yu Gothic UI / Meiryo / MS Gothic を
+      // 設定値に必ず含める (順序: BoxDrawing → CJK → monospace)。
+      fontFamily: applySafetyFallbacks(initial.terminalFontFamily || initial.editorFontFamily),
       fontSize: initial.terminalFontSize,
       // 選択座標ズレ対策: lineHeight=1.2 × fontSize=13 → cellHeight=15.6 (非整数) だと
       // xterm v6 の selection 矩形計算で行方向にサブピクセル誤差が積もり、ドラッグ選択
@@ -269,7 +325,7 @@ export function useXtermInstance(
   useEffect(() => {
     const term = termRef.current;
     if (!term) return;
-    term.options.fontFamily = ensureBoxDrawingFallbacks(
+    term.options.fontFamily = applySafetyFallbacks(
       settings.terminalFontFamily || settings.editorFontFamily
     );
     term.options.fontSize = settings.terminalFontSize;

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -73,19 +73,24 @@
 .react-flow__node {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  text-rendering: geometricPrecision;
+  /* Issue #349: geometricPrecision は CJK fallback の hinting を無視して
+     サブピクセル境界に乗せるため、日本語 glyph の縦位置がズレて見える。
+     auto に戻して Chromium 既定 (optimizeSpeed/Legibility 自動切替) に任せる。 */
+  text-rendering: auto;
 }
 
 /* Canvas 内の xterm DOM テキストを Chromium 任せに毎フレーム再ラスタさせる。
-   font-smoothing / text-rendering を明示しないと親 .react-flow__node の値が
-   行末の cursor 行など個別に上書きされていることがあるので、ここで揃える。
-   span 単位で当てると全文字にマッチして CSS コストが嵩むうえ、xterm が将来
-   cursor 等で transform を使ったときに壊れるので、構造要素にのみ適用する。 */
+   font-smoothing を明示しないと親 .react-flow__node の値が行末の cursor 行など
+   個別に上書きされていることがあるので、ここで揃える。span 単位で当てると
+   全文字にマッチして CSS コストが嵩むうえ、xterm が将来 cursor 等で transform
+   を使ったときに壊れるので、構造要素にのみ適用する。
+   Issue #349: text-rendering は geometricPrecision から auto に戻し、CJK
+   fallback フォントのサブピクセル描画ズレを緩和する。 */
 .react-flow__node .xterm,
 .react-flow__node .xterm-rows {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  text-rendering: geometricPrecision;
+  text-rendering: auto;
 }
 
 .react-flow__node img,

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -251,10 +251,21 @@ code,
 pre,
 kbd,
 samp,
-.terminal-view,
-.xterm,
 .monaco-editor {
   font-feature-settings: "kern", "liga", "calt", "tnum", "zero";
+  font-variant-numeric: tabular-nums slashed-zero;
+}
+
+/* Issue #349: xterm スコープでは ligatures / kerning / calt を切る。
+ * Canvas DOM renderer の CJK fallback フォントは GSUB / kern を持たないか壊れて
+ * いるケースがあり、ASCII 用に効かせた "kern" / "liga" / "calt" が日本語 glyph の
+ * 字幅・縦位置に微妙なズレを起こしていた。tnum / zero (slashed) は数字列の桁
+ * 揃え用なので維持し、それ以外は no-op に倒して fallback を素直に描画させる。 */
+.terminal-view,
+.xterm {
+  font-kerning: none;
+  font-variant-ligatures: none;
+  font-feature-settings: "tnum", "zero";
   font-variant-numeric: tabular-nums slashed-zero;
 }
 


### PR DESCRIPTION
## Summary
- xterm スコープの `font-kerning` / `font-variant-ligatures` / `font-feature-settings` を CJK fallback に優しい設定 (kern/liga/calt OFF, tnum/zero のみ) に絞り、日本語 glyph の字幅・縦位置のズレを抑える。Monaco / 他 UI には波及しない。
- Canvas (`.react-flow__node` 配下) の xterm の `text-rendering` を `geometricPrecision` → `auto` に戻し、CJK fallback フォントのサブピクセル縦位置ズレを緩和。
- `use-xterm-instance.ts` に `CJK_FALLBACKS` (Yu Gothic UI / Meiryo / MS Gothic) と `ensureCjkFallbacks` helper を追加。`BoxDrawing fallback → CJK fallback → monospace` の順で注入する `applySafetyFallbacks` を初期化時とリアクティブ effect の両方に適用。既定 `JetBrainsMono Nerd Font Mono` (latin-only) でも Windows 環境で常に同じ日本語フォントから glyph を拾うようにする。

Closes #349

## Scope (確認済み)
- 変更: `tokens.css` / `canvas.css` / `use-xterm-instance.ts` のみ
- 不変: `shared.ts` / Rust / 設定 UI / DEFAULT_SETTINGS / TERMINAL_FONT_PRESETS / Monaco / 他テーマ
- 既存 Issue (#126 / #123 / #261 / #272 / #333 / #343 / #346) の修正コードには手を入れていない
- xterm の primary font (ユーザー設定) は preserve、ASCII / 罫線 / Powerline glyph の見た目は不変

## Test plan
- [x] `npm run typecheck` pass
- [ ] Canvas モードで Claude Code / Codex / Terminal カードを開き、`こんにちは` / `こんにちは | ABC 123` / `─━█▀▄▌▐` / Powerline prompt を表示して輪郭・字幅・縦位置がシャープか確認
- [ ] IDE モードのターミナルでも従来通り表示されるか確認
- [ ] Canvas zoom 90% / 100% / 125% でも崩れないか確認
- [ ] DevTools で `.xterm-rows` の computed `font-family` に Yu Gothic UI / Meiryo / MS Gothic が末尾に含まれていることを確認