### PR TITLE
chore(release): v1.4.7 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-editor",
-  "version": "1.4.5",
+  "version": "1.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-editor",
-      "version": "1.4.5",
+      "version": "1.4.7",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/geist-mono": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5212,7 +5212,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.4.6"
+version = "1.4.7"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -507,3 +507,27 @@ _(未着手)_
 ### Next Tasks
 - Tauri 実機で Agent card の handoff 作成、新規セッション起動、`handoff_ack:<handoffId>` による旧 card 自動退役を smoke 確認する
 - PR 作成後に CodeRabbit と人間レビューを待つ。自動マージは禁止
+
+---
+
+## Release v1.4.7 計画
+
+Issue: #361
+
+### 計画
+- [x] `origin/main` を最新化し、`chore/release-1.4.7` ブランチを作成する
+- [x] `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` / `src-tauri/tauri.conf.json` を `1.4.7` に揃える
+- [x] `npm run typecheck`、`npm run build:vite`、`cargo check --manifest-path src-tauri\Cargo.toml --all-targets` を通す
+- [ ] release bump PR を作成し、CI / bot review の完了と merge を待つ
+- [ ] merge 後の `origin/main` に `v1.4.7` タグを作成して push し、release workflow を起動する
+- [ ] draft release の成果物と `latest.json` を確認し、問題なければ publish する
+
+### Next Steps
+- ユーザー確認後、release bump ブランチ作成とバージョン更新に進む
+- release workflow 完了後、成果物一覧・検証結果・残課題をここへ追記する
+
+### 検証
+- `npm run typecheck`: PASS
+- `npm run build:vite`: PASS (既存の chunk size / dynamic import warning あり)
+- `cargo check --manifest-path src-tauri\Cargo.toml --all-targets`: PASS
+- `git diff --check`: PASS


### PR DESCRIPTION
## Summary
- v1.4.7 release 用に package / Tauri / Cargo の version を更新
- `package-lock.json` の root version が 1.4.5 のままだった不整合を 1.4.7 に修正
- release 手順と検証結果を `tasks/todo.md` に記録

Closes #361

## Verification
- `npm run typecheck`
- `npm run build:vite`
- `cargo check --manifest-path src-tauri\Cargo.toml --all-targets`
- `git diff --check`

## Release Steps After Merge
- `v1.4.7` タグを merge 後の `origin/main` に作成して push
- release workflow の draft release 成果物と `latest.json` を確認
- 問題なければ draft release を publish