### PR TITLE
refactor(tauri-api): #373 Phase 5 tauri-api.ts を 11 領域別 sub-module に分割

### DIFF
--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -5,299 +5,48 @@
  * - `import { api } from './tauri-api'` で namespaced な API を提供
  * - 内部では `@tauri-apps/api/core` の `invoke()` と `listen()` を呼ぶ
  * - `window.api` にも同じインスタンスを割り当てている (旧コードパスとの互換のため)
+ *
+ * Phase 5 (Issue #373): 各領域の実装を `./tauri-api/<area>.ts` に分割し、本ファイルは
+ * thin facade として 11 領域を集約 + `ping` + `isTauri` + 自動 bootstrap だけを担う。
+ * 外部 API (`api` / `Api` / `isTauri` / `RoleProfileSummary`) は 1 文字も変えない。
  */
 
 import { invoke } from '@tauri-apps/api/core';
-import { subscribeEvent, subscribeEventReady } from './subscribe-event';
-import {
-  type AppSettings,
-  type AppUserInfo,
-  type ClaudeCheckResult,
-  type FileListResult,
-  type FileReadResult,
-  type FileWriteResult,
-  type GitDiffResult,
-  type GitStatus,
-  type HandoffCheckpoint,
-  type HandoffCreateRequest,
-  type HandoffCreateResult,
-  type HandoffMutationResult,
-  type ReadLogTailResponse,
-  type RoleProfilesFile,
-  type SessionInfo,
-  type SetWindowEffectsResult,
-  type TeamHistoryEntry,
-  type TerminalCreateOptions,
-  type TerminalCreateResult,
-  type TerminalExitInfo,
-  type ThemeName
-} from '../../../types/shared';
+
+import { app } from './tauri-api/app';
+import { dialog } from './tauri-api/dialog';
+import { files } from './tauri-api/files';
+import { git } from './tauri-api/git';
+import { handoffs } from './tauri-api/handoffs';
+import { logs } from './tauri-api/logs';
+import { roleProfiles } from './tauri-api/role-profiles';
+import { sessions } from './tauri-api/sessions';
+import { settings } from './tauri-api/settings';
+import { teamHistory } from './tauri-api/team-history';
+import { terminal } from './tauri-api/terminal';
+
+// 既存 import { RoleProfileSummary } from '../lib/tauri-api' との互換維持。
+// Tauri 側 TeamHub に同期する role profile の要約形。
+export type { RoleProfileSummary } from './tauri-api/app';
 
 // Issue #294: `subscribeEvent` / `subscribeEventReady` は `./subscribe-event.ts` に
 // 切り出し、`subscribeEvent` は `subscribeEventReady` の sync ラッパとして再実装。
-// これにより「await 解決前後の disposed sentinel」のロジックが 1 箇所に集約され、
-// Issue #285 と同型の post-subscribe race を構造的に再生産しないことを保証する。
-
-/** Tauri 側 TeamHub に同期する role profile の要約形 */
-export interface RoleProfileSummary {
-  id: string;
-  labelEn: string;
-  labelJa?: string;
-  descriptionEn: string;
-  descriptionJa?: string;
-  canRecruit: boolean;
-  canDismiss: boolean;
-  canAssignTasks: boolean;
-  /** Leader が team_create_role / team_recruit(role_definition=...) で動的ロールを作れるか */
-  canCreateRoleProfile: boolean;
-  defaultEngine: string;
-  singleton: boolean;
-}
-
-interface TeamMcpMember {
-  agentId: string;
-  role: string;
-  agent: string;
-}
-interface SetupTeamMcpResult {
-  ok: boolean;
-  error?: string;
-  socket?: string;
-  changed?: boolean;
-}
-interface CleanupTeamMcpResult {
-  ok: boolean;
-  error?: string;
-  removed?: boolean;
-}
-interface ActiveLeaderResult {
-  ok: boolean;
-  error?: string;
-}
-interface OpenExternalResult {
-  ok: boolean;
-  error?: string;
-}
-interface TeamHubInfo {
-  socket: string;
-  token: string;
-  bridgePath: string;
-}
-interface SavePastedImageResult {
-  ok: boolean;
-  path?: string;
-  error?: string;
-}
-interface MutationResult {
-  ok: boolean;
-  error?: string;
-}
+// terminal.* event ハンドラ (onData / onExit / ...) からのみ参照される。
 
 export const api = {
   ping: (): Promise<string> => invoke('ping'),
 
-  app: {
-    getProjectRoot: (): Promise<string> => invoke('app_get_project_root'),
-    /** Issue #29: renderer 側で project root が切り替わったとき Rust 側 state を同期する */
-    setProjectRoot: (projectRoot: string): Promise<void> =>
-      invoke('app_set_project_root', { projectRoot }),
-    restart: (): Promise<void> => invoke('app_restart'),
-    setWindowTitle: (title: string): Promise<void> => invoke('app_set_window_title', { title }),
-    checkClaude: (command: string): Promise<ClaudeCheckResult> =>
-      invoke('app_check_claude', { command }),
-    setZoomLevel: (level: number): Promise<void> => invoke('app_set_zoom_level', { level }),
-    /**
-     * Issue #260 PR-1: テーマに応じて OS ネイティブの window effect (Windows: Acrylic /
-     * macOS: vibrancy) を切り替える。Linux 等は no-op (applied=false で返る)。
-     * 引数を `ThemeName` に絞ることで誤った文字列での呼び出しをコンパイル時に弾く。
-     */
-    setWindowEffects: (theme: ThemeName): Promise<SetWindowEffectsResult> =>
-      invoke('app_set_window_effects', { theme }),
-    setupTeamMcp: (
-      projectRoot: string,
-      teamId: string,
-      teamName: string,
-      members: TeamMcpMember[]
-    ): Promise<SetupTeamMcpResult> =>
-      invoke('app_setup_team_mcp', { projectRoot, teamId, teamName, members }),
-    cleanupTeamMcp: (projectRoot: string, teamId: string): Promise<CleanupTeamMcpResult> =>
-      invoke('app_cleanup_team_mcp', { projectRoot, teamId }),
-    setActiveLeader: (teamId: string, agentId?: string | null): Promise<ActiveLeaderResult> =>
-      invoke('app_set_active_leader', { teamId, agentId }),
-    getTeamFilePath: (teamId: string): Promise<string> =>
-      invoke('app_get_team_file_path', { teamId }),
-    getMcpServerPath: (): Promise<string> => invoke('app_get_mcp_server_path'),
-    getTeamHubInfo: (): Promise<TeamHubInfo> => invoke('app_get_team_hub_info'),
-    /** RoleProfile summary を Hub へ同期 (team_list_role_profiles / permissions 検証用) */
-    setRoleProfileSummary: (summary: RoleProfileSummary[]): Promise<void> =>
-      invoke('app_set_role_profile_summary', { summary }),
-    /** recruit を手動キャンセル (timeout 待ち中にユーザーがカードを × で閉じた等) */
-    cancelRecruit: (agentId: string): Promise<void> =>
-      invoke('app_cancel_recruit', { agentId }),
-    /**
-     * `<projectRoot>/.claude/skills/vibe-team/SKILL.md` を書き出す。
-     * setupTeamMcp でも best-effort で実行されるが、Onboarding / 設定 UI から手動で
-     * 強制再配置 (forceOverwrite=true) したい場合のために露出する。
-     */
-    installVibeTeamSkill: (
-      projectRoot: string,
-      forceOverwrite?: boolean
-    ): Promise<{
-      ok: boolean;
-      path?: string;
-      skipped?: boolean;
-      overwritten?: boolean;
-      error?: string;
-    }> =>
-      invoke('app_install_vibe_team_skill', { projectRoot, forceOverwrite: !!forceOverwrite }),
-    getUserInfo: (): Promise<AppUserInfo> => invoke('app_get_user_info'),
-    openExternal: (url: string): Promise<OpenExternalResult> => invoke('app_open_external', { url }),
-    /** Issue #251: OS のファイルマネージャで親フォルダを開き該当ファイルをハイライト */
-    revealInFileManager: (path: string): Promise<OpenExternalResult> =>
-      invoke('app_reveal_in_file_manager', { path })
-  },
-
-  git: {
-    status: (projectRoot: string): Promise<GitStatus> => invoke('git_status', { projectRoot }),
-    diff: (
-      projectRoot: string,
-      relPath: string,
-      originalRelPath?: string
-    ): Promise<GitDiffResult> =>
-      invoke('git_diff', { projectRoot, relPath, originalRelPath })
-  },
-
-  files: {
-    list: (projectRoot: string, relPath: string): Promise<FileListResult> =>
-      invoke('files_list', { projectRoot, relPath }),
-    read: (projectRoot: string, relPath: string): Promise<FileReadResult> =>
-      invoke('files_read', { projectRoot, relPath }),
-    /**
-     * Issue #65 / #104 / #102 / #119: external-change 検出と元 encoding の保持。
-     *   - expectedMtimeMs: 開いた時点の mtime
-     *   - expectedSizeBytes: 開いた時点の size (mtime 解像度の補完)
-     *   - encoding: 開いたときに検出した encoding。指定するとその encoding で再エンコードされる
-     *   - expectedContentHash: 開いた時点の SHA-256 (hex)。同サイズかつ 1 秒以内の編集が
-     *     mtime/size 両方で見逃されるケースを内容ハッシュで補完検出する。
-     */
-    write: (
-      projectRoot: string,
-      relPath: string,
-      content: string,
-      expectedMtimeMs?: number,
-      expectedSizeBytes?: number,
-      encoding?: string,
-      expectedContentHash?: string
-    ): Promise<FileWriteResult> =>
-      invoke('files_write', {
-        projectRoot,
-        relPath,
-        content,
-        expectedMtimeMs,
-        expectedSizeBytes,
-        encoding,
-        expectedContentHash
-      })
-  },
-
-  sessions: {
-    list: (projectRoot: string): Promise<SessionInfo[]> =>
-      invoke('sessions_list', { projectRoot })
-  },
-
-  teamHistory: {
-    list: (projectRoot: string): Promise<TeamHistoryEntry[]> =>
-      invoke('team_history_list', { projectRoot }),
-    save: (entry: TeamHistoryEntry): Promise<MutationResult> =>
-      invoke('team_history_save', { entry }),
-    /** Issue #132: 複数チームを 1 IPC + 1 disk write でまとめて保存する */
-    saveBatch: (entries: TeamHistoryEntry[]): Promise<MutationResult> =>
-      invoke('team_history_save_batch', { entries }),
-    delete: (id: string): Promise<MutationResult> => invoke('team_history_delete', { id })
-  },
-
-  handoffs: {
-    create: (request: HandoffCreateRequest): Promise<HandoffCreateResult> =>
-      invoke('handoffs_create', { req: request }),
-    list: (projectRoot: string, teamId?: string | null): Promise<HandoffCheckpoint[]> =>
-      invoke('handoffs_list', { projectRoot, teamId }),
-    read: (
-      projectRoot: string,
-      teamId: string | null | undefined,
-      handoffId: string
-    ): Promise<HandoffCheckpoint | null> =>
-      invoke('handoffs_read', { projectRoot, teamId, handoffId }),
-    updateStatus: (
-      projectRoot: string,
-      teamId: string | null | undefined,
-      handoffId: string,
-      status: string,
-      toAgentId?: string | null
-    ): Promise<HandoffMutationResult> =>
-      invoke('handoffs_update_status', { projectRoot, teamId, handoffId, status, toAgentId })
-  },
-
-  dialog: {
-    openFolder: (title?: string): Promise<string | null> =>
-      invoke('dialog_open_folder', { title }),
-    openFile: (title?: string): Promise<string | null> => invoke('dialog_open_file', { title }),
-    isFolderEmpty: (folderPath: string): Promise<boolean> =>
-      invoke('dialog_is_folder_empty', { folderPath })
-  },
-
-  settings: {
-    // 既定値とのマージや schemaVersion 判定は settings-migrate.ts に集約する。
-    // ここで先に DEFAULT_SETTINGS を混ぜると、旧設定に現在の schemaVersion が
-    // 入ってしまい、必要なマイグレーションがスキップされる。
-    load: (): Promise<unknown> => invoke('settings_load'),
-    save: (settings: AppSettings): Promise<void> => invoke('settings_save', { settings })
-  },
-
-  roleProfiles: {
-    load: (): Promise<RoleProfilesFile | null> => invoke('role_profiles_load'),
-    save: (file: RoleProfilesFile): Promise<void> => invoke('role_profiles_save', { file })
-  },
-
-  /** Issue #326: 設定モーダルからログを表示する用。
-   *  Rust 側で stderr と並行して `~/.vibe-editor/logs/vibe-editor.log` に書き出している。 */
-  logs: {
-    /** ログファイル末尾の最大 maxBytes バイトを返す。省略時は 256KB。 */
-    readTail: (maxBytes?: number): Promise<ReadLogTailResponse> =>
-      invoke('logs_read_tail', { maxBytes }),
-    /** ログ格納ディレクトリを OS のファイルマネージャで開く。 */
-    openDir: (): Promise<void> => invoke('logs_open_dir')
-  },
-
-  terminal: {
-    create: (opts: TerminalCreateOptions): Promise<TerminalCreateResult> =>
-      invoke('terminal_create', { opts }),
-    write: (id: string, data: string): Promise<void> =>
-      invoke('terminal_write', { id, data }),
-    resize: (id: string, cols: number, rows: number): Promise<void> =>
-      invoke('terminal_resize', { id, cols, rows }),
-    kill: (id: string): Promise<void> => invoke('terminal_kill', { id }),
-    savePastedImage: (base64: string, mimeType: string): Promise<SavePastedImageResult> =>
-      invoke('terminal_save_pasted_image', { base64, mimeType }),
-
-    onData: (id: string, cb: (data: string) => void): (() => void) =>
-      subscribeEvent<string>(`terminal:data:${id}`, cb),
-
-    onExit: (id: string, cb: (info: TerminalExitInfo) => void): (() => void) =>
-      subscribeEvent<TerminalExitInfo>(`terminal:exit:${id}`, cb),
-
-    onSessionId: (id: string, cb: (sessionId: string) => void): (() => void) =>
-      subscribeEvent<string>(`terminal:sessionId:${id}`, cb),
-
-    /** Issue #285: pre-subscribe 用。`terminal.create` 前に await して使う。 */
-    onDataReady: (id: string, cb: (data: string) => void): Promise<() => void> =>
-      subscribeEventReady<string>(`terminal:data:${id}`, cb),
-
-    onExitReady: (id: string, cb: (info: TerminalExitInfo) => void): Promise<() => void> =>
-      subscribeEventReady<TerminalExitInfo>(`terminal:exit:${id}`, cb),
-
-    onSessionIdReady: (id: string, cb: (sessionId: string) => void): Promise<() => void> =>
-      subscribeEventReady<string>(`terminal:sessionId:${id}`, cb)
-  }
+  app,
+  git,
+  files,
+  sessions,
+  teamHistory,
+  handoffs,
+  dialog,
+  settings,
+  roleProfiles,
+  logs,
+  terminal
 };
 
 export type Api = typeof api;

--- a/src/renderer/src/lib/tauri-api/app.ts
+++ b/src/renderer/src/lib/tauri-api/app.ts
@@ -1,0 +1,116 @@
+// tauri-api/app.ts — app.* IPC namespace (Phase 5 / Issue #373)
+
+import { invoke } from '@tauri-apps/api/core';
+import type {
+  AppUserInfo,
+  ClaudeCheckResult,
+  SetWindowEffectsResult,
+  ThemeName
+} from '../../../../types/shared';
+
+/** Tauri 側 TeamHub に同期する role profile の要約形 */
+export interface RoleProfileSummary {
+  id: string;
+  labelEn: string;
+  labelJa?: string;
+  descriptionEn: string;
+  descriptionJa?: string;
+  canRecruit: boolean;
+  canDismiss: boolean;
+  canAssignTasks: boolean;
+  /** Leader が team_create_role / team_recruit(role_definition=...) で動的ロールを作れるか */
+  canCreateRoleProfile: boolean;
+  defaultEngine: string;
+  singleton: boolean;
+}
+
+interface TeamMcpMember {
+  agentId: string;
+  role: string;
+  agent: string;
+}
+interface SetupTeamMcpResult {
+  ok: boolean;
+  error?: string;
+  socket?: string;
+  changed?: boolean;
+}
+interface CleanupTeamMcpResult {
+  ok: boolean;
+  error?: string;
+  removed?: boolean;
+}
+interface ActiveLeaderResult {
+  ok: boolean;
+  error?: string;
+}
+interface OpenExternalResult {
+  ok: boolean;
+  error?: string;
+}
+interface TeamHubInfo {
+  socket: string;
+  token: string;
+  bridgePath: string;
+}
+
+export const app = {
+  getProjectRoot: (): Promise<string> => invoke('app_get_project_root'),
+  /** Issue #29: renderer 側で project root が切り替わったとき Rust 側 state を同期する */
+  setProjectRoot: (projectRoot: string): Promise<void> =>
+    invoke('app_set_project_root', { projectRoot }),
+  restart: (): Promise<void> => invoke('app_restart'),
+  setWindowTitle: (title: string): Promise<void> => invoke('app_set_window_title', { title }),
+  checkClaude: (command: string): Promise<ClaudeCheckResult> =>
+    invoke('app_check_claude', { command }),
+  setZoomLevel: (level: number): Promise<void> => invoke('app_set_zoom_level', { level }),
+  /**
+   * Issue #260 PR-1: テーマに応じて OS ネイティブの window effect (Windows: Acrylic /
+   * macOS: vibrancy) を切り替える。Linux 等は no-op (applied=false で返る)。
+   * 引数を `ThemeName` に絞ることで誤った文字列での呼び出しをコンパイル時に弾く。
+   */
+  setWindowEffects: (theme: ThemeName): Promise<SetWindowEffectsResult> =>
+    invoke('app_set_window_effects', { theme }),
+  setupTeamMcp: (
+    projectRoot: string,
+    teamId: string,
+    teamName: string,
+    members: TeamMcpMember[]
+  ): Promise<SetupTeamMcpResult> =>
+    invoke('app_setup_team_mcp', { projectRoot, teamId, teamName, members }),
+  cleanupTeamMcp: (projectRoot: string, teamId: string): Promise<CleanupTeamMcpResult> =>
+    invoke('app_cleanup_team_mcp', { projectRoot, teamId }),
+  setActiveLeader: (teamId: string, agentId?: string | null): Promise<ActiveLeaderResult> =>
+    invoke('app_set_active_leader', { teamId, agentId }),
+  getTeamFilePath: (teamId: string): Promise<string> =>
+    invoke('app_get_team_file_path', { teamId }),
+  getMcpServerPath: (): Promise<string> => invoke('app_get_mcp_server_path'),
+  getTeamHubInfo: (): Promise<TeamHubInfo> => invoke('app_get_team_hub_info'),
+  /** RoleProfile summary を Hub へ同期 (team_list_role_profiles / permissions 検証用) */
+  setRoleProfileSummary: (summary: RoleProfileSummary[]): Promise<void> =>
+    invoke('app_set_role_profile_summary', { summary }),
+  /** recruit を手動キャンセル (timeout 待ち中にユーザーがカードを × で閉じた等) */
+  cancelRecruit: (agentId: string): Promise<void> =>
+    invoke('app_cancel_recruit', { agentId }),
+  /**
+   * `<projectRoot>/.claude/skills/vibe-team/SKILL.md` を書き出す。
+   * setupTeamMcp でも best-effort で実行されるが、Onboarding / 設定 UI から手動で
+   * 強制再配置 (forceOverwrite=true) したい場合のために露出する。
+   */
+  installVibeTeamSkill: (
+    projectRoot: string,
+    forceOverwrite?: boolean
+  ): Promise<{
+    ok: boolean;
+    path?: string;
+    skipped?: boolean;
+    overwritten?: boolean;
+    error?: string;
+  }> =>
+    invoke('app_install_vibe_team_skill', { projectRoot, forceOverwrite: !!forceOverwrite }),
+  getUserInfo: (): Promise<AppUserInfo> => invoke('app_get_user_info'),
+  openExternal: (url: string): Promise<OpenExternalResult> => invoke('app_open_external', { url }),
+  /** Issue #251: OS のファイルマネージャで親フォルダを開き該当ファイルをハイライト */
+  revealInFileManager: (path: string): Promise<OpenExternalResult> =>
+    invoke('app_reveal_in_file_manager', { path })
+};

--- a/src/renderer/src/lib/tauri-api/dialog.ts
+++ b/src/renderer/src/lib/tauri-api/dialog.ts
@@ -1,0 +1,11 @@
+// tauri-api/dialog.ts — dialog.* IPC namespace (Phase 5 / Issue #373)
+
+import { invoke } from '@tauri-apps/api/core';
+
+export const dialog = {
+  openFolder: (title?: string): Promise<string | null> =>
+    invoke('dialog_open_folder', { title }),
+  openFile: (title?: string): Promise<string | null> => invoke('dialog_open_file', { title }),
+  isFolderEmpty: (folderPath: string): Promise<boolean> =>
+    invoke('dialog_is_folder_empty', { folderPath })
+};

--- a/src/renderer/src/lib/tauri-api/files.ts
+++ b/src/renderer/src/lib/tauri-api/files.ts
@@ -1,0 +1,41 @@
+// tauri-api/files.ts — files.* IPC namespace (Phase 5 / Issue #373)
+
+import { invoke } from '@tauri-apps/api/core';
+import type {
+  FileListResult,
+  FileReadResult,
+  FileWriteResult
+} from '../../../../types/shared';
+
+export const files = {
+  list: (projectRoot: string, relPath: string): Promise<FileListResult> =>
+    invoke('files_list', { projectRoot, relPath }),
+  read: (projectRoot: string, relPath: string): Promise<FileReadResult> =>
+    invoke('files_read', { projectRoot, relPath }),
+  /**
+   * Issue #65 / #104 / #102 / #119: external-change 検出と元 encoding の保持。
+   *   - expectedMtimeMs: 開いた時点の mtime
+   *   - expectedSizeBytes: 開いた時点の size (mtime 解像度の補完)
+   *   - encoding: 開いたときに検出した encoding。指定するとその encoding で再エンコードされる
+   *   - expectedContentHash: 開いた時点の SHA-256 (hex)。同サイズかつ 1 秒以内の編集が
+   *     mtime/size 両方で見逃されるケースを内容ハッシュで補完検出する。
+   */
+  write: (
+    projectRoot: string,
+    relPath: string,
+    content: string,
+    expectedMtimeMs?: number,
+    expectedSizeBytes?: number,
+    encoding?: string,
+    expectedContentHash?: string
+  ): Promise<FileWriteResult> =>
+    invoke('files_write', {
+      projectRoot,
+      relPath,
+      content,
+      expectedMtimeMs,
+      expectedSizeBytes,
+      encoding,
+      expectedContentHash
+    })
+};

--- a/src/renderer/src/lib/tauri-api/git.ts
+++ b/src/renderer/src/lib/tauri-api/git.ts
@@ -1,0 +1,14 @@
+// tauri-api/git.ts — git.* IPC namespace (Phase 5 / Issue #373)
+
+import { invoke } from '@tauri-apps/api/core';
+import type { GitDiffResult, GitStatus } from '../../../../types/shared';
+
+export const git = {
+  status: (projectRoot: string): Promise<GitStatus> => invoke('git_status', { projectRoot }),
+  diff: (
+    projectRoot: string,
+    relPath: string,
+    originalRelPath?: string
+  ): Promise<GitDiffResult> =>
+    invoke('git_diff', { projectRoot, relPath, originalRelPath })
+};

--- a/src/renderer/src/lib/tauri-api/handoffs.ts
+++ b/src/renderer/src/lib/tauri-api/handoffs.ts
@@ -1,0 +1,30 @@
+// tauri-api/handoffs.ts — handoffs.* IPC namespace (Phase 5 / Issue #373)
+
+import { invoke } from '@tauri-apps/api/core';
+import type {
+  HandoffCheckpoint,
+  HandoffCreateRequest,
+  HandoffCreateResult,
+  HandoffMutationResult
+} from '../../../../types/shared';
+
+export const handoffs = {
+  create: (request: HandoffCreateRequest): Promise<HandoffCreateResult> =>
+    invoke('handoffs_create', { req: request }),
+  list: (projectRoot: string, teamId?: string | null): Promise<HandoffCheckpoint[]> =>
+    invoke('handoffs_list', { projectRoot, teamId }),
+  read: (
+    projectRoot: string,
+    teamId: string | null | undefined,
+    handoffId: string
+  ): Promise<HandoffCheckpoint | null> =>
+    invoke('handoffs_read', { projectRoot, teamId, handoffId }),
+  updateStatus: (
+    projectRoot: string,
+    teamId: string | null | undefined,
+    handoffId: string,
+    status: string,
+    toAgentId?: string | null
+  ): Promise<HandoffMutationResult> =>
+    invoke('handoffs_update_status', { projectRoot, teamId, handoffId, status, toAgentId })
+};

--- a/src/renderer/src/lib/tauri-api/logs.ts
+++ b/src/renderer/src/lib/tauri-api/logs.ts
@@ -1,0 +1,14 @@
+// tauri-api/logs.ts — logs.* IPC namespace (Phase 5 / Issue #373)
+
+import { invoke } from '@tauri-apps/api/core';
+import type { ReadLogTailResponse } from '../../../../types/shared';
+
+/** Issue #326: 設定モーダルからログを表示する用。
+ *  Rust 側で stderr と並行して `~/.vibe-editor/logs/vibe-editor.log` に書き出している。 */
+export const logs = {
+  /** ログファイル末尾の最大 maxBytes バイトを返す。省略時は 256KB。 */
+  readTail: (maxBytes?: number): Promise<ReadLogTailResponse> =>
+    invoke('logs_read_tail', { maxBytes }),
+  /** ログ格納ディレクトリを OS のファイルマネージャで開く。 */
+  openDir: (): Promise<void> => invoke('logs_open_dir')
+};

--- a/src/renderer/src/lib/tauri-api/role-profiles.ts
+++ b/src/renderer/src/lib/tauri-api/role-profiles.ts
@@ -1,0 +1,9 @@
+// tauri-api/role-profiles.ts — roleProfiles.* IPC namespace (Phase 5 / Issue #373)
+
+import { invoke } from '@tauri-apps/api/core';
+import type { RoleProfilesFile } from '../../../../types/shared';
+
+export const roleProfiles = {
+  load: (): Promise<RoleProfilesFile | null> => invoke('role_profiles_load'),
+  save: (file: RoleProfilesFile): Promise<void> => invoke('role_profiles_save', { file })
+};

--- a/src/renderer/src/lib/tauri-api/sessions.ts
+++ b/src/renderer/src/lib/tauri-api/sessions.ts
@@ -1,0 +1,9 @@
+// tauri-api/sessions.ts — sessions.* IPC namespace (Phase 5 / Issue #373)
+
+import { invoke } from '@tauri-apps/api/core';
+import type { SessionInfo } from '../../../../types/shared';
+
+export const sessions = {
+  list: (projectRoot: string): Promise<SessionInfo[]> =>
+    invoke('sessions_list', { projectRoot })
+};

--- a/src/renderer/src/lib/tauri-api/settings.ts
+++ b/src/renderer/src/lib/tauri-api/settings.ts
@@ -1,0 +1,12 @@
+// tauri-api/settings.ts — settings.* IPC namespace (Phase 5 / Issue #373)
+
+import { invoke } from '@tauri-apps/api/core';
+import type { AppSettings } from '../../../../types/shared';
+
+export const settings = {
+  // 既定値とのマージや schemaVersion 判定は settings-migrate.ts に集約する。
+  // ここで先に DEFAULT_SETTINGS を混ぜると、旧設定に現在の schemaVersion が
+  // 入ってしまい、必要なマイグレーションがスキップされる。
+  load: (): Promise<unknown> => invoke('settings_load'),
+  save: (settings: AppSettings): Promise<void> => invoke('settings_save', { settings })
+};

--- a/src/renderer/src/lib/tauri-api/team-history.ts
+++ b/src/renderer/src/lib/tauri-api/team-history.ts
@@ -1,0 +1,20 @@
+// tauri-api/team-history.ts — teamHistory.* IPC namespace (Phase 5 / Issue #373)
+
+import { invoke } from '@tauri-apps/api/core';
+import type { TeamHistoryEntry } from '../../../../types/shared';
+
+interface MutationResult {
+  ok: boolean;
+  error?: string;
+}
+
+export const teamHistory = {
+  list: (projectRoot: string): Promise<TeamHistoryEntry[]> =>
+    invoke('team_history_list', { projectRoot }),
+  save: (entry: TeamHistoryEntry): Promise<MutationResult> =>
+    invoke('team_history_save', { entry }),
+  /** Issue #132: 複数チームを 1 IPC + 1 disk write でまとめて保存する */
+  saveBatch: (entries: TeamHistoryEntry[]): Promise<MutationResult> =>
+    invoke('team_history_save_batch', { entries }),
+  delete: (id: string): Promise<MutationResult> => invoke('team_history_delete', { id })
+};

--- a/src/renderer/src/lib/tauri-api/terminal.ts
+++ b/src/renderer/src/lib/tauri-api/terminal.ts
@@ -1,0 +1,46 @@
+// tauri-api/terminal.ts — terminal.* IPC namespace (Phase 5 / Issue #373)
+
+import { invoke } from '@tauri-apps/api/core';
+import { subscribeEvent, subscribeEventReady } from '../subscribe-event';
+import type {
+  TerminalCreateOptions,
+  TerminalCreateResult,
+  TerminalExitInfo
+} from '../../../../types/shared';
+
+interface SavePastedImageResult {
+  ok: boolean;
+  path?: string;
+  error?: string;
+}
+
+export const terminal = {
+  create: (opts: TerminalCreateOptions): Promise<TerminalCreateResult> =>
+    invoke('terminal_create', { opts }),
+  write: (id: string, data: string): Promise<void> =>
+    invoke('terminal_write', { id, data }),
+  resize: (id: string, cols: number, rows: number): Promise<void> =>
+    invoke('terminal_resize', { id, cols, rows }),
+  kill: (id: string): Promise<void> => invoke('terminal_kill', { id }),
+  savePastedImage: (base64: string, mimeType: string): Promise<SavePastedImageResult> =>
+    invoke('terminal_save_pasted_image', { base64, mimeType }),
+
+  onData: (id: string, cb: (data: string) => void): (() => void) =>
+    subscribeEvent<string>(`terminal:data:${id}`, cb),
+
+  onExit: (id: string, cb: (info: TerminalExitInfo) => void): (() => void) =>
+    subscribeEvent<TerminalExitInfo>(`terminal:exit:${id}`, cb),
+
+  onSessionId: (id: string, cb: (sessionId: string) => void): (() => void) =>
+    subscribeEvent<string>(`terminal:sessionId:${id}`, cb),
+
+  /** Issue #285: pre-subscribe 用。`terminal.create` 前に await して使う。 */
+  onDataReady: (id: string, cb: (data: string) => void): Promise<() => void> =>
+    subscribeEventReady<string>(`terminal:data:${id}`, cb),
+
+  onExitReady: (id: string, cb: (info: TerminalExitInfo) => void): Promise<() => void> =>
+    subscribeEventReady<TerminalExitInfo>(`terminal:exit:${id}`, cb),
+
+  onSessionIdReady: (id: string, cb: (sessionId: string) => void): Promise<() => void> =>
+    subscribeEventReady<string>(`terminal:sessionId:${id}`, cb)
+};


### PR DESCRIPTION
## Summary

Issue #373 / Phase 5 (横断クリーンアップ): `lib/tauri-api.ts` (328 行) を領域別に 11 sub-module へ分割し、本体は thin facade に。**move only / 機能変更なし / 公開 API (`api` / `Api` / `isTauri` / `RoleProfileSummary`) は 1 文字も変えない**。

## 構成

| ファイル | 行数 | 内容 |
|---|---|---|
| `lib/tauri-api.ts` | 328 → 70 | thin facade: import 11 領域 + `ping` + `isTauri` + 自動 bootstrap |
| `lib/tauri-api/app.ts` (新規) | 116 | `app.*` namespace + `RoleProfileSummary` export + 内部 helper interface 6 種 |
| `lib/tauri-api/git.ts` (新規) | 14 | `git.*` (status / diff) |
| `lib/tauri-api/files.ts` (新規) | 41 | `files.*` (list / read / write) |
| `lib/tauri-api/sessions.ts` (新規) | 10 | `sessions.*` (list) |
| `lib/tauri-api/team-history.ts` (新規) | 20 | `teamHistory.*` (list / save / saveBatch / delete) |
| `lib/tauri-api/handoffs.ts` (新規) | 30 | `handoffs.*` (create / list / read / updateStatus) |
| `lib/tauri-api/dialog.ts` (新規) | 11 | `dialog.*` (openFolder / openFile / isFolderEmpty) |
| `lib/tauri-api/settings.ts` (新規) | 12 | `settings.*` (load / save) |
| `lib/tauri-api/role-profiles.ts` (新規) | 9 | `roleProfiles.*` (load / save) |
| `lib/tauri-api/logs.ts` (新規) | 14 | `logs.*` (readTail / openDir) |
| `lib/tauri-api/terminal.ts` (新規) | 46 | `terminal.*` + onData/Exit/SessionId 6 種 + 内部 `SavePastedImageResult` |

## 公開 API の維持

- `import { api } from '../lib/tauri-api'` (FileTreePanel.tsx 等) — **不変**
- `import { isTauri } from '../lib/tauri-api'` (ImagePreview.tsx) — **不変**
- `import { RoleProfileSummary } from '../lib/tauri-api'` (role-profiles-context.tsx) — `export type { RoleProfileSummary } from './tauri-api/app'` で再 export
- IPC コマンド名 / event 名 / 関数 signature はすべて bit identical
- 自動 bootstrap (`window.api` への shim 注入) も逐字保持

## 検証結果

- `npm run typecheck`: ✅ green
- 削除 283 行 + 追加 32 行 = 圧縮 -251 行 (本体は 328 → 70 行)。合計は 11 sub-module + facade で +28 行 (helper interface の領域分散による軽微な重複)

## Agent Team で並列分担

11 sub-module の draft を 3 人の teammate (app-group / terminal-group / data-group extractor) に **並列で Write** させ、team-lead 側で thin facade を Write して typecheck 通しを実施。

| teammate | 担当 | 出力 |
|---|---|---|
| `app-group-extractor` | app + git + files | 116 + 14 + 41 = 171 行 |
| `terminal-group-extractor` | terminal + sessions | 46 + 10 = 56 行 |
| `data-group-extractor` | team-history + handoffs + dialog + settings + role-profiles + logs | 96 行 |

## Issue #373 Phase 1〜5 完了

これで引き継ぎ書 `tasks/refactor-handoff.md` の 5 Phase すべてが完了:

- ✅ Phase 0 ベースライン (PR #380, #382)
- ✅ Phase 1-1〜1-9 (PR #384, #389-#396)
- ✅ Phase 2 protocol.rs 分割 (PR #399)
- ✅ Phase 3 terminal.rs sub-module move (PR #403)
- ✅ Phase 4-1 files.rs (PR #404)
- ✅ Phase 4-2 SettingsModal.tsx (PR #405)
- ✅ Phase 4-3 CanvasLayout.tsx (PR #406)
- ✅ **Phase 5 tauri-api.ts (この PR)**

引き継ぎ書 L269 の「ベースラインタグ `refactor-baseline-v1.4.7` を main に打つ」はリリース系操作のためユーザー判断で。引き継ぎ書の最終更新 (Phase 5 完了反映) は別 PR で対応予定。

## Test plan

- [x] `npm run typecheck` green
- [x] CRLF → LF 正規化済み
- [x] 既存外部 import (`api` / `isTauri` / `RoleProfileSummary`) はすべて再 export で同じ参照を提供
- [ ] **手動 smoke** (推奨): プロジェクトオープン / git diff / ファイル open-edit-save / セッション履歴 / ターミナル create-write-resize-kill / paste-image / 設定保存 — IPC 呼び出しが全領域で動くこと

Closes #373

Refs #373