### PR TITLE
fix(terminal): #365 IDE ターミナル黒画面 (Glass→Dark) を解消

### DIFF
--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1698,10 +1698,13 @@ body.is-resizing * {
 /* Issue #252: IDE mode terminal scrollbar restore - L1668-1685 (このブロックから下)
    xterm v6 + WebGL renderer 利用時、`.xterm-viewport` の上に WebGL canvas が
    `position: absolute` で被さってネイティブスクロールバーが隠れる問題を回避するため
-   z-index を上げる。背景色は維持（!important で下層 canvas の透過を防ぐ）。
-   pointer-events も保持して通常のスクロールが効く。 */
+   z-index を上げる。pointer-events も保持して通常のスクロールが効く。
+   Issue #365: 背景色は親 `.terminal-view` が `var(--bg)` で担当する。viewport は
+   `.xterm-screen` の兄弟で z-index 1 により最前面に来るため、ここで背景色を持たせると
+   下層の文字レイヤ (WebGL canvas / DOM text rows) を完全に覆い、Glass 以外のテーマで
+   ターミナル表示が消える。全テーマで viewport は透過にして文字レイヤを覆わない。 */
 .terminal-view .xterm-viewport {
-  background-color: var(--bg) !important;
+  background-color: transparent !important;
   z-index: 1;
 }
 
@@ -1744,13 +1747,10 @@ body.is-resizing * {
 }
 
 /* Glass テーマ時は xterm を透過させて親の backdrop-filter を活かす (Issue #89)。
-   `.terminal-view` の solid 背景と `.xterm-viewport` の `!important` 背景を両方打ち消す。 */
+   `.xterm-viewport` の透過は Issue #365 の修正で全テーマ共通になったため、ここでは
+   `.terminal-view` の solid 背景のみを打ち消す。 */
 [data-theme="glass"] .terminal-view {
   background: transparent;
-}
-
-[data-theme="glass"] .terminal-view .xterm-viewport {
-  background-color: transparent !important;
 }
 
 /* ---------- 右側固定 Claude Code パネル ---------- */


### PR DESCRIPTION
## Summary
- `.terminal-view .xterm-viewport` の不透明背景 (`var(--bg) !important`) が `z-index: 1` で `.xterm-screen` の最前面に来た際、下層の文字レイヤ (WebGL canvas / DOM text rows) を完全に覆い、Glass 以外のテーマで IDE ターミナル表示が消える退行を修正。
- viewport の背景は親 `.terminal-view { background: var(--bg) }` に委譲し、viewport 自体は全テーマで `background-color: transparent !important` に統一。`z-index: 1` (Issue #252 の native scrollbar 復活策) は維持。
- Glass 専用に重複していた `[data-theme='glass'] .terminal-view .xterm-viewport { background-color: transparent !important }` の上書きは新グローバル規則と同値なので削除。

## Root cause
xterm v6 の DOM 構造では `.xterm-viewport` (scrollbar 担当) と `.xterm-screen` (文字レイヤ) が兄弟。Issue #252 の修正で viewport を `z-index: 1` に上げて WebGL canvas より前面に出した時、不透明な `background-color: var(--bg)` も同時に持っていたため、viewport が文字レイヤを完全に覆っていた。Glass テーマは `[data-theme='glass']` で透過上書きされていたため気づかなかった。

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build:vite`
- [x] `npx vitest run src/renderer/src/lib/__tests__/xterm-theme.test.ts` (4 tests pass)
- [ ] 手動確認: IDE モードで `claude-dark` / `dark` / `claude-light` / `light` / `midnight` / `glass` の各テーマを切替えてターミナル表示が読めること
- [ ] 手動確認: Glass → Dark / Dark → Glass の動的切替で表示が消えないこと
- [ ] 手動確認: native scrollbar (Issue #252) が表示・操作できること
- [ ] 手動確認: Canvas モードの TerminalCard / AgentNodeCard で文字が背景と同化しないこと (canvas.css 側の `z-index: auto` override は維持)

Closes #365