### PR TITLE
refactor(app): #373 Phase 1-3 use-terminal-tabs.ts に terminal tab を切り出し

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -59,6 +59,13 @@ import { dedupPrepend, listContainsPath } from './lib/path-norm';
 import { useProjectLoader } from './lib/hooks/use-project-loader';
 import { useFileTabs } from './lib/hooks/use-file-tabs';
 import type { DiffTab, EditorTab } from './lib/hooks/use-file-tabs';
+import {
+  MAX_TERMINALS,
+  TERMINAL_WARN_THRESHOLD,
+  getRoleDisplayLabel,
+  useTerminalTabs
+} from './lib/hooks/use-terminal-tabs';
+import type { TerminalTab } from './lib/hooks/use-terminal-tabs';
 import type { Command } from './lib/commands';
 
 const THEMES_FOR_PALETTE: ThemeName[] = [
@@ -72,29 +79,8 @@ const THEMES_FOR_PALETTE: ThemeName[] = [
 
 // DiffTab / EditorTab の型定義は use-file-tabs.ts に移管済み (Issue #373 Phase 1-2)。
 
-/** 同時に立てられるターミナルの上限。メモリ/レイアウト保護の安全弁 */
-const MAX_TERMINALS = 30;
-/** この数を超えたら警告トーストを出す */
-const TERMINAL_WARN_THRESHOLD = 25;
-
-interface TerminalTab {
-  id: number;
-  version: number;
-  agent: TerminalAgent;
-  role: TeamRole | null;
-  teamId: string | null;
-  /** MCP チーム通信用のエージェント識別子 */
-  agentId: string;
-  status: string;
-  exited: boolean;
-  resumeSessionId: string | null;
-  /** チーム履歴で使う member インデックス。未所属タブは null */
-  teamHistoryMemberIdx: number | null;
-  /** 自動生成されたデフォルトラベル（"Claude #1" / "Programmer A" など） */
-  label: string;
-  /** ユーザーが手動でリネームした値。空入力で blur すると null に戻り label が表示される */
-  customLabel: string | null;
-}
+// MAX_TERMINALS / TERMINAL_WARN_THRESHOLD / TerminalTab 型 / getRoleDisplayLabel は
+// use-terminal-tabs.ts に移管済み (Issue #373 Phase 1-3)。
 
 /** ロール別の短い説明（チームプロンプト内で使用、leader 以外は動的ロール由来）。 */
 const ROLE_DESC: Record<TeamRole, string> = {
@@ -108,18 +94,6 @@ const ROLE_DESC: Record<TeamRole, string> = {
 const ROLE_ORDER: Record<string, number> = {
   leader: 0
 };
-
-/** 重複ロールにレター接尾辞を付けた表示名を返す (例: "programmer A") */
-function getRoleDisplayLabel(tab: TerminalTab, allTabs: TerminalTab[]): string {
-  if (!tab.role) return '';
-  if (!tab.teamId) return tab.role;
-  const sameRole = allTabs
-    .filter((t) => t.teamId === tab.teamId && t.role === tab.role)
-    .sort((a, b) => a.agentId.localeCompare(b.agentId));
-  if (sameRole.length <= 1) return tab.role;
-  const idx = sameRole.findIndex((t) => t.id === tab.id);
-  return `${tab.role} ${String.fromCharCode(65 + idx)}`;
-}
 
 /** チームのシステムプロンプト（--append-system-prompt 用） */
 function generateTeamSystemPrompt(
@@ -339,59 +313,21 @@ export function App(): JSX.Element {
   // tabs (editor / diff / recentlyClosed) は useFileTabs で集中管理する。
   const [sideBySide, setSideBySide] = useState<boolean>(true);
 
-  // Claude Code / Codex terminal tabs (最大10個の同時実行をサポート)
-  const [terminalTabs, setTerminalTabs] = useState<TerminalTab[]>([]);
-  const [activeTerminalTabId, setActiveTerminalTabId] = useState<number>(0);
-  const nextTerminalIdRef = useRef(1);
-  const terminalRefs = useRef(new Map<number, TerminalViewHandle>());
-  // Issue #363: hasActivity を terminalTabs に持たせると PTY data 受信ごとに
-  // setTerminalTabs が走り、TerminalView の親 App 全体が ~16ms 周期で再レンダーする。
-  // mascot 表示のためだけに 60Hz で App を回すのは IDE モード xterm の初期化と
-  // 衝突するので、activity フラグは別 Set state として TerminalView の props と
-  // 完全に切り離す (Set 更新は mascot の StatusBar 経路のみに伝搬)。
-  const terminalActivityTimers = useRef(new Map<number, ReturnType<typeof setTimeout>>());
-  const [activeTerminalIds, setActiveTerminalIds] = useState<ReadonlySet<number>>(
-    () => new Set()
-  );
-  const [tabCreateMenuOpen, setTabCreateMenuOpen] = useState(false);
+  // teams は Phase 1-3 では App.tsx 残置。Phase 1-4 (use-team-management) で hook 化予定。
   const [teams, setTeams] = useState<Team[]>([]);
-  const [pendingTeamClose, setPendingTeamClose] = useState<{
-    tabId: number;
-    teamId: string;
-  } | null>(null);
-  const [dragTabId, setDragTabId] = useState<number | null>(null);
-  const [dragOverTabId, setDragOverTabId] = useState<number | null>(null);
-  const [editingLabelTabId, setEditingLabelTabId] = useState<number | null>(null);
-  const markTerminalActivity = useCallback((tabId: number) => {
-    const existing = terminalActivityTimers.current.get(tabId);
-    if (existing) window.clearTimeout(existing);
 
-    setActiveTerminalIds((prev) => {
-      if (prev.has(tabId)) return prev;
-      const next = new Set(prev);
-      next.add(tabId);
-      return next;
-    });
+  // Phase 1-3 (Issue #373): terminal tabs の state container を hook に外出し。
+  // doCloseTeam は teams setter / clearSpawnTimers / cleanupTeamMcp に依存するため
+  // App.tsx に残し、ref ブリッジで hook の opts.closeTeam に注入する (循環解消)。
+  const closeTeamRef = useRef<(teamId: string) => void>(() => {});
+  const stableCloseTeam = useCallback(
+    (teamId: string) => closeTeamRef.current(teamId),
+    []
+  );
 
-    const timer = window.setTimeout(() => {
-      terminalActivityTimers.current.delete(tabId);
-      setActiveTerminalIds((prev) => {
-        if (!prev.has(tabId)) return prev;
-        const next = new Set(prev);
-        next.delete(tabId);
-        return next;
-      });
-    }, 900);
-    terminalActivityTimers.current.set(tabId, timer);
-  }, []);
-  useEffect(() => {
-    return () => {
-      for (const timer of terminalActivityTimers.current.values()) {
-        window.clearTimeout(timer);
-      }
-      terminalActivityTimers.current.clear();
-    };
-  }, []);
+  // <TerminalView> ref は hook 化対象外: TerminalView の JSX 配線が App.tsx 側に
+  // 残るため (props が teams / TeamHub / role profile 系に依存)。Phase 1-4 で再検討。
+  const terminalRefs = useRef(new Map<number, TerminalViewHandle>());
 
   // Claude CLI 検査状態
   const [claudeCheck, setClaudeCheck] = useState<{
@@ -406,102 +342,43 @@ export function App(): JSX.Element {
     items: ContextMenuItem[];
   } | null>(null);
 
-  const addTerminalTab = useCallback(
-    (opts?: {
-      agent?: TerminalAgent;
-      role?: TeamRole | null;
-      teamId?: string | null;
-      resumeSessionId?: string | null;
-      agentId?: string;
-      teamHistoryMemberIdx?: number | null;
-      /** team-history からの resume 時に復元する手動リネーム名 */
-      customLabel?: string | null;
-    }): number | null => {
-      const id = nextTerminalIdRef.current++;
-      const agentType = opts?.agent ?? 'claude';
-      let accepted = false;
-      setTerminalTabs((prev) => {
-        // ラベル自動生成: チームロール or 連番
-        let label: string;
-        if (opts?.role) {
-          const sameRole = prev.filter(
-            (t) => t.teamId === opts.teamId && t.role === opts.role
-          );
-          const roleName = opts.role.charAt(0).toUpperCase() + opts.role.slice(1);
-          label = sameRole.length > 0 ? `${roleName} ${String.fromCharCode(65 + sameRole.length)}` : roleName;
-        } else {
-          const agentLabel = agentType === 'claude' ? 'Claude' : 'Codex';
-          const sameAgent = prev.filter((t) => t.agent === agentType && !t.role);
-          label = `${agentLabel} #${sameAgent.length + 1}`;
-        }
-        const tab: TerminalTab = {
-          id,
-          version: 0,
-          agent: agentType,
-          role: opts?.role ?? null,
-          teamId: opts?.teamId ?? null,
-          agentId: opts?.agentId ?? `agent-${id}`,
-          status: '',
-          exited: false,
-          resumeSessionId: opts?.resumeSessionId ?? null,
-          teamHistoryMemberIdx: opts?.teamHistoryMemberIdx ?? null,
-          label,
-          customLabel: opts?.customLabel ?? null
-        };
-        if (prev.length >= MAX_TERMINALS) {
-          showToast(`ターミナル上限（${MAX_TERMINALS}）に達しました`, { tone: 'warning' });
-          return prev;
-        }
-        // 閾値を超えそうなら軽く警告
-        if (prev.length + 1 === TERMINAL_WARN_THRESHOLD) {
-          showToast(
-            `ターミナル数が ${TERMINAL_WARN_THRESHOLD} に達しました（上限 ${MAX_TERMINALS}）`,
-            { tone: 'info' }
-          );
-        }
-        accepted = true;
-        return [...prev, tab];
-      });
-      if (!accepted) return null;
-      setActiveTerminalTabId(id);
-      return id;
-    },
-    [showToast]
-  );
+  // Phase 1-3 (Issue #373): terminal tabs の state / handler を hook に集約。
+  const {
+    terminalTabs,
+    setTerminalTabs,
+    activeTerminalTabId,
+    setActiveTerminalTabId,
+    activeTerminalIds,
+    markTerminalActivity,
+    addTerminalTab,
+    closeTerminalTab,
+    doCloseTab,
+    restartTerminalTab,
+    restartTerminal,
+    tabCreateMenuOpen,
+    setTabCreateMenuOpen,
+    pendingTeamClose,
+    setPendingTeamClose,
+    dragTabId,
+    dragOverTabId,
+    getDnDProps,
+    editingLabelTabId,
+    setEditingLabelTabId,
+    standaloneTabList,
+    teamGroupList,
+    nextTerminalIdRef,
+    resetForProjectSwitch: resetTerminalsForProjectSwitch
+  } = useTerminalTabs({
+    viewMode,
+    claudeReady: claudeCheck.state === 'ok',
+    projectRoot,
+    showToast,
+    teams,
+    closeTeam: stableCloseTeam
+  });
 
-  const doCloseTab = useCallback((tabId: number) => {
-    setTerminalTabs((prev) => {
-      const next = prev.filter((t) => t.id !== tabId);
-      if (next.length === 0) {
-        // 最後の1個 → 新しいスタンドアロンタブを自動生成
-        const newId = nextTerminalIdRef.current++;
-        const fresh: TerminalTab = {
-          id: newId,
-          version: 1,
-          agent: 'claude',
-          role: null,
-          teamId: null,
-          agentId: `agent-${newId}`,
-          status: '',
-          exited: false,
-          resumeSessionId: null,
-          teamHistoryMemberIdx: null,
-          label: 'Claude #1',
-          customLabel: null
-        };
-        setActiveTerminalTabId(newId);
-        return [fresh];
-      }
-      setActiveTerminalTabId((active) => {
-        if (active !== tabId) return active;
-        const idx = prev.findIndex((t) => t.id === tabId);
-        const neighbor = next[Math.min(idx, next.length - 1)];
-        return neighbor?.id ?? next[0]?.id ?? 0;
-      });
-      return next;
-    });
-  }, []);
-
+  // doCloseTeam は teams setter / clearSpawnTimers / cleanupTeamMcp に依存するため
+  // Phase 1-3 では App.tsx 残置。useTerminalTabs には ref ブリッジ経由で注入する。
   const doCloseTeam = useCallback(
     (teamId: string) => {
       // チーム作成進行中ならスタガー spawn を止める（同じチームかは問わない）
@@ -542,42 +419,15 @@ export function App(): JSX.Element {
           .catch((err) => console.warn('[team] cleanupTeamMcp failed:', err));
       }
     },
-    [projectRoot, clearSpawnTimers]
+    [
+      projectRoot,
+      clearSpawnTimers,
+      setTerminalTabs,
+      setActiveTerminalTabId,
+      nextTerminalIdRef
+    ]
   );
-
-  const closeTerminalTab = useCallback(
-    (tabId: number) => {
-      const tab = terminalTabs.find((t) => t.id === tabId);
-      if (tab?.role === 'leader' && tab.teamId) {
-        // Leader 1 人しか居ない "empty team" は確認ダイアログ不要。即チーム終了。
-        const otherMembers = terminalTabs.filter(
-          (t) => t.teamId === tab.teamId && t.id !== tabId
-        );
-        if (otherMembers.length === 0) {
-          doCloseTeam(tab.teamId);
-          return;
-        }
-        setPendingTeamClose({ tabId, teamId: tab.teamId });
-        return;
-      }
-      doCloseTab(tabId);
-    },
-    [terminalTabs, doCloseTab, doCloseTeam]
-  );
-
-  const restartTerminalTab = useCallback((tabId: number) => {
-    setTerminalTabs((prev) =>
-      prev.map((t) =>
-        t.id === tabId
-          ? { ...t, version: t.version + 1, exited: false, status: '' }
-          : t
-      )
-    );
-  }, []);
-
-  const restartTerminal = useCallback(() => {
-    restartTerminalTab(activeTerminalTabId);
-  }, [activeTerminalTabId, restartTerminalTab]);
+  closeTeamRef.current = doCloseTeam;
 
   // ---------- Claude CLI 検査 ----------
   const runClaudeCheck = useCallback(async () => {
@@ -782,34 +632,18 @@ export function App(): JSX.Element {
     void updateSettings({ sidebarWidth: DEFAULT_SIDEBAR });
   }, [updateSettings]);
 
-  // Phase 1-1 / 1-2 (Issue #373): loadProject / 初回ロード effect / タイトルバー effect /
-  // refreshGit は use-project-loader.ts、editor/diff tab 関連は use-file-tabs.ts に移管済み。
-  // confirmDiscardEditorTabs / onProjectSwitched / onLoaded を hook に橋渡しする。
+  // Phase 1-1 / 1-2 / 1-3 (Issue #373): loadProject / 初回ロード effect / タイトルバー
+  // effect / refreshGit は use-project-loader.ts、editor/diff tab 関連は use-file-tabs.ts、
+  // terminal tab 関連は use-terminal-tabs.ts に移管済み。confirmDiscardEditorTabs /
+  // onProjectSwitched / onLoaded を hook に橋渡しする。
   confirmDiscardRef.current = confirmDiscardEditorTabs;
   projectSwitchedRef.current = (root: string): void => {
-    // タブのリセットは use-file-tabs に委譲。
+    // editor/diff/terminal タブのリセットはそれぞれの hook に委譲。
     resetTabsForProjectSwitch();
     setActiveSessionId(null);
-    // ターミナル＆チームをリセット（全タブ閉じて新規1つ）
+    // teams は Phase 1-4 まで App.tsx で持つので個別にリセット。
     setTeams([]);
-    const newId = nextTerminalIdRef.current++;
-    setTerminalTabs([
-      {
-        id: newId,
-        version: 0,
-        agent: 'claude',
-        role: null,
-        teamId: null,
-        agentId: `agent-${newId}`,
-        status: '起動中…',
-        exited: false,
-        resumeSessionId: null,
-        teamHistoryMemberIdx: null,
-        label: 'Claude #1',
-        customLabel: null
-      }
-    ]);
-    setActiveTerminalTabId(newId);
+    resetTerminalsForProjectSwitch();
     void root; // root は現状未使用 (将来の拡張余地として残す)
   };
   projectLoadedRef.current = ({ sessions: sess }) => {
@@ -1419,20 +1253,7 @@ export function App(): JSX.Element {
     []
   );
 
-  // 初回タブ作成: Claude OK かつ projectRoot 設定済みでタブなし。
-  // Canvas モードでは App は不可視の裏マウントなので、ここでターミナルを生やすと
-  // Rust 側で無駄な PTY が常駐し、IDE へ切り替えたときにも "迷子ターミナル" として現れる。
-  // → viewMode === 'ide' のときだけ自動生成する。
-  useEffect(() => {
-    if (
-      claudeCheck.state === 'ok' &&
-      projectRoot &&
-      terminalTabs.length === 0 &&
-      viewMode === 'ide'
-    ) {
-      addTerminalTab();
-    }
-  }, [claudeCheck.state, projectRoot, terminalTabs.length, addTerminalTab, viewMode]);
+  // 初回タブ作成 effect は use-terminal-tabs.ts に移管済み (Issue #373 Phase 1-3)。
 
   // ---------- チーム履歴の resume / 削除 ----------
 
@@ -1629,28 +1450,8 @@ export function App(): JSX.Element {
     [saveTeamHistory]
   );
 
-  // ---------- ターミナルタブのグループ化 ----------
-
-  const { standaloneTabList, teamGroupList } = useMemo(() => {
-    const standalone = terminalTabs.filter((t) => !t.teamId);
-    const teamMap = new Map<string, TerminalTab[]>();
-    for (const t of terminalTabs) {
-      if (t.teamId) {
-        const arr = teamMap.get(t.teamId) || [];
-        arr.push(t);
-        teamMap.set(t.teamId, arr);
-      }
-    }
-    const teamGroups = [...teamMap.entries()].map(([teamId, tabs]) => ({
-      team: teams.find((t) => t.id === teamId) ?? { id: teamId, name: 'Team' },
-      tabs: tabs.sort((a, b) => {
-        if (a.role === 'leader') return -1;
-        if (b.role === 'leader') return 1;
-        return a.id - b.id;
-      })
-    }));
-    return { standaloneTabList: standalone, teamGroupList: teamGroups };
-  }, [terminalTabs, teams]);
+  // standaloneTabList / teamGroupList は use-terminal-tabs.ts の useMemo で計算済み
+  // (Issue #373 Phase 1-3)。
 
   // ---------- タブリスト ----------
 
@@ -2107,42 +1908,7 @@ export function App(): JSX.Element {
                     設定されている場合は隠すと編集手段 (double-click) を失うので常に表示する。
                     Issue #91 */}
                 {(terminalTabs.length > 1 || tab.teamId || tab.customLabel) && (
-                  <div
-                    className="terminal-pane__header"
-                    draggable
-                    onDragStart={(e) => {
-                      setDragTabId(tab.id);
-                      e.dataTransfer.effectAllowed = 'move';
-                    }}
-                    onDragOver={(e) => {
-                      e.preventDefault();
-                      e.dataTransfer.dropEffect = 'move';
-                      setDragOverTabId(tab.id);
-                    }}
-                    onDragLeave={() => {
-                      if (dragOverTabId === tab.id) setDragOverTabId(null);
-                    }}
-                    onDrop={(e) => {
-                      e.preventDefault();
-                      if (dragTabId !== null && dragTabId !== tab.id) {
-                        setTerminalTabs((prev) => {
-                          const fromIdx = prev.findIndex((t) => t.id === dragTabId);
-                          const toIdx = prev.findIndex((t) => t.id === tab.id);
-                          if (fromIdx === -1 || toIdx === -1) return prev;
-                          const next = [...prev];
-                          const [moved] = next.splice(fromIdx, 1);
-                          next.splice(toIdx, 0, moved);
-                          return next;
-                        });
-                      }
-                      setDragTabId(null);
-                      setDragOverTabId(null);
-                    }}
-                    onDragEnd={() => {
-                      setDragTabId(null);
-                      setDragOverTabId(null);
-                    }}
-                  >
+                  <div className="terminal-pane__header" {...getDnDProps(tab.id)}>
                     <span className={`terminal-tab__agent terminal-tab__agent--${tab.agent}`}>
                       {tab.agent === 'claude' ? 'C' : 'X'}
                     </span>

--- a/src/renderer/src/lib/hooks/use-terminal-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs.ts
@@ -1,0 +1,461 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  Team,
+  TerminalAgent,
+  TeamRole
+} from '../../../../types/shared';
+
+/** 同時に立てられるターミナルの上限。メモリ/レイアウト保護の安全弁 */
+export const MAX_TERMINALS = 30;
+/** この数を超えたら警告トーストを出す */
+export const TERMINAL_WARN_THRESHOLD = 25;
+
+export interface TerminalTab {
+  id: number;
+  version: number;
+  agent: TerminalAgent;
+  role: TeamRole | null;
+  teamId: string | null;
+  /** MCP チーム通信用のエージェント識別子 */
+  agentId: string;
+  status: string;
+  exited: boolean;
+  resumeSessionId: string | null;
+  /** チーム履歴で使う member インデックス。未所属タブは null */
+  teamHistoryMemberIdx: number | null;
+  /** 自動生成されたデフォルトラベル（"Claude #1" / "Programmer A" など） */
+  label: string;
+  /** ユーザーが手動でリネームした値。空入力で blur すると null に戻り label が表示される */
+  customLabel: string | null;
+}
+
+/** 重複ロールにレター接尾辞を付けた表示名を返す (例: "programmer A") */
+export function getRoleDisplayLabel(tab: TerminalTab, allTabs: TerminalTab[]): string {
+  if (!tab.role) return '';
+  if (!tab.teamId) return tab.role;
+  const sameRole = allTabs
+    .filter((t) => t.teamId === tab.teamId && t.role === tab.role)
+    .sort((a, b) => a.agentId.localeCompare(b.agentId));
+  if (sameRole.length <= 1) return tab.role;
+  const idx = sameRole.findIndex((t) => t.id === tab.id);
+  return `${tab.role} ${String.fromCharCode(65 + idx)}`;
+}
+
+export interface AddTerminalTabOptions {
+  agent?: TerminalAgent;
+  role?: TeamRole | null;
+  teamId?: string | null;
+  resumeSessionId?: string | null;
+  agentId?: string;
+  teamHistoryMemberIdx?: number | null;
+  /** team-history からの resume 時に復元する手動リネーム名 */
+  customLabel?: string | null;
+}
+
+type ToastFn = (
+  msg: string,
+  opts?: { tone?: 'info' | 'success' | 'warning' | 'error' }
+) => void;
+
+export interface UseTerminalTabsOptions {
+  /** Canvas 裏マウント時の初回タブ自動生成抑制に使う。 */
+  viewMode: 'ide' | 'canvas';
+  /** Claude CLI 検査が通ったか。初回タブ自動生成のガード。 */
+  claudeReady: boolean;
+  /** 初回タブ自動生成のガード (use-project-loader の戻り値)。 */
+  projectRoot: string;
+  /** 上限警告 / 復元失敗トースト用。 */
+  showToast: ToastFn;
+  /**
+   * teams 配列。Phase 1-3 では read-only に opts 経由で受け取る。
+   * standaloneTabList / teamGroupList の useMemo・closeTerminalTab の
+   * leader 判定で参照する。Phase 1-4 (use-team-management) で本格移管予定。
+   */
+  teams: Team[];
+  /**
+   * leader タブを閉じる確認後、または leader 1 人だけの "empty team" を
+   * 即終了するパスで呼ばれる callback。Phase 1-4 まで App.tsx に実装を残し、
+   * hook には注入する (teams setter / clearSpawnTimers / cleanupTeamMcp が絡むため)。
+   */
+  closeTeam: (teamId: string) => void;
+}
+
+export interface DnDHandlers {
+  draggable: true;
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDragLeave: () => void;
+  onDrop: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+}
+
+export interface UseTerminalTabsResult {
+  // ---- state ----
+  terminalTabs: TerminalTab[];
+  setTerminalTabs: React.Dispatch<React.SetStateAction<TerminalTab[]>>;
+  activeTerminalTabId: number;
+  setActiveTerminalTabId: React.Dispatch<React.SetStateAction<number>>;
+
+  // ---- mascot 用の activity Set (Issue #363) ----
+  activeTerminalIds: ReadonlySet<number>;
+  markTerminalActivity: (tabId: number) => void;
+
+  // ---- handlers ----
+  addTerminalTab: (opts?: AddTerminalTabOptions) => number | null;
+  closeTerminalTab: (tabId: number) => void;
+  /** team-aware close path で leader を **タブ単独閉じ** にする時に使う薄い wrapper */
+  doCloseTab: (tabId: number) => void;
+  restartTerminalTab: (tabId: number) => void;
+  restartTerminal: () => void;
+
+  // ---- tab create menu UI ----
+  tabCreateMenuOpen: boolean;
+  setTabCreateMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
+
+  // ---- pending team close confirmation ----
+  pendingTeamClose: { tabId: number; teamId: string } | null;
+  setPendingTeamClose: React.Dispatch<
+    React.SetStateAction<{ tabId: number; teamId: string } | null>
+  >;
+
+  // ---- DnD ----
+  dragTabId: number | null;
+  dragOverTabId: number | null;
+  /** ペインヘッダー draggable に渡す bundle。JSX 側で展開して使う。 */
+  getDnDProps: (tabId: number) => DnDHandlers;
+
+  // ---- inline label edit ----
+  editingLabelTabId: number | null;
+  setEditingLabelTabId: React.Dispatch<React.SetStateAction<number | null>>;
+
+  // ---- 派生値 ----
+  standaloneTabList: TerminalTab[];
+  teamGroupList: { team: Team; tabs: TerminalTab[] }[];
+
+  // ---- next id ref (App.tsx 残置 callback で id 採番が必要な場合に使う) ----
+  nextTerminalIdRef: React.MutableRefObject<number>;
+
+  // ---- project switch lifecycle ----
+  /** projectSwitchedRef.current から呼ぶ。新規 Claude #1 を 1 つ自動生成して active に。 */
+  resetForProjectSwitch: () => void;
+}
+
+/**
+ * Issue #373 Phase 1-3: terminal tabs の state container と自己完結ハンドラを
+ * App.tsx から切り出した hook。
+ *
+ * - opts は `optsRef.current = opts` で毎 render 更新し、内部 useCallback の
+ *   deps から外す (use-project-loader.ts / use-file-tabs.ts と同じ流儀)。
+ * - team / TeamHub / spawn / role 系は Phase 1-4 待ち。teams は read-only に
+ *   opts 経由で受け取り、doCloseTeam は callback として外注する。
+ * - terminalRefs (TerminalViewHandle Map) は <TerminalView> JSX が App.tsx に
+ *   残るため hook では持たない。
+ */
+export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsResult {
+  const optsRef = useRef(opts);
+  optsRef.current = opts;
+
+  const [terminalTabs, setTerminalTabs] = useState<TerminalTab[]>([]);
+  const [activeTerminalTabId, setActiveTerminalTabId] = useState<number>(0);
+  const nextTerminalIdRef = useRef(1);
+
+  // Issue #363: hasActivity を terminalTabs に持たせると PTY data 受信ごとに
+  // setTerminalTabs が走り、TerminalView の親 App 全体が ~16ms 周期で再レンダーする。
+  // mascot 表示のためだけに 60Hz で App を回すのは IDE モード xterm の初期化と
+  // 衝突するので、activity フラグは別 Set state として TerminalView の props と
+  // 完全に切り離す (Set 更新は mascot の StatusBar 経路のみに伝搬)。
+  const terminalActivityTimers = useRef(new Map<number, ReturnType<typeof setTimeout>>());
+  const [activeTerminalIds, setActiveTerminalIds] = useState<ReadonlySet<number>>(
+    () => new Set()
+  );
+
+  const [tabCreateMenuOpen, setTabCreateMenuOpen] = useState(false);
+  const [pendingTeamClose, setPendingTeamClose] = useState<{
+    tabId: number;
+    teamId: string;
+  } | null>(null);
+  const [dragTabId, setDragTabId] = useState<number | null>(null);
+  const [dragOverTabId, setDragOverTabId] = useState<number | null>(null);
+  const [editingLabelTabId, setEditingLabelTabId] = useState<number | null>(null);
+
+  const markTerminalActivity = useCallback((tabId: number) => {
+    const existing = terminalActivityTimers.current.get(tabId);
+    if (existing) window.clearTimeout(existing);
+
+    setActiveTerminalIds((prev) => {
+      if (prev.has(tabId)) return prev;
+      const next = new Set(prev);
+      next.add(tabId);
+      return next;
+    });
+
+    const timer = window.setTimeout(() => {
+      terminalActivityTimers.current.delete(tabId);
+      setActiveTerminalIds((prev) => {
+        if (!prev.has(tabId)) return prev;
+        const next = new Set(prev);
+        next.delete(tabId);
+        return next;
+      });
+    }, 900);
+    terminalActivityTimers.current.set(tabId, timer);
+  }, []);
+
+  useEffect(() => {
+    const timers = terminalActivityTimers.current;
+    return () => {
+      for (const timer of timers.values()) {
+        window.clearTimeout(timer);
+      }
+      timers.clear();
+    };
+  }, []);
+
+  const addTerminalTab = useCallback(
+    (addOpts?: AddTerminalTabOptions): number | null => {
+      const id = nextTerminalIdRef.current++;
+      const agentType = addOpts?.agent ?? 'claude';
+      let accepted = false;
+      setTerminalTabs((prev) => {
+        // ラベル自動生成: チームロール or 連番
+        let label: string;
+        if (addOpts?.role) {
+          const sameRole = prev.filter(
+            (t) => t.teamId === addOpts.teamId && t.role === addOpts.role
+          );
+          const roleName = addOpts.role.charAt(0).toUpperCase() + addOpts.role.slice(1);
+          label = sameRole.length > 0 ? `${roleName} ${String.fromCharCode(65 + sameRole.length)}` : roleName;
+        } else {
+          const agentLabel = agentType === 'claude' ? 'Claude' : 'Codex';
+          const sameAgent = prev.filter((t) => t.agent === agentType && !t.role);
+          label = `${agentLabel} #${sameAgent.length + 1}`;
+        }
+        const tab: TerminalTab = {
+          id,
+          version: 0,
+          agent: agentType,
+          role: addOpts?.role ?? null,
+          teamId: addOpts?.teamId ?? null,
+          agentId: addOpts?.agentId ?? `agent-${id}`,
+          status: '',
+          exited: false,
+          resumeSessionId: addOpts?.resumeSessionId ?? null,
+          teamHistoryMemberIdx: addOpts?.teamHistoryMemberIdx ?? null,
+          label,
+          customLabel: addOpts?.customLabel ?? null
+        };
+        if (prev.length >= MAX_TERMINALS) {
+          optsRef.current.showToast(`ターミナル上限（${MAX_TERMINALS}）に達しました`, {
+            tone: 'warning'
+          });
+          return prev;
+        }
+        // 閾値を超えそうなら軽く警告
+        if (prev.length + 1 === TERMINAL_WARN_THRESHOLD) {
+          optsRef.current.showToast(
+            `ターミナル数が ${TERMINAL_WARN_THRESHOLD} に達しました（上限 ${MAX_TERMINALS}）`,
+            { tone: 'info' }
+          );
+        }
+        accepted = true;
+        return [...prev, tab];
+      });
+      if (!accepted) return null;
+      setActiveTerminalTabId(id);
+      return id;
+    },
+    []
+  );
+
+  const doCloseTab = useCallback((tabId: number) => {
+    setTerminalTabs((prev) => {
+      const next = prev.filter((t) => t.id !== tabId);
+      if (next.length === 0) {
+        // 最後の1個 → 新しいスタンドアロンタブを自動生成
+        const newId = nextTerminalIdRef.current++;
+        const fresh: TerminalTab = {
+          id: newId,
+          version: 1,
+          agent: 'claude',
+          role: null,
+          teamId: null,
+          agentId: `agent-${newId}`,
+          status: '',
+          exited: false,
+          resumeSessionId: null,
+          teamHistoryMemberIdx: null,
+          label: 'Claude #1',
+          customLabel: null
+        };
+        setActiveTerminalTabId(newId);
+        return [fresh];
+      }
+      setActiveTerminalTabId((active) => {
+        if (active !== tabId) return active;
+        const idx = prev.findIndex((t) => t.id === tabId);
+        const neighbor = next[Math.min(idx, next.length - 1)];
+        return neighbor?.id ?? next[0]?.id ?? 0;
+      });
+      return next;
+    });
+  }, []);
+
+  const closeTerminalTab = useCallback(
+    (tabId: number) => {
+      const tab = terminalTabs.find((t) => t.id === tabId);
+      if (tab?.role === 'leader' && tab.teamId) {
+        // Leader 1 人しか居ない "empty team" は確認ダイアログ不要。即チーム終了。
+        const otherMembers = terminalTabs.filter(
+          (t) => t.teamId === tab.teamId && t.id !== tabId
+        );
+        if (otherMembers.length === 0) {
+          optsRef.current.closeTeam(tab.teamId);
+          return;
+        }
+        setPendingTeamClose({ tabId, teamId: tab.teamId });
+        return;
+      }
+      doCloseTab(tabId);
+    },
+    [terminalTabs, doCloseTab]
+  );
+
+  const restartTerminalTab = useCallback((tabId: number) => {
+    setTerminalTabs((prev) =>
+      prev.map((t) =>
+        t.id === tabId
+          ? { ...t, version: t.version + 1, exited: false, status: '' }
+          : t
+      )
+    );
+  }, []);
+
+  const restartTerminal = useCallback(() => {
+    restartTerminalTab(activeTerminalTabId);
+  }, [activeTerminalTabId, restartTerminalTab]);
+
+  // 初回タブ作成: Claude OK かつ projectRoot 設定済みでタブなし。
+  // Canvas モードでは App は不可視の裏マウントなので、ここでターミナルを生やすと
+  // Rust 側で無駄な PTY が常駐し、IDE へ切り替えたときにも "迷子ターミナル" として現れる。
+  // → viewMode === 'ide' のときだけ自動生成する。
+  useEffect(() => {
+    if (
+      opts.claudeReady &&
+      opts.projectRoot &&
+      terminalTabs.length === 0 &&
+      opts.viewMode === 'ide'
+    ) {
+      addTerminalTab();
+    }
+  }, [opts.claudeReady, opts.projectRoot, terminalTabs.length, addTerminalTab, opts.viewMode]);
+
+  const { standaloneTabList, teamGroupList } = useMemo(() => {
+    const standalone = terminalTabs.filter((t) => !t.teamId);
+    const teamMap = new Map<string, TerminalTab[]>();
+    for (const t of terminalTabs) {
+      if (t.teamId) {
+        const arr = teamMap.get(t.teamId) || [];
+        arr.push(t);
+        teamMap.set(t.teamId, arr);
+      }
+    }
+    const teamGroups = [...teamMap.entries()].map(([teamId, tabs]) => ({
+      team: opts.teams.find((t) => t.id === teamId) ?? { id: teamId, name: 'Team' },
+      tabs: tabs.sort((a, b) => {
+        if (a.role === 'leader') return -1;
+        if (b.role === 'leader') return 1;
+        return a.id - b.id;
+      })
+    }));
+    return { standaloneTabList: standalone, teamGroupList: teamGroups };
+  }, [terminalTabs, opts.teams]);
+
+  const getDnDProps = useCallback(
+    (tabId: number): DnDHandlers => ({
+      draggable: true,
+      onDragStart: (e) => {
+        setDragTabId(tabId);
+        e.dataTransfer.effectAllowed = 'move';
+      },
+      onDragOver: (e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        setDragOverTabId(tabId);
+      },
+      onDragLeave: () => {
+        setDragOverTabId((prev) => (prev === tabId ? null : prev));
+      },
+      onDrop: (e) => {
+        e.preventDefault();
+        setDragTabId((from) => {
+          if (from !== null && from !== tabId) {
+            setTerminalTabs((prev) => {
+              const fromIdx = prev.findIndex((t) => t.id === from);
+              const toIdx = prev.findIndex((t) => t.id === tabId);
+              if (fromIdx === -1 || toIdx === -1) return prev;
+              const next = [...prev];
+              const [moved] = next.splice(fromIdx, 1);
+              next.splice(toIdx, 0, moved);
+              return next;
+            });
+          }
+          return null;
+        });
+        setDragOverTabId(null);
+      },
+      onDragEnd: () => {
+        setDragTabId(null);
+        setDragOverTabId(null);
+      }
+    }),
+    []
+  );
+
+  const resetForProjectSwitch = useCallback(() => {
+    const newId = nextTerminalIdRef.current++;
+    setTerminalTabs([
+      {
+        id: newId,
+        version: 0,
+        agent: 'claude',
+        role: null,
+        teamId: null,
+        agentId: `agent-${newId}`,
+        status: '起動中…',
+        exited: false,
+        resumeSessionId: null,
+        teamHistoryMemberIdx: null,
+        label: 'Claude #1',
+        customLabel: null
+      }
+    ]);
+    setActiveTerminalTabId(newId);
+  }, []);
+
+  return {
+    terminalTabs,
+    setTerminalTabs,
+    activeTerminalTabId,
+    setActiveTerminalTabId,
+    activeTerminalIds,
+    markTerminalActivity,
+    addTerminalTab,
+    closeTerminalTab,
+    doCloseTab,
+    restartTerminalTab,
+    restartTerminal,
+    tabCreateMenuOpen,
+    setTabCreateMenuOpen,
+    pendingTeamClose,
+    setPendingTeamClose,
+    dragTabId,
+    dragOverTabId,
+    getDnDProps,
+    editingLabelTabId,
+    setEditingLabelTabId,
+    standaloneTabList,
+    teamGroupList,
+    nextTerminalIdRef,
+    resetForProjectSwitch
+  };
+}


### PR DESCRIPTION
## Summary

Issue #373 (God File 解体ロードマップ) の **Phase 1-3**。`App.tsx` から terminal tab の state container と自己完結ハンドラを `src/renderer/src/lib/hooks/use-terminal-tabs.ts` に切り出した。

- \`App.tsx\` 2341 → 2107 行 (**-234**)
- 新規 hook 461 行
- 累計削減 (Issue #373): **-688 行** (目標 -1995)

### 移管した内容

- **state**: \`terminalTabs\` / \`activeTerminalTabId\` / \`nextTerminalIdRef\` / \`terminalActivityTimers\` / \`activeTerminalIds\` / \`tabCreateMenuOpen\` / \`pendingTeamClose\` / \`dragTabId\` / \`dragOverTabId\` / \`editingLabelTabId\`
- **handler**: \`addTerminalTab\` / \`closeTerminalTab\` / \`doCloseTab\` / \`restartTerminalTab\` / \`restartTerminal\` / \`markTerminalActivity\`
- **派生値**: \`standaloneTabList\` / \`teamGroupList\` の \`useMemo\`
- **定数 / 純粋関数**: \`MAX_TERMINALS\` / \`TERMINAL_WARN_THRESHOLD\` / \`getRoleDisplayLabel\` / \`TerminalTab\` interface
- **effect**: 初回タブ自動生成 (\`viewMode === 'ide'\` ガード付き) と activity timer の cleanup
- **DnD**: \`onDragStart\` / \`Over\` / \`Leave\` / \`Drop\` / \`End\` の 5 ハンドラを \`getDnDProps(tabId)\` factory にまとめて JSX 側でスプレッド可能に

### Phase 1-1 / 1-2 と揃えた点

- opts (\`viewMode\` / \`claudeReady\` / \`projectRoot\` / \`showToast\` / \`teams\` / \`closeTeam\`) は \`optsRef.current = opts\` で毎 render 更新し、内部 \`useCallback\` の deps から外す
- \`useT\` は使用箇所が無いため取り込まず (現状トースト文言は日本語ハードコード)
- \`resetForProjectSwitch()\` を expose し、\`projectSwitchedRef.current\` から呼ぶ流儀

### Phase 1-4 待ち / App.tsx 残置の理由

- \`teams\` / \`setTeams\` state、\`doCloseTeam\` 関数: Phase 1-4 (use-team-management) で本格移管する。本 PR では \`closeTeamRef\` ブリッジで hook の \`opts.closeTeam\` に注入して循環を解消
- \`terminalRefs\` (\`TerminalViewHandle\` Map): \`<TerminalView>\` の JSX 配線が App.tsx に残るため (props が teams / TeamHub / role profile 系に依存)。Phase 1-4 で再検討
- \`getTerminalArgs\` / \`getCodexInstructions\` / \`getRolePrompt\` / \`generateTeamSystemPrompt\` 等: TeamHub / role profile / settings 系に深く依存するため Phase 1-4 送り

### 不変式 (Issue #373 全 Phase 共通)

維持していることを確認:
- IPC コマンド名・event 名は一切変更なし
- \`subscribeEventReady\` / pre-subscribe パターンは触らず
- Canvas モード裏マウント時の初回タブ生成抑制 (\`viewMode === 'ide'\` ガード) は hook 内 effect として維持。CLAUDE.md 不変式 #5 (Canvas 常時マウント前提) を保つ
- Issue #363 (activity フラグを別 Set state に分離して TerminalView から切り離す) を hook 内でも維持
- DnD 中の race ガード (\`fromIdx === -1 || toIdx === -1\` 早期 return) を維持
- \`<TerminalView key=...>\` の安定性に依存する xterm + PTY の re-mount 防止は JSX 側で完結 (本 PR は state container 化のみ)

## Test plan

- [x] \`npm run typecheck\` — green
- [x] \`cargo check --manifest-path src-tauri/Cargo.toml\` — green
- [x] \`cargo clippy --no-deps\` — 既存ベースライン 15 件のまま (新規警告ゼロ)
- [ ] 手動 smoke (\`tasks/refactor-smoke.md\` Phase 1 必須項目): #1 起動, #4 タブ open/close/save (今回の対象外だが確認), #7 ショートカット, **追加で**: ターミナル起動 / DnD 並べ替え / leader close 確認ダイアログ / Canvas ↔ IDE 切替 / project switch 時の terminal リセット / mascot activity 表示

Refs #373