### PR TITLE
refactor(app): #373 Phase 1-6 use-app-shortcuts.ts にショートカットを切り出し

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -50,7 +50,6 @@ import {
 } from './lib/settings-context';
 import { useToast } from './lib/toast-context';
 import { useUiStore } from './stores/ui';
-import { webviewZoom } from './lib/webview-zoom';
 import { dedupPrepend, listContainsPath } from './lib/path-norm';
 import { useProjectLoader } from './lib/hooks/use-project-loader';
 import { useFileTabs } from './lib/hooks/use-file-tabs';
@@ -64,6 +63,7 @@ import {
 import type { TerminalTab } from './lib/hooks/use-terminal-tabs';
 import { useTeamManagement } from './lib/hooks/use-team-management';
 import { useLayoutResize } from './lib/hooks/use-layout-resize';
+import { useAppShortcuts } from './lib/hooks/use-app-shortcuts';
 import type { Command } from './lib/commands';
 
 const THEMES_FOR_PALETTE: ThemeName[] = [
@@ -797,85 +797,18 @@ export function App(): JSX.Element {
     dismissToast
   ]);
 
-  // ---------- Shift+ホイールで webview zoom ----------
-  // webviewZoom (factor 0.5-3.0) に委譲。Ctrl+=/-/0 と同じ値を共有するので
-  // 両方の経路を混ぜて操作しても状態が食い違わない。
-  useEffect(() => {
-    const handler = (e: WheelEvent): void => {
-      if (!e.shiftKey) return;
-      e.preventDefault();
-      webviewZoom.adjust(e.deltaY > 0 ? -webviewZoom.STEP : webviewZoom.STEP);
-    };
-    window.addEventListener('wheel', handler, { passive: false });
-    return () => window.removeEventListener('wheel', handler);
-  }, []);
-
-  // ---------- グローバルショートカット ----------
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent): void => {
-      const mod = e.ctrlKey || e.metaKey;
-      if (!mod) {
-        if (e.key === 'Escape') {
-          if (paletteOpen) setPaletteOpen(false);
-          else if (settingsOpen) setSettingsOpen(false);
-        }
-        return;
-      }
-      // Issue #162: Ctrl+Shift+P (パレット toggle) と Ctrl+, (設定) は modal open 中でも
-      // 反応してよい (toggle 用途のため)。それ以外のショートカット (Ctrl+S / Ctrl+Tab /
-      // Ctrl+W / Ctrl+Shift+T) は modal/palette open 中はブロックする。
-      const modalIsOpen = paletteOpen || settingsOpen;
-      if (e.shiftKey && (e.key === 'P' || e.key === 'p')) {
-        e.preventDefault();
-        e.stopPropagation();
-        setPaletteOpen((v) => !v);
-        return;
-      }
-      if (e.key === ',') {
-        e.preventDefault();
-        setSettingsOpen(true);
-        return;
-      }
-      if (modalIsOpen) {
-        // 以降の保存・タブ切替・タブ閉じはブロック
-        return;
-      }
-      if (!e.shiftKey && (e.key === 's' || e.key === 'S')) {
-        if (activeTabId && activeTabId.startsWith('edit:')) {
-          e.preventDefault();
-          e.stopPropagation();
-          void saveEditorTab(activeTabId);
-        }
-        return;
-      }
-      if (e.key === 'Tab') {
-        e.preventDefault();
-        e.stopPropagation();
-        cycleTab(e.shiftKey ? -1 : 1);
-        return;
-      }
-      if (e.key === 'w' || e.key === 'W') {
-        // Issue #38: フォーカスが xterm (Claude / Codex / シェル) の中にあるときは
-        // Ctrl+W を「直前の単語を削除」として PTY に素通しさせる。
-        const active = document.activeElement as HTMLElement | null;
-        const inTerminal = active?.closest?.('.xterm') !== undefined &&
-          active?.closest?.('.xterm') !== null;
-        if (!inTerminal && activeTabId) {
-          e.preventDefault();
-          e.stopPropagation();
-          closeTab(activeTabId);
-        }
-        return;
-      }
-      if (e.shiftKey && (e.key === 'T' || e.key === 't')) {
-        e.preventDefault();
-        reopenLastClosed();
-      }
-    };
-    window.addEventListener('keydown', handler, true);
-    return () => window.removeEventListener('keydown', handler, true);
-  }, [paletteOpen, settingsOpen, activeTabId, cycleTab, closeTab, reopenLastClosed, saveEditorTab]);
+  // Phase 1-6 (Issue #373): グローバルショートカット + Shift+wheel zoom を hook に集約。
+  useAppShortcuts({
+    paletteOpen,
+    setPaletteOpen,
+    settingsOpen,
+    setSettingsOpen,
+    activeTabId,
+    cycleTab,
+    closeTab,
+    reopenLastClosed,
+    saveEditorTab
+  });
 
   // 起動引数合成 (getTerminalArgs / getCodexInstructions / getTerminalEnv /
   // getRolePrompt) と チーム履歴 resume/削除 / Leader-only close /

--- a/src/renderer/src/lib/hooks/use-app-shortcuts.ts
+++ b/src/renderer/src/lib/hooks/use-app-shortcuts.ts
@@ -1,0 +1,124 @@
+import { useEffect, useRef } from 'react';
+import { webviewZoom } from '../webview-zoom';
+
+export interface UseAppShortcutsOptions {
+  /** コマンドパレットの開閉状態。Escape / Ctrl+Shift+P で参照・更新する。 */
+  paletteOpen: boolean;
+  setPaletteOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  /** 設定モーダルの開閉状態。Escape / Ctrl+, で参照・更新する。 */
+  settingsOpen: boolean;
+  setSettingsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /** Phase 1-2 (use-file-tabs) hook 戻り値ブリッジ。 */
+  activeTabId: string | null;
+  cycleTab: (direction: 1 | -1) => void;
+  closeTab: (id: string) => void;
+  reopenLastClosed: () => void;
+  saveEditorTab: (id: string) => Promise<void>;
+}
+
+/**
+ * Issue #373 Phase 1-6: グローバルショートカット (Ctrl+Shift+P / Ctrl+, /
+ * Ctrl+S / Ctrl+Tab / Ctrl+W / Ctrl+Shift+T / Escape) と Shift+wheel zoom を
+ * App.tsx から切り出した hook。
+ *
+ * 設計:
+ * - opts は `optsRef.current = opts` で毎 render 更新し、内部 useEffect の
+ *   deps を `[]` で固定する (Phase 1-1 〜 1-5 と同じ流儀)。これにより
+ *   listener を 1 度だけ register/unregister する形になり、毎 render の
+ *   attach/detach コストを排除する。
+ * - 不変式 (絶対に壊さない):
+ *   - Issue #38: Ctrl+W で xterm 内にフォーカスがあれば PTY に素通し
+ *   - Issue #162: modal open 中は Ctrl+S / Ctrl+Tab / Ctrl+W / Ctrl+Shift+T を
+ *     ブロック (Ctrl+Shift+P と Ctrl+, は toggle 用途のため通す)
+ *   - keydown は `{ capture: true }` で attach (子の stopPropagation より先に拾う)
+ *   - wheel は `{ passive: false }` で attach (preventDefault が効くために必須)
+ *   - Escape の優先順位: palette が開いていれば palette、そうでなければ settings
+ *
+ * Phase 1-9 (AppShell 化) で Ctrl+B (sidebar toggle) や theme cycle を統合する
+ * 場合はここに合流させる。
+ */
+export function useAppShortcuts(opts: UseAppShortcutsOptions): void {
+  const optsRef = useRef(opts);
+  optsRef.current = opts;
+
+  // Shift+ホイールで webview zoom
+  // webviewZoom (factor 0.5-3.0) に委譲。Ctrl+=/-/0 と同じ値を共有するので
+  // 両方の経路を混ぜて操作しても状態が食い違わない。
+  useEffect(() => {
+    const handler = (e: WheelEvent): void => {
+      if (!e.shiftKey) return;
+      e.preventDefault();
+      webviewZoom.adjust(e.deltaY > 0 ? -webviewZoom.STEP : webviewZoom.STEP);
+    };
+    window.addEventListener('wheel', handler, { passive: false });
+    return () => window.removeEventListener('wheel', handler);
+  }, []);
+
+  // グローバルショートカット
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      const o = optsRef.current;
+      const mod = e.ctrlKey || e.metaKey;
+      if (!mod) {
+        if (e.key === 'Escape') {
+          if (o.paletteOpen) o.setPaletteOpen(false);
+          else if (o.settingsOpen) o.setSettingsOpen(false);
+        }
+        return;
+      }
+      // Issue #162: Ctrl+Shift+P (パレット toggle) と Ctrl+, (設定) は modal open 中でも
+      // 反応してよい (toggle 用途のため)。それ以外のショートカット (Ctrl+S / Ctrl+Tab /
+      // Ctrl+W / Ctrl+Shift+T) は modal/palette open 中はブロックする。
+      const modalIsOpen = o.paletteOpen || o.settingsOpen;
+      if (e.shiftKey && (e.key === 'P' || e.key === 'p')) {
+        e.preventDefault();
+        e.stopPropagation();
+        o.setPaletteOpen((v) => !v);
+        return;
+      }
+      if (e.key === ',') {
+        e.preventDefault();
+        o.setSettingsOpen(true);
+        return;
+      }
+      if (modalIsOpen) {
+        // 以降の保存・タブ切替・タブ閉じはブロック
+        return;
+      }
+      if (!e.shiftKey && (e.key === 's' || e.key === 'S')) {
+        if (o.activeTabId && o.activeTabId.startsWith('edit:')) {
+          e.preventDefault();
+          e.stopPropagation();
+          void o.saveEditorTab(o.activeTabId);
+        }
+        return;
+      }
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        e.stopPropagation();
+        o.cycleTab(e.shiftKey ? -1 : 1);
+        return;
+      }
+      if (e.key === 'w' || e.key === 'W') {
+        // Issue #38: フォーカスが xterm (Claude / Codex / シェル) の中にあるときは
+        // Ctrl+W を「直前の単語を削除」として PTY に素通しさせる。
+        const active = document.activeElement as HTMLElement | null;
+        const inTerminal = active?.closest?.('.xterm') !== undefined &&
+          active?.closest?.('.xterm') !== null;
+        if (!inTerminal && o.activeTabId) {
+          e.preventDefault();
+          e.stopPropagation();
+          o.closeTab(o.activeTabId);
+        }
+        return;
+      }
+      if (e.shiftKey && (e.key === 'T' || e.key === 't')) {
+        e.preventDefault();
+        o.reopenLastClosed();
+      }
+    };
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, []);
+}


### PR DESCRIPTION
## Summary

Issue #373 (God File 解体ロードマップ) の **Phase 1-6**。\`App.tsx\` からグローバルショートカット (Ctrl+Shift+P / Ctrl+, / Ctrl+S / Ctrl+Tab / Ctrl+W / Ctrl+Shift+T / Escape) と Shift+wheel zoom を新規 hook に集約。

- \`App.tsx\` 1535 → **1468 行 (-67)**
- 新規 \`use-app-shortcuts.ts\` 124 行
- 累計削減 (Phase 1-1〜1-6): **-1359 行** (Issue #373 目標 -1995 の **68%**)

### 移管した内容

- **Shift+wheel zoom** useEffect (\`webviewZoom.adjust\` 経由)
- **グローバルキーボードショートカット** useEffect:
  - Escape: palette → settings の優先順位で modal を閉じる
  - Ctrl+Shift+P: コマンドパレット toggle
  - Ctrl+,: 設定モーダルを開く
  - Ctrl+S: エディタタブ保存 (\`edit:\` プレフィックスのタブのみ)
  - Ctrl+Tab / Ctrl+Shift+Tab: タブ循環
  - Ctrl+W: タブ close (xterm 内なら PTY に素通し)
  - Ctrl+Shift+T: 直近 close したタブを復元

### Phase 1-1〜1-5 と揃えた点

- opts は \`optsRef.current = opts\` で毎 render 更新し、内部 useEffect の deps を \`[]\` で固定
- listener の attach/detach は 1 度だけ。毎 render での再 attach コストを排除
- 戻り値なし (副作用のみ) — \`use-recruit-listener\` / \`use-window-frame-insets\` と同じパターン

### 不変式 (Issue #373 全 Phase 共通)

維持していることを確認:
- **Issue #38**: Ctrl+W で xterm にフォーカスがあれば PTY に素通し (\`document.activeElement?.closest('.xterm')\` 判定は逐字保持)
- **Issue #162**: modal open 中は Ctrl+S / Ctrl+Tab / Ctrl+W / Ctrl+Shift+T をブロック (Ctrl+Shift+P と Ctrl+, は toggle 用途のため通す)
- keydown listener は \`{ capture: true }\` で attach (子の \`stopPropagation\` より先に拾う)
- wheel listener は \`{ passive: false }\` で attach (\`preventDefault\` が効くために必須)
- Escape の優先順位 (palette 優先、なければ settings) を維持
- \`e.preventDefault()\` / \`e.stopPropagation()\` の有無は元コードから逐字保持

### スコープ外 (Phase 1-9 検討)

- Ctrl+B sidebar toggle (\`useUiStore.toggleSidebar\` 由来) は別 effect として残置。opts 肥大化を避けるため、Phase 1-9 (AppShell 化) で他の UI 系統と一緒に整理する候補

## Test plan

- [x] \`npm run typecheck\` — green
- [x] \`cargo check --manifest-path src-tauri/Cargo.toml\` — green
- [x] \`cargo clippy --no-deps\` — 既存ベースライン 15 件のまま (新規警告ゼロ)
- [ ] 手動 smoke: Ctrl+Shift+P でパレット toggle / Ctrl+, で設定 / Ctrl+S でエディタ保存 / Ctrl+Tab でタブ循環 / Ctrl+W でタブ close (xterm 内では PTY に流れる) / Ctrl+Shift+T で reopen / Escape で modal close / Shift+wheel で zoom

Refs #373