### PR TITLE
fix(ui): #356 右クリックメニューが Canvas モードで隠れる問題 + Terminal メニュー新設

### DIFF
--- a/src/renderer/src/components/TerminalView.tsx
+++ b/src/renderer/src/components/TerminalView.tsx
@@ -1,5 +1,6 @@
-import { forwardRef, useImperativeHandle, useRef } from 'react';
+import { forwardRef, useImperativeHandle, useRef, useState, useCallback } from 'react';
 import { useSettings } from '../lib/settings-context';
+import { useT } from '../lib/i18n';
 import { useXtermInstance } from '../lib/use-xterm-instance';
 import {
   usePtySession,
@@ -10,6 +11,7 @@ import { useTerminalClipboard } from '../lib/use-terminal-clipboard';
 import { useAutoInitialMessage } from '../lib/use-auto-initial-message';
 import { useFitToContainer } from '../lib/use-fit-to-container';
 import type { CellSize } from '../lib/measure-cell-size';
+import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 
 /**
  * TerminalView を外から操作するためのハンドル。
@@ -137,10 +139,18 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
     ref
   ): JSX.Element {
     const { settings } = useSettings();
+    const t = useT();
     // Issue #338: useTerminalClipboard が React Context を直接引かないように、言語の current を
     // ref で渡す。settings 変化のたびに同期するので stale にならない。
     const langRef = useRef(settings.language);
     langRef.current = settings.language;
+
+    // Issue #356: 右クリックコンテキストメニュー (paste / copy selection / clear)。
+    const [contextMenu, setContextMenu] = useState<{
+      x: number;
+      y: number;
+      items: ContextMenuItem[];
+    } | null>(null);
 
     // --- Terminal インスタンス ---
     const { containerRef, termRef, fitRef } = useXtermInstance(
@@ -266,6 +276,52 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       lastScheduledRef
     });
 
+    // Issue #356: 右クリックでカスタムメニューを開く。xterm 本体上の contextmenu を拾う。
+    const handleContextMenu = useCallback(
+      (e: React.MouseEvent): void => {
+        const term = termRef.current;
+        if (!term) return;
+        e.preventDefault();
+        e.stopPropagation();
+        const selection = term.getSelection();
+        const items: ContextMenuItem[] = [
+          {
+            label: t('terminal.ctxMenu.paste'),
+            action: () => {
+              void (async () => {
+                try {
+                  // 画像があれば clipboard event 経由 (use-terminal-clipboard) に任せ、
+                  // ここではテキストペーストを優先する。
+                  const text = await navigator.clipboard.readText();
+                  if (text) term.paste(text);
+                } catch {
+                  /* noop */
+                }
+              })();
+            }
+          },
+          {
+            label: t('terminal.ctxMenu.copySelection'),
+            action: () => {
+              if (!selection) return;
+              void navigator.clipboard.writeText(selection);
+              term.clearSelection();
+            },
+            disabled: !selection,
+            divider: true
+          },
+          {
+            label: t('terminal.ctxMenu.clear'),
+            action: () => term.clear()
+          }
+        ];
+        setContextMenu({ x: e.clientX, y: e.clientY, items });
+      },
+      // termRef は stable
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [t]
+    );
+
     // --- 外部操作用ハンドル (public API は不変) ---
     useImperativeHandle(
       ref,
@@ -289,13 +345,24 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
     );
 
     return (
-      <div
-        className="terminal-view"
-        ref={containerRef}
-        // Canvas の TerminalCard 内では、xterm のテキストエリアに focus が入らず
-        // キー入力が届かない現象がある。空白領域をクリックしても明示的に focus を奪う。
-        onMouseDown={() => termRef.current?.focus()}
-      />
+      <>
+        <div
+          className="terminal-view"
+          ref={containerRef}
+          // Canvas の TerminalCard 内では、xterm のテキストエリアに focus が入らず
+          // キー入力が届かない現象がある。空白領域をクリックしても明示的に focus を奪う。
+          onMouseDown={() => termRef.current?.focus()}
+          onContextMenu={handleContextMenu}
+        />
+        {contextMenu && (
+          <ContextMenu
+            x={contextMenu.x}
+            y={contextMenu.y}
+            items={contextMenu.items}
+            onClose={() => setContextMenu(null)}
+          />
+        )}
+      </>
     );
   }
 );

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -332,6 +332,11 @@ const ja: Dict = {
   'terminal.pasteImageFailed': '画像保存失敗',
   'terminal.pasteException': 'ペースト例外',
 
+  // ---------- Terminal context menu (Issue #356) ----------
+  'terminal.ctxMenu.paste': '貼り付け',
+  'terminal.ctxMenu.copySelection': '選択範囲をコピー',
+  'terminal.ctxMenu.clear': 'ターミナルをクリア',
+
   // ---------- Command palette (Issue #39) ----------
   'palette.ariaLabel': 'コマンドパレット',
   'palette.placeholder': 'コマンドを検索…',
@@ -804,6 +809,11 @@ const en: Dict = {
   // ---------- Terminal (paste errors) ----------
   'terminal.pasteImageFailed': 'Paste image failed',
   'terminal.pasteException': 'Paste exception',
+
+  // ---------- Terminal context menu (Issue #356) ----------
+  'terminal.ctxMenu.paste': 'Paste',
+  'terminal.ctxMenu.copySelection': 'Copy selection',
+  'terminal.ctxMenu.clear': 'Clear terminal',
 
   // ---------- Command palette (Issue #39) ----------
   'palette.ariaLabel': 'Command palette',

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -340,7 +340,12 @@ samp,
  * "画面全体に対してどの層にいるか" が問題になるものだけを集約する。
  *
  * 9000 台は Canvas モード (常時最前面) とノイズオーバーレイ専用。
- * アプリ全体の最前面 (modal/context-menu/toast) は 1000〜3500 台。
+ * アプリ全体の最前面 (modal/palette/toast) は 1000〜3500 台。
+ *
+ * Issue #356: ContextMenu は createPortal(document.body) で body 直下に出るため、
+ * Canvas モード時は .canvas-layout (z-index: --z-canvas-root = 9200) と body の
+ * stacking context を共有する。3500 のままでは Canvas root の後ろに完全に隠れて
+ * 右クリックメニューが見えない。9500 (canvas-root + noise-overlay より上) に置く。
  */
 :root {
   --z-dropdown: 100;
@@ -352,10 +357,10 @@ samp,
   --z-palette: 2000;
   --z-toast: 3000;
   --z-toast-top: 3200;
-  --z-context-menu: 3500;
   --z-noise-overlay: 9000;
   --z-canvas-toggle: 9100;
   --z-canvas-root: 9200;
+  --z-context-menu: 9500;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
@
## Summary

- **根本原因 (Canvas/FileTree)**: `ContextMenu` は `createPortal(_, document.body)` で body 直下に出るため、Canvas モード時は `.canvas-layout` (`z-index: var(--z-canvas-root) = 9200`) と body の stacking context を共有する。これまで `--z-context-menu: 3500` だったので Canvas root の後ろに完全に隠れていた。`--z-context-menu: 9500` (canvas-root + noise-overlay より上) に引き上げて解消。
- **未実装だった部分 (Terminal)**: xterm にはそもそも右クリックメニューが無かった。`paste` / `copy selection` (選択時のみ enabled) / `clear terminal` の 3 項目を持つカスタムメニューを新設。既存の `ContextMenu` コンポーネントを再利用。
- **i18n**: `terminal.ctxMenu.paste` / `copySelection` / `clear` を ja/en で追加。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `src/renderer/src/styles/tokens.css` | `--z-context-menu: 3500 → 9500` + 経緯コメント |
| `src/renderer/src/components/TerminalView.tsx` | `onContextMenu` ハンドラ + `<ContextMenu>` レンダー追加 |
| `src/renderer/src/lib/i18n.ts` | `terminal.ctxMenu.*` を ja/en に追加 |

modal (1000) / palette (2000) / toast (3000) は `.canvas-layout` の内側でレンダーされるため、`--z-context-menu` 引き上げの影響は受けない。

## Test plan

- [ ] IDE モードでファイルツリー上のファイルを右クリック → 絶対パスコピー等のメニューが表示される
- [ ] **Canvas モード**で FileTreeCard 内のファイルを右クリック → メニューが Canvas 上に visible (これまで隠れていた)
- [ ] **Canvas モード**で Pane (空白) を右クリック → 「ここに Claude を追加」メニューが表示
- [ ] **Canvas モード**でノードを右クリック → 削除 / チームロックメニューが表示
- [ ] ターミナル (IDE / Canvas TerminalCard 両方) で右クリック → paste / copy selection / clear の 3 項目メニューが表示
- [ ] 選択中に右クリック → "選択範囲をコピー" が enabled、未選択時は disabled
- [ ] Glass / Dark / Light の 3 テーマで視認できる
- [ ] 既存のブラウザ既定メニュー抑止 (`main.tsx:52`) は維持
- [ ] `npm run typecheck` 通過 ✅

Closes #356
@