### PR TITLE
docs(refactor): #373 clippy ベースラインのカテゴリ集計を修正

### DIFF
--- a/tasks/refactor-clippy-baseline.md
+++ b/tasks/refactor-clippy-baseline.md
@@ -41,10 +41,10 @@ cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 
 | カテゴリ | 件数 | コメント |
 |---|---|---|
-| `doc_lazy_continuation` (日本語 doc) | 6 | 機械的修正可。挙動には無関係 |
+| `doc_lazy_continuation` (日本語 doc) | 7 | 機械的修正可。挙動には無関係 |
 | イディオム (`len_zero` / `manual_range_contains` / `question_mark` / `manual_unwrap_or_default` / `useless_conversion` / `needless_return`) | 6 | 機械的修正可 |
 | 構造変更が必要 (`result_large_err`, `too_many_arguments`) | 2 | API 変更を伴うのでリファクタ Phase で扱う |
-| その他 | 1 | — |
+| **合計** | **15** | — |
 
 ---
 


### PR DESCRIPTION
## Summary

PR #380 (Phase 0 ベースライン) で取りこぼした CodeRabbit 指摘を反映する追跡 PR。
詳細表 (15 件) と集計表の数が合っていなかった点を修正する **数値訂正のみ** の docs PR。

| 修正前 | 修正後 |
|---|---|
| `doc_lazy_continuation` 6 | **7** (詳細表の実数と一致) |
| その他 1 | (削除) |
| — | **合計 15** (明示) |

## 背景

PR #380 は bot が trivial 判定で Haiku pass1 のみで即 merge されたため、後続 push した CodeRabbit 指摘修正 commit が main に取り込まれなかった。本 PR で main に反映する。

## CodeRabbit 元コメント

> Update the category summary table under "カテゴリ別集計" so the per-category counts match the detailed list: change the doc_lazy_continuation count from 6 to 7, change その他 from 1 to 0, and keep "イディオム" at 6 and "構造変更が必要" at 2 so the total remains 15.

## Test plan

- [x] 詳細表 (15 件) の `doc_lazy_continuation` を数えると 7 件 (`app.rs:666` / `terminal.rs:136` / `inject.rs:46` / `protocol.rs:881` / `mod.rs:215` / `mod.rs:557` / `mod.rs:558`)
- [x] 7 + 6 + 2 = 15 で詳細表と一致

Refs #373