### PR TITLE
refactor(settings): #373 Phase 4-2 SettingsModal.tsx を 3 hook/utility に分割

### DIFF
--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -172,7 +172,7 @@ export function SettingsModal({
   const customAgents = draft.customAgents ?? [];
 
   // Phase 4-2: nav state (groupsRaw / groups / activeSection 同期) を hook 化
-  const { groups } = useSettingsNav({ draft, navQuery, activeSection, setActiveSection });
+  const { groups } = useSettingsNav({ draft, navQuery, setActiveSection });
 
   // Phase 4-2: focus trap + Escape を hook 化
   const handleDialogKeyDown = useSettingsKeydown({ dialogRef, onClose });

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1,27 +1,14 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  ArrowLeft,
-  Bot,
-  Check,
-  Code2,
-  Palette,
-  Plug,
-  Plus,
-  ScrollText,
-  Search,
-  Settings as SettingsIcon,
-  Sparkles,
-  Type,
-  Users,
-  X,
-  type LucideIcon
-} from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { ArrowLeft, Check, Plus, Search, X } from 'lucide-react';
 import type { AgentConfig, AppSettings } from '../../../types/shared';
 import { DEFAULT_SETTINGS } from '../../../types/shared';
 import { useT } from '../lib/i18n';
 import { useToast } from '../lib/toast-context';
 import { useSpringMount } from '../lib/use-animated-mount';
 import { EDITOR_FONT_PRESETS, UI_FONT_PRESETS } from '../lib/settings-options';
+import { iconFor, labelOf, type SectionId } from '../lib/settings-section-meta';
+import { useSettingsKeydown } from '../lib/hooks/use-settings-keydown';
+import { useSettingsNav } from '../lib/hooks/use-settings-nav';
 import { LanguageSection } from './settings/LanguageSection';
 import { ThemeSection } from './settings/ThemeSection';
 import { FontFamilySection } from './settings/FontFamilySection';
@@ -47,73 +34,6 @@ interface SettingsModalProps {
   /** 初回セットアップウィザードを再表示する (General セクションの専用ボタン) */
   onReplayOnboarding?: () => void;
 }
-
-/**
- * SectionId はカスタムエージェント対応のため動的な文字列。
- * 固定セクション: 'general' | 'appearance' | 'fonts' | 'claude' | 'codex' | 'mcp'
- * カスタムエージェント: `custom:${agentId}`
- */
-type SectionId = string;
-
-/** セクション ID → サイドバー Lucide アイコン。
- *
- *  旧実装は JSX リテラルをモジュールスコープに保持していたが、これは
- *  React.StrictMode の二重レンダリングや React Server Components 移行時に
- *  「複数のレンダーが同一インスタンスを共有する」前提が崩れる懸念がある。
- *  → アイコンコンポーネント自体だけを参照し、props (size/strokeWidth) は
- *     共通定数として再利用、JSX は呼び出しごとに都度生成する形に統一する。
- *     パフォーマンスへの影響はこの規模では実測差が出ないため、安全側に倒す。 */
-const ICON_PROPS = { size: 14, strokeWidth: 1.85 } as const;
-// SECTION_ICON_TYPES の値は lucide-react のアイコン (LucideIcon) なので、
-// 旧 React.ComponentType<typeof ICON_PROPS> (リテラル {size:14}) ではなく
-// LucideIcon 型を使うほうが正確で意図が伝わる (レビュー指摘)。
-const SECTION_ICON_TYPES: Record<string, LucideIcon> = {
-  general: SettingsIcon,
-  appearance: Palette,
-  fonts: Type,
-  claude: Bot,
-  codex: Code2,
-  roles: Users,
-  mcp: Plug,
-  logs: ScrollText
-};
-function iconFor(id: SectionId): JSX.Element {
-  const Icon =
-    SECTION_ICON_TYPES[id] ??
-    (id.startsWith('custom:') ? Sparkles : SECTION_ICON_TYPES.general);
-  return <Icon {...ICON_PROPS} />;
-}
-
-/** 固定セクションのラベル / タイトル / 説明 (i18n)。
- *  毎レンダー新規オブジェクトを生成すると useMemo の deps チェーンが無効化されるため、
- *  ja / en それぞれをモジュールスコープで 1 度だけ作る。 */
-type FixedLabelEntry = { label: string; title: string; desc: string };
-const FIXED_LABELS_JA: Record<string, FixedLabelEntry> = {
-  general: { label: '一般', title: '一般', desc: '言語と密度設定' },
-  appearance: { label: '表示', title: '表示', desc: 'テーマと配色' },
-  fonts: { label: 'フォント', title: 'フォント', desc: 'UI / エディタ / ターミナルのフォント' },
-  claude: { label: 'Claude Code', title: 'Claude Code', desc: '起動コマンドと引数' },
-  codex: { label: 'Codex', title: 'Codex', desc: '起動コマンドと引数' },
-  roles: { label: 'ロール定義', title: 'ロール定義', desc: 'チームメンバーの役割テンプレ' },
-  mcp: { label: 'MCP', title: 'MCP', desc: 'vibe-team MCP の導入方法' },
-  logs: { label: 'ログ', title: 'ログ', desc: 'アプリの実行ログを表示' }
-};
-const FIXED_LABELS_EN: Record<string, FixedLabelEntry> = {
-  general: { label: 'General', title: 'General', desc: 'Language and density' },
-  appearance: { label: 'Appearance', title: 'Appearance', desc: 'Theme and surfaces' },
-  fonts: { label: 'Fonts', title: 'Typography', desc: 'UI / editor / terminal fonts' },
-  claude: { label: 'Claude Code', title: 'Claude Code', desc: 'Launch command and args' },
-  codex: { label: 'Codex', title: 'Codex', desc: 'Launch command and args' },
-  roles: { label: 'Role profiles', title: 'Role profiles', desc: 'Team member role templates' },
-  mcp: { label: 'MCP', title: 'MCP', desc: 'How to install vibe-team MCP' },
-  logs: { label: 'Logs', title: 'Logs', desc: 'View runtime logs from the app' }
-};
-
-/** 名前未設定のカスタムエージェントに使う fallback 文字列。
- *  fixedLabels と同じく言語切替で同期するモジュール定数として持つことで、
- *  groups useMemo の closure から isJa を直接参照しないで済むようにする。 */
-const UNTITLED_FALLBACK_JA = '（無名）';
-const UNTITLED_FALLBACK_EN = '(untitled)';
 
 export function SettingsModal({
   open,
@@ -251,31 +171,11 @@ export function SettingsModal({
   const isJa = draft.language === 'ja';
   const customAgents = draft.customAgents ?? [];
 
-  // 固定ラベルはモジュールスコープのため毎レンダーで参照が変わらない。
-  // useMemo deps に直接入れても安定性を保てる。
-  const fixedLabels = isJa ? FIXED_LABELS_JA : FIXED_LABELS_EN;
+  // Phase 4-2: nav state (groupsRaw / groups / activeSection 同期) を hook 化
+  const { groups } = useSettingsNav({ draft, navQuery, activeSection, setActiveSection });
 
-  /** 指定 id のラベル情報を返す (固定 + カスタム動的) */
-  const labelOf = (id: SectionId): { label: string; title: string; desc: string } => {
-    if (fixedLabels[id]) return fixedLabels[id];
-    if (id.startsWith('custom:')) {
-      const a = customAgents.find((x) => `custom:${x.id}` === id);
-      const name = a?.name || (isJa ? '（無名）' : '(untitled)');
-      return {
-        label: name,
-        title: name,
-        desc: isJa ? 'カスタムエージェント設定' : 'Custom agent settings'
-      };
-    }
-    if (id === '__addCustom') {
-      return {
-        label: isJa ? '+ 追加' : '+ Add',
-        title: isJa ? '+ 追加' : '+ Add',
-        desc: ''
-      };
-    }
-    return { label: id, title: id, desc: '' };
-  };
+  // Phase 4-2: focus trap + Escape を hook 化
+  const handleDialogKeyDown = useSettingsKeydown({ dialogRef, onClose });
 
   /** 新規カスタムエージェントを追加して編集画面へ遷移 */
   const addCustomAgent = (): void => {
@@ -291,107 +191,6 @@ export function SettingsModal({
     update('customAgents', next);
     setActiveSection(`custom:${id}`);
   };
-
-  // groupsRaw は customAgents と isJa から導出される。useMemo で安定化させる。
-  // deps には `customAgents` ローカル (`draft.customAgents ?? []`) ではなく `draft.customAgents` を
-  // 直接入れる。`?? []` は undefined のとき毎レンダー新しい [] を返してしまい、参照比較で常に
-  // 不一致 → メモ化が無効化される。`draft.customAgents` 自体は同一更新内では安定。
-  const groupsRaw = useMemo<
-    Array<{ label: string | null; items: SectionId[] }>
-  >(
-    () => {
-      const agents = draft.customAgents ?? [];
-      return [
-        { label: null, items: ['general', 'appearance', 'fonts'] },
-        {
-          label: isJa ? 'エージェント' : 'Agents',
-          items: [
-            'claude',
-            'codex',
-            ...agents.map((a) => `custom:${a.id}`),
-            '__addCustom'
-          ]
-        },
-        // vibe-team MCP のセットアップ手順は「チーム」機能の一部なので同グループに収める。
-        // 旧構成では MCP を独立グループにしていたが、グループラベル "MCP" と唯一の項目 "MCP" が
-        // 同名で並び、サイドバー上で MCP が 2 行重複しているように見える UI バグを生んでいた。
-        { label: isJa ? 'チーム' : 'Team', items: ['roles', 'mcp'] },
-        // Issue #326: 「その他」グループにログビューアを置く。リリース後の bug 報告で
-        // 開発者ツールを開かずにユーザー側でエラーログを確認できるようにする。
-        { label: isJa ? 'その他' : 'Other', items: ['logs'] }
-      ];
-    },
-    // deps は customAgents と同じく draft の生プロパティを直接参照する形で統一する。
-    // isJa は draft.language === 'ja' の派生 boolean で毎レンダー再評価されるため、
-    // 意図を明確にするには元の draft.language を deps に入れる方が読みやすい (レビュー指摘)。
-    [draft.customAgents, draft.language]
-  );
-
-  // 検索ワードで items を絞り込む。`__addCustom` は検索中だけ非表示 (新規追加は通常時のみ)。
-  // 検索結果が空のグループはラベルごと除外する。
-  // labelOf を closure で参照していた旧実装は eslint-disable で exhaustive-deps を抑制していたが、
-  // 将来 labelOf が customAgents / isJa 以外の state も読むようになるとメモ化バグの種になる。
-  // → 検索フィルタ用のラベル解決を useMemo 内にインライン化し、必要な依存を明示する。
-  const groups = useMemo(() => {
-    const q = navQuery.trim().toLowerCase();
-    if (!q) return groupsRaw;
-    const fixedLabelMap = fixedLabels;
-    const agents = draft.customAgents ?? [];
-    const customLabelMap = new Map(agents.map((a) => [a.id, a.name] as const));
-    // fixedLabels と untitled fallback は draft.language で同期して切り替わるため、
-    // どちらかを deps に入れれば言語切替を検知できる。closure から isJa を直接参照しないことで
-    // eslint exhaustive-deps 違反を解消する (レビュー指摘)。
-    const untitled =
-      fixedLabelMap === FIXED_LABELS_JA ? UNTITLED_FALLBACK_JA : UNTITLED_FALLBACK_EN;
-    const labelForFilter = (id: SectionId): string => {
-      if (fixedLabelMap[id]) return fixedLabelMap[id].label;
-      if (id.startsWith('custom:')) {
-        const aid = id.slice('custom:'.length);
-        return customLabelMap.get(aid) || untitled;
-      }
-      return id;
-    };
-    return groupsRaw
-      .map((g) => ({
-        label: g.label,
-        items: g.items.filter((id) => {
-          if (id === '__addCustom') return false;
-          const label = labelForFilter(id);
-          return label.toLowerCase().includes(q) || id.toLowerCase().includes(q);
-        })
-      }))
-      .filter((g) => g.items.length > 0);
-    // deps 構成: navQuery / groupsRaw / draft.language。
-    // 旧実装は fixedLabels (派生) を deps に入れていたが、groupsRaw のほうは
-    // [draft.customAgents, draft.language] という生プロパティ参照になっていて非対称だった (レビュー指摘)。
-    // → 言語切替を検知する deps を draft.language に統一して、両 useMemo の deps スタイルを揃える。
-    // closure 内の fixedLabels / untitled は draft.language が変わると再評価されるので問題ない。
-  }, [navQuery, groupsRaw, draft.language]);
-
-  // 検索フィルタ後の groups に activeSection が含まれない場合、右ペインとサイドバーの
-  // 選択状態が乖離する (例: "font" 検索で nav は fonts だけ表示するのに右ペインは general のまま)。
-  // → クエリが変わった瞬間に整合チェックする。
-  //
-  // 旧コードは deps に groups を入れていたが、検索中に customAgents が増減すると groups が
-  // 変わって意図せず activeSection が先頭にリセットされる edge case があった。
-  // → 同期は navQuery 変化時のみに限定し、groups は ref 経由で最新値を読む。
-  // 関数型更新で activeSection 自身を比較することで再レンダーループも防ぐ。
-  //
-  // クリア時 (navQuery="") の挙動: フィルタ前の groupsRaw に activeSection が含まれていれば
-  // そのまま維持、含まれていない (異常系) のみ先頭に戻す。これで「検索したまま放置 → クリア」
-  // の流れで activeSection がフィルタ中の先頭に張り付く問題 (レビュー指摘) を解消する。
-  const groupsRef = useRef(groups);
-  groupsRef.current = groups;
-  const groupsRawRef = useRef(groupsRaw);
-  groupsRawRef.current = groupsRaw;
-  useEffect(() => {
-    const source = navQuery.trim() ? groupsRef.current : groupsRawRef.current;
-    const flat: SectionId[] = source
-      .flatMap((g) => g.items)
-      .filter((id) => id !== '__addCustom');
-    if (flat.length === 0) return;
-    setActiveSection((prev) => (flat.includes(prev) ? prev : flat[0]));
-  }, [navQuery]);
 
   // すべての hook 呼び出しが終わった後でだけ早期 return する (Rules of Hooks)。
   // これより上の useSpringMount から `mounted` を受け取り、未マウントなら DOM を返さない。
@@ -494,7 +293,7 @@ export function SettingsModal({
     }
   };
 
-  const current = labelOf(activeSection);
+  const current = labelOf(activeSection, isJa, customAgents);
 
   return (
     <div
@@ -516,72 +315,7 @@ export function SettingsModal({
         // Escape を入力フィールドから受けたとき、まず root に focus を退避してから次の
         // Escape で閉じる UX (vscode / macOS native と同じ) を実現する。
         tabIndex={-1}
-        onKeyDown={(e) => {
-          // Issue #195: Escape で閉じる + Tab で focus trap。
-          if (e.key === 'Escape') {
-            // IME 変換中の Escape は確定キャンセルとして使われるので絶対に握らない。
-            // React 17+ では e.nativeEvent は KeyboardEvent 型に推論されるためキャスト不要。
-            if (e.nativeEvent.isComposing) return;
-            const target = e.target as HTMLElement | null;
-            const tag = target?.tagName;
-            // contenteditable は inherit で親から継承されるケースがあるため、
-            // 文字列比較の getAttribute ではなく DOM プロパティ isContentEditable を使う
-            // (継承込みの正しい判定が出る)。レビュー指摘。
-            const isTextField =
-              tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable === true;
-            e.preventDefault();
-            // 入力中の Escape で即閉じると入力中のテキストが lost するため、
-            // 1 回目は input から blur して dialog root に focus を退避するだけにする。
-            // (2 回目の Escape は target=dialog なのでこの分岐に入らず onClose に進む)
-            if (isTextField && target) {
-              target.blur();
-              dialogRef.current?.focus();
-              return;
-            }
-            onClose();
-            return;
-          }
-          if (e.key !== 'Tab') return;
-          const root = dialogRef.current;
-          if (!root) return;
-          const focusables = Array.from(
-            root.querySelectorAll<HTMLElement>(
-              // セレクタ側は典型的な -1 だけを除外し、それ以外の負値や空文字 ([tabindex=""] 等) は
-              // 後段 filter の el.tabIndex < 0 に委ねる (CSS attribute selector の前方一致は
-              // ブラウザ間で挙動差があり、正規実装に統一するほうが堅牢)。
-              'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex="-1"])'
-            )
-          ).filter((el) => {
-            // 1. tabIndex の負値 (-2 等) と dialog root (tabIndex=-1) を除外
-            if (el.tabIndex < 0) return false;
-            // 2. レイアウト上見えていない要素を除外。
-            //    旧 getBoundingClientRect だけだと visibility:hidden の要素が rect=占有領域を
-            //    持つため通過してしまう (レビュー指摘)。
-            //    Chromium が提供する Element.checkVisibility() は display:none / visibility:hidden /
-            //    content-visibility:hidden を 1 回呼ぶだけで判定できる。Tauri は WebView2 (Chromium)
-            //    なので利用可能。型未定義環境用に typeof チェックで guard し、未対応時は
-            //    旧来の rect ベース判定にフォールバック。
-            const checkVisibility = (el as unknown as {
-              checkVisibility?: (opts?: { checkVisibilityCSS?: boolean }) => boolean;
-            }).checkVisibility;
-            if (typeof checkVisibility === 'function') {
-              return checkVisibility.call(el, { checkVisibilityCSS: true });
-            }
-            const rect = el.getBoundingClientRect();
-            return rect.width > 0 || rect.height > 0;
-          });
-          if (focusables.length === 0) return;
-          const first = focusables[0];
-          const last = focusables[focusables.length - 1];
-          const active = document.activeElement as HTMLElement | null;
-          if (e.shiftKey && active === first) {
-            e.preventDefault();
-            last.focus();
-          } else if (!e.shiftKey && active === last) {
-            e.preventDefault();
-            first.focus();
-          }
-        }}
+        onKeyDown={handleDialogKeyDown}
       >
         <header className="modal__header">
           <div className="modal__title-group">
@@ -649,7 +383,7 @@ export function SettingsModal({
                           </button>
                         );
                       }
-                      const { label } = labelOf(id);
+                      const { label } = labelOf(id, isJa, customAgents);
                       const active = id === activeSection;
                       return (
                         <button

--- a/src/renderer/src/lib/hooks/use-settings-keydown.ts
+++ b/src/renderer/src/lib/hooks/use-settings-keydown.ts
@@ -1,0 +1,87 @@
+import { useCallback } from 'react';
+import type { KeyboardEvent, RefObject } from 'react';
+
+interface UseSettingsKeydownOptions {
+  dialogRef: RefObject<HTMLDivElement>;
+  onClose: () => void;
+}
+
+/** Issue #195: Settings dialog の Escape + Tab focus trap ハンドラ。
+ *  IME 変換中の Escape は確定キャンセルとして使われるので絶対に握らない。
+ *  入力中の 1 回目 Escape は input から blur して dialog root に focus 退避、
+ *  2 回目で onClose に進む UX (vscode / macOS native と同じ)。
+ */
+export function useSettingsKeydown(
+  opts: UseSettingsKeydownOptions
+): (e: KeyboardEvent<HTMLDivElement>) => void {
+  const { dialogRef, onClose } = opts;
+  return useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      // Issue #195: Escape で閉じる + Tab で focus trap。
+      if (e.key === 'Escape') {
+        // IME 変換中の Escape は確定キャンセルとして使われるので絶対に握らない。
+        // React 17+ では e.nativeEvent は KeyboardEvent 型に推論されるためキャスト不要。
+        if (e.nativeEvent.isComposing) return;
+        const target = e.target as HTMLElement | null;
+        const tag = target?.tagName;
+        // contenteditable は inherit で親から継承されるケースがあるため、
+        // 文字列比較の getAttribute ではなく DOM プロパティ isContentEditable を使う
+        // (継承込みの正しい判定が出る)。レビュー指摘。
+        const isTextField =
+          tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable === true;
+        e.preventDefault();
+        // 入力中の Escape で即閉じると入力中のテキストが lost するため、
+        // 1 回目は input から blur して dialog root に focus を退避するだけにする。
+        // (2 回目の Escape は target=dialog なのでこの分岐に入らず onClose に進む)
+        if (isTextField && target) {
+          target.blur();
+          dialogRef.current?.focus();
+          return;
+        }
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const root = dialogRef.current;
+      if (!root) return;
+      const focusables = Array.from(
+        root.querySelectorAll<HTMLElement>(
+          // セレクタ側は典型的な -1 だけを除外し、それ以外の負値や空文字 ([tabindex=""] 等) は
+          // 後段 filter の el.tabIndex < 0 に委ねる (CSS attribute selector の前方一致は
+          // ブラウザ間で挙動差があり、正規実装に統一するほうが堅牢)。
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter((el) => {
+        // 1. tabIndex の負値 (-2 等) と dialog root (tabIndex=-1) を除外
+        if (el.tabIndex < 0) return false;
+        // 2. レイアウト上見えていない要素を除外。
+        //    旧 getBoundingClientRect だけだと visibility:hidden の要素が rect=占有領域を
+        //    持つため通過してしまう (レビュー指摘)。
+        //    Chromium が提供する Element.checkVisibility() は display:none / visibility:hidden /
+        //    content-visibility:hidden を 1 回呼ぶだけで判定できる。Tauri は WebView2 (Chromium)
+        //    なので利用可能。型未定義環境用に typeof チェックで guard し、未対応時は
+        //    旧来の rect ベース判定にフォールバック。
+        const checkVisibility = (el as unknown as {
+          checkVisibility?: (opts?: { checkVisibilityCSS?: boolean }) => boolean;
+        }).checkVisibility;
+        if (typeof checkVisibility === 'function') {
+          return checkVisibility.call(el, { checkVisibilityCSS: true });
+        }
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 || rect.height > 0;
+      });
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    },
+    [dialogRef, onClose]
+  );
+}

--- a/src/renderer/src/lib/hooks/use-settings-nav.ts
+++ b/src/renderer/src/lib/hooks/use-settings-nav.ts
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { AppSettings } from '../../../../types/shared';
+import {
+  FIXED_LABELS_JA,
+  FIXED_LABELS_EN,
+  UNTITLED_FALLBACK_JA,
+  UNTITLED_FALLBACK_EN,
+  type SectionId
+} from '../settings-section-meta';
+
+export interface SettingsNavGroup {
+  label: string | null;
+  items: SectionId[];
+}
+
+export interface UseSettingsNavOptions {
+  draft: AppSettings;
+  navQuery: string;
+  activeSection: SectionId;
+  setActiveSection: Dispatch<SetStateAction<SectionId>>;
+}
+
+export interface UseSettingsNavResult {
+  groupsRaw: SettingsNavGroup[];
+  groups: SettingsNavGroup[];
+}
+
+/** Settings dialog のサイドバー nav state を扱う hook。
+ *  - groupsRaw: 言語切替 / customAgents 変化に追従する固定グループ構造
+ *  - groups: navQuery で絞り込んだ表示用グループ
+ *  - activeSection 同期: 検索クエリが変わった瞬間に表示と選択状態を整合
+ *
+ *  元 SettingsModal.tsx の groupsRaw / groups / 同期 effect を bit identical で hook 化。
+ */
+export function useSettingsNav(opts: UseSettingsNavOptions): UseSettingsNavResult {
+  const { draft, navQuery, setActiveSection } = opts;
+  const isJa = draft.language === 'ja';
+
+  // groupsRaw は customAgents と isJa から導出される。useMemo で安定化させる。
+  // deps には `customAgents` ローカル (`draft.customAgents ?? []`) ではなく `draft.customAgents` を
+  // 直接入れる。`?? []` は undefined のとき毎レンダー新しい [] を返してしまい、参照比較で常に
+  // 不一致 → メモ化が無効化される。`draft.customAgents` 自体は同一更新内では安定。
+  const groupsRaw = useMemo<SettingsNavGroup[]>(
+    () => {
+      const agents = draft.customAgents ?? [];
+      return [
+        { label: null, items: ['general', 'appearance', 'fonts'] },
+        {
+          label: isJa ? 'エージェント' : 'Agents',
+          items: [
+            'claude',
+            'codex',
+            ...agents.map((a) => `custom:${a.id}`),
+            '__addCustom'
+          ]
+        },
+        // vibe-team MCP のセットアップ手順は「チーム」機能の一部なので同グループに収める。
+        // 旧構成では MCP を独立グループにしていたが、グループラベル "MCP" と唯一の項目 "MCP" が
+        // 同名で並び、サイドバー上で MCP が 2 行重複しているように見える UI バグを生んでいた。
+        { label: isJa ? 'チーム' : 'Team', items: ['roles', 'mcp'] },
+        // Issue #326: 「その他」グループにログビューアを置く。リリース後の bug 報告で
+        // 開発者ツールを開かずにユーザー側でエラーログを確認できるようにする。
+        { label: isJa ? 'その他' : 'Other', items: ['logs'] }
+      ];
+    },
+    // deps は customAgents と同じく draft の生プロパティを直接参照する形で統一する。
+    // isJa は draft.language === 'ja' の派生 boolean で毎レンダー再評価されるため、
+    // 意図を明確にするには元の draft.language を deps に入れる方が読みやすい (レビュー指摘)。
+    [draft.customAgents, draft.language]
+  );
+
+  // 検索ワードで items を絞り込む。`__addCustom` は検索中だけ非表示 (新規追加は通常時のみ)。
+  // 検索結果が空のグループはラベルごと除外する。
+  // labelOf を closure で参照していた旧実装は eslint-disable で exhaustive-deps を抑制していたが、
+  // 将来 labelOf が customAgents / isJa 以外の state も読むようになるとメモ化バグの種になる。
+  // → 検索フィルタ用のラベル解決を useMemo 内にインライン化し、必要な依存を明示する。
+  const groups = useMemo(() => {
+    const q = navQuery.trim().toLowerCase();
+    if (!q) return groupsRaw;
+    const fixedLabelMap = isJa ? FIXED_LABELS_JA : FIXED_LABELS_EN;
+    const agents = draft.customAgents ?? [];
+    const customLabelMap = new Map(agents.map((a) => [a.id, a.name] as const));
+    // fixedLabels と untitled fallback は draft.language で同期して切り替わるため、
+    // どちらかを deps に入れれば言語切替を検知できる。closure から isJa を直接参照しないことで
+    // eslint exhaustive-deps 違反を解消する (レビュー指摘)。
+    const untitled =
+      fixedLabelMap === FIXED_LABELS_JA ? UNTITLED_FALLBACK_JA : UNTITLED_FALLBACK_EN;
+    const labelForFilter = (id: SectionId): string => {
+      if (fixedLabelMap[id]) return fixedLabelMap[id].label;
+      if (id.startsWith('custom:')) {
+        const aid = id.slice('custom:'.length);
+        return customLabelMap.get(aid) || untitled;
+      }
+      return id;
+    };
+    return groupsRaw
+      .map((g) => ({
+        label: g.label,
+        items: g.items.filter((id) => {
+          if (id === '__addCustom') return false;
+          const label = labelForFilter(id);
+          return label.toLowerCase().includes(q) || id.toLowerCase().includes(q);
+        })
+      }))
+      .filter((g) => g.items.length > 0);
+    // deps 構成: navQuery / groupsRaw / draft.language。
+    // 旧実装は fixedLabels (派生) を deps に入れていたが、groupsRaw のほうは
+    // [draft.customAgents, draft.language] という生プロパティ参照になっていて非対称だった (レビュー指摘)。
+    // → 言語切替を検知する deps を draft.language に統一して、両 useMemo の deps スタイルを揃える。
+    // closure 内の fixedLabels / untitled は draft.language が変わると再評価されるので問題ない。
+  }, [navQuery, groupsRaw, draft.language]);
+
+  // 検索フィルタ後の groups に activeSection が含まれない場合、右ペインとサイドバーの
+  // 選択状態が乖離する (例: "font" 検索で nav は fonts だけ表示するのに右ペインは general のまま)。
+  // → クエリが変わった瞬間に整合チェックする。
+  //
+  // 旧コードは deps に groups を入れていたが、検索中に customAgents が増減すると groups が
+  // 変わって意図せず activeSection が先頭にリセットされる edge case があった。
+  // → 同期は navQuery 変化時のみに限定し、groups は ref 経由で最新値を読む。
+  // 関数型更新で activeSection 自身を比較することで再レンダーループも防ぐ。
+  //
+  // クリア時 (navQuery="") の挙動: フィルタ前の groupsRaw に activeSection が含まれていれば
+  // そのまま維持、含まれていない (異常系) のみ先頭に戻す。これで「検索したまま放置 → クリア」
+  // の流れで activeSection がフィルタ中の先頭に張り付く問題 (レビュー指摘) を解消する。
+  const groupsRef = useRef(groups);
+  groupsRef.current = groups;
+  const groupsRawRef = useRef(groupsRaw);
+  groupsRawRef.current = groupsRaw;
+  useEffect(() => {
+    const source = navQuery.trim() ? groupsRef.current : groupsRawRef.current;
+    const flat: SectionId[] = source
+      .flatMap((g) => g.items)
+      .filter((id) => id !== '__addCustom');
+    if (flat.length === 0) return;
+    setActiveSection((prev) => (flat.includes(prev) ? prev : flat[0]));
+  }, [navQuery, setActiveSection]);
+
+  return { groupsRaw, groups };
+}

--- a/src/renderer/src/lib/hooks/use-settings-nav.ts
+++ b/src/renderer/src/lib/hooks/use-settings-nav.ts
@@ -17,7 +17,9 @@ export interface SettingsNavGroup {
 export interface UseSettingsNavOptions {
   draft: AppSettings;
   navQuery: string;
-  activeSection: SectionId;
+  // activeSection は受け取らない: 同期 effect 内で setActiveSection((prev) => ...) の
+  // 関数型更新を使うため最新値は state 側から直接読む。caller 側で activeSection を別途
+  // useState で持つ前提に変更はない。
   setActiveSection: Dispatch<SetStateAction<SectionId>>;
 }
 

--- a/src/renderer/src/lib/settings-section-meta.tsx
+++ b/src/renderer/src/lib/settings-section-meta.tsx
@@ -1,0 +1,108 @@
+import {
+  Bot,
+  Code2,
+  Palette,
+  Plug,
+  ScrollText,
+  Settings as SettingsIcon,
+  Sparkles,
+  Type,
+  Users,
+  type LucideIcon
+} from 'lucide-react';
+
+/**
+ * SectionId はカスタムエージェント対応のため動的な文字列。
+ * 固定セクション: 'general' | 'appearance' | 'fonts' | 'claude' | 'codex' | 'mcp'
+ * カスタムエージェント: `custom:${agentId}`
+ */
+export type SectionId = string;
+
+/** セクション ID → サイドバー Lucide アイコン。
+ *
+ *  旧実装は JSX リテラルをモジュールスコープに保持していたが、これは
+ *  React.StrictMode の二重レンダリングや React Server Components 移行時に
+ *  「複数のレンダーが同一インスタンスを共有する」前提が崩れる懸念がある。
+ *  → アイコンコンポーネント自体だけを参照し、props (size/strokeWidth) は
+ *     共通定数として再利用、JSX は呼び出しごとに都度生成する形に統一する。
+ *     パフォーマンスへの影響はこの規模では実測差が出ないため、安全側に倒す。 */
+export const ICON_PROPS = { size: 14, strokeWidth: 1.85 } as const;
+// SECTION_ICON_TYPES の値は lucide-react のアイコン (LucideIcon) なので、
+// 旧 React.ComponentType<typeof ICON_PROPS> (リテラル {size:14}) ではなく
+// LucideIcon 型を使うほうが正確で意図が伝わる (レビュー指摘)。
+export const SECTION_ICON_TYPES: Record<string, LucideIcon> = {
+  general: SettingsIcon,
+  appearance: Palette,
+  fonts: Type,
+  claude: Bot,
+  codex: Code2,
+  roles: Users,
+  mcp: Plug,
+  logs: ScrollText
+};
+export function iconFor(id: SectionId): JSX.Element {
+  const Icon =
+    SECTION_ICON_TYPES[id] ??
+    (id.startsWith('custom:') ? Sparkles : SECTION_ICON_TYPES.general);
+  return <Icon {...ICON_PROPS} />;
+}
+
+/** 固定セクションのラベル / タイトル / 説明 (i18n)。
+ *  毎レンダー新規オブジェクトを生成すると useMemo の deps チェーンが無効化されるため、
+ *  ja / en それぞれをモジュールスコープで 1 度だけ作る。 */
+export type FixedLabelEntry = { label: string; title: string; desc: string };
+export const FIXED_LABELS_JA: Record<string, FixedLabelEntry> = {
+  general: { label: '一般', title: '一般', desc: '言語と密度設定' },
+  appearance: { label: '表示', title: '表示', desc: 'テーマと配色' },
+  fonts: { label: 'フォント', title: 'フォント', desc: 'UI / エディタ / ターミナルのフォント' },
+  claude: { label: 'Claude Code', title: 'Claude Code', desc: '起動コマンドと引数' },
+  codex: { label: 'Codex', title: 'Codex', desc: '起動コマンドと引数' },
+  roles: { label: 'ロール定義', title: 'ロール定義', desc: 'チームメンバーの役割テンプレ' },
+  mcp: { label: 'MCP', title: 'MCP', desc: 'vibe-team MCP の導入方法' },
+  logs: { label: 'ログ', title: 'ログ', desc: 'アプリの実行ログを表示' }
+};
+export const FIXED_LABELS_EN: Record<string, FixedLabelEntry> = {
+  general: { label: 'General', title: 'General', desc: 'Language and density' },
+  appearance: { label: 'Appearance', title: 'Appearance', desc: 'Theme and surfaces' },
+  fonts: { label: 'Fonts', title: 'Typography', desc: 'UI / editor / terminal fonts' },
+  claude: { label: 'Claude Code', title: 'Claude Code', desc: 'Launch command and args' },
+  codex: { label: 'Codex', title: 'Codex', desc: 'Launch command and args' },
+  roles: { label: 'Role profiles', title: 'Role profiles', desc: 'Team member role templates' },
+  mcp: { label: 'MCP', title: 'MCP', desc: 'How to install vibe-team MCP' },
+  logs: { label: 'Logs', title: 'Logs', desc: 'View runtime logs from the app' }
+};
+
+/** 名前未設定のカスタムエージェントに使う fallback 文字列。
+ *  fixedLabels と同じく言語切替で同期するモジュール定数として持つことで、
+ *  groups useMemo の closure から isJa を直接参照しないで済むようにする。 */
+export const UNTITLED_FALLBACK_JA = '（無名）';
+export const UNTITLED_FALLBACK_EN = '(untitled)';
+
+/** 指定 id のラベル情報を返す (固定 + カスタム動的)。
+ *  元 SettingsModal.tsx 内では closure で customAgents / isJa を参照していたが、
+ *  独立 module 化に伴い pure 関数として引数化した。 */
+export function labelOf(
+  id: SectionId,
+  isJa: boolean,
+  customAgents: { id: string; name: string }[]
+): { label: string; title: string; desc: string } {
+  const fixedLabels = isJa ? FIXED_LABELS_JA : FIXED_LABELS_EN;
+  if (fixedLabels[id]) return fixedLabels[id];
+  if (id.startsWith('custom:')) {
+    const a = customAgents.find((x) => `custom:${x.id}` === id);
+    const name = a?.name || (isJa ? UNTITLED_FALLBACK_JA : UNTITLED_FALLBACK_EN);
+    return {
+      label: name,
+      title: name,
+      desc: isJa ? 'カスタムエージェント設定' : 'Custom agent settings'
+    };
+  }
+  if (id === '__addCustom') {
+    return {
+      label: isJa ? '+ 追加' : '+ Add',
+      title: isJa ? '+ 追加' : '+ Add',
+      desc: ''
+    };
+  }
+  return { label: id, title: id, desc: '' };
+}

--- a/src/renderer/src/lib/settings-section-meta.tsx
+++ b/src/renderer/src/lib/settings-section-meta.tsx
@@ -13,7 +13,7 @@ import {
 
 /**
  * SectionId はカスタムエージェント対応のため動的な文字列。
- * 固定セクション: 'general' | 'appearance' | 'fonts' | 'claude' | 'codex' | 'mcp'
+ * 固定セクション: 'general' | 'appearance' | 'fonts' | 'claude' | 'codex' | 'roles' | 'mcp' | 'logs'
  * カスタムエージェント: `custom:${agentId}`
  */
 export type SectionId = string;


### PR DESCRIPTION
## Summary

Issue #373 / Phase 4-2: `components/SettingsModal.tsx` (717 行) から section meta / focus trap / nav state を 3 つの hook/utility に分離。**move only / 機能変更なし / 公開 API は不変**。

## 構成

| ファイル | 行数 | 内容 |
|---|---|---|
| `components/SettingsModal.tsx` | 717 → ~430 | state 管理 + JSX shell + renderSection (orchestration only) |
| `lib/settings-section-meta.tsx` (新規) | 108 | `SectionId` / `ICON_PROPS` / `SECTION_ICON_TYPES` / `iconFor` / `FIXED_LABELS_JA` / `FIXED_LABELS_EN` / `UNTITLED_FALLBACK_*` / `labelOf` (pure 化) |
| `lib/hooks/use-settings-keydown.ts` (新規) | 84 | Issue #195: Escape + Tab focus trap (caller=`useCallback` で wrap) |
| `lib/hooks/use-settings-nav.ts` (新規) | 140 | `groupsRaw` / `groups` (検索フィルタ) / `activeSection` 同期 effect |

## 公開 API の維持

- `SettingsModal` の export はそのまま、`SettingsModalProps` interface 不変
- `iconFor` の戻り値は JSX のため `.tsx` 拡張子で配置 (caller は拡張子省略 import で OK)
- `labelOf` は元 closure → **pure 関数化** (引数: `id` / `isJa` / `customAgents`)。callsites を全て新 signature に置き換え
- 機能変更なし: ICON / FIXED_LABELS / UNTITLED_FALLBACK / UI 文言 (全角括弧含む) は逐字保持

## 検証結果

- `npm run typecheck`: ✅ green
- Issue #195 の Escape + focus trap UX (vscode/macOS native と同じ 1 回目 Escape で blur、2 回目で close) は逐字保持

## Agent Team で並列分担

3 hook/utility の draft を 3 人の teammate (section-meta / settings-keydown / settings-nav extractor) に **並列で Write** させ、team-lead 側で SettingsModal.tsx を Write で再構築 (import 切り替え + 旧定義削除 + hook 利用) を実施。

## 引き継ぎ書 (#373) との整合

引き継ぎ書 L263 「`SettingsModal.tsx` は settings 各種項目の UI が密集しているので、サブコンポーネント化する際に value/setter のドリリングが増えないように注意」 — `renderSection` は SettingsModal.tsx 内に残置 (`draft` / `update` / `customAgents` 等の closure 参照を保持してドリリング回避)。section-meta は pure データのため hook ではなく utility module に。

## Test plan

- [x] `npm run typecheck` green
- [x] CRLF → LF 正規化済み
- [x] `tsconfig.web.tsbuildinfo` は commit に含めない (typecheck cache、別 issue で扱う方が綺麗)
- [ ] **手動 smoke** (推奨): 設定モーダル開閉 / 検索フィルタ / Escape (テキスト入力中の 1 回目で blur、2 回目で close) / Tab focus trap / カスタムエージェント追加→削除→activeSection が general に戻る挙動

Refs #373