### PR TITLE
fix(terminal): #363 IDE モード xterm 黒画面を解消

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -124,7 +124,6 @@ interface TerminalTab {
   status: string;
   exited: boolean;
   resumeSessionId: string | null;
-  hasActivity: boolean;
   /** チーム履歴で使う member インデックス。未所属タブは null */
   teamHistoryMemberIdx: number | null;
   /** 自動生成されたデフォルトラベル（"Claude #1" / "Programmer A" など） */
@@ -334,7 +333,15 @@ export function App(): JSX.Element {
   const [activeTerminalTabId, setActiveTerminalTabId] = useState<number>(0);
   const nextTerminalIdRef = useRef(1);
   const terminalRefs = useRef(new Map<number, TerminalViewHandle>());
+  // Issue #363: hasActivity を terminalTabs に持たせると PTY data 受信ごとに
+  // setTerminalTabs が走り、TerminalView の親 App 全体が ~16ms 周期で再レンダーする。
+  // mascot 表示のためだけに 60Hz で App を回すのは IDE モード xterm の初期化と
+  // 衝突するので、activity フラグは別 Set state として TerminalView の props と
+  // 完全に切り離す (Set 更新は mascot の StatusBar 経路のみに伝搬)。
   const terminalActivityTimers = useRef(new Map<number, ReturnType<typeof setTimeout>>());
+  const [activeTerminalIds, setActiveTerminalIds] = useState<ReadonlySet<number>>(
+    () => new Set()
+  );
   const [tabCreateMenuOpen, setTabCreateMenuOpen] = useState(false);
   const [teams, setTeams] = useState<Team[]>([]);
   const [pendingTeamClose, setPendingTeamClose] = useState<{
@@ -348,17 +355,21 @@ export function App(): JSX.Element {
     const existing = terminalActivityTimers.current.get(tabId);
     if (existing) window.clearTimeout(existing);
 
-    setTerminalTabs((prev) =>
-      prev.map((tab) =>
-        tab.id === tabId && !tab.hasActivity ? { ...tab, hasActivity: true } : tab
-      )
-    );
+    setActiveTerminalIds((prev) => {
+      if (prev.has(tabId)) return prev;
+      const next = new Set(prev);
+      next.add(tabId);
+      return next;
+    });
 
     const timer = window.setTimeout(() => {
       terminalActivityTimers.current.delete(tabId);
-      setTerminalTabs((prev) =>
-        prev.map((tab) => (tab.id === tabId ? { ...tab, hasActivity: false } : tab))
-      );
+      setActiveTerminalIds((prev) => {
+        if (!prev.has(tabId)) return prev;
+        const next = new Set(prev);
+        next.delete(tabId);
+        return next;
+      });
     }, 900);
     terminalActivityTimers.current.set(tabId, timer);
   }, []);
@@ -422,7 +433,6 @@ export function App(): JSX.Element {
           status: '',
           exited: false,
           resumeSessionId: opts?.resumeSessionId ?? null,
-          hasActivity: false,
           teamHistoryMemberIdx: opts?.teamHistoryMemberIdx ?? null,
           label,
           customLabel: opts?.customLabel ?? null
@@ -464,7 +474,6 @@ export function App(): JSX.Element {
           status: '',
           exited: false,
           resumeSessionId: null,
-          hasActivity: false,
           teamHistoryMemberIdx: null,
           label: 'Claude #1',
           customLabel: null
@@ -501,7 +510,6 @@ export function App(): JSX.Element {
             status: '',
             exited: false,
             resumeSessionId: null,
-            hasActivity: false,
             teamHistoryMemberIdx: null,
             label: 'Claude #1',
             customLabel: null
@@ -550,7 +558,7 @@ export function App(): JSX.Element {
     setTerminalTabs((prev) =>
       prev.map((t) =>
         t.id === tabId
-          ? { ...t, version: t.version + 1, exited: false, status: '', hasActivity: false }
+          ? { ...t, version: t.version + 1, exited: false, status: '' }
           : t
       )
     );
@@ -830,7 +838,6 @@ export function App(): JSX.Element {
             status: '起動中…',
             exited: false,
             resumeSessionId: null,
-            hasActivity: false,
             teamHistoryMemberIdx: null,
             label: 'Claude #1',
             customLabel: null
@@ -1923,7 +1930,7 @@ export function App(): JSX.Element {
         setTerminalTabs((prev) =>
           prev.map((tab) =>
             tab.agent === 'claude' && !tab.exited
-              ? { ...tab, version: tab.version + 1, status: '', hasActivity: false }
+              ? { ...tab, version: tab.version + 1, status: '' }
               : tab
           )
         );
@@ -2116,10 +2123,18 @@ export function App(): JSX.Element {
         terminals: terminalTabs.map((tab) => ({
           status: tab.status,
           exited: tab.exited,
-          hasActivity: tab.hasActivity
+          hasActivity: activeTerminalIds.has(tab.id)
         }))
       }),
-    [activeDiffTab, activeEditorTab, activeFilePath, gitStatus, terminalTabs, viewMode]
+    [
+      activeDiffTab,
+      activeEditorTab,
+      activeFilePath,
+      activeTerminalIds,
+      gitStatus,
+      terminalTabs,
+      viewMode
+    ]
   );
 
   const projectName = projectRoot.split(/[\\/]/).pop() || 'no project';


### PR DESCRIPTION
Closes #363

## Summary
- IDE モードで Claude Code タブが完全な黒のまま無反応になる regression を修正
- 原因: PR #358 (mascot) が PTY data 受信ごとに ``setTerminalTabs`` を発火させていたため、``terminalTabs`` の identity が ~16ms 周期で変わって App 全体が継続的に再レンダーされ、IDE モードの WebGL renderer による xterm 初期化と衝突していた
- Canvas モードは ``disableWebgl=true`` で DOM renderer 経路のため許容度が高く症状が出ていなかった

## 修正
- ``hasActivity: boolean`` を ``TerminalTab`` interface から削除し、別の ``activeTerminalIds: ReadonlySet<number>`` state として App に保持
- ``markTerminalActivity`` は ``setTerminalTabs`` を呼ばず ``setActiveTerminalIds`` のみを更新する。Set は「id が既に含まれていれば prev を返す」ので連続 data 受信時は React の bail-out が効き、再レンダーは false→true / true→false の 2 回のみに収束する
- ``mascotState`` の ``useMemo`` 内では ``activeTerminalIds.has(tab.id)`` で ``hasActivity`` を計算するため mascot のアニメーション挙動は変わらない
- 5 箇所のタブ生成・restart で不要になった ``hasActivity: false`` を削除

## Test plan
- [ ] ``npm run typecheck`` 成功 (確認済み)
- [ ] ``npx vitest run src/renderer/src/lib/__tests__/status-mascot.test.ts`` 全 6 件成功 (確認済み)
- [ ] IDE モード起動 → Claude Code タブで claude プロンプトが描画される (テーマ: claude-dark)
- [ ] IDE モードで黒領域をクリックしてキー入力が claude に届く
- [ ] Canvas モードでも従来通り claude が描画される (退行確認)
- [ ] 複数 IDE タブ ($+$ ボタン) を開いても全部正常に xterm が描画される
- [ ] 全テーマ (claude-dark / claude-light / dark / light / midnight / glass) で xterm が描画される
- [ ] mascot が PTY ストリーミング中に ``running`` モーションになる
- [ ] mascot が idle 復帰する (最終 data から ~900ms 後)

## 関連
- 起因 PR: #358 (animated status mascot)