### PR TITLE
feat(canvas): #369 ターミナル/エージェントカードを一括整理整頓するボタンを追加

### DIFF
--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -1,23 +1,61 @@
-import { List, Maximize2, Users, ZoomIn, ZoomOut } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { LayoutGrid, List, Maximize2, Ruler, Users, ZoomIn, ZoomOut } from 'lucide-react';
 import { useReactFlow } from '@xyflow/react';
 import { useT } from '../../lib/i18n';
 import { useCanvasStore, type StageView } from '../../stores/canvas';
+import type { ArrangeGap } from '../../lib/canvas-arrange';
 
 /**
  * StageHud — Canvas 中央下部のガラス調ピル HUD。
  * Claude Design バンドルの .tc__hud を移植。
- * view 切替 (Stage / List / Focus) + fit + zoom in/out を含む。
+ * view 切替 (Stage / List / Focus) + fit + zoom in/out + arrange を含む。
+ *
+ * Issue #369: 整理ボタンを追加。占有を増やさないため通常時は 1 ボタンのみ表示し、
+ * クリックで小さなポップオーバーを開いて 整頓 / サイズ統一 / 間隔 (Tight/Normal/Wide) を選ぶ。
  */
 export function StageHud(): JSX.Element {
   const t = useT();
   const stageView = useCanvasStore((s) => s.stageView);
   const setStageView = useCanvasStore((s) => s.setStageView);
+  const arrangeGap = useCanvasStore((s) => s.arrangeGap);
+  const setArrangeGap = useCanvasStore((s) => s.setArrangeGap);
+  const tidyTerminalCards = useCanvasStore((s) => s.tidyTerminalCards);
+  const unifyTerminalCardSize = useCanvasStore((s) => s.unifyTerminalCardSize);
   const { fitView, zoomIn, zoomOut } = useReactFlow();
+
+  const [arrangeOpen, setArrangeOpen] = useState(false);
+  const arrangeWrapRef = useRef<HTMLDivElement | null>(null);
+
+  // ポップオーバー外クリック / Escape で閉じる
+  useEffect(() => {
+    if (!arrangeOpen) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!arrangeWrapRef.current) return;
+      if (!arrangeWrapRef.current.contains(e.target as Node)) {
+        setArrangeOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setArrangeOpen(false);
+    };
+    window.addEventListener('pointerdown', onPointerDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [arrangeOpen]);
 
   const views: Array<{ id: StageView; label: string; icon: JSX.Element }> = [
     { id: 'stage', label: t('canvas.hud.stage'), icon: <Users size={12} strokeWidth={2} /> },
     { id: 'list', label: t('canvas.hud.list'), icon: <List size={12} strokeWidth={2} /> },
     { id: 'focus', label: t('canvas.hud.focus'), icon: <Maximize2 size={12} strokeWidth={2} /> }
+  ];
+
+  const gaps: Array<{ id: ArrangeGap; label: string }> = [
+    { id: 'tight', label: t('canvas.hud.arrange.gap.tight') },
+    { id: 'normal', label: t('canvas.hud.arrange.gap.normal') },
+    { id: 'wide', label: t('canvas.hud.arrange.gap.wide') }
   ];
 
   return (
@@ -56,6 +94,65 @@ export function StageHud(): JSX.Element {
       >
         <ZoomIn size={12} strokeWidth={2} />
       </button>
+      <span className="tc__hud-sep" aria-hidden="true" />
+      <div className="tc__hud-arrange" ref={arrangeWrapRef}>
+        <button
+          type="button"
+          className={arrangeOpen ? 'is-active' : ''}
+          onClick={() => setArrangeOpen((v) => !v)}
+          title={t('canvas.hud.arrange.open')}
+          aria-haspopup="menu"
+          aria-expanded={arrangeOpen}
+        >
+          <LayoutGrid size={12} strokeWidth={2} />
+        </button>
+        {arrangeOpen ? (
+          <div className="tc__hud-arrange-pop" role="menu">
+            <button
+              type="button"
+              role="menuitem"
+              className="tc__hud-arrange-item"
+              onClick={() => {
+                tidyTerminalCards();
+                setArrangeOpen(false);
+              }}
+            >
+              <LayoutGrid size={13} strokeWidth={2} />
+              <span>{t('canvas.hud.arrange.tidy')}</span>
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className="tc__hud-arrange-item"
+              onClick={() => {
+                unifyTerminalCardSize();
+                setArrangeOpen(false);
+              }}
+            >
+              <Ruler size={13} strokeWidth={2} />
+              <span>{t('canvas.hud.arrange.unifySize')}</span>
+            </button>
+            <div className="tc__hud-arrange-sep" aria-hidden="true" />
+            <div className="tc__hud-arrange-label">{t('canvas.hud.arrange.gap.label')}</div>
+            <div className="tc__hud-arrange-gaps" role="group">
+              {gaps.map((g) => (
+                <button
+                  key={g.id}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={arrangeGap === g.id}
+                  className={
+                    'tc__hud-arrange-gap' + (arrangeGap === g.id ? ' is-active' : '')
+                  }
+                  onClick={() => setArrangeGap(g.id)}
+                >
+                  {g.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/renderer/src/lib/__tests__/canvas-arrange.test.ts
+++ b/src/renderer/src/lib/__tests__/canvas-arrange.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@xyflow/react';
+import {
+  ARRANGE_GAP_PX,
+  computeColumns,
+  isTerminalLike,
+  tidyTerminals,
+  unifyTerminalSize
+} from '../canvas-arrange';
+import { NODE_W, NODE_H, type CardData, type CardType } from '../../stores/canvas';
+
+function makeNode(
+  id: string,
+  type: CardType,
+  position: { x: number; y: number },
+  size?: { width?: number; height?: number }
+): Node<CardData> {
+  return {
+    id,
+    type,
+    position,
+    data: { cardType: type, title: id, payload: { kept: true } },
+    style: {
+      width: size?.width ?? NODE_W,
+      height: size?.height ?? NODE_H
+    }
+  };
+}
+
+describe('canvas-arrange / isTerminalLike', () => {
+  it('matches terminal and agent only', () => {
+    expect(isTerminalLike(makeNode('a', 'terminal', { x: 0, y: 0 }))).toBe(true);
+    expect(isTerminalLike(makeNode('b', 'agent', { x: 0, y: 0 }))).toBe(true);
+    expect(isTerminalLike(makeNode('c', 'editor', { x: 0, y: 0 }))).toBe(false);
+    expect(isTerminalLike(makeNode('d', 'diff', { x: 0, y: 0 }))).toBe(false);
+    expect(isTerminalLike(makeNode('e', 'fileTree', { x: 0, y: 0 }))).toBe(false);
+    expect(isTerminalLike(makeNode('f', 'changes', { x: 0, y: 0 }))).toBe(false);
+  });
+});
+
+describe('canvas-arrange / computeColumns', () => {
+  it('uses ceil(sqrt(n)) but never less than 1', () => {
+    expect(computeColumns(0)).toBe(1);
+    expect(computeColumns(1)).toBe(1);
+    expect(computeColumns(2)).toBe(2);
+    expect(computeColumns(4)).toBe(2);
+    expect(computeColumns(5)).toBe(3);
+    expect(computeColumns(9)).toBe(3);
+    expect(computeColumns(10)).toBe(4);
+  });
+});
+
+describe('canvas-arrange / tidyTerminals', () => {
+  it('grids only terminal-like nodes; leaves others untouched', () => {
+    const nodes: Node<CardData>[] = [
+      makeNode('t1', 'terminal', { x: 100, y: 200 }, { width: 500, height: 350 }),
+      makeNode('t2', 'agent', { x: 900, y: 200 }, { width: 700, height: 420 }),
+      makeNode('t3', 'terminal', { x: 100, y: 800 }, { width: 480, height: 280 }),
+      makeNode('e1', 'editor', { x: 50, y: 50 }, { width: 800, height: 600 }),
+      makeNode('f1', 'fileTree', { x: 5000, y: 5000 }, { width: 320, height: 600 })
+    ];
+
+    const out = tidyTerminals(nodes, { gap: 'normal' });
+    const gap = ARRANGE_GAP_PX.normal;
+
+    // editor / fileTree は触らない
+    const e1 = out.find((n) => n.id === 'e1');
+    const f1 = out.find((n) => n.id === 'f1');
+    expect(e1).toEqual(nodes.find((n) => n.id === 'e1'));
+    expect(f1).toEqual(nodes.find((n) => n.id === 'f1'));
+
+    // terminal-like のサイズが NODE_W/H に揃う
+    const targets = out.filter((n) => n.type === 'terminal' || n.type === 'agent');
+    for (const n of targets) {
+      expect(n.style?.width).toBe(NODE_W);
+      expect(n.style?.height).toBe(NODE_H);
+    }
+
+    // 起点は元 terminal-like の最小 (x=100, y=200)
+    const cols = computeColumns(targets.length); // 3 件 → 2 列
+    expect(cols).toBe(2);
+    const positions = targets.map((n) => n.position).sort((a, b) => a.y - b.y || a.x - b.x);
+    expect(positions[0]).toEqual({ x: 100, y: 200 });
+    expect(positions[1]).toEqual({ x: 100 + NODE_W + gap, y: 200 });
+    expect(positions[2]).toEqual({ x: 100, y: 200 + NODE_H + gap });
+  });
+
+  it('preserves node id, data, payload (no PTY restart risk)', () => {
+    const nodes: Node<CardData>[] = [
+      makeNode('keep-id', 'terminal', { x: 0, y: 0 })
+    ];
+    nodes[0].data.payload = { sessionId: 'sess-xyz', teamId: 'team-1' };
+
+    const out = tidyTerminals(nodes);
+    expect(out[0].id).toBe('keep-id');
+    expect(out[0].data.title).toBe('keep-id');
+    expect(out[0].data.payload).toEqual({ sessionId: 'sess-xyz', teamId: 'team-1' });
+  });
+
+  it('honors gap option (tight / wide)', () => {
+    const nodes: Node<CardData>[] = [
+      makeNode('a', 'terminal', { x: 0, y: 0 }),
+      makeNode('b', 'terminal', { x: 9999, y: 0 })
+    ];
+    const tight = tidyTerminals(nodes, { gap: 'tight' });
+    const wide = tidyTerminals(nodes, { gap: 'wide' });
+    const tightDx = tight[1].position.x - tight[0].position.x;
+    const wideDx = wide[1].position.x - wide[0].position.x;
+    expect(tightDx).toBe(NODE_W + ARRANGE_GAP_PX.tight);
+    expect(wideDx).toBe(NODE_W + ARRANGE_GAP_PX.wide);
+  });
+
+  it('returns the input untouched when there are no terminal-like nodes', () => {
+    const nodes: Node<CardData>[] = [
+      makeNode('e1', 'editor', { x: 10, y: 10 }),
+      makeNode('f1', 'fileTree', { x: 20, y: 20 })
+    ];
+    const out = tidyTerminals(nodes);
+    expect(out).toBe(nodes);
+  });
+});
+
+describe('canvas-arrange / unifyTerminalSize', () => {
+  it('only touches sizes; positions are kept', () => {
+    const nodes: Node<CardData>[] = [
+      makeNode('t1', 'terminal', { x: 100, y: 200 }, { width: 320, height: 240 }),
+      makeNode('a1', 'agent', { x: 700, y: 50 }, { width: 900, height: 600 }),
+      makeNode('e1', 'editor', { x: 0, y: 0 }, { width: 400, height: 400 })
+    ];
+    const out = unifyTerminalSize(nodes);
+    expect(out.find((n) => n.id === 't1')?.position).toEqual({ x: 100, y: 200 });
+    expect(out.find((n) => n.id === 'a1')?.position).toEqual({ x: 700, y: 50 });
+    expect(out.find((n) => n.id === 't1')?.style?.width).toBe(NODE_W);
+    expect(out.find((n) => n.id === 'a1')?.style?.height).toBe(NODE_H);
+    // editor は触らない
+    expect(out.find((n) => n.id === 'e1')?.style).toEqual({ width: 400, height: 400 });
+  });
+
+  it('returns input untouched when no terminal-like nodes', () => {
+    const nodes: Node<CardData>[] = [makeNode('e1', 'editor', { x: 0, y: 0 })];
+    const out = unifyTerminalSize(nodes);
+    expect(out).toBe(nodes);
+  });
+});

--- a/src/renderer/src/lib/canvas-arrange.ts
+++ b/src/renderer/src/lib/canvas-arrange.ts
@@ -1,0 +1,113 @@
+/**
+ * Issue #369: Canvas モードの terminal / agent カードを「一括整理整頓」する純粋関数。
+ *
+ * 整列対象は `terminal` と `agent` (どちらも内部に TerminalView を抱える) に限定し、
+ * editor / diff / fileTree / changes は触らない。ノード id / data / payload は維持し、
+ * `position` と `style.width/height` だけを書き換えるので、内蔵 PTY が再生成される
+ * リスクは無い。
+ */
+import type { Node } from '@xyflow/react';
+import type { CardData, CardType } from '../stores/canvas';
+import { NODE_W, NODE_H } from '../stores/canvas';
+
+export type ArrangeGap = 'tight' | 'normal' | 'wide';
+
+export const ARRANGE_GAP_PX: Record<ArrangeGap, number> = {
+  tight: 24,
+  normal: 32,
+  wide: 48
+};
+
+const TERMINAL_LIKE: ReadonlySet<CardType> = new Set<CardType>(['terminal', 'agent']);
+
+export function isTerminalLike(node: Node<CardData>): boolean {
+  const t = (node.type ?? node.data?.cardType) as CardType | undefined;
+  return t !== undefined && TERMINAL_LIKE.has(t);
+}
+
+/** sqrt 基準で列数を決定。少数ノードでも過剰横長にならないようにする。 */
+export function computeColumns(count: number): number {
+  if (count <= 0) return 1;
+  return Math.max(1, Math.ceil(Math.sqrt(count)));
+}
+
+interface ArrangeOptions {
+  /** ピッチ (cards 間 gap) */
+  gap?: ArrangeGap;
+  /** カード幅 */
+  width?: number;
+  /** カード高さ */
+  height?: number;
+}
+
+/**
+ * `tidy`: terminal-like ノードを起点 (左上の最小 x/y) から grid 配置し、
+ * size と position を統一する。非 terminal-like は元のまま返す。
+ */
+export function tidyTerminals(
+  nodes: Node<CardData>[],
+  options: ArrangeOptions = {}
+): Node<CardData>[] {
+  const width = options.width ?? NODE_W;
+  const height = options.height ?? NODE_H;
+  const gap = ARRANGE_GAP_PX[options.gap ?? 'normal'];
+
+  const targets = nodes.filter(isTerminalLike);
+  if (targets.length === 0) return nodes;
+
+  const originX = Math.min(...targets.map((n) => n.position.x));
+  const originY = Math.min(...targets.map((n) => n.position.y));
+  const cols = computeColumns(targets.length);
+
+  // 元の左→右、上→下の順を尊重して並べ替えてから grid に埋める
+  const sorted = [...targets].sort((a, b) => {
+    if (a.position.y !== b.position.y) return a.position.y - b.position.y;
+    return a.position.x - b.position.x;
+  });
+  const orderById = new Map<string, number>();
+  sorted.forEach((n, i) => orderById.set(n.id, i));
+
+  return nodes.map((n) => {
+    if (!isTerminalLike(n)) return n;
+    const idx = orderById.get(n.id) ?? 0;
+    const col = idx % cols;
+    const row = Math.floor(idx / cols);
+    return {
+      ...n,
+      position: {
+        x: originX + col * (width + gap),
+        y: originY + row * (height + gap)
+      },
+      style: {
+        ...(n.style ?? {}),
+        width,
+        height
+      }
+    };
+  });
+}
+
+/**
+ * `unifySize`: 位置はそのままで terminal-like ノードのサイズだけを統一する。
+ */
+export function unifyTerminalSize(
+  nodes: Node<CardData>[],
+  options: Pick<ArrangeOptions, 'width' | 'height'> = {}
+): Node<CardData>[] {
+  const width = options.width ?? NODE_W;
+  const height = options.height ?? NODE_H;
+  let touched = false;
+  const next = nodes.map((n) => {
+    if (!isTerminalLike(n)) return n;
+    touched = true;
+    return {
+      ...n,
+      style: {
+        ...(n.style ?? {}),
+        width,
+        height
+      }
+    };
+  });
+  return touched ? next : nodes;
+}

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -70,6 +70,13 @@ const ja: Dict = {
   'canvas.hud.fit': 'フィット',
   'canvas.hud.zoomIn': 'ズームイン',
   'canvas.hud.zoomOut': 'ズームアウト',
+  'canvas.hud.arrange.open': '整理',
+  'canvas.hud.arrange.tidy': '整頓',
+  'canvas.hud.arrange.unifySize': 'サイズ統一',
+  'canvas.hud.arrange.gap.label': '間隔',
+  'canvas.hud.arrange.gap.tight': '狭い',
+  'canvas.hud.arrange.gap.normal': '標準',
+  'canvas.hud.arrange.gap.wide': '広い',
 
   // ---------- AppMenu ----------
   'appMenu.title': 'プロジェクトメニュー',
@@ -560,6 +567,13 @@ const en: Dict = {
   'canvas.hud.fit': 'Fit',
   'canvas.hud.zoomIn': 'Zoom in',
   'canvas.hud.zoomOut': 'Zoom out',
+  'canvas.hud.arrange.open': 'Arrange',
+  'canvas.hud.arrange.tidy': 'Tidy up',
+  'canvas.hud.arrange.unifySize': 'Unify size',
+  'canvas.hud.arrange.gap.label': 'Gap',
+  'canvas.hud.arrange.gap.tight': 'Tight',
+  'canvas.hud.arrange.gap.normal': 'Normal',
+  'canvas.hud.arrange.gap.wide': 'Wide',
 
   // ---------- AppMenu ----------
   'appMenu.title': 'Project menu',

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -7,6 +7,11 @@
 import { create } from 'zustand';
 import { persist, subscribeWithSelector } from 'zustand/middleware';
 import type { Edge, Node, Viewport } from '@xyflow/react';
+import {
+  tidyTerminals,
+  unifyTerminalSize,
+  type ArrangeGap
+} from '../lib/canvas-arrange';
 
 export type CardType = 'terminal' | 'agent' | 'editor' | 'diff' | 'fileTree' | 'changes';
 
@@ -66,6 +71,16 @@ interface CanvasState {
    */
   lastRecruitAt: number | null;
   notifyRecruit: () => void;
+  /**
+   * Issue #369: Canvas 内の terminal / agent カードを一括整理整頓する。
+   * 既存 PTY を維持するため node id / data / payload は触らず、
+   * position と style.width/height だけを更新する。
+   * 次回 `tidyTerminals` 用に最後に選ばれた gap も保存しておく。
+   */
+  arrangeGap: ArrangeGap;
+  setArrangeGap: (gap: ArrangeGap) => void;
+  tidyTerminalCards: (gap?: ArrangeGap) => void;
+  unifyTerminalCardSize: () => void;
 }
 
 export type StageView = 'stage' | 'list' | 'focus';
@@ -273,7 +288,17 @@ export const useCanvasStore = create<CanvasState>()(
       },
       // Issue #253: recruit 後の fitView トリガー (use-recruit-listener が書き、Canvas が監視)
       lastRecruitAt: null,
-      notifyRecruit: () => set({ lastRecruitAt: Date.now() })
+      notifyRecruit: () => set({ lastRecruitAt: Date.now() }),
+      // Issue #369: terminal/agent カードの一括整理整頓
+      arrangeGap: 'normal',
+      setArrangeGap: (gap) => set({ arrangeGap: gap }),
+      tidyTerminalCards: (gap) =>
+        set((state) => ({
+          nodes: tidyTerminals(state.nodes, { gap: gap ?? state.arrangeGap }),
+          arrangeGap: gap ?? state.arrangeGap
+        })),
+      unifyTerminalCardSize: () =>
+        set((state) => ({ nodes: unifyTerminalSize(state.nodes) }))
     }),
     {
       name: 'vibe-editor:canvas',
@@ -388,7 +413,8 @@ export const useCanvasStore = create<CanvasState>()(
         nodes: s.nodes,
         viewport: s.viewport,
         stageView: s.stageView,
-        teamLocks: s.teamLocks
+        teamLocks: s.teamLocks,
+        arrangeGap: s.arrangeGap
       })
     }
     )

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -809,6 +809,87 @@
   margin: 0 3px;
 }
 
+/* Issue #369: arrange popover anchored to HUD */
+.tc__hud-arrange {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.tc__hud-arrange-pop {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  right: 0;
+  min-width: 168px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px;
+  background: var(--surface-glass, rgba(20, 20, 19, 0.86));
+  backdrop-filter: blur(14px) saturate(160%);
+  -webkit-backdrop-filter: blur(14px) saturate(160%);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-md);
+  z-index: 30;
+  font-size: 11.5px;
+  color: var(--text);
+}
+.tc__hud-arrange-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  background: transparent;
+  border: none;
+  color: var(--text-mute);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition: all 140ms var(--ease-out);
+}
+.tc__hud-arrange-item:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.tc__hud-arrange-sep {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 2px;
+}
+.tc__hud-arrange-label {
+  padding: 2px 10px;
+  color: var(--text-mute);
+  font-size: 10.5px;
+  letter-spacing: 0.02em;
+}
+.tc__hud-arrange-gaps {
+  display: flex;
+  gap: 4px;
+  padding: 2px;
+}
+.tc__hud-arrange-gap {
+  flex: 1;
+  padding: 5px 8px;
+  border-radius: 8px;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-mute);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  transition: all 140ms var(--ease-out);
+}
+.tc__hud-arrange-gap:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+.tc__hud-arrange-gap.is-active {
+  background: var(--bg-elev);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
 /* handoff edge: stroke-dasharray flow */
 @keyframes tcEdgeFlow {
   to {


### PR DESCRIPTION
## Summary
- Canvas モードの `terminal` / `agent` カードを一括整理整頓するボタンを `StageHud` 右端に追加
- 純粋関数 `tidyTerminals` / `unifyTerminalSize` (`src/renderer/src/lib/canvas-arrange.ts`) で位置とサイズだけを更新し、ノード id / data / payload を保持して内蔵 PTY が再起動しないようにする
- ポップオーバー内に **整頓** / **サイズ統一** / **間隔 (Tight / Normal / Wide)** の 3 機能を集約。HUD 常時占有を 1 ボタンに抑える

## 主な変更
- `src/renderer/src/lib/canvas-arrange.ts` (新規): `isTerminalLike` / `computeColumns` / `tidyTerminals` / `unifyTerminalSize` の純粋関数
- `src/renderer/src/stores/canvas.ts`: `arrangeGap` / `setArrangeGap` / `tidyTerminalCards` / `unifyTerminalCardSize` を追加し persist に含める
- `src/renderer/src/components/canvas/StageHud.tsx`: LayoutGrid アイコンのトリガーボタン + ポップオーバー (外クリック / Esc 閉じ、`role=menu` / `aria-expanded` / `aria-checked`)
- `src/renderer/src/lib/i18n.ts`: `canvas.hud.arrange.*` を ja/en に追加
- `src/renderer/src/styles/components/canvas.css`: `.tc__hud-arrange*` スタイル追加
- `src/renderer/src/lib/__tests__/canvas-arrange.test.ts` (新規): vitest 8 ケース

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run` (91 件 pass, 新規 8 件含む)
- [x] `npm run build:vite`
- [ ] Canvas モードで Claude / Codex / Terminal カードを複数並べ、サイズ・位置をばらした状態から **整頓** / **サイズ統一** / **間隔切替** を実行して挙動を確認
- [ ] editor / diff / fileTree / changes カードが整理対象から除外されることを確認
- [ ] ターミナル PTY が整理後も継続動作 (再起動しない) することを確認

Closes #369