### PR TITLE
refactor(app): #373 Phase 1-7 use-claude-check.ts に CLI 検査を切り出し

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -64,6 +64,7 @@ import type { TerminalTab } from './lib/hooks/use-terminal-tabs';
 import { useTeamManagement } from './lib/hooks/use-team-management';
 import { useLayoutResize } from './lib/hooks/use-layout-resize';
 import { useAppShortcuts } from './lib/hooks/use-app-shortcuts';
+import { useClaudeCheck } from './lib/hooks/use-claude-check';
 import type { Command } from './lib/commands';
 
 const THEMES_FOR_PALETTE: ThemeName[] = [
@@ -197,11 +198,9 @@ export function App(): JSX.Element {
   // 残るため。
   const terminalRefs = useRef(new Map<number, TerminalViewHandle>());
 
-  // Claude CLI 検査状態
-  const [claudeCheck, setClaudeCheck] = useState<{
-    state: 'checking' | 'ok' | 'missing';
-    error?: string;
-  }>({ state: 'checking' });
+  // Phase 1-7 (Issue #373): Claude CLI 検査と起動時アップデーター遅延 effect を
+  // hook に集約。
+  const { claudeCheck, runClaudeCheck } = useClaudeCheck();
 
   // コンテキストメニュー
   const [contextMenu, setContextMenu] = useState<{
@@ -269,45 +268,8 @@ export function App(): JSX.Element {
   });
   closeTeamRef.current = doCloseTeam;
 
-  // ---------- Claude CLI 検査 ----------
-  const runClaudeCheck = useCallback(async () => {
-    setClaudeCheck({ state: 'checking' });
-    try {
-      const res = await window.api.app.checkClaude(settings.claudeCommand || 'claude');
-      setClaudeCheck(
-        res.ok
-          ? { state: 'ok' }
-          : { state: 'missing', error: res.error }
-      );
-    } catch (err) {
-      setClaudeCheck({ state: 'missing', error: String(err) });
-    }
-  }, [settings.claudeCommand]);
-
-  // 設定の claudeCommand が変わるたびに再検査
-  useEffect(() => {
-    void runClaudeCheck();
-  }, [runClaudeCheck]);
-
-  // 起動時に GitHub Release の latest.json を「確認だけ」する (prod のみ)。
-  // 旧仕様の「ask → 即 install → relaunch」は撤廃。代わりに silentCheckForUpdate で
-  // 更新の有無を検出して useUiStore.availableUpdate に書き、Topbar / CanvasLayout の
-  // 「Update」ボタンを点灯させる。実 install はユーザーがボタンを押したときだけ走る。
-  // 起動直後の負荷を避けるため少し遅延させる (5 秒)。
-  useEffect(() => {
-    let cancelled = false;
-    const handle = window.setTimeout(() => {
-      void import('./lib/updater-check').then(async (m) => {
-        const info = await m.silentCheckForUpdate();
-        if (cancelled) return;
-        useUiStore.getState().setAvailableUpdate(info);
-      });
-    }, 5_000);
-    return () => {
-      cancelled = true;
-      window.clearTimeout(handle);
-    };
-  }, []);
+  // Claude CLI 検査 / 起動時アップデーター遅延 effect は use-claude-check.ts に
+  // 移管済み (Issue #373 Phase 1-7)。
 
   // Issue #66: project_root の外部変更 (git pull / Claude 編集 / 他エディタ) を検知して
   //           UI を更新する。Rust 側 fs_watch が debounce した `project:files-changed` を emit。

--- a/src/renderer/src/lib/hooks/use-claude-check.ts
+++ b/src/renderer/src/lib/hooks/use-claude-check.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useSettingsValue } from '../settings-context';
+import { useUiStore } from '../../stores/ui';
+
+export interface ClaudeCheckState {
+  state: 'checking' | 'ok' | 'missing';
+  error?: string;
+}
+
+export interface UseClaudeCheckResult {
+  /** Claude CLI 検査状態 (生)。JSX の分岐 (`<ClaudeNotFound>` の checking/missing/ok)
+   *  や `useTerminalTabs.opts.claudeReady` 派生値の組み立てに使う。 */
+  claudeCheck: ClaudeCheckState;
+  /** 検査をリトライ。`<ClaudeNotFound onRetry>` から呼ばれる。 */
+  runClaudeCheck: () => Promise<void>;
+}
+
+/**
+ * Issue #373 Phase 1-7: Claude CLI 検査と起動時アップデーター遅延 effect を
+ * App.tsx から切り出した hook。
+ *
+ * 同居の根拠: tasks/refactor-handoff.md で「Phase 1-7 use-claude-check.ts
+ * (claudeCheck / アップデーター遅延 effect)」と明示されており、両者とも
+ * 「起動時 1 回 / 設定変更時に追従する App ライフサイクル系の副作用」という
+ * 共通点を持つ。内部実装は別 useEffect で完全分離してある。
+ *
+ * 将来 updater 周りが太ったら use-updater-poll.ts に再分離する余地あり。
+ *
+ * 流儀:
+ * - opts なし純粋 hook (Phase 1-5 use-layout-resize と同じ)
+ * - useSettingsValue('claudeCommand') を hook 内で直接呼ぶ (Phase 1-4 流儀)
+ * - 既存挙動を完全保持: runClaudeCheck の deps は [claudeCommand]、
+ *   再検査 effect の deps は [runClaudeCheck] のまま
+ */
+export function useClaudeCheck(): UseClaudeCheckResult {
+  const claudeCommand = useSettingsValue('claudeCommand');
+
+  const [claudeCheck, setClaudeCheck] = useState<ClaudeCheckState>({
+    state: 'checking'
+  });
+
+  const runClaudeCheck = useCallback(async () => {
+    setClaudeCheck({ state: 'checking' });
+    try {
+      const res = await window.api.app.checkClaude(claudeCommand || 'claude');
+      setClaudeCheck(
+        res.ok ? { state: 'ok' } : { state: 'missing', error: res.error }
+      );
+    } catch (err) {
+      setClaudeCheck({ state: 'missing', error: String(err) });
+    }
+  }, [claudeCommand]);
+
+  // 設定の claudeCommand が変わるたびに再検査
+  useEffect(() => {
+    void runClaudeCheck();
+  }, [runClaudeCheck]);
+
+  // 起動時に GitHub Release の latest.json を「確認だけ」する (prod のみ)。
+  // 旧仕様の「ask → 即 install → relaunch」は撤廃。代わりに silentCheckForUpdate で
+  // 更新の有無を検出して useUiStore.availableUpdate に書き、Topbar / CanvasLayout の
+  // 「Update」ボタンを点灯させる。実 install はユーザーがボタンを押したときだけ走る。
+  // 起動直後の負荷を避けるため少し遅延させる (5 秒)。
+  useEffect(() => {
+    let cancelled = false;
+    const handle = window.setTimeout(() => {
+      void import('../updater-check').then(async (m) => {
+        const info = await m.silentCheckForUpdate();
+        if (cancelled) return;
+        useUiStore.getState().setAvailableUpdate(info);
+      });
+    }, 5_000);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, []);
+
+  return { claudeCheck, runClaudeCheck };
+}


### PR DESCRIPTION
## Summary

Issue #373 (God File 解体ロードマップ) の **Phase 1-7**。\`App.tsx\` から Claude CLI 検査 (\`claudeCheck\` state + \`runClaudeCheck\` callback + \`claudeCommand\` 変更検知 effect) と起動時アップデーター遅延 effect (5 秒後の \`silentCheckForUpdate\`) を新規 hook に集約。

- \`App.tsx\` 1468 → **1430 行 (-38)**
- 新規 \`use-claude-check.ts\` 80 行
- 累計削減 (Phase 1-1〜1-7): **-1397 行** (Issue #373 目標 -1995 の **70%**)

### 同居の根拠

\`tasks/refactor-handoff.md\` で Phase 1-7 として「claudeCheck / アップデーター遅延 effect」が一括指定されており、両者とも「起動時 1 回 / 設定変更時に追従する App ライフサイクル系の副作用」という共通点を持つ。内部実装は別 \`useEffect\` で完全分離してあるため、将来 updater 周りが太ったら \`use-updater-poll.ts\` に再分離可能。

### Phase 1-1〜1-6 と揃えた点

- **opts なし純粋 hook** (Phase 1-5 \`use-layout-resize\` と同じ流儀)
- \`useSettingsValue('claudeCommand')\` を hook 内で直接呼ぶ (Phase 1-4 流儀)
- 戻り値は \`{ claudeCheck, runClaudeCheck }\` の最小限
- **派生 flag (claudeReady / claudeMissing 等) は作らない**: JSX 側で \`claudeCheck.state === 'X'\` を直接判定 (現状コードと完全一致)

### 不変式 (Issue #373 全 Phase 共通)

維持していることを確認:
- \`runClaudeCheck\` の deps は \`[claudeCommand]\` のまま (identity 安定化は別 issue 候補)
- 再検査 effect の deps は \`[runClaudeCheck]\` のまま
- アップデーター effect の \`cancelled\` flag + \`clearTimeout\` race 防止を保持
- \`window.api.app.checkClaude(claudeCommand || 'claude')\` の \`|| 'claude'\` フォールバック保持
- dynamic import パスは hook ファイル位置に合わせて \`./lib/updater-check\` → \`../updater-check\` に訂正 (機能は同一)
- \`useUiStore.getState().setAvailableUpdate(info)\` の zustand 外部書き込みパターンも維持
- \`<ClaudeNotFound>\` の JSX (\`claudeCheck.state\` を直接読む 3 分岐) は無変更

## Test plan

- [x] \`npm run typecheck\` — green
- [x] \`cargo check --manifest-path src-tauri/Cargo.toml\` — green
- [x] \`cargo clippy --no-deps\` — 既存ベースライン 15 件のまま (新規警告ゼロ)
- [ ] 手動 smoke: 起動 → Claude CLI 検査 (\`checking\` → \`ok\` or \`missing\`) / 設定で claudeCommand を変えて再検査 / \`<ClaudeNotFound>\` の \`onRetry\` が動く / 起動 5 秒後に updater が走り Topbar の Update バッジが点く (prod でのみ)

Refs #373