### PR TITLE
refactor(app): #373 Phase 1-8 paletteOpen / status を useUiStore に統一

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -110,9 +110,14 @@ export function App(): JSX.Element {
   // Canvas モードでは App が裏で常時マウントされるが、下の初回タブ生成
   // useEffect を抑制して "迷子ターミナル" が裏で起動しないようにする。
   const viewMode = useUiStore((s) => s.viewMode);
-  const [settingsOpen, setSettingsOpen] = useState<boolean>(false);
-  const [paletteOpen, setPaletteOpen] = useState<boolean>(false);
-  const [status, setStatus] = useState<string>('');
+  // Phase 1-8 (Issue #373): UI 系 state を useUiStore に集約。
+  // settingsOpen は元々 zustand に存在 (Rail からも開ける用)、
+  // paletteOpen / status は Phase 1-8 で追加。
+  const settingsOpen = useUiStore((s) => s.settingsOpen);
+  const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
+  const paletteOpen = useUiStore((s) => s.paletteOpen);
+  const setPaletteOpen = useUiStore((s) => s.setPaletteOpen);
+  const status = useUiStore((s) => s.status);
 
   // sidebar
   const [sidebarView, setSidebarView] = useState<SidebarView>('changes');
@@ -145,8 +150,7 @@ export function App(): JSX.Element {
   } = useProjectLoader({
     confirmDiscardEditorTabs: stableConfirmDiscard,
     onProjectSwitched: stableProjectSwitched,
-    onLoaded: stableProjectLoaded,
-    setStatus
+    onLoaded: stableProjectLoaded
   });
 
   // Phase 1-2 (Issue #373): editor / diff tab + recentlyClosed を hook に外出し。
@@ -760,11 +764,8 @@ export function App(): JSX.Element {
   ]);
 
   // Phase 1-6 (Issue #373): グローバルショートカット + Shift+wheel zoom を hook に集約。
+  // Phase 1-8: paletteOpen / settingsOpen は useUiStore に集約済みなので opts 不要。
   useAppShortcuts({
-    paletteOpen,
-    setPaletteOpen,
-    settingsOpen,
-    setSettingsOpen,
     activeTabId,
     cycleTab,
     closeTab,

--- a/src/renderer/src/lib/hooks/use-app-shortcuts.ts
+++ b/src/renderer/src/lib/hooks/use-app-shortcuts.ts
@@ -1,14 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { webviewZoom } from '../webview-zoom';
+import { useUiStore } from '../../stores/ui';
 
 export interface UseAppShortcutsOptions {
-  /** コマンドパレットの開閉状態。Escape / Ctrl+Shift+P で参照・更新する。 */
-  paletteOpen: boolean;
-  setPaletteOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  /** 設定モーダルの開閉状態。Escape / Ctrl+, で参照・更新する。 */
-  settingsOpen: boolean;
-  setSettingsOpen: React.Dispatch<React.SetStateAction<boolean>>;
-
   /** Phase 1-2 (use-file-tabs) hook 戻り値ブリッジ。 */
   activeTabId: string | null;
   cycleTab: (direction: 1 | -1) => void;
@@ -59,27 +53,30 @@ export function useAppShortcuts(opts: UseAppShortcutsOptions): void {
   useEffect(() => {
     const handler = (e: KeyboardEvent): void => {
       const o = optsRef.current;
+      // Phase 1-8: paletteOpen / settingsOpen は useUiStore で一元管理。
+      // handler 起動時に getState() でスナップショットを読む (subscribe 不要)。
+      const ui = useUiStore.getState();
       const mod = e.ctrlKey || e.metaKey;
       if (!mod) {
         if (e.key === 'Escape') {
-          if (o.paletteOpen) o.setPaletteOpen(false);
-          else if (o.settingsOpen) o.setSettingsOpen(false);
+          if (ui.paletteOpen) ui.setPaletteOpen(false);
+          else if (ui.settingsOpen) ui.setSettingsOpen(false);
         }
         return;
       }
       // Issue #162: Ctrl+Shift+P (パレット toggle) と Ctrl+, (設定) は modal open 中でも
       // 反応してよい (toggle 用途のため)。それ以外のショートカット (Ctrl+S / Ctrl+Tab /
       // Ctrl+W / Ctrl+Shift+T) は modal/palette open 中はブロックする。
-      const modalIsOpen = o.paletteOpen || o.settingsOpen;
+      const modalIsOpen = ui.paletteOpen || ui.settingsOpen;
       if (e.shiftKey && (e.key === 'P' || e.key === 'p')) {
         e.preventDefault();
         e.stopPropagation();
-        o.setPaletteOpen((v) => !v);
+        ui.togglePalette();
         return;
       }
       if (e.key === ',') {
         e.preventDefault();
-        o.setSettingsOpen(true);
+        ui.setSettingsOpen(true);
         return;
       }
       if (modalIsOpen) {

--- a/src/renderer/src/lib/hooks/use-project-loader.ts
+++ b/src/renderer/src/lib/hooks/use-project-loader.ts
@@ -6,6 +6,7 @@ import {
   useSettingsLoading,
   useSettingsValue
 } from '../settings-context';
+import { useUiStore } from '../../stores/ui';
 import { dedupPrepend } from '../path-norm';
 
 export interface UseProjectLoaderOptions {
@@ -19,8 +20,6 @@ export interface UseProjectLoaderOptions {
   /** loadProject / 初回ロード effect で取得した snapshot を上に流す。
    *  hook が責務外として保持しない state (sessions など) を親に伝える橋渡し。 */
   onLoaded: (snapshot: { gitStatus: GitStatus; sessions: SessionInfo[] }) => void;
-  /** ステータスバー文字列を更新する callback (App.tsx の setStatus を渡す)。 */
-  setStatus: (msg: string) => void;
 }
 
 export interface UseProjectLoaderResult {
@@ -63,7 +62,7 @@ export function useProjectLoader(
         return false;
       }
       setProjectRoot(root);
-      optsRef.current.setStatus('プロジェクト読み込み中…');
+      useUiStore.getState().setStatus('プロジェクト読み込み中…');
       setGitLoading(true);
 
       try {
@@ -85,7 +84,7 @@ export function useProjectLoader(
         optsRef.current.onLoaded({ gitStatus: gs, sessions: sess });
         // タブ・セッション・チーム・ターミナル等の reset は親に外注。
         optsRef.current.onProjectSwitched(root);
-        optsRef.current.setStatus(`${root.split(/[\\/]/).pop()}`);
+        useUiStore.getState().setStatus(`${root.split(/[\\/]/).pop()}`);
         // ここでは runtime の「最後に開いたルート」のみ永続化する。
         // `claudeCwd` は SettingsModal で設定されるユーザー設定のため上書き厳禁。
         if (options.addToRecent !== false) {
@@ -99,7 +98,7 @@ export function useProjectLoader(
         }
         return true;
       } catch (err) {
-        optsRef.current.setStatus(`読み込みエラー: ${String(err)}`);
+        useUiStore.getState().setStatus(`読み込みエラー: ${String(err)}`);
         return false;
       } finally {
         setGitLoading(false);
@@ -131,7 +130,7 @@ export function useProjectLoader(
           if (!picked) {
             // ユーザーがキャンセルした場合は projectRoot 未設定のまま空状態を維持。
             // 上部の AppMenu / コマンドパレットから後で開けるようにしておく。
-            optsRef.current.setStatus(t('status.noProject'));
+            useUiStore.getState().setStatus(t('status.noProject'));
             setGitLoading(false);
             return;
           }
@@ -158,9 +157,9 @@ export function useProjectLoader(
         setGitStatus(gs);
         setGitLoading(false);
         optsRef.current.onLoaded({ gitStatus: gs, sessions: sess });
-        optsRef.current.setStatus(root.split(/[\\/]/).pop() ?? root);
+        useUiStore.getState().setStatus(root.split(/[\\/]/).pop() ?? root);
       } catch (err) {
-        optsRef.current.setStatus(`初期化エラー: ${String(err)}`);
+        useUiStore.getState().setStatus(`初期化エラー: ${String(err)}`);
         setGitLoading(false);
       }
     })();

--- a/src/renderer/src/stores/ui.ts
+++ b/src/renderer/src/stores/ui.ts
@@ -18,6 +18,10 @@ interface UiState {
   /** 共通サイドバーから「設定」を開くためのグローバルフラグ */
   settingsOpen: boolean;
   setSettingsOpen: (open: boolean) => void;
+  /** Phase 1-8 (Issue #373): コマンドパレット表示フラグ。Ctrl+Shift+P で toggle。 */
+  paletteOpen: boolean;
+  setPaletteOpen: (open: boolean) => void;
+  togglePalette: () => void;
   /** Redesign: 右ドロワーの Activity (handoff feed) 表示フラグ */
   activityOpen: boolean;
   setActivityOpen: (open: boolean) => void;
@@ -36,6 +40,10 @@ interface UiState {
    *  null = 更新なし or 未チェック。永続化しない (再起動時に再検出する)。 */
   availableUpdate: AvailableUpdateInfo | null;
   setAvailableUpdate: (info: AvailableUpdateInfo | null) => void;
+  /** Phase 1-8 (Issue #373): ステータスバーに流す文字列。プロジェクト読み込み等で
+   *  use-project-loader.ts が直接更新する。永続化しない。 */
+  status: string;
+  setStatus: (s: string) => void;
 }
 
 export const useUiStore = create<UiState>()(
@@ -46,6 +54,9 @@ export const useUiStore = create<UiState>()(
       toggleViewMode: () => set({ viewMode: get().viewMode === 'ide' ? 'canvas' : 'ide' }),
       settingsOpen: false,
       setSettingsOpen: (open) => set({ settingsOpen: open }),
+      paletteOpen: false,
+      setPaletteOpen: (open) => set({ paletteOpen: open }),
+      togglePalette: () => set({ paletteOpen: !get().paletteOpen }),
       activityOpen: false,
       setActivityOpen: (open) => set({ activityOpen: open }),
       toggleActivity: () => set({ activityOpen: !get().activityOpen }),
@@ -56,7 +67,9 @@ export const useUiStore = create<UiState>()(
       setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
       toggleSidebar: () => set({ sidebarCollapsed: !get().sidebarCollapsed }),
       availableUpdate: null,
-      setAvailableUpdate: (info) => set({ availableUpdate: info })
+      setAvailableUpdate: (info) => set({ availableUpdate: info }),
+      status: '',
+      setStatus: (s) => set({ status: s })
     }),
     {
       name: 'vibe-editor:ui',


### PR DESCRIPTION
## Summary

Issue #373 (God File 解体ロードマップ) の **Phase 1-8 (UI state 統一)**。UI 系 state を zustand store (\`useUiStore\`) に集約して single source of truth 化し、各 hook の opts を簡素化する。

- \`settingsOpen\` は元々 zustand に存在 (Rail からも開ける用)
- \`paletteOpen\` / \`togglePalette\` / \`status\` を本 PR で **新規追加**
- 累計削減 (Phase 1-1〜1-8): **-1365 行** (Issue #373 目標 -1995 の **68%**) — 本 PR の行数純増減は約 ±0 行 (主目的は行数削減ではない)

## 主な変更

### \`stores/ui.ts\`
- \`paletteOpen\` / \`setPaletteOpen\` / \`togglePalette\` を追加 (\`toggleViewMode\` / \`toggleSidebar\` / \`toggleActivity\` と同じ流儀)
- \`status\` / \`setStatus\` を追加 (\`use-project-loader.ts\` が直接書き込む)
- **\`partialize\` には入れない**: 永続化すると再起動時に modal が開いたままになる UX 破壊

### \`App.tsx\`
- \`useState\` 3 行 (\`settingsOpen\` / \`paletteOpen\` / \`status\`) を \`useUiStore\` selector に置換
- \`useProjectLoader\` opts から \`setStatus\` を削除
- \`useAppShortcuts\` opts から paletteOpen / setPaletteOpen / settingsOpen / setSettingsOpen を削除 (4 keys → 0 keys)

### \`use-app-shortcuts.ts\` (Phase 1-6)
- opts の paletteOpen / settingsOpen 関連 4 keys を削除
- handler 内で \`useUiStore.getState()\` を呼んでスナップショット取得 (subscribe 不要なので \`useEffect\` deps は \`[]\` のまま)
- Ctrl+Shift+P toggle は \`togglePalette()\` 経由 (旧 \`setPaletteOpen(v => !v)\` の updater 形式は zustand setter で動かないため)
- Esc 閉じの優先順位 (palette → settings) は維持

### \`use-project-loader.ts\` (Phase 1-1)
- \`opts.setStatus\` を削除し、内部 6 箇所を \`useUiStore.getState().setStatus(...)\` に置換 (現状挙動と完全等価)

## スコープ外 (Phase 1-8 で zustand 化しない)

- \`sidebarView\`: CanvasLayout 側が独立した同名 state を持つため
- \`sideBySide\`: DiffView の表示モードで App.tsx / CanvasLayout / DiffCard の 3 箇所が独立した state を持つため
- \`contextMenu\`: ContextMenuItem の action がクロージャを含み cross-component で共有する意味がない
- \`sessions\` / \`sessionsLoading\` / \`activeSessionId\`: Phase 1-? の sessions hook スコープ
- 「やらないこと」: \`SettingsContext\` / \`ToastContext\` は永続層境界として残す

## 不変式

維持していることを確認:
- IPC コマンド名・event 名は一切変更なし
- Esc 閉じの優先順位 (palette → settings) は逐字保持
- Ctrl+Shift+P toggle / Ctrl+, settings open / プロジェクト読み込み時の status 文字列更新は現状と完全等価
- HMR 永続化リスクへの対応: \`partialize\` には paletteOpen / status を入れない

## Test plan

- [x] \`npm run typecheck\` — green
- [x] \`cargo check --manifest-path src-tauri/Cargo.toml\` — green
- [x] \`cargo clippy --no-deps\` — 既存ベースライン 15 件のまま (新規警告ゼロ)
- [ ] 手動 smoke: Ctrl+Shift+P で palette toggle / Ctrl+, で settings open / Esc で palette → settings の順で閉じる / プロジェクト読み込み時に Topbar の status 文字列が更新される / Topbar / Rail / Sidebar / ClaudeNotFound 等から settings を開けることを確認

Refs #373