### PR TITLE
fix(ui): #366 機能の無いヘッダー右上のユーザー初期文字アイコンを削除

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2151,24 +2151,6 @@ export function App(): JSX.Element {
       setSidebarView('files');
     }
   }, [hasGitRepo, sidebarView]);
-  const [userInitial, setUserInitial] = useState<string>('');
-  useEffect(() => {
-    let cancelled = false;
-    window.api.app
-      .getUserInfo()
-      .then((info) => {
-        if (cancelled) return;
-        const first = (info.username || '').trim().slice(0, 1);
-        setUserInitial(first ? first.toUpperCase() : '?');
-      })
-      .catch(() => {
-        if (!cancelled) setUserInitial('?');
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   const activityFeed = useActivityFeed();
   // Phase 6: vibe-canvas:recruit/dismiss イベントを listen して canvas store に反映
   useRecruitListener();
@@ -2218,7 +2200,6 @@ export function App(): JSX.Element {
         status={status}
         onRestart={handleRestart}
         onOpenPalette={() => setPaletteOpen(true)}
-        userInitial={userInitial}
         availableUpdate={availableUpdate}
         onClickUpdate={handleClickUpdate}
         menuBar={

--- a/src/renderer/src/components/shell/Topbar.tsx
+++ b/src/renderer/src/components/shell/Topbar.tsx
@@ -17,7 +17,6 @@ interface TopbarProps {
   status: string;
   onRestart: () => void;
   onOpenPalette: () => void;
-  userInitial?: string;
   /** 左側に置く自作メニューバー (File / View / Help…) */
   menuBar?: ReactNode;
   /** silentCheckForUpdate で検出された更新情報。null のときボタンは出さない */
@@ -30,14 +29,13 @@ interface TopbarProps {
  * Redesign shell の上端バー (44px)。
  * Claude Design バンドル "vibe-editor Redesign" の .topbar セクションを
  * Tauri アプリ向けに移植。ブランドドット + プロジェクトクラム + モードピル
- * + ⌘K 検索トリガ + アイコン + ユーザーアバター の 6 パート構成。
+ * + ⌘K 検索トリガ + アイコンの 5 パート構成。
  */
 export function Topbar({
   projectRoot,
   status,
   onRestart,
   onOpenPalette,
-  userInitial = 'U',
   menuBar,
   availableUpdate,
   onClickUpdate
@@ -140,10 +138,6 @@ export function Topbar({
         >
           <CommandIcon size={14} strokeWidth={1.9} />
         </button>
-      </div>
-
-      <div className="topbar__user" aria-label="user">
-        {userInitial.slice(0, 1).toUpperCase()}
       </div>
 
       {/* Issue #260 PR-2: カスタムタイトルバーのウィンドウ制御 (decorations: false の代替) */}

--- a/src/renderer/src/styles/components/shell.css
+++ b/src/renderer/src/styles/components/shell.css
@@ -371,21 +371,6 @@
   white-space: nowrap;
 }
 
-.topbar__user {
-  -webkit-app-region: no-drag;
-  width: 30px;
-  height: 30px;
-  border-radius: 999px;
-  background: var(--accent);
-  color: white;
-  display: grid;
-  place-items: center;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  flex-shrink: 0;
-}
-
 /* ==================== WINDOW CONTROLS (Issue #260 PR-2) ==================== */
 /* `decorations: false` でネイティブ chrome を外した代わりのカスタムボタン群。
    .topbar の右端に座り、`-webkit-app-region: drag` の親領域から自身は no-drag に


### PR DESCRIPTION
## Summary
- ヘッダー右上に表示されていたユーザー初期文字 (`Z` などの丸アイコン) は `onClick` も `aria-haspopup` も持たず、クリックしても何も起きない静的 `div` だった
- `Topbar.tsx` から `userInitial` prop と `.topbar__user` 描画を削除
- `App.tsx` から専用 state / `getUserInfo()` effect / `Topbar` への prop 受け渡しを削除
- `shell.css` から `.topbar__user` スタイル定義を削除
- 既存の Sidebar 下部 `UserMenu` (設定 / テーマ / 言語 / リリース情報導線) は変更なし。Topbar 右端は WindowControls だけになる

Closes #366

## Test plan
- [x] `npm run typecheck`
- [ ] `npm run dev` で実機確認: ヘッダー右上に丸い `Z` アイコンが表示されないこと、Activity / Tweaks / Restart / ⌘ / WindowControls の並びが崩れていないこと
- [ ] Sidebar の `UserMenu` から設定 / テーマ変更が引き続きできること