### PR TITLE
refactor(app): #373 Phase 1-5 use-layout-resize.ts に panel resize を切り出し

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -63,6 +63,7 @@ import {
 } from './lib/hooks/use-terminal-tabs';
 import type { TerminalTab } from './lib/hooks/use-terminal-tabs';
 import { useTeamManagement } from './lib/hooks/use-team-management';
+import { useLayoutResize } from './lib/hooks/use-layout-resize';
 import type { Command } from './lib/commands';
 
 const THEMES_FOR_PALETTE: ThemeName[] = [
@@ -341,135 +342,13 @@ export function App(): JSX.Element {
     };
   }, []);
 
-  // ---------- Claude Code パネル リサイズ ----------
-  const MIN_PANEL = 320;
-  const MAX_PANEL = 900;
-  const resizeDragRef = useRef<{ startX: number; startWidth: number } | null>(null);
-
-  // ---------- サイドバー リサイズ (Issue #337) ----------
-  const MIN_SIDEBAR = 200;
-  const MAX_SIDEBAR = 600;
-  const DEFAULT_SIDEBAR = 272;
-  const sidebarResizeDragRef = useRef<{ startX: number; startWidth: number } | null>(null);
-
-  // 設定からの初期幅を CSS 変数に反映
-  useEffect(() => {
-    const w = Math.max(
-      MIN_PANEL,
-      Math.min(MAX_PANEL, settings.claudeCodePanelWidth ?? 460)
-    );
-    document.documentElement.style.setProperty('--claude-code-width', `${w}px`);
-  }, [settings.claudeCodePanelWidth]);
-
-  // Issue #337: サイドバー幅を CSS 変数に反映
-  useEffect(() => {
-    const w = Math.max(
-      MIN_SIDEBAR,
-      Math.min(MAX_SIDEBAR, settings.sidebarWidth ?? DEFAULT_SIDEBAR)
-    );
-    document.documentElement.style.setProperty('--shell-sidebar-w', `${w}px`);
-  }, [settings.sidebarWidth]);
-
-  const handleResizeStart = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      const currentWidth = Math.max(
-        MIN_PANEL,
-        Math.min(MAX_PANEL, settings.claudeCodePanelWidth ?? 460)
-      );
-      resizeDragRef.current = {
-        startX: e.clientX,
-        startWidth: currentWidth
-      };
-      document.body.classList.add('is-resizing');
-      const handleEl = e.currentTarget;
-      handleEl.classList.add('is-dragging');
-
-      let latestWidth = currentWidth;
-
-      const onMove = (ev: MouseEvent): void => {
-        const drag = resizeDragRef.current;
-        if (!drag) return;
-        const dx = drag.startX - ev.clientX; // 左へドラッグ = width 増える
-        const next = Math.max(
-          MIN_PANEL,
-          Math.min(MAX_PANEL, drag.startWidth + dx)
-        );
-        latestWidth = next;
-        // ドラッグ中は CSS 変数を直接書き換え（React 再レンダリング回避）
-        document.documentElement.style.setProperty(
-          '--claude-code-width',
-          `${next}px`
-        );
-      };
-
-      const onUp = (): void => {
-        resizeDragRef.current = null;
-        document.body.classList.remove('is-resizing');
-        handleEl.classList.remove('is-dragging');
-        document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', onUp);
-        // 確定値を設定に保存
-        void updateSettings({ claudeCodePanelWidth: latestWidth });
-      };
-
-      document.addEventListener('mousemove', onMove);
-      document.addEventListener('mouseup', onUp);
-    },
-    [settings.claudeCodePanelWidth, updateSettings]
-  );
-
-  // Issue #337: サイドバーと main の境界をドラッグして幅を調整する
-  const handleSidebarResizeStart = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      const currentWidth = Math.max(
-        MIN_SIDEBAR,
-        Math.min(MAX_SIDEBAR, settings.sidebarWidth ?? DEFAULT_SIDEBAR)
-      );
-      sidebarResizeDragRef.current = {
-        startX: e.clientX,
-        startWidth: currentWidth
-      };
-      document.body.classList.add('is-resizing');
-      const handleEl = e.currentTarget;
-      handleEl.classList.add('is-dragging');
-
-      let latestWidth = currentWidth;
-
-      const onMove = (ev: MouseEvent): void => {
-        const drag = sidebarResizeDragRef.current;
-        if (!drag) return;
-        // 右へドラッグ = width 増える (claude-code-panel と方向が逆)
-        const dx = ev.clientX - drag.startX;
-        const next = Math.max(
-          MIN_SIDEBAR,
-          Math.min(MAX_SIDEBAR, drag.startWidth + dx)
-        );
-        latestWidth = next;
-        document.documentElement.style.setProperty('--shell-sidebar-w', `${next}px`);
-      };
-
-      const onUp = (): void => {
-        sidebarResizeDragRef.current = null;
-        document.body.classList.remove('is-resizing');
-        handleEl.classList.remove('is-dragging');
-        document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', onUp);
-        void updateSettings({ sidebarWidth: latestWidth });
-      };
-
-      document.addEventListener('mousemove', onMove);
-      document.addEventListener('mouseup', onUp);
-    },
-    [settings.sidebarWidth, updateSettings]
-  );
-
-  // Issue #337: ダブルクリックで default 幅にリセット
-  const handleSidebarResizeDouble = useCallback(() => {
-    document.documentElement.style.setProperty('--shell-sidebar-w', `${DEFAULT_SIDEBAR}px`);
-    void updateSettings({ sidebarWidth: DEFAULT_SIDEBAR });
-  }, [updateSettings]);
+  // Phase 1-5 (Issue #373): Claude Code パネル / サイドバーの drag リサイズと
+  // CSS 変数同期は use-layout-resize.ts に集約。
+  const {
+    onClaudePanelResizeStart,
+    onSidebarResizeStart,
+    onSidebarResizeDouble
+  } = useLayoutResize();
 
   // Phase 1-1 / 1-2 / 1-3 (Issue #373): loadProject / 初回ロード effect / タイトルバー
   // effect / refreshGit は use-project-loader.ts、editor/diff tab 関連は use-file-tabs.ts、
@@ -1269,8 +1148,8 @@ export function App(): JSX.Element {
       {/* Issue #337: サイドバー幅調整ハンドル */}
       <div
         className="resize-handle resize-handle--sidebar"
-        onMouseDown={handleSidebarResizeStart}
-        onDoubleClick={handleSidebarResizeDouble}
+        onMouseDown={onSidebarResizeStart}
+        onDoubleClick={onSidebarResizeDouble}
         title="ドラッグでサイドバー幅を調整 / ダブルクリックでリセット"
         role="separator"
         aria-orientation="vertical"
@@ -1324,7 +1203,7 @@ export function App(): JSX.Element {
       {hasActiveContent && (
         <div
           className="resize-handle"
-          onMouseDown={handleResizeStart}
+          onMouseDown={onClaudePanelResizeStart}
           title="ドラッグで Claude Code パネルの幅を調整"
           role="separator"
           aria-orientation="vertical"

--- a/src/renderer/src/lib/hooks/use-layout-resize.ts
+++ b/src/renderer/src/lib/hooks/use-layout-resize.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useSettingsActions, useSettingsValue } from '../settings-context';
+
+/** Claude Code パネル最小幅 (px) */
+const MIN_PANEL = 320;
+/** Claude Code パネル最大幅 (px) */
+const MAX_PANEL = 900;
+/** Claude Code パネルのデフォルト幅。CSS の var() フォールバックと一致 */
+const DEFAULT_PANEL = 460;
+
+/** サイドバー最小幅 (px) - Issue #337 */
+const MIN_SIDEBAR = 200;
+/** サイドバー最大幅 (px) - Issue #337 */
+const MAX_SIDEBAR = 600;
+/** サイドバーのデフォルト幅。dblclick リセット先 - Issue #337 */
+const DEFAULT_SIDEBAR = 272;
+
+export interface UseLayoutResizeResult {
+  /** Claude Code パネル左端ハンドルの onMouseDown */
+  onClaudePanelResizeStart: (e: React.MouseEvent<HTMLDivElement>) => void;
+  /** サイドバー右端ハンドルの onMouseDown */
+  onSidebarResizeStart: (e: React.MouseEvent<HTMLDivElement>) => void;
+  /** サイドバー右端ハンドルの onDoubleClick (DEFAULT_SIDEBAR にリセット) */
+  onSidebarResizeDouble: () => void;
+}
+
+/**
+ * Issue #373 Phase 1-5: Claude Code パネル / サイドバーの drag リサイズと
+ * settings 永続化を App.tsx から切り出した hook。
+ *
+ * 設計:
+ * - drag 中は React の再レンダリングを避けるため、CSS 変数 (`--claude-code-width` /
+ *   `--shell-sidebar-w`) を `document.documentElement.style.setProperty` で直接更新
+ *   する。`updateSettings` は **mouseup の 1 回のみ** で呼んで永続化する
+ *   (debounce ではなく mouseup gating)。
+ * - 起動時 / settings 復元時に CSS 変数を初期化する effect を 2 本持つ。
+ *   `index.css` / `tokens.css` 側に var() フォールバックがあるので、ロード前は
+ *   既定値で描画される。
+ *
+ * Phase 1-1 〜 1-4 と異なり、本 hook は **opts を一切取らない** (settings の
+ * 読み書きのみで完結する純粋な責務のため)。
+ */
+export function useLayoutResize(): UseLayoutResizeResult {
+  const claudeCodePanelWidth = useSettingsValue('claudeCodePanelWidth');
+  const sidebarWidth = useSettingsValue('sidebarWidth');
+  const { update: updateSettings } = useSettingsActions();
+
+  const resizeDragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const sidebarResizeDragRef = useRef<{ startX: number; startWidth: number } | null>(
+    null
+  );
+
+  // 設定からの初期幅を CSS 変数に反映 (Claude Code パネル)
+  useEffect(() => {
+    const w = Math.max(MIN_PANEL, Math.min(MAX_PANEL, claudeCodePanelWidth ?? DEFAULT_PANEL));
+    document.documentElement.style.setProperty('--claude-code-width', `${w}px`);
+  }, [claudeCodePanelWidth]);
+
+  // Issue #337: サイドバー幅を CSS 変数に反映
+  useEffect(() => {
+    const w = Math.max(MIN_SIDEBAR, Math.min(MAX_SIDEBAR, sidebarWidth ?? DEFAULT_SIDEBAR));
+    document.documentElement.style.setProperty('--shell-sidebar-w', `${w}px`);
+  }, [sidebarWidth]);
+
+  const onClaudePanelResizeStart = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const currentWidth = Math.max(
+        MIN_PANEL,
+        Math.min(MAX_PANEL, claudeCodePanelWidth ?? DEFAULT_PANEL)
+      );
+      resizeDragRef.current = {
+        startX: e.clientX,
+        startWidth: currentWidth
+      };
+      document.body.classList.add('is-resizing');
+      const handleEl = e.currentTarget;
+      handleEl.classList.add('is-dragging');
+
+      let latestWidth = currentWidth;
+
+      const onMove = (ev: MouseEvent): void => {
+        const drag = resizeDragRef.current;
+        if (!drag) return;
+        const dx = drag.startX - ev.clientX; // 左へドラッグ = width 増える
+        const next = Math.max(MIN_PANEL, Math.min(MAX_PANEL, drag.startWidth + dx));
+        latestWidth = next;
+        // ドラッグ中は CSS 変数を直接書き換え（React 再レンダリング回避）
+        document.documentElement.style.setProperty(
+          '--claude-code-width',
+          `${next}px`
+        );
+      };
+
+      const onUp = (): void => {
+        resizeDragRef.current = null;
+        document.body.classList.remove('is-resizing');
+        handleEl.classList.remove('is-dragging');
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        // 確定値を設定に保存
+        void updateSettings({ claudeCodePanelWidth: latestWidth });
+      };
+
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [claudeCodePanelWidth, updateSettings]
+  );
+
+  // Issue #337: サイドバーと main の境界をドラッグして幅を調整する
+  const onSidebarResizeStart = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const currentWidth = Math.max(
+        MIN_SIDEBAR,
+        Math.min(MAX_SIDEBAR, sidebarWidth ?? DEFAULT_SIDEBAR)
+      );
+      sidebarResizeDragRef.current = {
+        startX: e.clientX,
+        startWidth: currentWidth
+      };
+      document.body.classList.add('is-resizing');
+      const handleEl = e.currentTarget;
+      handleEl.classList.add('is-dragging');
+
+      let latestWidth = currentWidth;
+
+      const onMove = (ev: MouseEvent): void => {
+        const drag = sidebarResizeDragRef.current;
+        if (!drag) return;
+        // 右へドラッグ = width 増える (claude-code-panel と方向が逆)
+        const dx = ev.clientX - drag.startX;
+        const next = Math.max(
+          MIN_SIDEBAR,
+          Math.min(MAX_SIDEBAR, drag.startWidth + dx)
+        );
+        latestWidth = next;
+        document.documentElement.style.setProperty('--shell-sidebar-w', `${next}px`);
+      };
+
+      const onUp = (): void => {
+        sidebarResizeDragRef.current = null;
+        document.body.classList.remove('is-resizing');
+        handleEl.classList.remove('is-dragging');
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        void updateSettings({ sidebarWidth: latestWidth });
+      };
+
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [sidebarWidth, updateSettings]
+  );
+
+  // Issue #337: ダブルクリックで default 幅にリセット
+  const onSidebarResizeDouble = useCallback(() => {
+    document.documentElement.style.setProperty(
+      '--shell-sidebar-w',
+      `${DEFAULT_SIDEBAR}px`
+    );
+    void updateSettings({ sidebarWidth: DEFAULT_SIDEBAR });
+  }, [updateSettings]);
+
+  return {
+    onClaudePanelResizeStart,
+    onSidebarResizeStart,
+    onSidebarResizeDouble
+  };
+}


### PR DESCRIPTION
## Summary

Issue #373 (God File 解体ロードマップ) の **Phase 1-5**。`App.tsx` から Claude Code パネル / サイドバーの drag リサイズ・CSS 変数同期・dblclick リセットを新規 hook に集約。

- \`App.tsx\` 1656 → **1535 行 (-121)**
- 新規 \`use-layout-resize.ts\` 171 行
- 累計削減 (Phase 1-1〜1-5): **-1292 行** (Issue #373 目標 -1995 の **65%**)

### 移管した内容

- **定数**: \`MIN_PANEL\` / \`MAX_PANEL\` / \`DEFAULT_PANEL\` / \`MIN_SIDEBAR\` / \`MAX_SIDEBAR\` / \`DEFAULT_SIDEBAR\`
- **ref**: \`resizeDragRef\` / \`sidebarResizeDragRef\`
- **effect**: settings 復元時に CSS 変数 (\`--claude-code-width\` / \`--shell-sidebar-w\`) を初期化する 2 本
- **handler**: \`onClaudePanelResizeStart\` / \`onSidebarResizeStart\` / \`onSidebarResizeDouble\` (旧 \`handleResizeStart\` / \`handleSidebarResizeStart\` / \`handleSidebarResizeDouble\` から rename)

### Phase 1-1〜1-4 との違い

Phase 1-1 〜 1-4 と異なり **opts を一切取らない**。settings の読み書きのみで完結する純粋な責務のため、\`useSettingsValue\` / \`useSettingsActions\` を hook 内で直接呼ぶ流儀のみ採用。

### 不変式 (Issue #373 全 Phase 共通)

維持していることを確認:
- drag 中の React 再レンダリング回避 (CSS 変数を \`documentElement.style.setProperty\` に直接書き込み) は完全保持
- \`updateSettings\` の呼び出し頻度は **mouseup の 1 回のみ** (debounce ではなく mouseup gating) — 現行と同一
- \`body.classList.add('is-resizing')\` / \`handle.classList.add('is-dragging')\` の付与・剥がしは現行どおり
- CSS 変数名 (\`--claude-code-width\` / \`--shell-sidebar-w\`) は据え置き (リネームは別 issue 化)
- IPC コマンド名・event 名は一切変更なし

## Test plan

- [x] \`npm run typecheck\` — green
- [x] \`cargo check --manifest-path src-tauri/Cargo.toml\` — green
- [x] \`cargo clippy --no-deps\` — 既存ベースライン 15 件のまま (新規警告ゼロ)
- [ ] 手動 smoke: Claude Code パネルの drag 幅変更 → リロードで復元 / サイドバーの drag 幅変更 → リロードで復元 / サイドバー dblclick で 272px にリセット / drag 中の body cursor 変化

Refs #373