### PR TITLE
refactor(app): #373 Phase 1-9 commands を lib/app-commands.ts へ切り出し

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -18,8 +18,7 @@ import type {
   GitFileChange,
   GitStatus,
   SessionInfo,
-  TerminalAgent,
-  ThemeName
+  TerminalAgent
 } from '../../types/shared';
 import { Sidebar, type SidebarView } from './components/Sidebar';
 import { TabBar, type TabItem } from './components/TabBar';
@@ -66,15 +65,7 @@ import { useLayoutResize } from './lib/hooks/use-layout-resize';
 import { useAppShortcuts } from './lib/hooks/use-app-shortcuts';
 import { useClaudeCheck } from './lib/hooks/use-claude-check';
 import type { Command } from './lib/commands';
-
-const THEMES_FOR_PALETTE: ThemeName[] = [
-  'claude-dark',
-  'claude-light',
-  'dark',
-  'midnight',
-  'glass',
-  'light'
-];
+import { buildAppCommands } from './lib/app-commands';
 
 // DiffTab / EditorTab の型定義は use-file-tabs.ts に移管済み (Issue #373 Phase 1-2)。
 
@@ -543,225 +534,78 @@ export function App(): JSX.Element {
     ]
   );
 
-  // ---------- コマンドパレット ----------
-
-  const commands = useMemo<Command[]>(() => {
-    // Issue #57: タイトル / カテゴリ / subtitle を i18n キー経由に置換
-    const CAT = {
-      project: t('cmd.cat.project'),
-      workspace: t('cmd.cat.workspace'),
-      view: t('cmd.cat.view'),
-      tab: t('cmd.cat.tab'),
-      git: t('cmd.cat.git'),
-      sessions: t('cmd.cat.sessions'),
-      terminal: t('cmd.cat.terminal'),
-      settings: t('cmd.cat.settings'),
-      theme: t('cmd.cat.theme')
-    };
-    const list: Command[] = [
-      {
-        id: 'project.new',
-        title: t('cmd.project.new'),
-        category: CAT.project,
-        run: () => void handleNewProject()
-      },
-      {
-        id: 'project.openFolder',
-        title: t('cmd.project.openFolder'),
-        category: CAT.project,
-        run: () => void handleOpenFolder()
-      },
-      {
-        id: 'project.openFile',
-        title: t('cmd.project.openFile'),
-        category: CAT.project,
-        run: () => void handleOpenFile()
-      },
-      {
-        id: 'workspace.addFolder',
-        title: t('cmd.workspace.addFolder'),
-        category: CAT.workspace,
-        run: () => void handleAddWorkspaceFolder()
-      },
-      ...(settings.recentProjects ?? []).slice(0, 5).map<Command>((p) => ({
-        id: `project.recent.${p}`,
-        title: t('cmd.project.recent', { name: p.split(/[\\/]/).pop() ?? p }),
-        subtitle: p,
-        category: CAT.project,
-        run: () => void handleOpenRecent(p)
-      })),
-      {
-        id: 'view.sidebar.changes',
-        title: t('cmd.view.sidebarChanges'),
-        category: CAT.view,
-        run: () => setSidebarView('changes')
-      },
-      {
-        id: 'view.sidebar.sessions',
-        title: t('cmd.view.sidebarSessions'),
-        category: CAT.view,
-        run: () => setSidebarView('sessions')
-      },
-      {
-        id: 'view.nextTab',
-        title: t('cmd.view.nextTab'),
-        subtitle: 'Ctrl+Tab',
-        category: CAT.view,
-        when: () => diffTabs.length > 0,
-        run: () => cycleTab(1)
-      },
-      {
-        id: 'view.prevTab',
-        title: t('cmd.view.prevTab'),
-        subtitle: 'Ctrl+Shift+Tab',
-        category: CAT.view,
-        when: () => diffTabs.length > 0,
-        run: () => cycleTab(-1)
-      },
-      {
-        id: 'tab.close',
-        title: t('cmd.tab.close'),
-        subtitle: 'Ctrl+W',
-        category: CAT.tab,
-        when: () => !!activeTabId,
-        run: () => { if (activeTabId) closeTab(activeTabId); }
-      },
-      {
-        id: 'tab.reopen',
-        title: t('cmd.tab.reopen'),
-        subtitle: 'Ctrl+Shift+T',
-        category: CAT.tab,
-        when: () => recentlyClosed.length > 0,
-        run: () => reopenLastClosed()
-      },
-      {
-        id: 'tab.togglePin',
-        title: t('cmd.tab.togglePin'),
-        category: CAT.tab,
-        when: () => !!activeTabId,
-        run: () => { if (activeTabId) togglePin(activeTabId); }
-      },
-      {
-        id: 'git.refresh',
-        title: t('cmd.git.refresh'),
-        category: CAT.git,
-        run: () => refreshGit()
-      },
-      {
-        id: 'sessions.refresh',
-        title: t('cmd.sessions.refresh'),
-        category: CAT.sessions,
-        run: () => refreshSessions()
-      },
-      {
-        id: 'terminal.addClaude',
-        title: t('cmd.terminal.addClaude'),
-        subtitle: `${terminalTabs.length}/${MAX_TERMINALS}`,
-        category: CAT.terminal,
-        when: () => terminalTabs.length < MAX_TERMINALS,
-        run: () => { addTerminalTab({ agent: 'claude' }); }
-      },
-      {
-        id: 'terminal.addCodex',
-        title: t('cmd.terminal.addCodex'),
-        subtitle: `${terminalTabs.length}/${MAX_TERMINALS}`,
-        category: CAT.terminal,
-        when: () => terminalTabs.length < MAX_TERMINALS,
-        run: () => { addTerminalTab({ agent: 'codex' }); }
-      },
-      {
-        id: 'terminal.closeTab',
-        title: t('cmd.terminal.closeTab'),
-        category: CAT.terminal,
-        when: () => terminalTabs.length > 1,
-        run: () => closeTerminalTab(activeTerminalTabId)
-      },
-      {
-        id: 'terminal.restart',
-        title: t('cmd.terminal.restart'),
-        category: CAT.terminal,
-        run: () => restartTerminal()
-      },
-      {
-        id: 'settings.open',
-        title: t('cmd.settings.open'),
-        subtitle: 'Ctrl+,',
-        category: CAT.settings,
-        run: () => setSettingsOpen(true)
-      },
-      {
-        id: 'settings.cycleDensity',
-        title: t('cmd.settings.cycleDensity'),
-        subtitle: t('cmd.settings.cycleDensitySub', { density: settings.density }),
-        category: CAT.settings,
-        run: () => {
-          const order: typeof settings.density[] = ['compact', 'normal', 'comfortable'];
-          const nextDensity = order[(order.indexOf(settings.density) + 1) % order.length];
-          void updateSettings({ density: nextDensity });
-        }
-      },
-      ...THEMES_FOR_PALETTE.map<Command>((tn) => ({
-        id: `theme.${tn}`,
-        title: t('cmd.theme.title', { name: tn }),
-        subtitle: tn === settings.theme ? t('cmd.theme.current') : undefined,
-        category: CAT.theme,
-        run: () => void updateSettings({ theme: tn })
-      })),
-      {
-        id: 'app.restart',
-        title: t('cmd.app.restart'),
-        category: t('cmd.cat.app'),
-        run: () => void handleRestart()
-      },
-      {
-        id: 'app.checkForUpdates',
-        title: t('updater.checkNow'),
-        category: t('cmd.cat.app'),
-        run: () => {
-          void import('./lib/updater-check').then((m) => {
-            // manual=true: didCheck を無視して再試行可能 + 「最新です」も明示通知
-            void m.checkForUpdates({
-              language: settings.language,
-              showToast,
-              dismissToast,
-              manual: true,
-              runningTaskCount: terminalTabs.length
-            });
-          });
-        }
-      }
-    ];
-    return list;
-  }, [
-    t,
-    handleNewProject,
-    handleOpenFolder,
-    handleOpenFile,
-    handleOpenRecent,
-    handleAddWorkspaceFolder,
-    cycleTab,
-    activeTabId,
-    closeTab,
-    recentlyClosed,
-    reopenLastClosed,
-    togglePin,
-    refreshGit,
-    refreshSessions,
-    settings.theme,
-    settings.density,
-    settings.recentProjects,
-    settings.language,
-    updateSettings,
-    handleRestart,
-    restartTerminal,
-    addTerminalTab,
-    closeTerminalTab,
-    activeTerminalTabId,
-    terminalTabs.length,
-    diffTabs.length,
-    showToast,
-    dismissToast
-  ]);
+  // Phase 1-9 (Issue #373): コマンドパレット用 Command[] 構築は lib/app-commands.ts に集約。
+  // useMemo の deps 配列は呼び出し側に残し、react-hooks/exhaustive-deps が機能する形を維持。
+  const commands = useMemo<Command[]>(
+    () =>
+      buildAppCommands({
+        t,
+        handleNewProject,
+        handleOpenFolder,
+        handleOpenFile,
+        handleOpenRecent,
+        handleAddWorkspaceFolder,
+        setSidebarView,
+        activeTabId,
+        cycleTab,
+        closeTab,
+        togglePin,
+        reopenLastClosed,
+        diffTabsLength: diffTabs.length,
+        recentlyClosedLength: recentlyClosed.length,
+        refreshGit,
+        refreshSessions,
+        terminalTabsLength: terminalTabs.length,
+        maxTerminals: MAX_TERMINALS,
+        activeTerminalTabId,
+        addTerminalTab,
+        closeTerminalTab,
+        restartTerminal,
+        settings: {
+          theme: settings.theme,
+          density: settings.density,
+          recentProjects: settings.recentProjects,
+          language: settings.language
+        },
+        updateSettings,
+        setSettingsOpen,
+        handleRestart,
+        showToast,
+        dismissToast
+      }),
+    [
+      t,
+      handleNewProject,
+      handleOpenFolder,
+      handleOpenFile,
+      handleOpenRecent,
+      handleAddWorkspaceFolder,
+      setSidebarView,
+      activeTabId,
+      cycleTab,
+      closeTab,
+      togglePin,
+      reopenLastClosed,
+      diffTabs.length,
+      recentlyClosed.length,
+      refreshGit,
+      refreshSessions,
+      terminalTabs.length,
+      activeTerminalTabId,
+      addTerminalTab,
+      closeTerminalTab,
+      restartTerminal,
+      settings.theme,
+      settings.density,
+      settings.recentProjects,
+      settings.language,
+      updateSettings,
+      setSettingsOpen,
+      handleRestart,
+      showToast,
+      dismissToast
+    ]
+  );
 
   // Phase 1-6 (Issue #373): グローバルショートカット + Shift+wheel zoom を hook に集約。
   // Phase 1-8: paletteOpen / settingsOpen は useUiStore に集約済みなので opts 不要。

--- a/src/renderer/src/lib/app-commands.ts
+++ b/src/renderer/src/lib/app-commands.ts
@@ -1,0 +1,323 @@
+import type { AppSettings, ThemeName } from '../../../types/shared';
+import type { Command } from './commands';
+import type { SidebarView } from '../components/Sidebar';
+
+/** コマンドパレットでサイクル可能なテーマ一覧。`theme.${name}` コマンドの種に使う。 */
+export const THEMES_FOR_PALETTE: ThemeName[] = [
+  'claude-dark',
+  'claude-light',
+  'dark',
+  'midnight',
+  'glass',
+  'light'
+];
+
+type Tone = 'info' | 'success' | 'warning' | 'error';
+type ShowToast = (
+  message: string,
+  options?: { tone?: Tone; durationMs?: number; id?: number }
+) => number;
+type DismissToast = (id: number) => void;
+type T = (key: string, params?: Record<string, string | number>) => string;
+
+/**
+ * `buildAppCommands` の依存。App.tsx で hook 戻り値や handler を集めて渡す。
+ *
+ * - 配列 `recentlyClosed` / `terminalTabs` / `diffTabs` を生で渡さず、必要な
+ *   `length` や `recentProjects` slice を渡すことで useMemo の identity 振動を防ぐ。
+ * - i18n 関数 `t` は呼び出し時にビルド (現状仕様)。言語切替時は呼び出し側 useMemo の
+ *   deps `[t, ...]` で再計算される。
+ */
+export interface AppCommandsDeps {
+  // i18n
+  t: T;
+
+  // プロジェクト系 (use-project-loader 戻り値ブリッジ)
+  handleNewProject: () => Promise<void> | void;
+  handleOpenFolder: () => Promise<void> | void;
+  handleOpenFile: () => Promise<void> | void;
+  handleOpenRecent: (path: string) => Promise<void> | void;
+  handleAddWorkspaceFolder: () => Promise<void> | void;
+
+  // ビュー / サイドバー
+  setSidebarView: (v: SidebarView) => void;
+
+  // ファイルタブ (use-file-tabs)
+  activeTabId: string | null;
+  cycleTab: (direction: 1 | -1) => void;
+  closeTab: (id: string) => void;
+  togglePin: (id: string) => void;
+  reopenLastClosed: () => void;
+  diffTabsLength: number;
+  recentlyClosedLength: number;
+
+  // git / sessions
+  refreshGit: () => Promise<void> | void;
+  refreshSessions: () => Promise<void> | void;
+
+  // ターミナル (use-terminal-tabs)
+  terminalTabsLength: number;
+  /** ターミナル上限。use-terminal-tabs.ts の MAX_TERMINALS。 */
+  maxTerminals: number;
+  activeTerminalTabId: number;
+  addTerminalTab: (opts: { agent: 'claude' | 'codex' }) => void;
+  closeTerminalTab: (id: number) => void;
+  restartTerminal: () => void;
+
+  // 設定
+  /** settings 全体ではなく、コマンドパレットが実際に使う 4 項目だけを受ける。 */
+  settings: {
+    theme: ThemeName;
+    density: AppSettings['density'];
+    recentProjects?: string[];
+    language: AppSettings['language'];
+  };
+  updateSettings: (patch: Partial<AppSettings>) => Promise<void> | void;
+  setSettingsOpen: (open: boolean) => void;
+
+  // アプリ
+  handleRestart: () => Promise<void> | void;
+
+  // toast (updater check 用)
+  showToast: ShowToast;
+  dismissToast: DismissToast;
+}
+
+/**
+ * Issue #373 Phase 1-9: コマンドパレット用 Command[] を組み立てる pure 関数。
+ *
+ * 副作用なし: 配列を return するだけ。`run` / `when` のクロージャが deps を
+ * closure-capture するので、deps が freshness 不変なら呼び出されるだけで OK。
+ *
+ * useMemo の deps 配列は **呼び出し側 (App.tsx)** で組む流儀。これにより
+ * `react-hooks/exhaustive-deps` が呼び出し側で機能し続け、依存漏れ検出力を保つ。
+ *
+ * 純粋関数として `lib/team-prompts.ts` と同じ系譜の置き場 (`lib/*.ts`)。
+ */
+export function buildAppCommands(deps: AppCommandsDeps): Command[] {
+  const {
+    t,
+    handleNewProject,
+    handleOpenFolder,
+    handleOpenFile,
+    handleOpenRecent,
+    handleAddWorkspaceFolder,
+    setSidebarView,
+    activeTabId,
+    cycleTab,
+    closeTab,
+    togglePin,
+    reopenLastClosed,
+    diffTabsLength,
+    recentlyClosedLength,
+    refreshGit,
+    refreshSessions,
+    terminalTabsLength,
+    maxTerminals,
+    activeTerminalTabId,
+    addTerminalTab,
+    closeTerminalTab,
+    restartTerminal,
+    settings,
+    updateSettings,
+    setSettingsOpen,
+    handleRestart,
+    showToast,
+    dismissToast
+  } = deps;
+
+  // Issue #57: タイトル / カテゴリ / subtitle を i18n キー経由に置換
+  const CAT = {
+    project: t('cmd.cat.project'),
+    workspace: t('cmd.cat.workspace'),
+    view: t('cmd.cat.view'),
+    tab: t('cmd.cat.tab'),
+    git: t('cmd.cat.git'),
+    sessions: t('cmd.cat.sessions'),
+    terminal: t('cmd.cat.terminal'),
+    settings: t('cmd.cat.settings'),
+    theme: t('cmd.cat.theme')
+  };
+
+  return [
+    {
+      id: 'project.new',
+      title: t('cmd.project.new'),
+      category: CAT.project,
+      run: () => void handleNewProject()
+    },
+    {
+      id: 'project.openFolder',
+      title: t('cmd.project.openFolder'),
+      category: CAT.project,
+      run: () => void handleOpenFolder()
+    },
+    {
+      id: 'project.openFile',
+      title: t('cmd.project.openFile'),
+      category: CAT.project,
+      run: () => void handleOpenFile()
+    },
+    {
+      id: 'workspace.addFolder',
+      title: t('cmd.workspace.addFolder'),
+      category: CAT.workspace,
+      run: () => void handleAddWorkspaceFolder()
+    },
+    ...(settings.recentProjects ?? []).slice(0, 5).map<Command>((p) => ({
+      id: `project.recent.${p}`,
+      title: t('cmd.project.recent', { name: p.split(/[\\/]/).pop() ?? p }),
+      subtitle: p,
+      category: CAT.project,
+      run: () => void handleOpenRecent(p)
+    })),
+    {
+      id: 'view.sidebar.changes',
+      title: t('cmd.view.sidebarChanges'),
+      category: CAT.view,
+      run: () => setSidebarView('changes')
+    },
+    {
+      id: 'view.sidebar.sessions',
+      title: t('cmd.view.sidebarSessions'),
+      category: CAT.view,
+      run: () => setSidebarView('sessions')
+    },
+    {
+      id: 'view.nextTab',
+      title: t('cmd.view.nextTab'),
+      subtitle: 'Ctrl+Tab',
+      category: CAT.view,
+      when: () => diffTabsLength > 0,
+      run: () => cycleTab(1)
+    },
+    {
+      id: 'view.prevTab',
+      title: t('cmd.view.prevTab'),
+      subtitle: 'Ctrl+Shift+Tab',
+      category: CAT.view,
+      when: () => diffTabsLength > 0,
+      run: () => cycleTab(-1)
+    },
+    {
+      id: 'tab.close',
+      title: t('cmd.tab.close'),
+      subtitle: 'Ctrl+W',
+      category: CAT.tab,
+      when: () => !!activeTabId,
+      run: () => {
+        if (activeTabId) closeTab(activeTabId);
+      }
+    },
+    {
+      id: 'tab.reopen',
+      title: t('cmd.tab.reopen'),
+      subtitle: 'Ctrl+Shift+T',
+      category: CAT.tab,
+      when: () => recentlyClosedLength > 0,
+      run: () => reopenLastClosed()
+    },
+    {
+      id: 'tab.togglePin',
+      title: t('cmd.tab.togglePin'),
+      category: CAT.tab,
+      when: () => !!activeTabId,
+      run: () => {
+        if (activeTabId) togglePin(activeTabId);
+      }
+    },
+    {
+      id: 'git.refresh',
+      title: t('cmd.git.refresh'),
+      category: CAT.git,
+      run: () => void refreshGit()
+    },
+    {
+      id: 'sessions.refresh',
+      title: t('cmd.sessions.refresh'),
+      category: CAT.sessions,
+      run: () => void refreshSessions()
+    },
+    {
+      id: 'terminal.addClaude',
+      title: t('cmd.terminal.addClaude'),
+      subtitle: `${terminalTabsLength}/${maxTerminals}`,
+      category: CAT.terminal,
+      when: () => terminalTabsLength < maxTerminals,
+      run: () => {
+        addTerminalTab({ agent: 'claude' });
+      }
+    },
+    {
+      id: 'terminal.addCodex',
+      title: t('cmd.terminal.addCodex'),
+      subtitle: `${terminalTabsLength}/${maxTerminals}`,
+      category: CAT.terminal,
+      when: () => terminalTabsLength < maxTerminals,
+      run: () => {
+        addTerminalTab({ agent: 'codex' });
+      }
+    },
+    {
+      id: 'terminal.closeTab',
+      title: t('cmd.terminal.closeTab'),
+      category: CAT.terminal,
+      when: () => terminalTabsLength > 1,
+      run: () => closeTerminalTab(activeTerminalTabId)
+    },
+    {
+      id: 'terminal.restart',
+      title: t('cmd.terminal.restart'),
+      category: CAT.terminal,
+      run: () => restartTerminal()
+    },
+    {
+      id: 'settings.open',
+      title: t('cmd.settings.open'),
+      subtitle: 'Ctrl+,',
+      category: CAT.settings,
+      run: () => setSettingsOpen(true)
+    },
+    {
+      id: 'settings.cycleDensity',
+      title: t('cmd.settings.cycleDensity'),
+      subtitle: t('cmd.settings.cycleDensitySub', { density: settings.density }),
+      category: CAT.settings,
+      run: () => {
+        const order: typeof settings.density[] = ['compact', 'normal', 'comfortable'];
+        const nextDensity = order[(order.indexOf(settings.density) + 1) % order.length];
+        void updateSettings({ density: nextDensity });
+      }
+    },
+    ...THEMES_FOR_PALETTE.map<Command>((tn) => ({
+      id: `theme.${tn}`,
+      title: t('cmd.theme.title', { name: tn }),
+      subtitle: tn === settings.theme ? t('cmd.theme.current') : undefined,
+      category: CAT.theme,
+      run: () => void updateSettings({ theme: tn })
+    })),
+    {
+      id: 'app.restart',
+      title: t('cmd.app.restart'),
+      category: t('cmd.cat.app'),
+      run: () => void handleRestart()
+    },
+    {
+      id: 'app.checkForUpdates',
+      title: t('updater.checkNow'),
+      category: t('cmd.cat.app'),
+      run: () => {
+        void import('./updater-check').then((m) => {
+          // manual=true: didCheck を無視して再試行可能 + 「最新です」も明示通知
+          void m.checkForUpdates({
+            language: settings.language,
+            showToast,
+            dismissToast,
+            manual: true,
+            runningTaskCount: terminalTabsLength
+          });
+        });
+      }
+    }
+  ];
+}


### PR DESCRIPTION
## Summary

Issue #373 (God File 解体ロードマップ) の **Phase 1-9 (AppShell 化)**。コマンドパレット用 \`Command[]\` 構築 (useMemo 本体 + recentProjects / THEMES_FOR_PALETTE の動的展開) を新規ファイル \`src/renderer/src/lib/app-commands.ts\` の pure 関数 \`buildAppCommands\` に集約。

- \`App.tsx\` 1431 → **1275 行 (-156)**
- 新規 \`lib/app-commands.ts\` 323 行 (pure 関数 + 型定義 + JSDoc)
- 累計削減 (Phase 1-1〜1-9): **-1520 行** (Issue #373 目標 -1995 の **76%**)

## 設計

### pure 関数アプローチ (選択肢 A)

- 副作用なしで \`Command[]\` を return するだけの pure 関数。\`run\` / \`when\` クロージャは引数を closure-capture する
- ファイル位置: \`src/renderer/src/lib/app-commands.ts\` (引き継ぎ書通り、\`hooks/\` 配下ではない)
- \`lib/team-prompts.ts\` (Phase 1-4 で純粋関数として独立) と同じ系譜
- \`useMemo\` の deps 配列は **App.tsx 呼び出し側に残す**: \`react-hooks/exhaustive-deps\` が呼び出し側で機能する形を維持。pure 関数なので hook をかぶせる必要はない (Phase 1-1〜1-7 の useEffect 持ち hook とは性質が違う)
- \`THEMES_FOR_PALETTE\` 定数を \`app-commands.ts\` に移動 (App.tsx で他に参照なし、grep で確認済み)

### deps の最適化

useMemo の identity 振動を防ぐため、配列を生で渡さず必要な値だけ受ける:
- \`recentlyClosedLength\` / \`terminalTabsLength\` / \`diffTabsLength\` (配列の length のみ)
- \`settings\` 全体ではなく \`{ theme, density, recentProjects, language }\` の 4 項目 slice
- \`maxTerminals\` は use-terminal-tabs.ts の \`MAX_TERMINALS\` を呼び出し側から渡す

## スコープ判断

引き継ぎ書記載の「JSX サブツリーを子 component 化」は **Phase 1-9 では同梱しない**:

- 1 PR = 1 関心事 (Phase 1-1〜1-8 で踏襲してきた) を維持し、PR 肥大化を回避
- 引き継ぎ書「Phase 4: CanvasLayout / SettingsModal の細分化」と JSX 子化は本来同じ関心 (= レイアウト分割) であり、Phase 4 と合流させるのが自然
- commands 切り出しは型レベルで完結する純粋作業 → diff も読みやすく、回帰リスクが「deps 漏れ」に集約される

## 不変式 (Issue #373 全 Phase 共通)

維持していることを確認:
- IPC コマンド名・event 名は一切変更なし
- コマンド ID (\`project.new\` / \`theme.{name}\` / \`app.checkForUpdates\` 等) は逐字保持
- \`t()\` による i18n キー解決タイミングは現状と同一 (build 時)
- \`when()\` / \`run()\` のクロージャ依存も現状と同一
- dynamic import パスは \`./lib/updater-check\` → \`./updater-check\` に hook ファイル位置に合わせて訂正 (機能は同一)
- \`react-hooks/exhaustive-deps\` の Lint 効きは呼び出し側で維持

## Test plan

- [x] \`npm run typecheck\` — green
- [x] \`cargo check --manifest-path src-tauri/Cargo.toml\` — green
- [x] \`cargo clippy --no-deps\` — 既存ベースライン 15 件のまま (新規警告ゼロ)
- [ ] 手動 smoke: Ctrl+Shift+P でパレット → 22+α 件が一覧表示 / project.new / view.nextTab / terminal.addClaude / theme.claude-dark / app.checkForUpdates が動作 / ターミナル数 = MAX_TERMINALS で terminal.addClaude が when で消える / recentlyClosed 空状態で tab.reopen が消える / 言語切替で再翻訳

Refs #373