### PR TITLE
fix(team_hub): #409 ワーカー無応答誤判定を防ぐ ACK / 進捗 / 生存判定ガード追加

### DIFF
--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -171,6 +171,11 @@ pub struct MemberDiagnostics {
     pub messages_in_count: u64,
     pub messages_out_count: u64,
     pub tasks_claimed_count: u64,
+    /// Issue #409: `team_status(status)` で agent が自己申告した最新ステータス文字列。
+    /// Leader が `team_diagnostics` で「直近で生きているか / 何をしているか」を判断するために使う。
+    pub current_status: Option<String>,
+    /// Issue #409: `current_status` を更新した最終時刻 (RFC3339)。
+    pub last_status_at: Option<String>,
 }
 
 /// Issue #342 Phase 3 (3.11): tracing-appender が書き出すログファイルの絶対パスを

--- a/src-tauri/src/team_hub/protocol/schema.rs
+++ b/src-tauri/src/team_hub/protocol/schema.rs
@@ -36,10 +36,20 @@ pub(super) fn tool_defs() -> Value {
         },
         {
             "name": "team_status",
-            "description": "Report your current status (informational).",
+            "description":
+                "Record your current status so the Leader can tell you are alive and what you are doing. \
+                 Stored on the Hub and surfaced via team_diagnostics (currentStatus / lastStatusAt). \
+                 Send a short 1-line update on every meaningful step (e.g. \"ACK: starting clone\", \
+                 \"running cargo test\", \"waiting on review\") — call frequently for long-running work \
+                 so the Leader does not mistake silence for a hang.",
             "inputSchema": {
                 "type": "object",
-                "properties": { "status": { "type": "string" } },
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "description": "One short line describing what you are currently doing (non-empty)."
+                    }
+                },
                 "required": ["status"]
             }
         },

--- a/src-tauri/src/team_hub/protocol/tools/assign_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/assign_task.rs
@@ -82,7 +82,12 @@ pub async fn team_assign_task(
     }
     // 「長文ペイロード・ルール」: description も SOFT_PAYLOAD_LIMIT で弾いてファイル経由を強制。
     // bulk な指示 (21 連続 issue 起票の YAML 等) はここで必ず途中切れしないために。
-    if description.len() > SOFT_PAYLOAD_LIMIT {
+    // Issue #409: 通知本文には Standard response protocol hint (~700 bytes) を後から append するため、
+    // 1 KiB の安全マージンを引いてから判定し、合算後に SOFT_PAYLOAD_LIMIT (= team_send 側の上限) を
+    // 超えるリスクを避ける。
+    const PROTOCOL_HINT_RESERVE: usize = 1024;
+    let description_limit = SOFT_PAYLOAD_LIMIT.saturating_sub(PROTOCOL_HINT_RESERVE);
+    if description.len() > description_limit {
         return Err(AssignError {
             code: "assign_payload_threshold".into(),
             message: format!(
@@ -93,7 +98,7 @@ pub async fn team_assign_task(
                  (Inline descriptions up to 32 KiB are now delivered via bracketed paste, but anything \
                  beyond that should still be passed by file path.)",
                 description.len(),
-                SOFT_PAYLOAD_LIMIT
+                description_limit
             ),
             phase: None,
             elapsed_ms: None,
@@ -139,7 +144,16 @@ pub async fn team_assign_task(
     // Issue #172: 通知の team_send を await せず fire-and-forget でバックグラウンド spawn する。
     // assignee="all" のとき fan-out で sleep 累積して MCP RPC を秒単位でブロックしていたのを解消。
     // 配信失敗のときも呼び出し側 (Leader) には task 作成結果だけを即返す。
-    let notify_args = json!({ "to": assignee, "message": format!("[Task #{task_id}] {description}") });
+    //
+    // Issue #409: タスク本文の末尾に「最低限の応答プロトコル」を必ず付与する。
+    // Leader が個別タスク説明に書き忘れても、ワーカーが
+    //   1) 開始 ACK を team_send で返す
+    //   2) team_update_task(task_id, "in_progress") に変える
+    //   3) 長時間タスクでは team_status で進捗を残す
+    //   4) 完了時に team_send + team_update_task("done" or "blocked") を呼ぶ
+    // ことで、Leader が `team_read` 0 件だけで「無応答」と誤判定するのを防ぐ。
+    let notify_message = build_task_notification(task_id, description);
+    let notify_args = json!({ "to": assignee, "message": notify_message });
     let hub_clone = hub.clone();
     let ctx_clone = ctx.clone();
     let task_id_for_log = task_id;
@@ -173,4 +187,44 @@ pub async fn team_assign_task(
         "taskId": task_id,
         "assignedAt": assigned_at,
     }))
+}
+
+/// Issue #409: タスク通知本文に「最低限の応答プロトコル」を必ず付与する。
+/// Leader が個別タスク説明にプロトコル指示を書き忘れても、ワーカーが
+///   1) 開始 ACK を team_send で返す
+///   2) team_update_task(task_id, "in_progress") に変える
+///   3) 長時間タスクでは team_status で進捗を残す
+///   4) 完了時に team_send + team_update_task("done"/"blocked") を呼ぶ
+/// ことで、Leader が `team_read` 0 件だけで「無応答」と誤判定するのを防ぐ。
+pub(super) fn build_task_notification(task_id: u32, description: &str) -> String {
+    format!(
+        "[Task #{task_id}] {description}\n\n\
+         [Standard response protocol — follow even if not repeated in the task body]\n\
+         1. Reply immediately with `team_send(\"leader\", \"ACK: Task #{task_id} received, starting...\")`.\n\
+         2. Call `team_update_task({task_id}, \"in_progress\")`.\n\
+         3. For long-running steps, call `team_status(\"...short progress line...\")` every meaningful step \
+         so the Leader can see you are alive via team_diagnostics.\n\
+         4. When done, send a `team_send(\"leader\", \"完了報告: ...\")` and call \
+         `team_update_task({task_id}, \"done\")` (or `\"blocked\"` if you cannot finish)."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_task_notification;
+
+    /// Issue #409: 通知 payload に ACK / in_progress / status / 完了プロトコルが含まれること。
+    #[test]
+    fn notification_embeds_standard_response_protocol() {
+        let msg = build_task_notification(42u32, "リポジトリ clone & 調査");
+        // 元の description が落ちていない
+        assert!(msg.starts_with("[Task #42] リポジトリ clone & 調査"));
+        // プロトコル節 4 項目が含まれる
+        assert!(msg.contains("Standard response protocol"));
+        assert!(msg.contains("ACK: Task #42 received"));
+        assert!(msg.contains("team_update_task(42, \"in_progress\")"));
+        assert!(msg.contains("team_status("));
+        assert!(msg.contains("team_update_task(42, \"done\")"));
+        assert!(msg.contains("\"blocked\""));
+    }
 }

--- a/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
+++ b/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
@@ -23,7 +23,8 @@ use super::super::permissions::caller_has_permission;
 ///   "serverLogPath": "~/.vibe-editor/logs/vibe-editor.log" or "<stderr>",
 ///   "members": [{ agentId, role, online, inconsistent, recruitedAt,
 ///                 lastHandshakeAt, lastSeenAt, lastMessageInAt, lastMessageOutAt,
-///                 messagesInCount, messagesOutCount, tasksClaimedCount }]
+///                 messagesInCount, messagesOutCount, tasksClaimedCount,
+///                 currentStatus, lastStatusAt }]
 /// }
 /// ```
 ///
@@ -66,6 +67,9 @@ pub async fn team_diagnostics(hub: &TeamHub, ctx: &CallContext) -> Result<Value,
                 "messagesInCount": d.messages_in_count,
                 "messagesOutCount": d.messages_out_count,
                 "tasksClaimedCount": d.tasks_claimed_count,
+                // Issue #409: 自己申告ステータス。team_status を呼んでいなければ null。
+                "currentStatus": d.current_status,
+                "lastStatusAt": d.last_status_at,
             })
         })
         .collect();

--- a/src-tauri/src/team_hub/protocol/tools/status.rs
+++ b/src-tauri/src/team_hub/protocol/tools/status.rs
@@ -1,14 +1,110 @@
-//! tool: `team_status` — informational status report (no-op success).
+//! tool: `team_status` — 自己申告ステータスを Hub に保存し、
+//! `team_diagnostics` 経由で Leader が「直近で生きていて何をしているか」を判別できるようにする。
 //!
-//! Issue #373 Phase 2 で `protocol.rs::dispatch_tool` のインライン実装から関数化。
+//! Issue #373 Phase 2 で `protocol.rs` のインライン実装から関数化 (旧来は no-op)。
+//! Issue #409 で「実状態の記録」へ拡張。`current_status` と `last_status_at` を
+//! `MemberDiagnostics` に保存する。`status` 引数は string 必須、空白 trim 後に空ならエラー。
 
 use crate::team_hub::{CallContext, TeamHub};
+use chrono::Utc;
 use serde_json::{json, Value};
 
+/// Issue #409: `team_status(status)` を呼んだ agent の自己申告ステータスを Hub に記録する。
+///
+/// 引数:
+///   - `status` (string, required): 1 行の現況テキスト (例 "ACK: starting clone", "running cargo test").
+///
+/// 戻り値:
+///   - `success`: 常に true (バリデーション失敗は Err で返す)
+///   - `recordedAt`: RFC3339 timestamp
+///   - `currentStatus`: 保存された status 文字列 (trim 済み)
+///
+/// 副作用:
+///   - 呼び出し元 agent の `MemberDiagnostics.current_status` / `last_status_at` を更新
+///   - `last_seen_at` も同時に更新 (heartbeat 兼)
 pub async fn team_status(
-    _hub: &TeamHub,
-    _ctx: &CallContext,
-    _args: &Value,
+    hub: &TeamHub,
+    ctx: &CallContext,
+    args: &Value,
 ) -> Result<Value, String> {
-    Ok(json!({ "success": true }))
+    let status_raw = args.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    let status = status_raw.trim();
+    if status.is_empty() {
+        return Err("status is required and must be a non-empty string".to_string());
+    }
+    let now_iso = Utc::now().to_rfc3339();
+    {
+        let mut state = hub.state.lock().await;
+        let diag = state
+            .member_diagnostics
+            .entry(ctx.agent_id.clone())
+            .or_default();
+        diag.current_status = Some(status.to_string());
+        diag.last_status_at = Some(now_iso.clone());
+        diag.last_seen_at = Some(now_iso.clone());
+    }
+    Ok(json!({
+        "success": true,
+        "recordedAt": now_iso,
+        "currentStatus": status,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pty::SessionRegistry;
+    use crate::team_hub::TeamHub;
+    use std::sync::Arc;
+
+    /// 最小の TeamHub を組み立てる (テスト専用)。
+    /// 本物の listener / endpoint は要らないので、in-memory の state だけ初期化できれば十分。
+    fn make_hub() -> TeamHub {
+        TeamHub::new(Arc::new(SessionRegistry::new()))
+    }
+
+    #[tokio::test]
+    async fn records_status_and_timestamp_in_diagnostics() {
+        let hub = make_hub();
+        let ctx = CallContext {
+            agent_id: "agent-a".into(),
+            role: "programmer".into(),
+            team_id: "team-1".into(),
+        };
+        let args = json!({ "status": "running cargo test" });
+        let result = team_status(&hub, &ctx, &args).await.expect("ok");
+        assert_eq!(result["success"], json!(true));
+        assert_eq!(result["currentStatus"], json!("running cargo test"));
+        assert!(result["recordedAt"].as_str().is_some());
+
+        let state = hub.state.lock().await;
+        let diag = state
+            .member_diagnostics
+            .get("agent-a")
+            .expect("diag entry created");
+        assert_eq!(diag.current_status.as_deref(), Some("running cargo test"));
+        assert!(diag.last_status_at.is_some());
+        assert!(diag.last_seen_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn trims_whitespace_and_rejects_empty_status() {
+        let hub = make_hub();
+        let ctx = CallContext {
+            agent_id: "agent-b".into(),
+            role: "programmer".into(),
+            team_id: "team-1".into(),
+        };
+
+        let trimmed = team_status(&hub, &ctx, &json!({ "status": "  hello  " }))
+            .await
+            .expect("ok");
+        assert_eq!(trimmed["currentStatus"], json!("hello"));
+
+        let empty = team_status(&hub, &ctx, &json!({ "status": "   " })).await;
+        assert!(empty.is_err(), "empty status must be rejected");
+
+        let missing = team_status(&hub, &ctx, &json!({})).await;
+        assert!(missing.is_err(), "missing status must be rejected");
+    }
 }

--- a/src/renderer/src/lib/__tests__/team-prompts-liveness.test.ts
+++ b/src/renderer/src/lib/__tests__/team-prompts-liveness.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Issue #409: Worker / Leader テンプレに「ACK / 進捗 / 無応答判定ガード」が
+ * 確実に埋め込まれていることを保証する回帰テスト。
+ *
+ * これらの語が消えると Leader が `team_read` 0 件で即時 dismiss する旧挙動に戻り、
+ * Issue #409 の root cause が再発する。
+ */
+import { describe, expect, it } from 'vitest';
+import { WORKER_TEMPLATE_EN, WORKER_TEMPLATE_JA, BUILTIN_BY_ID } from '../role-profiles-builtin';
+
+describe('Issue #409: worker template enforces ACK / progress / completion protocol', () => {
+  it('English worker template requires ACK + team_update_task on receipt', () => {
+    expect(WORKER_TEMPLATE_EN).toMatch(/ACK:/);
+    expect(WORKER_TEMPLATE_EN).toMatch(/team_update_task\(N, "in_progress"\)/);
+  });
+
+  it('English worker template requires periodic team_status while working', () => {
+    expect(WORKER_TEMPLATE_EN).toMatch(/team_status\(/);
+    expect(WORKER_TEMPLATE_EN).toMatch(/team_diagnostics/);
+  });
+
+  it('English worker template requires done/blocked update on completion', () => {
+    expect(WORKER_TEMPLATE_EN).toMatch(/team_update_task\(N, "done"\)/);
+    expect(WORKER_TEMPLATE_EN).toMatch(/"blocked"/);
+  });
+
+  it('Japanese worker template requires ACK + team_update_task on receipt', () => {
+    expect(WORKER_TEMPLATE_JA).toMatch(/ACK:/);
+    expect(WORKER_TEMPLATE_JA).toMatch(/team_update_task\(N, "in_progress"\)/);
+  });
+
+  it('Japanese worker template requires periodic team_status while working', () => {
+    expect(WORKER_TEMPLATE_JA).toMatch(/team_status\(/);
+    expect(WORKER_TEMPLATE_JA).toMatch(/team_diagnostics/);
+  });
+
+  it('Japanese worker template requires done/blocked update on completion', () => {
+    expect(WORKER_TEMPLATE_JA).toMatch(/team_update_task\(N, "done"\)/);
+    expect(WORKER_TEMPLATE_JA).toMatch(/"blocked"/);
+  });
+});
+
+describe('Issue #409: leader template forbids dismiss-on-team_read-zero', () => {
+  const leader = BUILTIN_BY_ID['leader'];
+
+  it('leader is registered in builtin profiles', () => {
+    expect(leader).toBeTruthy();
+  });
+
+  it('English leader template tells the leader not to dismiss on team_read 0 alone', () => {
+    const en = leader.prompt.template;
+    // do NOT dismiss / team_diagnostics の確認手順 / team_get_tasks の確認 が必要
+    expect(en).toMatch(/do NOT dismiss/i);
+    expect(en).toMatch(/team_diagnostics/);
+    expect(en).toMatch(/team_get_tasks/);
+    expect(en).toMatch(/lastSeenAt/);
+    // 60 秒で切らない / 数分は待つ ニュアンス
+    expect(en).toMatch(/60 seconds|several minutes/);
+  });
+
+  it('Japanese leader template embeds the same liveness-judgment guard', () => {
+    const ja = leader.prompt.templateJa ?? '';
+    expect(ja).toMatch(/team_dismiss/);
+    expect(ja).toMatch(/team_diagnostics/);
+    expect(ja).toMatch(/team_get_tasks/);
+    expect(ja).toMatch(/lastSeenAt/);
+    expect(ja).toMatch(/60 秒|数分/);
+  });
+});

--- a/src/renderer/src/lib/role-profiles-builtin.ts
+++ b/src/renderer/src/lib/role-profiles-builtin.ts
@@ -46,12 +46,19 @@ export const WORKER_TEMPLATE_EN =
   '[ABSOLUTE RULES — follow these without reading any external file]\n' +
   '1. Do nothing until an instruction arrives as `[Team <- leader] ...` (or `[Team <- <role>] ...`).\n' +
   '   Do not investigate the project, read files, run commands, or modify code on your own.\n' +
-  '2. When an instruction arrives, complete the requested work, then immediately call\n' +
-  '   `team_send("leader", "完了報告: ...")` (or the requesting role) with a concise result.\n' +
-  '3. After reporting, return to a quiet idle state. Do NOT poll, do NOT print "waiting for approval",\n' +
+  '2. When an instruction with `[Task #N]` arrives, immediately (BEFORE doing the actual work):\n' +
+  '   (a) Reply `team_send("leader", "ACK: Task #N received, starting <one-line plan>")`.\n' +
+  '   (b) Call `team_update_task(N, "in_progress")`.\n' +
+  '   This stops the Leader from mistaking your silent work for a hang and dismissing you.\n' +
+  '3. While working on a long task (clone / install / build / test / multi-step edits), call\n' +
+  '   `team_status("...short progress line...")` on every meaningful step (every 30–120 s),\n' +
+  '   so the Leader can see your liveness via `team_diagnostics`.\n' +
+  '4. When the work is done, send `team_send("leader", "完了報告: ...")` AND call\n' +
+  '   `team_update_task(N, "done")` (or `"blocked"` if you cannot finish — explain why).\n' +
+  '5. After reporting, return to a quiet idle state. Do NOT poll, do NOT print "waiting for approval",\n' +
   '   do NOT ask follow-up questions on your own. The next instruction will arrive as `[Team <- ...]`.\n' +
-  '4. You are NOT allowed to assign tasks to other members. Only the Leader does that.\n' +
-  '5. LONG-PAYLOAD RULE — `team_send` is delivered via bracketed paste, so multi-line content\n' +
+  '6. You are NOT allowed to assign tasks to other members. Only the Leader does that.\n' +
+  '7. LONG-PAYLOAD RULE — `team_send` is delivered via bracketed paste, so multi-line content\n' +
   '   up to ~32 KiB is OK inline. Above that the Hub rejects it; write to\n' +
   '   `.vibe-team/tmp/<short_id>.md` and send a summary + path instead.\n' +
   '\n' +
@@ -72,12 +79,20 @@ export const WORKER_TEMPLATE_JA =
   '【絶対ルール — 外部ファイルを読まずに先に従うこと】\n' +
   '1. 指示が `[Team ← leader] ...` (または `[Team ← <role>] ...`) で届くまで何もしない。\n' +
   '   自分からプロジェクト調査・ファイル読み・コマンド実行・コード変更を始めてはいけない。\n' +
-  '2. 指示が届いたら作業を完遂し、直後に `team_send("leader", "完了報告: ...")` ' +
-  '(依頼元が leader 以外ならその役職) で簡潔に結果を返す。\n' +
-  '3. 報告後は静かなアイドル状態に戻る。ポーリング・「承認待ち」表示・自発的な追加質問は禁止。' +
+  '2. `[Task #N]` 形式の指示が届いたら、実作業を始める **前に** 必ず次の 2 つを行う:\n' +
+  '   (a) `team_send("leader", "ACK: Task #N 受領、これから <1 行プラン> を開始")` で着手 ACK を返す\n' +
+  '   (b) `team_update_task(N, "in_progress")` でタスクを進行中に変える\n' +
+  '   これをやらないと Leader は「無応答」と誤判定して dismiss してしまう。\n' +
+  '3. 長時間タスク (clone / install / build / test / 複数ステップの編集など) の進行中は、' +
+  '`team_status("...今やっていることの 1 行...")` を「意味のあるステップごと (目安 30〜120 秒ごと)」に呼ぶ。' +
+  'Leader は `team_diagnostics` の `currentStatus` / `lastStatusAt` で生存確認するので、' +
+  '黙って作業しない。\n' +
+  '4. 完了したら `team_send("leader", "完了報告: ...")` と `team_update_task(N, "done")` ' +
+  '(完了不能なら `"blocked"` + 理由) の両方を必ず呼ぶ。\n' +
+  '5. 報告後は静かなアイドル状態に戻る。ポーリング・「承認待ち」表示・自発的な追加質問は禁止。' +
   '次の指示は `[Team ← ...]` で自動的に届く。\n' +
-  '4. 自分から他メンバーにタスクを割り振ってはいけない。それは Leader の仕事。\n' +
-  '5. 【長文ペイロード・ルール】`team_send` は bracketed paste で配送されるので、' +
+  '6. 自分から他メンバーにタスクを割り振ってはいけない。それは Leader の仕事。\n' +
+  '7. 【長文ペイロード・ルール】`team_send` は bracketed paste で配送されるので、' +
   '改行入りの内容も ~32 KiB まではそのまま渡して大丈夫。それを超える場合のみ ' +
   '`.vibe-team/tmp/<short_id>.md` に書き出して「サマリ + ファイルパス」を送る。\n' +
   '\n' +
@@ -130,7 +145,22 @@ export const BUILTIN_ROLE_PROFILES: RoleProfile[] = [
         '   Results return as `[Team <- <role>] ...` — review them and follow up via `team_send`.\n' +
         '6. Engine choice: default to `claude` (coding, refactor, careful reasoning, file/git tools).\n' +
         '   Use `codex` only when there is an explicit reason.\n' +
-        '7. LONG-PAYLOAD RULE.\n' +
+        '7. LIVENESS / NO-RESPONSE JUDGMENT — do NOT dismiss a member just because `team_read` returns 0.\n' +
+        '   Workers do their actual work in their own terminals; their progress shows up in\n' +
+        '   `team_diagnostics` and `team_get_tasks`, NOT in `team_read` (which only shows messages\n' +
+        '   sent to YOU). Before deciding a member is unresponsive:\n' +
+        '   (a) Call `team_diagnostics` and inspect that member\'s `lastSeenAt`, `lastMessageOutAt`,\n' +
+        '       `currentStatus`, `lastStatusAt`. If any of these is recent (within the last few minutes),\n' +
+        '       the member is alive — keep waiting.\n' +
+        '   (b) Call `team_get_tasks` and check the assigned task\'s `status`. If it is `in_progress`,\n' +
+        '       the worker is actively running it — keep waiting.\n' +
+        '   (c) For tasks involving clone / install / build / test, allow at least several minutes of\n' +
+        '       silence before suspecting a hang. Do not dismiss in under 60 seconds.\n' +
+        '   (d) If you suspect the worker is stuck, FIRST send a ping via\n' +
+        '       `team_send("<role>", "Status check: please reply with team_status(\'...\') and a 1-line update.")`\n' +
+        '       and give them another minute. Only `team_dismiss` after you have evidence (no `lastSeenAt`\n' +
+        '       update, no task status change, no reply to the ping).\n' +
+        '8. LONG-PAYLOAD RULE.\n' +
         '   Inline `team_send.message` / `team_assign_task.description` / `team_recruit.instructions`\n' +
         '   are delivered via bracketed paste, so multi-line content (YAML, code blocks, lists) up to\n' +
         '   ~32 KiB is fine inline — the receiver sees it as a single paste, not a typed-in stream.\n' +
@@ -171,7 +201,20 @@ export const BUILTIN_ROLE_PROFILES: RoleProfile[] = [
         '   結果は `[Team ← <role>] ...` で届くので都度レビュー、追指示は `team_send` で行う。\n' +
         '6. エンジン選択: 既定は `claude` (コーディング・refactor・慎重な推論・file/git ツールに強い)。\n' +
         '   `codex` は明示的な理由があるときだけ選ぶ。\n' +
-        '7. 【長文ペイロード・ルール】\n' +
+        '7. 【生存判定 / 無応答判定ガード】 — `team_read` の 0 件 (= 自分宛て新着メッセージ無し) ' +
+        'だけで「ワーカー無応答」と判断して `team_dismiss` してはいけない。\n' +
+        '   ワーカーは自分のターミナルで実作業しており、進捗は `team_read` ではなく ' +
+        '`team_diagnostics` / `team_get_tasks` に出る (team_read は「自分宛てメッセージ」しか返さない)。\n' +
+        '   無応答と判断する前に、必ず次の確認を行う:\n' +
+        '   (a) `team_diagnostics` を呼び、対象メンバーの `lastSeenAt` / `lastMessageOutAt` / ' +
+        '`currentStatus` / `lastStatusAt` を見る。直近数分以内に動きがあれば「生きている」とみなして待つ。\n' +
+        '   (b) `team_get_tasks` で対象タスクの `status` を確認する。`in_progress` なら作業継続中。\n' +
+        '   (c) clone / install / build / test を含むタスクは数分単位で沈黙することがある。' +
+        '60 秒前後で dismiss しない。最低でも数分は待つ。\n' +
+        '   (d) 本当に詰まっていそうなら、まず `team_send("<role>", "状況確認: team_status(\'...\') と ' +
+        '1 行で進捗を返してください")` で ping を送り、もう 1 分待つ。それでも `lastSeenAt` が更新されず、' +
+        'タスク status も変わらず、ping にも返事が無いときに初めて `team_dismiss` する。\n' +
+        '8. 【長文ペイロード・ルール】\n' +
         '   `team_send.message` / `team_assign_task.description` / `team_recruit.instructions` の' +
         'インラインは bracketed paste で配送されるので、改行入りの YAML / code / リストも ~32 KiB ' +
         'まではそのまま渡して大丈夫 (受信側は「1 件のペースト」として受け取り、tail が truncate しない)。\n' +

--- a/src/renderer/src/lib/team-prompts.ts
+++ b/src/renderer/src/lib/team-prompts.ts
@@ -60,7 +60,8 @@ export function generateTeamSystemPrompt(
       `既存ロール (hr や自分が作成済みの role_id) の再採用は role_id + engine だけで OK。\n` +
       `4. 3 名以上必要なときは、まず team_recruit({role_id:"hr", engine:"claude"}) で HR を採用し、team_send("hr", "採用してほしい: ...") で一括採用を委譲する。\n` +
       `5. チームが揃ったら team_assign_task で割り振り、結果は [Team ← <role>] で届くので都度レビュー、追指示は team_send で行う。\n` +
-      `6. 【長文ペイロード・ルール】team_recruit.instructions / team_send.message / team_assign_task.description は bracketed paste で配送されるので改行入り YAML / code / リストも ~32 KiB まではそのままインラインで OK。32 KiB を超える本文のみ Write で .vibe-team/tmp/<short_id>.md に書き出してから引数には「サマリ + パス」を渡す (Hub が 32 KiB 超を拒否)。\n` +
+      `6. 【生存判定ガード】team_read 0 件だけで「ワーカー無応答」と判定して team_dismiss してはいけない。team_read は「自分宛てメッセージ」しか返さない。先に (a) team_diagnostics で lastSeenAt / lastMessageOutAt / currentStatus / lastStatusAt を確認、(b) team_get_tasks でタスク status (in_progress なら継続中) を確認、(c) clone/install/build/test を含むタスクは数分単位で沈黙しうるので 60 秒前後で dismiss しない、(d) 詰まっていそうなら team_send で ping を送りもう 1 分待つ — の手順を踏む。それでも lastSeenAt 更新も task status 変化も ping への返答も無いときだけ team_dismiss する。\n` +
+      `7. 【長文ペイロード・ルール】team_recruit.instructions / team_send.message / team_assign_task.description は bracketed paste で配送されるので改行入り YAML / code / リストも ~32 KiB まではそのままインラインで OK。32 KiB を超える本文のみ Write で .vibe-team/tmp/<short_id>.md に書き出してから引数には「サマリ + パス」を渡す (Hub が 32 KiB 超を拒否)。\n` +
       `設計思想や応用パターンの詳細は .claude/skills/vibe-team/SKILL.md を Read ツールで参照可 (補助情報、必須ではない)。`
     );
   }
@@ -73,10 +74,12 @@ export function generateTeamSystemPrompt(
     `あなたはチーム「${team.name}」の${tab.role}。役割:${roleDesc}。構成: ${roster}。${mcpTools}\n` +
     `【絶対ルール】\n` +
     `1. 指示が [Team ← leader] (または [Team ← <role>]) で届くまで何もしない。自発的な調査・コード変更は禁止。\n` +
-    `2. 指示が届いたら作業を完遂し、直後に team_send('leader', "完了報告: ...") で簡潔に結果を返す。\n` +
-    `3. 報告後は静かなアイドル状態に戻る。ポーリング・「承認待ち」表示・自発的な追加質問は禁止。次の指示は [Team ← ...] で自動的に届く。\n` +
-    `4. 自分から他メンバーにタスクを割り振ってはいけない (それは Leader の仕事)。\n` +
-    `5. 【長文ペイロード・ルール】team_send は bracketed paste で配送されるので改行入りの内容も ~32 KiB まではそのまま OK。それを超える場合のみ Write で .vibe-team/tmp/<short_id>.md に書き出してパスを渡す。`
+    `2. [Task #N] 形式で届いたら、実作業を始める前に必ず (a) team_send('leader', "ACK: Task #N 受領、これから <1 行プラン> を開始") と (b) team_update_task(N, "in_progress") の 2 つを呼ぶ。これをやらないと Leader に「無応答」と誤判定されて dismiss される。\n` +
+    `3. 長時間タスク (clone/install/build/test/複数ステップ編集) の進行中は team_status("...今やっていることの 1 行...") を意味のあるステップごと (30〜120 秒目安) に呼ぶ。Leader は team_diagnostics の currentStatus / lastStatusAt で生存確認するため、黙って作業しない。\n` +
+    `4. 完了したら team_send('leader', "完了報告: ...") と team_update_task(N, "done") (完了不能なら "blocked" + 理由) の両方を必ず呼ぶ。\n` +
+    `5. 報告後は静かなアイドル状態に戻る。ポーリング・「承認待ち」表示・自発的な追加質問は禁止。次の指示は [Team ← ...] で自動的に届く。\n` +
+    `6. 自分から他メンバーにタスクを割り振ってはいけない (それは Leader の仕事)。\n` +
+    `7. 【長文ペイロード・ルール】team_send は bracketed paste で配送されるので改行入りの内容も ~32 KiB まではそのまま OK。それを超える場合のみ Write で .vibe-team/tmp/<short_id>.md に書き出してパスを渡す。`
   );
 }
 


### PR DESCRIPTION
## Summary
- Worker テンプレ (en/ja) に `[Task #N]` 受領時の **ACK + `team_update_task(in_progress)`** / 長時間タスク中の `team_status` 進捗 / 完了時の `team_send` + `team_update_task(done|blocked)` を必須化。
- Leader テンプレ (en/ja) と `team-prompts.ts` の Leader fallback に「`team_read` 0 件だけで `team_dismiss` しない / `team_diagnostics` の `lastSeenAt` / `currentStatus` / `lastStatusAt` と `team_get_tasks` の status を必ず確認 / clone・install・build・test 等は数分待つ / 詰まっていそうなら `team_send` で ping → もう 1 分待つ」**生存判定ガード**を追加。
- `team_status` を no-op から「**実状態を記録する MCP tool**」へ拡張。`MemberDiagnostics.current_status` / `last_status_at` を追加し、`team_diagnostics` の戻り値と schema description も更新。
- `team_assign_task` の通知本文に **Standard response protocol** を必ず付与 (`build_task_notification` に切り出し)。description の長文閾値から hint 分 1 KiB を予約し、合算後に 32 KiB を超えないようにする。

## 背景 (Issue #409)
ワーカーは実際に作業していたのに、Leader が `team_read(unread_only=true)` の未読 0 件だけを根拠に 1 分弱で `team_dismiss` してしまう問題。
ワーカーの作業ログは自分のターミナルで進行する一方、Leader の `team_read` には何も届かないため「無応答」と誤判定されていた。

ルートは「(a) ワーカープロンプトが着手 ACK / 定期進捗を要求していない」「(b) Leader プロンプトが `team_read` 以外の生存確認手順を持たない」の 2 点。本 PR は両側を同時に塞ぐ。

## Test plan
- [x] `npm run typecheck` (PASS)
- [x] `npm run test` — 100/100 PASS。`Issue #409: worker template enforces ACK / progress / completion protocol` ほか新規 9 件含む。
- [x] `cd src-tauri && cargo test team_hub` — 19/19 PASS。`status::tests::records_status_and_timestamp_in_diagnostics` / `trims_whitespace_and_rejects_empty_status` / `assign_task::tests::notification_embeds_standard_response_protocol` を含む。

Closes #409