### PR TITLE
fix(team_hub): #342 [Phase 1/3] recruit を ack 駆動化し失敗を即時返す

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -543,6 +543,81 @@ pub async fn app_cancel_recruit(
     Ok(())
 }
 
+/// Issue #342 Phase 1: renderer から `team:recruit-request` を受領 / spawn 結果を通知するための ack 経路。
+///
+/// renderer が `team:recruit-request` event を受けて addCard / spawn を開始した時点で
+/// `ok=true` を打つ。spawn 失敗 / requester 不在等で起動できなかった場合は `ok=false`
+/// + `phase` (`spawn` / `engine_binary_missing` / `instructions_load` / `requester_not_found`)
+/// + 任意 `reason` を打つ。
+///
+/// 設計原則:
+///   - **flat 引数**: 既存 `app_cancel_recruit(agent_id)` の流儀に揃える (renderer 側合意)
+///   - **ack の意味は受領通知のみ**: `ok=true` でも MCP `team_recruit` の戻り値はまだ成功にしない。
+///     真の成功判定は handshake 経路 (`resolve_pending_recruit`) のみ。renderer 信頼境界違反で
+///     偽 `ok=true` を打たれても MCP caller は騙されない。
+///   - **入力サニタイズ (Reviewer D Critical 反映)**:
+///       - `phase` は enum ホワイトリスト 4 値に制限 (任意文字列を log injection に使われないように)
+///       - `reason` は 256 byte 上限で truncate (DoS 抑止)
+///   - **認可ガード**: pending 不在 / team_id 不一致 / 重複 ack はすべて Hub 側で no-op + warn ログ。
+///     呼び出し側 (renderer) には `Ok(())` を返してエラー観測点を作らない (偽装試行を区別不能にする)。
+#[tauri::command]
+pub async fn app_recruit_ack(
+    state: State<'_, AppState>,
+    new_agent_id: String,
+    team_id: String,
+    ok: bool,
+    reason: Option<String>,
+    phase: Option<String>,
+) -> Result<(), String> {
+    use crate::team_hub::error::AckFailPhase;
+    use crate::team_hub::RecruitAckOutcome;
+
+    /// renderer 側 reason 文字列の最大長 (UTF-8 byte 数)。これを超えたら byte 単位で切り詰める。
+    /// 文字境界をまたぐと char_indices で見つかる手前位置に丸める。
+    const MAX_REASON_BYTES: usize = 256;
+
+    fn truncate_reason(s: String) -> String {
+        if s.len() <= MAX_REASON_BYTES {
+            return s;
+        }
+        // UTF-8 boundary を尊重して切り詰め
+        let mut cut = MAX_REASON_BYTES;
+        while cut > 0 && !s.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        let mut out = s;
+        out.truncate(cut);
+        out
+    }
+
+    // phase 文字列を enum に正規化。未知値は ok=false 時のみ問題なので、
+    // None に丸めて後続ロジックは「不明な失敗」として扱う。
+    let phase_enum = phase.as_deref().and_then(AckFailPhase::from_str);
+    if !ok && phase.is_some() && phase_enum.is_none() {
+        tracing::warn!(
+            "[teamhub] recruit_ack rejected unknown phase value: {:?} (agent={new_agent_id})",
+            phase
+        );
+        // 未知 phase は無視せず、no-op で握り潰す代わりに pending を cancel して
+        // ユーザーをロックさせない (この経路は renderer のバグか改ざんなので cancel が安全側)
+        state.team_hub.cancel_pending_recruit(&new_agent_id).await;
+        return Ok(());
+    }
+
+    let outcome = RecruitAckOutcome {
+        ok,
+        reason: reason.map(truncate_reason),
+        phase: phase_enum,
+    };
+
+    // 認可ガードは Hub 側で完結。エラーは呼び出し元には返さず、内部診断ログのみ。
+    let _ = state
+        .team_hub
+        .resolve_recruit_ack(&new_agent_id, &team_id, outcome)
+        .await;
+    Ok(())
+}
+
 #[tauri::command]
 pub fn app_get_user_info(app: tauri::AppHandle) -> AppUserInfo {
     tracing::info!("[IPC] app_get_user_info called");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,6 +81,7 @@ pub fn run() {
             commands::app::app_get_team_hub_info,
             commands::app::app_set_role_profile_summary,
             commands::app::app_cancel_recruit,
+            commands::app::app_recruit_ack,
             commands::app::app_get_user_info,
             commands::app::app_open_external,
             commands::app::app_reveal_in_file_manager,

--- a/src-tauri/src/team_hub/error.rs
+++ b/src-tauri/src/team_hub/error.rs
@@ -1,0 +1,96 @@
+// Issue #342 Phase 1: 構造化エラー型 (recruit ack 駆動)。
+//
+// MCP の `team_recruit` 失敗を呼び出し側 (renderer / Claude / Codex) が `code` で機械的に
+// 分岐できるように、`result.content[0].text` の JSON 文字列内に詰める形で返す。
+// Phase 3 では `DismissError` / `SendError` / `AssignError` をここに追加する想定。
+
+use serde::Serialize;
+
+/// `team_recruit` 失敗時に MCP 戻り値へ詰める構造化エラー。
+///
+/// シリアライズ後の例:
+/// ```json
+/// {"code":"recruit_ack_timeout","message":"...","phase":"ack","elapsed_ms":5012}
+/// ```
+#[derive(Clone, Debug, Serialize)]
+pub struct RecruitError {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elapsed_ms: Option<u64>,
+}
+
+impl std::fmt::Display for RecruitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl RecruitError {
+    /// JSON 文字列化して `Err(String)` に詰めるヘルパ。
+    /// to_string() に失敗したら message だけを返す (生 String fallback)。
+    pub fn into_err_string(self) -> String {
+        match serde_json::to_string(&self) {
+            Ok(s) => s,
+            Err(_) => self.message,
+        }
+    }
+}
+
+/// `app_recruit_ack` invoke で renderer から渡される失敗 phase。
+///
+/// 任意文字列を受けると log injection / 偽装の余地が出るので、enum で受け側が固定する。
+/// renderer 側の文字列 `phase` を `from_str` でこの enum に正規化し、未知値は弾く。
+#[derive(Clone, Copy, Debug)]
+pub enum AckFailPhase {
+    Spawn,
+    EngineBinaryMissing,
+    InstructionsLoad,
+    RequesterNotFound,
+}
+
+impl AckFailPhase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Spawn => "spawn",
+            Self::EngineBinaryMissing => "engine_binary_missing",
+            Self::InstructionsLoad => "instructions_load",
+            Self::RequesterNotFound => "requester_not_found",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "spawn" => Some(Self::Spawn),
+            "engine_binary_missing" => Some(Self::EngineBinaryMissing),
+            "instructions_load" => Some(Self::InstructionsLoad),
+            "requester_not_found" => Some(Self::RequesterNotFound),
+            _ => None,
+        }
+    }
+}
+
+/// `resolve_recruit_ack` の失敗種別 (内部診断用)。
+/// renderer 信頼境界違反 / 競合 ack のいずれも MCP caller に対しては no-op + warn ログで吸収するため、
+/// このエラーは Tauri command 層では握り潰されてログにだけ出す。
+#[derive(Debug)]
+pub enum AckError {
+    /// `pending_recruits` に該当 agent_id が無い (cancel 後 / 偽装)
+    NotFound,
+    /// pending の team_id と expected_team_id が一致しない (cross-team 偽 cancel 試行)
+    TeamMismatch,
+    /// 既に ack 済み (重複呼び出し)
+    AlreadyAcked,
+}
+
+impl std::fmt::Display for AckError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "no pending recruit for agent_id"),
+            Self::TeamMismatch => write!(f, "team_id mismatch with pending recruit"),
+            Self::AlreadyAcked => write!(f, "recruit already acked"),
+        }
+    }
+}

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -9,16 +9,19 @@
 // - team_send 等のツール呼び出しを PTY に直接 write 注入する (64B / 15ms)
 
 pub mod bridge;
+pub mod error;
 pub mod inject;
 pub mod protocol;
 
 use crate::pty::SessionRegistry;
+use crate::team_hub::error::{AckError, AckFailPhase};
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
 #[cfg(unix)]
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
@@ -188,10 +191,45 @@ pub struct RecruitOutcome {
 
 /// pending_recruits の値。team_id と role を保持して、並行 recruit でも整合性のある
 /// 人数 / singleton 判定ができるようにする (Issue #122)。
+///
+/// Issue #342 Phase 1: ack 駆動への移行に伴い、以下を追加:
+/// - `requester_agent_id`: ack 認可ガード時の診断ログ用 (誰の recruit が落ちたか追跡可能にする)
+/// - `ack_tx`: renderer の `app_recruit_ack` invoke を待つための oneshot。受領通知のみで
+///   handshake 完了は別経路 (`tx`) で待つ。
+/// - `ack_done`: 重複 ack を弾くための AtomicBool。renderer のバグや競合で 2 回 ack が来ても
+///   2 回目以降は no-op になる。
 pub struct PendingRecruit {
     pub team_id: String,
     pub role_profile_id: String,
+    pub requester_agent_id: String,
     pub tx: oneshot::Sender<RecruitOutcome>,
+    pub ack_tx: Option<oneshot::Sender<RecruitAckOutcome>>,
+    pub ack_done: AtomicBool,
+}
+
+/// Issue #342 Phase 1: renderer から `app_recruit_ack` で渡される受領通知 outcome。
+///
+/// `ok=true` は「renderer が `team:recruit-request` を受け取って addCard / spawn を開始した」
+/// という受領通知のみ。**handshake 完了ではない**。真の成功判定は既存の
+/// `resolve_pending_recruit` (handshake 経由) で行う。
+///
+/// `ok=false` の場合は `phase` に失敗種別 (spawn / engine_binary_missing / 等) が入り、
+/// `reason` に追加情報 (任意の文字列、長さ 256 byte 上限) が入る。
+#[derive(Clone, Debug)]
+pub struct RecruitAckOutcome {
+    pub ok: bool,
+    pub reason: Option<String>,
+    pub phase: Option<AckFailPhase>,
+}
+
+/// Issue #342 Phase 1: `try_register_pending_recruit` が返す 2 系統の Receiver。
+///
+/// - `ack`: renderer から `app_recruit_ack` invoke が来たら resolve される短期 (5s) 待機用
+/// - `handshake`: spawn された agent が socket / pipe で handshake を済ませると resolve される
+///   長期 (30s) 待機用 (既存 `resolve_pending_recruit` 経路)
+pub struct PendingRecruitChannels {
+    pub handshake: oneshot::Receiver<RecruitOutcome>,
+    pub ack: oneshot::Receiver<RecruitAckOutcome>,
 }
 
 #[derive(Default, Clone)]
@@ -322,11 +360,13 @@ impl TeamHub {
         agent_id: String,
         team_id: String,
         role_profile_id: String,
+        requester_agent_id: String,
         is_singleton: bool,
         current_members: &[(String, String)],
         max_members: usize,
-    ) -> Result<oneshot::Receiver<RecruitOutcome>, String> {
+    ) -> Result<PendingRecruitChannels, String> {
         let (tx, rx) = oneshot::channel();
+        let (ack_tx, ack_rx) = oneshot::channel();
         let mut s = self.state.lock().await;
         // 同 team_id に属する pending を列挙
         let pending_for_team: Vec<&PendingRecruit> = s
@@ -358,10 +398,16 @@ impl TeamHub {
             PendingRecruit {
                 team_id,
                 role_profile_id,
+                requester_agent_id,
                 tx,
+                ack_tx: Some(ack_tx),
+                ack_done: AtomicBool::new(false),
             },
         );
-        Ok(rx)
+        Ok(PendingRecruitChannels {
+            handshake: rx,
+            ack: ack_rx,
+        })
     }
 
     /// handshake 内で agent_id がマッチしたら呼ぶ。recruit が待機中ならここで resolve。
@@ -411,6 +457,62 @@ impl TeamHub {
     pub async fn cancel_pending_recruit(&self, agent_id: &str) {
         let mut s = self.state.lock().await;
         s.pending_recruits.remove(agent_id);
+    }
+
+    /// Issue #342 Phase 1: renderer 側 `app_recruit_ack` invoke の核ロジック。
+    ///
+    /// 認可ガード (3 重防御):
+    ///   1. **pending エントリ存在確認**: `pending_recruits.get(agent_id)` が None なら no-op + warn
+    ///   2. **team_id 一致確認**: pending の `team_id != expected_team_id` なら no-op + warn
+    ///      (cross-team から偽の cancel を仕込めないようにする)
+    ///   3. **重複 ack 弾き**: `ack_done.compare_exchange(false, true, ...)` で 2 回目以降を no-op 化
+    ///
+    /// `ok=true` を受け取っても **MCP `team_recruit` の戻り値はまだ成功にしない**。
+    /// 真の成功判定は `resolve_pending_recruit` (handshake 経由) のみ。renderer 信頼境界違反で
+    /// 偽 `ok=true` を打たれても MCP caller は騙されない。
+    pub async fn resolve_recruit_ack(
+        &self,
+        agent_id: &str,
+        expected_team_id: &str,
+        outcome: RecruitAckOutcome,
+    ) -> Result<(), AckError> {
+        let mut s = self.state.lock().await;
+        let pending = match s.pending_recruits.get_mut(agent_id) {
+            Some(p) => p,
+            None => {
+                tracing::warn!(
+                    "[teamhub] recruit_ack ignored: no pending recruit for agent={agent_id}"
+                );
+                return Err(AckError::NotFound);
+            }
+        };
+        if pending.team_id != expected_team_id {
+            tracing::warn!(
+                "[teamhub] recruit_ack ignored: team_id mismatch agent={agent_id} \
+                 pending_team={} expected_team={expected_team_id} requester={}",
+                pending.team_id,
+                pending.requester_agent_id
+            );
+            return Err(AckError::TeamMismatch);
+        }
+        if pending
+            .ack_done
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            tracing::warn!(
+                "[teamhub] recruit_ack ignored: already acked agent={agent_id}"
+            );
+            return Err(AckError::AlreadyAcked);
+        }
+        let ack_tx = pending.ack_tx.take();
+        // pending エントリ自体は handshake 待機中の `tx` をまだ保持している必要があるため remove しない。
+        drop(s);
+        if let Some(tx) = ack_tx {
+            // 受信側 (team_recruit) が既に drop していても無視 (タイムアウト後の遅延 ack 等)
+            let _ = tx.send(outcome);
+        }
+        Ok(())
     }
 
     /// setup 後に AppHandle を注入 (event::emit で使う)

--- a/src-tauri/src/team_hub/protocol.rs
+++ b/src-tauri/src/team_hub/protocol.rs
@@ -3,14 +3,18 @@
 // 旧 team-hub.ts の handleMcpRequest 等価。
 // initialize / tools/list / tools/call (team_send 等 7 ツール + 新 recruit 系) を実装。
 
+use crate::team_hub::error::RecruitError;
 use crate::team_hub::{inject, CallContext, DynamicRole, TeamHub, TeamMessage, TeamTask};
 use chrono::Utc;
 use serde_json::{json, Value};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::Emitter;
 use uuid::Uuid;
 
 const RECRUIT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Issue #342 Phase 1: renderer 側 `app_recruit_ack` invoke 受領を待つ短期タイムアウト。
+/// 「addCard / spawn 開始の受領通知」だけを待つので 5s で十分 (handshake 完了までは待たない)。
+const RECRUIT_ACK_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_MEMBERS_PER_TEAM: usize = 12;
 /// 動的ロール instructions の最大長。Leader が暴走して巨大プロンプトを投げてくるのを抑える。
 const MAX_DYNAMIC_INSTRUCTIONS_LEN: usize = 16 * 1024; // 16 KiB
@@ -79,16 +83,27 @@ pub async fn handle(hub: &TeamHub, ctx: &CallContext, req: &Value) -> Option<Val
                         ]
                     }
                 })),
-                Err(msg) => Some(json!({
-                    "jsonrpc": "2.0",
-                    "id": id,
-                    "result": {
-                        "content": [
-                            { "type": "text", "text": json!({ "error": msg }).to_string() }
-                        ],
-                        "isError": true
-                    }
-                })),
+                Err(msg) => {
+                    // Issue #342 Phase 1 (1.7b): 構造化 JSON 文字列を Err に詰めるツール
+                    // (現在は team_recruit のみ) が、`json!({"error": msg})` で文字列値として
+                    // 二重エスケープされてクライアントが 2 回 parse する必要がある問題を回避。
+                    // msg が JSON object として parse できれば object のまま `error` キーに乗せ、
+                    // そうでなければ従来どおり文字列値として包む。
+                    let text = match serde_json::from_str::<Value>(&msg) {
+                        Ok(v) if v.is_object() => json!({ "error": v }).to_string(),
+                        _ => json!({ "error": msg }).to_string(),
+                    };
+                    Some(json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": {
+                            "content": [
+                                { "type": "text", "text": text }
+                            ],
+                            "isError": true
+                        }
+                    }))
+                }
             }
         }
         _ => {
@@ -533,21 +548,28 @@ async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<
     // Issue #122: 「singleton / 人数上限チェック」と「pending 登録」を同じクリティカルセクションで実行。
     // pending recruit も人数 / role 重複の判定対象に含めることで、並行 team_recruit が
     // 両方 pass して上限超過 / singleton 重複が発生する競合を防ぐ。
+    //
+    // Issue #342 Phase 1: ack 駆動への移行に伴い、handshake 用の `rx` に加えて renderer 側
+    // `app_recruit_ack` invoke を待つ `ack_rx` も同時に生成する。
+    let started = Instant::now();
     let current_members = hub.registry.list_team_members(&ctx.team_id);
-    let rx = match hub
+    let channels = match hub
         .try_register_pending_recruit(
             new_agent_id.clone(),
             ctx.team_id.clone(),
             role_profile_id.clone(),
+            ctx.agent_id.clone(),
             is_singleton,
             &current_members,
             MAX_MEMBERS_PER_TEAM,
         )
         .await
     {
-        Ok(rx) => rx,
+        Ok(c) => c,
         Err(e) => return Err(e),
     };
+    let rx = channels.handshake;
+    let ack_rx = channels.ack;
 
     // 動的ロールであれば、その定義もペイロードに同梱する。renderer 側はこの payload を見て
      // RoleProfilesContext のメモリキャッシュへ追加し、worker template に instructions を流し込む。
@@ -585,7 +607,88 @@ async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<
         return Err("renderer not available (canvas mode required)".into());
     }
 
-    // handshake 完了を待つ
+    // Issue #342 Phase 1 (1.11): 環境変数 `VIBE_TEAM_DISABLE_RECRUIT_ACK=1` で旧 fire-and-forget
+    // 動作にフォールバック (ack 待ちをスキップしていきなり handshake 30s 待機)。緊急ロールバック用。
+    let disable_ack =
+        std::env::var("VIBE_TEAM_DISABLE_RECRUIT_ACK").as_deref() == Ok("1");
+
+    if !disable_ack {
+        // Issue #342 Phase 1: ack 短期待機 (5s)。renderer が `team:recruit-request` を受領して
+        // addCard / spawn を開始した時点で `app_recruit_ack(ok=true)` が来る。
+        // ack 失敗 / timeout なら handshake を待たずに即座に構造化エラーを返す。
+        match tokio::time::timeout(RECRUIT_ACK_TIMEOUT, ack_rx).await {
+            Ok(Ok(ack)) if ack.ok => {
+                // ack 受領 OK。続けて handshake 待機へ。
+                // ※ ack=true は受領通知のみ。MCP 成功判定は依然 handshake 経由のみ。
+            }
+            Ok(Ok(ack)) => {
+                // renderer から ack(ok=false) が来た = 起動失敗を即時通知された
+                hub.cancel_pending_recruit(&new_agent_id).await;
+                let phase_str = ack
+                    .phase
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+                let reason = ack.reason.unwrap_or_default();
+                if let Some(app) = &app {
+                    let _ = app.emit(
+                        "team:recruit-cancelled",
+                        json!({ "newAgentId": new_agent_id, "reason": phase_str.clone() }),
+                    );
+                }
+                let message = if reason.is_empty() {
+                    format!("recruit failed (phase={phase_str})")
+                } else {
+                    format!("recruit failed: {reason}")
+                };
+                return Err(RecruitError {
+                    code: "recruit_failed".into(),
+                    message,
+                    phase: Some(phase_str),
+                    elapsed_ms: Some(started.elapsed().as_millis() as u64),
+                }
+                .into_err_string());
+            }
+            Ok(Err(_)) => {
+                // ack_tx が drop された (renderer 側が pending を resolve せずに崩壊) — 緊急 cancel 扱い
+                hub.cancel_pending_recruit(&new_agent_id).await;
+                if let Some(app) = &app {
+                    let _ = app.emit(
+                        "team:recruit-cancelled",
+                        json!({ "newAgentId": new_agent_id, "reason": "ack_dropped" }),
+                    );
+                }
+                return Err(RecruitError {
+                    code: "recruit_ack_dropped".into(),
+                    message: "renderer ack channel was dropped before reply".into(),
+                    phase: Some("ack".into()),
+                    elapsed_ms: Some(started.elapsed().as_millis() as u64),
+                }
+                .into_err_string());
+            }
+            Err(_) => {
+                // ack timeout (5s)。renderer が `team:recruit-request` を受け取れていない可能性。
+                hub.cancel_pending_recruit(&new_agent_id).await;
+                if let Some(app) = &app {
+                    let _ = app.emit(
+                        "team:recruit-cancelled",
+                        json!({ "newAgentId": new_agent_id, "reason": "ack_timeout" }),
+                    );
+                }
+                return Err(RecruitError {
+                    code: "recruit_ack_timeout".into(),
+                    message: format!(
+                        "renderer did not ack recruit-request within {}s",
+                        RECRUIT_ACK_TIMEOUT.as_secs()
+                    ),
+                    phase: Some("ack".into()),
+                    elapsed_ms: Some(started.elapsed().as_millis() as u64),
+                }
+                .into_err_string());
+            }
+        }
+    }
+
+    // handshake 完了を待つ (Issue #342 Phase 1: ack 成功後のみ到達。disable_ack=1 では従来通り即座に到達)
     match tokio::time::timeout(RECRUIT_TIMEOUT, rx).await {
         Ok(Ok(outcome)) => Ok(json!({
             "success": true,
@@ -598,7 +701,14 @@ async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<
             // 孤立 pending が try_register_pending_recruit の人数/singleton 判定に
             // 永久カウントされ、再起動まで採用不能化していた。
             hub.cancel_pending_recruit(&new_agent_id).await;
-            Err("recruit cancelled".into())
+            // Issue #342 Phase 1: 構造化エラーで返す (cancelled は handshake 直前 cancel 等)
+            Err(RecruitError {
+                code: "recruit_cancelled".into(),
+                message: "recruit cancelled before handshake".into(),
+                phase: Some("handshake".into()),
+                elapsed_ms: Some(started.elapsed().as_millis() as u64),
+            }
+            .into_err_string())
         }
         Err(_) => {
             // timeout
@@ -607,13 +717,20 @@ async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<
             if let Some(app) = &app {
                 let _ = app.emit(
                     "team:recruit-cancelled",
-                    json!({ "newAgentId": new_agent_id, "reason": "timeout" }),
+                    json!({ "newAgentId": new_agent_id, "reason": "handshake_timeout" }),
                 );
             }
-            Err(format!(
-                "recruit timeout (>{}s); the spawned agent failed to handshake",
-                RECRUIT_TIMEOUT.as_secs()
-            ))
+            // Issue #342 Phase 1: 構造化エラー化
+            Err(RecruitError {
+                code: "recruit_handshake_timeout".into(),
+                message: format!(
+                    "agent did not handshake within {}s",
+                    RECRUIT_TIMEOUT.as_secs()
+                ),
+                phase: Some("handshake".into()),
+                elapsed_ms: Some(started.elapsed().as_millis() as u64),
+            }
+            .into_err_string())
         }
     }
 }

--- a/src/renderer/src/components/TerminalView.tsx
+++ b/src/renderer/src/components/TerminalView.tsx
@@ -63,6 +63,13 @@ interface TerminalViewProps {
   /** ユーザーが xterm 上で入力したキーストロークの sniff (タイトル auto-summary 等の用途) */
   onUserInput?: (data: string) => void;
   /**
+   * Issue #342 Phase 1: terminal_create の spawn 失敗時に呼ばれる。
+   * AgentNodeCard などが本コールバックで `ackRecruit` を発火し、recruit timeout
+   * (>30s) を待たず即座に Hub へ失敗を通知できる。recruit 経路に紐付かない通常
+   * タブでは未指定で OK (no-op)。
+   */
+  onSpawnError?: (error: string) => void;
+  /**
    * Canvas モードのカード内で使うとき true にする。
    * WebglAddon を読み込まず DOM renderer に固定することで、React Flow の親 transform
    * で xterm が滲む問題を回避する。
@@ -119,6 +126,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       onExit,
       onSessionId,
       onUserInput,
+      onSpawnError,
       disableWebgl,
       forceWheelScrollback,
       unscaledFit,
@@ -180,9 +188,17 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       onActivity,
       onExit,
       onSessionId,
-      onUserInput
+      onUserInput,
+      onSpawnError
     });
-    callbacksRef.current = { onStatus, onActivity, onExit, onSessionId, onUserInput };
+    callbacksRef.current = {
+      onStatus,
+      onActivity,
+      onExit,
+      onSessionId,
+      onUserInput,
+      onSpawnError
+    };
 
     // --- 共通の write ヘルパ (closure で ptyIdRef を読む) ---
     const writeToPty = (text: string): void => {

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
@@ -20,6 +20,7 @@ import { useXtermScrollToBottomOnResize } from '../../../lib/use-xterm-scroll-on
 import { fallbackProfile, profileText, renderSystemPrompt, useRoleProfiles } from '../../../lib/role-profiles-context';
 import { parseShellArgs } from '../../../lib/parse-args';
 import { resolveAgentConfig } from '../../../lib/agent-resolver';
+import { useRecruitSpawnAck } from '../../../lib/use-terminal-spawn';
 
 interface AgentPayload {
   agent?: 'claude' | 'codex';
@@ -108,6 +109,10 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   const accent = profile.visual.color;
   const meta = profileText(profile, settings.language);
   const title = (data?.title as string) ?? meta.label;
+  // Issue #342 Phase 1: recruit 経路の spawn 失敗を Hub に ack するためのコールバック。
+  // payload.agentId / payload.teamId が揃っているとき (= 通常の AgentNode は常に揃う)
+  // のみ実体化し、それ以外は no-op を返す。
+  const onSpawnError = useRecruitSpawnAck(payload.agentId, payload.teamId);
   const [status, setStatus] = useState<string>('');
   // Phase 4: ステータスバッジ。出力を最近受け取ったら typing、暫く来なければ idle。
   const [activity, setActivity] = useState<AgentStatus>('idle');
@@ -375,6 +380,9 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
             onSessionId={(sid) => {
               if (sid) setCardPayload(id, { resumeSessionId: sid });
             }}
+            // Issue #342 Phase 1: terminal_create 失敗を Hub に ack(false) する。
+            // 30 秒の handshake timeout を待たず、recruit MCP に構造化エラーが即返る。
+            onSpawnError={onSpawnError}
             // Canvas zoom で xterm canvas が滲むのを避けるため WebGL を切る (DOM renderer 固定)。
             // text は実 DOM になるので Chromium が親 transform に応じて再ラスタライズしシャープに描く。
             disableWebgl

--- a/src/renderer/src/lib/recruit-ack.ts
+++ b/src/renderer/src/lib/recruit-ack.ts
@@ -1,0 +1,81 @@
+/**
+ * recruit-ack — Issue #342 Phase 1
+ *
+ * `team:recruit-request` event を受領した renderer 側が、Tauri Hub に
+ * 「受領通知 / 失敗通知」を返すための薄いヘルパ。
+ *
+ * Hub 側 (`team_recruit` MCP) は emit 後に `RECRUIT_ACK_TIMEOUT=5s` で本 invoke を
+ * 待機する。renderer は次のいずれかで `app_recruit_ack` を呼ぶ:
+ *
+ *   - addCard 完了 (= spawn 開始) 時点で `ackRecruit(..., { ok: true })`
+ *     ※ handshake 完了は待たない (それは既存の handshake 30s 経路で判定する)
+ *   - requester カードが見つからない / spawn 失敗 / engine binary 不在 等で
+ *     `ackRecruit(..., { ok: false, reason, phase })`
+ *
+ * ok=true でも MCP の真の成功判定は Hub 側 handshake のみ。renderer の
+ * 偽 ack(true) で MCP caller を騙せない多層防御の片側を担う (Phase 1 計画
+ * 「設計原則 3」を参照)。
+ *
+ * IPC contract: `app_recruit_ack(newAgentId, teamId, ok, reason, phase)`
+ *   - 引数は flat camelCase 5 個
+ *   - reason / phase は省略時 null を送る
+ *   - Rust 側は no-op + warn ログで pending 不在 / team_id 不一致 / 重複 ack を吸収
+ *
+ * Rust 側仕様 (rust_engineer_p1 と並走で確定):
+ *   #[tauri::command]
+ *   pub async fn app_recruit_ack(
+ *       state: State<'_, AppState>,
+ *       new_agent_id: String,
+ *       team_id: String,
+ *       ok: bool,
+ *       reason: Option<String>,
+ *       phase: Option<String>,
+ *   ) -> Result<(), String>
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * ack の失敗理由を表す phase。
+ * - `requester_not_found`: `team:recruit-request` の `requesterAgentId` に一致するカードが
+ *   canvas store に無く、200ms grace + leader/hr fallback でも見つからなかった。
+ * - `spawn`: `terminal.create` IPC が失敗した (PTY allocation failure 等の汎用エラー)。
+ * - `engine_binary_missing`: spawn 失敗のうち、`claude` / `codex` 実行ファイルが PATH に
+ *   見つからない sub-case (renderer 側で error string ヒューリスティックで分類)。
+ * - `instructions_load`: customInstructions 読込が失敗した (将来拡張用、現状未発火)。
+ */
+export type RecruitAckPhase =
+  | 'requester_not_found'
+  | 'spawn'
+  | 'engine_binary_missing'
+  | 'instructions_load';
+
+export interface RecruitAckOutcome {
+  ok: boolean;
+  /** 失敗理由 (max 256 byte 程度の短文を推奨)。Rust 側で長さ上限ガードあり。 */
+  reason?: string;
+  /** 失敗 phase。Rust 側は enum で受けるため任意文字列を入れない。 */
+  phase?: RecruitAckPhase;
+}
+
+/**
+ * Hub に recruit-request の受領 / 失敗を通知する。
+ *
+ * 失敗を invoke してもカードを自分で消さない。Hub が ack を受けて
+ * `cancel_pending_recruit` した後に必ず `team:recruit-cancelled` event を emit するため、
+ * `useRecruitListener` の cancelled ハンドラで一元的に `removeCard` される。
+ * (チャネル方向の一意化: Client→Server は invoke、Server→Client は event)
+ */
+export async function ackRecruit(
+  newAgentId: string,
+  teamId: string,
+  outcome: RecruitAckOutcome
+): Promise<void> {
+  await invoke('app_recruit_ack', {
+    newAgentId,
+    teamId,
+    ok: outcome.ok,
+    reason: outcome.reason ?? null,
+    phase: outcome.phase ?? null
+  });
+}

--- a/src/renderer/src/lib/use-pty-session.ts
+++ b/src/renderer/src/lib/use-pty-session.ts
@@ -24,6 +24,14 @@ export interface PtySessionCallbacks {
   /** ユーザーの xterm 入力 (キーストローク・改行含む) を観察したいとき。
    *  画面表示や pty 書き込みは別途行うので、純粋にスニファとして使う想定。 */
   onUserInput?: (data: string) => void;
+  /**
+   * Issue #342 Phase 1: terminal_create の spawn 失敗時に呼ばれる。
+   * `res.error` の文字列をそのまま渡す。AgentNodeCard などが本コールバックで
+   * `ackRecruit({ ok: false, phase: 'spawn' | 'engine_binary_missing' })` を発火し、
+   * Hub の recruit timeout (>30s) を待たず即座に構造化エラーを返せるようにする。
+   * 通常タブ等 recruit に紐付かない経路では未指定で OK (no-op)。
+   */
+  onSpawnError?: (error: string) => void;
 }
 
 export interface UsePtySessionOptions {
@@ -510,8 +518,12 @@ export function usePtySession(options: UsePtySessionOptions): void {
         if (!res.ok || !res.id) {
           // pre-subscribe 経路で create が失敗した場合は orphan listener を必ず解除。
           unsubscribePtyListeners();
-          term.writeln(`\x1b[31m[起動エラー] ${res.error ?? '不明なエラー'}\x1b[0m`);
+          const errMsg = res.error ?? '不明なエラー';
+          term.writeln(`\x1b[31m[起動エラー] ${errMsg}\x1b[0m`);
           callbacksRef.current.onStatus?.(`起動失敗: ${res.error ?? ''}`);
+          // Issue #342 Phase 1: recruit 経路から呼ばれた spawn なら、Hub に失敗を ack して
+          // 30 秒の handshake timeout を待たず即座に構造化エラーで返せるようにする。
+          callbacksRef.current.onSpawnError?.(errMsg);
           return;
         }
 

--- a/src/renderer/src/lib/use-recruit-listener.ts
+++ b/src/renderer/src/lib/use-recruit-listener.ts
@@ -13,6 +13,7 @@ import { useCanvasStore, NODE_W, NODE_H } from '../stores/canvas';
 import type { Node } from '@xyflow/react';
 import type { CardData } from '../stores/canvas';
 import { useRoleProfiles } from './role-profiles-context';
+import { ackRecruit } from './recruit-ack';
 
 interface RecruitRequestPayload {
   teamId: string;
@@ -142,53 +143,103 @@ export function useRecruitListener(): void {
     void listen<RecruitRequestPayload>('team:recruit-request', (e) => {
       if (cancelled) return;
       const p = e.payload;
-      const store = useCanvasStore.getState();
-      const requester = store.nodes.find((n) => {
-        const data = n.data?.payload as { agentId?: string } | undefined;
-        return data?.agentId === p.requesterAgentId;
-      });
-      if (!requester) {
-        console.warn('[recruit] requester card not found', p.requesterAgentId);
-        return;
-      }
-      // 動的ロール定義が同梱されていれば、AgentNodeCard が system prompt を組み立てる前に
-      // RoleProfilesContext に登録する。team:role-created event でも同じことが起きるが、
-      // 到達順に依存しないようここでも投入する。
-      if (p.dynamicRole) {
-        registerDynamicRole({
-          id: p.dynamicRole.id,
-          label: p.dynamicRole.label,
-          description: p.dynamicRole.description,
-          instructions: p.dynamicRole.instructions,
-          instructionsJa: p.dynamicRole.instructionsJa,
-          teamId: p.teamId
-        });
-      }
-      const teamNodes = store.nodes.filter((n) => {
-        const data = n.data?.payload as { teamId?: string } | undefined;
-        return data?.teamId === p.teamId;
-      });
-      const pos = findRecruitPosition(requester, teamNodes);
-      const titleHint = p.agentLabelHint?.trim() || p.roleProfileId;
-      store.addCard({
-        type: 'agent',
-        title: titleHint,
-        position: pos,
-        payload: {
-          agent: p.engine,
-          roleProfileId: p.roleProfileId,
-          // 旧コード互換: role 旧フィールドにも書く (一時的)
-          role: p.roleProfileId,
-          teamId: p.teamId,
-          agentId: p.newAgentId,
-          // Issue #117: AgentNodeCard が拾って Claude(--append-system-prompt) /
-          // Codex(model_instructions_file) 両方の経路に注入する正本フィールド。
-          customInstructions: p.customInstructions || undefined
+      void (async () => {
+        // Issue #342 Phase 1: requester 探索は 2 段階で行う。
+        //   1. agentId 完全一致で 1 回走査 (旧挙動)。
+        //   2. 見つからなければ 200ms grace を 1 回挟んで再走査
+        //      (Canvas mode 起動直後・HMR 直後等、recruit emit が canvas store の
+        //       hydration を追い越すレースを緩和する)。
+        //   3. それでも無ければ「同 teamId の leader / hr」を fallback として採用
+        //      (識別子分離で agentId が古いままになっても、同チームの権限ある
+        //       カードに対して配置できれば UX 上は復帰できる)。
+        // すべて失敗したら Hub に `phase=requester_not_found` で ack(false) を返す。
+        // 自カードは消さず、Hub が emit する `team:recruit-cancelled` event の
+        // ハンドラ側で一元的に removeCard する (チャネル方向の一意化)。
+        const findRequester = (): Node<CardData> | undefined => {
+          const nodes = useCanvasStore.getState().nodes;
+          const exact = nodes.find((n) => {
+            const data = n.data?.payload as { agentId?: string } | undefined;
+            return data?.agentId === p.requesterAgentId;
+          });
+          if (exact) return exact;
+          // 同 teamId 内の leader / hr に fallback
+          return nodes.find((n) => {
+            const data = n.data?.payload as
+              | { agentId?: string; teamId?: string; roleProfileId?: string; role?: string }
+              | undefined;
+            if (!data || data.teamId !== p.teamId) return false;
+            const r = data.roleProfileId ?? data.role ?? '';
+            return r === 'leader' || r === 'hr';
+          });
+        };
+
+        let requester = findRequester();
+        if (!requester) {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          if (cancelled) return;
+          requester = findRequester();
         }
-      });
-      // Issue #253: 新メンバー配置後に Canvas 側で fitView を発火させる。
-      // RECRUIT_RADIUS=NODE_W+80 で 6 名同心円配置時に端が viewport 外になる UX 退行を吸収。
-      store.notifyRecruit();
+        if (!requester) {
+          console.warn('[recruit] requester card not found', p.requesterAgentId);
+          try {
+            await ackRecruit(p.newAgentId, p.teamId, {
+              ok: false,
+              reason: 'requester card not found',
+              phase: 'requester_not_found'
+            });
+          } catch (err) {
+            console.warn('[recruit] ack(requester_not_found) failed', err);
+          }
+          return;
+        }
+        // 動的ロール定義が同梱されていれば、AgentNodeCard が system prompt を組み立てる前に
+        // RoleProfilesContext に登録する。team:role-created event でも同じことが起きるが、
+        // 到達順に依存しないようここでも投入する。
+        if (p.dynamicRole) {
+          registerDynamicRole({
+            id: p.dynamicRole.id,
+            label: p.dynamicRole.label,
+            description: p.dynamicRole.description,
+            instructions: p.dynamicRole.instructions,
+            instructionsJa: p.dynamicRole.instructionsJa,
+            teamId: p.teamId
+          });
+        }
+        const store = useCanvasStore.getState();
+        const teamNodes = store.nodes.filter((n) => {
+          const data = n.data?.payload as { teamId?: string } | undefined;
+          return data?.teamId === p.teamId;
+        });
+        const pos = findRecruitPosition(requester, teamNodes);
+        const titleHint = p.agentLabelHint?.trim() || p.roleProfileId;
+        store.addCard({
+          type: 'agent',
+          title: titleHint,
+          position: pos,
+          payload: {
+            agent: p.engine,
+            roleProfileId: p.roleProfileId,
+            // 旧コード互換: role 旧フィールドにも書く (一時的)
+            role: p.roleProfileId,
+            teamId: p.teamId,
+            agentId: p.newAgentId,
+            // Issue #117: AgentNodeCard が拾って Claude(--append-system-prompt) /
+            // Codex(model_instructions_file) 両方の経路に注入する正本フィールド。
+            customInstructions: p.customInstructions || undefined
+          }
+        });
+        // Issue #253: 新メンバー配置後に Canvas 側で fitView を発火させる。
+        // RECRUIT_RADIUS=NODE_W+80 で 6 名同心円配置時に端が viewport 外になる UX 退行を吸収。
+        store.notifyRecruit();
+        // Issue #342 Phase 1: addCard 完了 (= spawn 開始) 時点で Hub に受領通知を返す。
+        // handshake 完了は待たない (それは Hub 側 RECRUIT_TIMEOUT=30s 経路の責務)。
+        // ack(true) だけでは MCP success にはならず、真の成功判定は handshake のみ。
+        try {
+          await ackRecruit(p.newAgentId, p.teamId, { ok: true });
+        } catch (err) {
+          console.warn('[recruit] ack(ok) failed', err);
+        }
+      })();
     }).then((u) => {
       if (cancelled) {
         u();

--- a/src/renderer/src/lib/use-terminal-spawn.ts
+++ b/src/renderer/src/lib/use-terminal-spawn.ts
@@ -1,0 +1,113 @@
+/**
+ * use-terminal-spawn — Issue #342 Phase 1
+ *
+ * recruit 経路で立ったエージェントカードの spawn 失敗を Hub に ack するための
+ * 薄いコールバック生成フック。
+ *
+ * 旧挙動: `terminal_create` IPC が失敗すると `usePtySession` が xterm に
+ * `[起動エラー]` を書くだけで Hub には何も返らず、`team_recruit` MCP は
+ * 30 秒の handshake timeout を待ってから「the spawned agent failed to handshake」
+ * を返していた (事象 2 の主因の 1 つ)。
+ *
+ * 本フックを使うと:
+ *   1. `terminal_create` の失敗を `onSpawnError(error)` で受け取る
+ *   2. error 文字列のヒューリスティックで `phase` を `engine_binary_missing` /
+ *      `spawn` に分類する (engine binary が PATH に無い ENOENT 系を切り出す)
+ *   3. `ackRecruit({ ok: false, reason, phase })` を invoke する
+ *   4. Hub は受け取り次第 `cancel_pending_recruit` + `team:recruit-cancelled`
+ *      emit を行い、useRecruitListener の cancelled ハンドラ経由で当該カードを
+ *      removeCard する (チャネル方向の一意化)
+ *
+ * agentId / teamId が無い (= recruit 経路で生成されたカードではない) 場合は
+ * 何もしない安全側に倒す。Hub も pending 不在を no-op + warn する多層防御だが、
+ * 余計な invoke を避けるため renderer 側でも先にガードする。
+ */
+
+import { useCallback } from 'react';
+import { ackRecruit, type RecruitAckPhase } from './recruit-ack';
+
+/**
+ * 「engine binary が PATH に無い」系のエラーを判別するヒューリスティック。
+ *
+ * portable-pty (`spawn_command`) は OS の CreateProcess / execvp 失敗をそのまま
+ * `io::Error` で投げるため、Rust 側から見たエラーメッセージはロケールと OS で
+ * バラつく:
+ *   - Windows ja-JP: 「指定されたファイルが見つかりません。」
+ *   - Windows en-US: "The system cannot find the file specified." / "program not found"
+ *   - Unix:          "No such file or directory" / "ENOENT"
+ *   - which::which:  "cannot find binary path"
+ *
+ * 上記のいずれかにマッチすれば `engine_binary_missing` で返す。マッチしなければ
+ * 汎用 `spawn` (= PTY allocation failure / 権限エラー / 環境変数 escape 失敗等)
+ * として扱う。Phase 1 ではこのヒューリスティックで十分 (Rust 側で構造化エラー化
+ * するのは Phase 3 のスコープ)。
+ */
+function classifySpawnPhase(error: string): RecruitAckPhase {
+  const e = error.toLowerCase();
+  if (
+    e.includes('enoent') ||
+    e.includes('no such file or directory') ||
+    e.includes('cannot find the file') ||
+    e.includes('cannot find binary') ||
+    e.includes('program not found') ||
+    e.includes('command not found') ||
+    e.includes('not recognized') ||
+    error.includes('指定されたファイルが見つかりません') ||
+    error.includes('ファイルが見つかりません')
+  ) {
+    return 'engine_binary_missing';
+  }
+  return 'spawn';
+}
+
+/**
+ * agentId / teamId が分かっているカード (recruit 経路で立った AgentNode 等) で
+ * 使う。返された関数を `<TerminalView onSpawnError={...} />` にそのまま渡す。
+ *
+ * agentId / teamId のいずれかが空なら no-op を返す。
+ *
+ * 例:
+ * ```tsx
+ * const onSpawnError = useRecruitSpawnAck(payload.agentId, payload.teamId);
+ * <TerminalView onSpawnError={onSpawnError} ... />
+ * ```
+ */
+export function useRecruitSpawnAck(
+  agentId: string | undefined,
+  teamId: string | undefined
+): (error: string) => void {
+  return useCallback(
+    (error: string) => {
+      if (!agentId || !teamId) {
+        // recruit 経路ではない (= 通常タブで開かれた terminal 等)。Hub に ack は不要。
+        return;
+      }
+      const phase = classifySpawnPhase(error);
+      // reason は 256 byte 上限を Rust 側で課す予定なので、こちらでも長すぎる
+      // エラー文字列は先頭 240 byte に切り詰める (UTF-8 の境界を尊重するため
+      // String.prototype.slice ではなく TextEncoder で正確にカウント)。
+      const reason = truncateBytes(error, 240);
+      void ackRecruit(agentId, teamId, { ok: false, reason, phase }).catch((err) => {
+        console.warn('[recruit] ack(spawn-failure) failed', err);
+      });
+    },
+    [agentId, teamId]
+  );
+}
+
+/** UTF-8 byte 単位で文字列を切り詰める。multi-byte の途中で切らない。 */
+function truncateBytes(s: string, maxBytes: number): string {
+  const enc = new TextEncoder();
+  const buf = enc.encode(s);
+  if (buf.length <= maxBytes) return s;
+  // maxBytes 以下になる最後の char index を探す
+  let bytes = 0;
+  let out = '';
+  for (const ch of s) {
+    const chBytes = enc.encode(ch).length;
+    if (bytes + chBytes > maxBytes) break;
+    bytes += chBytes;
+    out += ch;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
Issue #342 の **Phase 1/3** (事象 2: recruit timeout >30s 解消)。Issue 本文の実装計画 (3 番目のコメント) sub-items 1.1-1.7b + 1.11 (Rust) / 1.8-1.10 (renderer) を実装。

`team_recruit` を **2 段階フロー (ack 5s → handshake 30s)** に切り替え、renderer 側 `app_recruit_ack` 経由で受領通知を返してもらう構造に変更。失敗時は構造化エラー `{ code, message, phase, elapsed_ms }` を MCP に返し、`phase` は enum (`spawn` / `engine_binary_missing` / `instructions_load` / `requester_not_found` / `ack_timeout` / `handshake_timeout` / `recruit_cancelled`) で識別可能。

## Rust 側 (sub-items 1.1-1.7b + 1.11)
- 新規 `src-tauri/src/team_hub/error.rs`: `RecruitError` / `AckFailPhase` / `AckError` を集約
- `PendingRecruit` に `requester_agent_id` / `ack_tx` / `ack_done: AtomicBool` を追加
- `resolve_recruit_ack` で 3 重認可ガード (pending 不在 / team_id 不一致 / 重複 ack) + ack_done CAS。renderer には常に `Ok(())` を返して偽装試行を区別不能化
- `team_recruit` を ack 駆動化 + 構造化エラー詰め直し
- `dispatch_tool` で JSON object の二重エスケープを解消
- `VIBE_TEAM_DISABLE_RECRUIT_ACK=1` で旧 fire-and-forget 動作にフォールバック (再ビルド不要)
- `commands/app.rs` に `#[tauri::command] app_recruit_ack` (reason 256 byte 上限 + phase enum サニタイズ)
- `lib.rs` の `invoke_handler!` に登録

## Renderer 側 (sub-items 1.8-1.10)
- 新規 `src/renderer/src/lib/recruit-ack.ts`: `ackRecruit` ヘルパ
- `use-recruit-listener.ts`: 200ms grace 再走査 + leader/hr fallback + `addCard` 完了後 `ackRecruit(ok:true)`
- 新規 `src/renderer/src/lib/use-terminal-spawn.ts`: spawn 失敗時に `engine_binary_missing` / `spawn` を切り分け
- `use-pty-session.ts` → `TerminalView` → `AgentNodeCard` で `onSpawnError` を pass-through

## IPC contract
\`\`\`
invoke('app_recruit_ack', {
  newAgentId: string,
  teamId: string,
  ok: boolean,
  reason: string | null,    // 256 byte 上限
  phase: string | null      // enum 4 値
}): Promise<void>
\`\`\`

## 検証
- [x] `cargo check`: 警告なし
- [x] `cargo test --lib team_hub`: 10 tests pass
- [x] `npm run typecheck`: pass
- [ ] vibe-editor 起動 → Canvas で leader 配置 → 偽 `team_recruit` で `requesterAgentId: 存在しない` を投げて 5 秒以内に `recruit_failed (phase=requester_not_found)` が返る (manual)
- [ ] `VIBE_TEAM_DISABLE_RECRUIT_ACK=1` で旧 fire-and-forget 動作にフォールバックする (manual)

## 後続 (本 issue 内、別 PR)
- Phase 2/3: `resolved_recipient_ids` (事象 1 の identity 分離耐性)
- Phase 3/3: `team_diagnostics` (timestamp / counter / `serverLogPath`)

## Test plan
- [ ] 既存 recruit 正常系のリグレッション (Canvas で leader spawn → role を recruit → handshake 成功)
- [ ] recruit timeout が ~5s で `phase=ack_timeout` で返ってくる (renderer 側で意図的に ack を抑制すれば再現可)
- [ ] spawn 失敗 (codex バイナリ無し等) で `phase=engine_binary_missing` が返る
- [ ] 構造化エラー JSON が `JSON.parse(content[0].text).error` で 1 段で取り出せる

Refs #342