### PR TITLE
feat(team-hub): #386 1 チームあたりのメンバー人数上限 (12 名) を撤廃

### DIFF
--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -479,11 +479,13 @@ impl TeamHub {
         self.state.lock().await.role_profile_summary.clone()
     }
 
-    /// recruit を pending に登録する。Issue #122: 「人数 / singleton 判定」と「pending 登録」を
-    /// 同じクリティカルセクションで行うことで並行 recruit による上限超過や singleton 重複を防ぐ。
+    /// recruit を pending に登録する。Issue #122: 「singleton 判定」と「pending 登録」を
+    /// 同じクリティカルセクションで行うことで並行 recruit による singleton 重複を防ぐ。
+    ///
+    /// Issue #386: 1 チームあたりのメンバー人数上限は撤廃済み。
     ///
     /// `current_members` は呼び出し側で先に取得した「handshake 済みメンバー (agent_id, role) の一覧」。
-    /// クリティカルセクション内で pending と合わせて人数 / 役職重複をチェックし、
+    /// クリティカルセクション内で pending と合わせて役職重複をチェックし、
     /// パスしたらこの場で pending に挿入して Receiver を返す。
     pub async fn try_register_pending_recruit(
         &self,
@@ -493,7 +495,6 @@ impl TeamHub {
         requester_agent_id: String,
         is_singleton: bool,
         current_members: &[(String, String)],
-        max_members: usize,
     ) -> Result<PendingRecruitChannels, String> {
         let (tx, rx) = oneshot::channel();
         let (ack_tx, ack_rx) = oneshot::channel();
@@ -504,13 +505,6 @@ impl TeamHub {
             .values()
             .filter(|p| p.team_id == team_id)
             .collect();
-        // 人数上限チェック (handshake 済み + pending)
-        let total = current_members.len() + pending_for_team.len();
-        if total >= max_members {
-            return Err(format!(
-                "team is full ({total}/{max_members} members; including pending recruits)"
-            ));
-        }
         // singleton チェック (handshake 済み + pending を両方見る)
         if is_singleton {
             let already = current_members.iter().any(|(_, r)| r == &role_profile_id)

--- a/src-tauri/src/team_hub/protocol.rs
+++ b/src-tauri/src/team_hub/protocol.rs
@@ -18,7 +18,6 @@ const RECRUIT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Issue #342 Phase 1: renderer 側 `app_recruit_ack` invoke 受領を待つ短期タイムアウト。
 /// 「addCard / spawn 開始の受領通知」だけを待つので 5s で十分 (handshake 完了までは待たない)。
 const RECRUIT_ACK_TIMEOUT: Duration = Duration::from_secs(5);
-const MAX_MEMBERS_PER_TEAM: usize = 12;
 /// 動的ロール instructions の最大長。Leader が暴走して巨大プロンプトを投げてくるのを抑える。
 const MAX_DYNAMIC_INSTRUCTIONS_LEN: usize = 16 * 1024; // 16 KiB
 /// 動的ロール label / description の最大長
@@ -559,9 +558,11 @@ async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<
     // 新 agentId を採番 (vc- prefix で他システムと区別)
     let new_agent_id = format!("vc-{}", Uuid::new_v4());
 
-    // Issue #122: 「singleton / 人数上限チェック」と「pending 登録」を同じクリティカルセクションで実行。
-    // pending recruit も人数 / role 重複の判定対象に含めることで、並行 team_recruit が
-    // 両方 pass して上限超過 / singleton 重複が発生する競合を防ぐ。
+    // Issue #122: 「singleton 重複チェック」と「pending 登録」を同じクリティカルセクションで実行。
+    // pending recruit も singleton の判定対象に含めることで、並行 team_recruit が
+    // 両方 pass して singleton 重複が発生する競合を防ぐ。
+    //
+    // Issue #386: 1 チームあたりのメンバー人数上限 (旧 MAX_MEMBERS_PER_TEAM=12) は撤廃済み。
     //
     // Issue #342 Phase 1: ack 駆動への移行に伴い、handshake 用の `rx` に加えて renderer 側
     // `app_recruit_ack` invoke を待つ `ack_rx` も同時に生成する。
@@ -575,7 +576,6 @@ async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<
             ctx.agent_id.clone(),
             is_singleton,
             &current_members,
-            MAX_MEMBERS_PER_TEAM,
         )
         .await
     {


### PR DESCRIPTION
@
## Summary
- `src-tauri/src/team_hub/protocol.rs` の `const MAX_MEMBERS_PER_TEAM: usize = 12;` を削除
- `src-tauri/src/team_hub/mod.rs` の `try_register_pending_recruit` から `max_members` パラメータと人数上限チェックブロックを削除
- singleton 重複排除と pending 登録のクリティカルセクションは維持。動的ロール数 cap (`MAX_DYNAMIC_ROLES_PER_TEAM=64`) や入力長 cap は据え置き

これにより `team_recruit` で 13 人目以降を採用しても `team is full (12/12 members; ...)` エラーが出なくなる。

Closes #386

## Test plan
- [x] `cargo check --all-targets` 通過
- [x] `npm run typecheck` 通過
- [ ] 起動して `team_recruit` を 13 回以上呼び、full エラーが出ないことを bot レビュー後に手元確認
@