### PR TITLE
fix(pty): Codex broker stale stateを掃除

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -3,9 +3,9 @@
 // portable-pty 経由で PTY を spawn、SessionRegistry に登録、
 // terminal:data:{id} / terminal:exit:{id} イベントを emit する。
 
-mod paste_image;
 mod codex_instructions;
 mod command_validation;
+mod paste_image;
 
 use crate::pty::{spawn_session, SpawnOptions, UserWriteOutcome};
 use crate::state::AppState;
@@ -164,6 +164,7 @@ pub async fn terminal_create(
             ..Default::default()
         });
     }
+    let is_codex_command = command_validation::is_codex_command(&command);
 
     // Issue #271: HMR remount 経路では renderer 側 hook が `attachIfExists: true` を立て、
     // 既存 PTY に bind し直したいシグナルを送る。allowlist / immediate-exec チェックを通った
@@ -225,6 +226,9 @@ pub async fn terminal_create(
 
     let (cwd, warning) =
         crate::pty::session::resolve_valid_cwd(&opts.cwd, opts.fallback_cwd.as_deref());
+    if is_codex_command {
+        crate::pty::codex_broker::cleanup_stale_for_cwd(&cwd);
+    }
 
     // Issue #99 / Codex stability: codex かつ instructions ありなら、
     // (1) 一時ファイル化して `--config model_instructions_file=<path>` を args 末尾に追加 (古い経路)。
@@ -233,7 +237,7 @@ pub async fn terminal_create(
     //     その場合でもプロンプトが「最初の user input」としては必ず届くようにする。
     //     team_hub::inject::build_chunks を共有して ConPTY-safe (64B / 15ms チャンク + UTF-8 境界保護) な
     //     注入を行う。同じロジックでチームメッセージの注入と挙動を揃えることで、xterm 表示の崩れも避けられる。
-    let codex_instructions_for_inject: Option<String> = if command_validation::is_codex_command(&command) {
+    let codex_instructions_for_inject: Option<String> = if is_codex_command {
         if let Some(instr) = opts
             .codex_instructions
             .as_deref()
@@ -242,9 +246,7 @@ pub async fn terminal_create(
         {
             if let Some(path) = codex_instructions::prepare_codex_instructions_file(instr).await {
                 let path_str = path.to_string_lossy().into_owned();
-                tracing::info!(
-                    "[terminal] codex model_instructions_file={path_str}"
-                );
+                tracing::info!("[terminal] codex model_instructions_file={path_str}");
                 args.push("--config".to_string());
                 args.push(format!("model_instructions_file={path_str}"));
             }
@@ -266,9 +268,7 @@ pub async fn terminal_create(
         opts.cols,
         opts.rows
     );
-    tracing::debug!(
-        "[IPC] terminal_create (verbose) args={args:?} cwd={cwd}"
-    );
+    tracing::debug!("[IPC] terminal_create (verbose) args={args:?} cwd={cwd}");
 
     if let Some(w) = &warning {
         tracing::warn!("[terminal] {w}");
@@ -314,6 +314,7 @@ pub async fn terminal_create(
         command: command.clone(),
         args: args.clone(),
         cwd,
+        is_codex: is_codex_command,
         cols: opts.cols.min(u32::from(u16::MAX)) as u16,
         rows: opts.rows.min(u32::from(u16::MAX)) as u16,
         env,
@@ -398,9 +399,12 @@ pub async fn terminal_create(
                 } else {
                     watcher_root
                 };
-                crate::pty::claude_watcher::spawn_watcher(app.clone(), watcher_id.clone(), actual_root, move || {
-                    registry.get(&watcher_id).is_some()
-                });
+                crate::pty::claude_watcher::spawn_watcher(
+                    app.clone(),
+                    watcher_id.clone(),
+                    actual_root,
+                    move || registry.get(&watcher_id).is_some(),
+                );
             }
             let cmdline = std::iter::once(command.clone())
                 .chain(args.iter().cloned())
@@ -462,7 +466,10 @@ pub async fn terminal_resize(
 ) -> Result<(), String> {
     if let Some(s) = state.pty_registry.get(&id) {
         // resize 失敗は無害なので握りつぶす (旧実装と同じ)
-        let _ = s.resize(cols.min(u32::from(u16::MAX)) as u16, rows.min(u32::from(u16::MAX)) as u16);
+        let _ = s.resize(
+            cols.min(u32::from(u16::MAX)) as u16,
+            rows.min(u32::from(u16::MAX)) as u16,
+        );
     }
     Ok(())
 }

--- a/src-tauri/src/pty/codex_broker.rs
+++ b/src-tauri/src/pty/codex_broker.rs
@@ -1,0 +1,426 @@
+// Codex plugin broker stale state cleanup.
+//
+// Issue #402:
+// Codex plugin の broker state (`broker.json`) は正常な SessionEnd hook では消えるが、
+// vibe-editor / worker の異常終了では stale な named pipe endpoint が残ることがある。
+// 次回 Codex 起動時の handshake timeout を避けるため、Codex PTY の spawn 前と終了後に
+// 「PID が死んでいる broker state だけ」を best-effort で掃除する。
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const PLUGIN_DATA_ENV: &str = "CLAUDE_PLUGIN_DATA";
+const CODEX_PLUGIN_DATA_DIR: &str = "codex-openai-codex";
+const BROKER_STATE_FILE: &str = "broker.json";
+const FALLBACK_STATE_ROOT_DIR: &str = "codex-companion";
+const BROKER_SESSION_PREFIX: &str = "cxc-";
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CleanupSummary {
+    pub checked: usize,
+    pub removed_files: usize,
+    pub removed_dirs: usize,
+    pub skipped_live: usize,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BrokerSession {
+    endpoint: Option<String>,
+    pid_file: Option<String>,
+    log_file: Option<String>,
+    session_dir: Option<String>,
+    pid: Option<u32>,
+}
+
+pub fn cleanup_stale_for_cwd(cwd: &str) -> CleanupSummary {
+    let mut summary = CleanupSummary::default();
+    for state_dir in resolve_state_dirs(cwd) {
+        let part = cleanup_stale_in_state_dir(&state_dir, is_process_alive);
+        summary.checked += part.checked;
+        summary.removed_files += part.removed_files;
+        summary.removed_dirs += part.removed_dirs;
+        summary.skipped_live += part.skipped_live;
+    }
+    if summary.removed_files > 0 || summary.removed_dirs > 0 || summary.skipped_live > 0 {
+        tracing::info!(
+            "[codex_broker] cleanup cwd={} checked={} removed_files={} removed_dirs={} skipped_live={}",
+            cwd,
+            summary.checked,
+            summary.removed_files,
+            summary.removed_dirs,
+            summary.skipped_live
+        );
+    }
+    summary
+}
+
+fn cleanup_stale_in_state_dir(state_dir: &Path, is_alive: impl Fn(u32) -> bool) -> CleanupSummary {
+    let mut summary = CleanupSummary::default();
+    let broker_file = state_dir.join(BROKER_STATE_FILE);
+    if !broker_file.is_file() {
+        return summary;
+    }
+    summary.checked = 1;
+
+    let session = match std::fs::read_to_string(&broker_file)
+        .ok()
+        .and_then(|s| serde_json::from_str::<BrokerSession>(&s).ok())
+    {
+        Some(session) => session,
+        None => {
+            tracing::warn!(
+                "[codex_broker] malformed broker state skipped: {}",
+                broker_file.display()
+            );
+            return summary;
+        }
+    };
+
+    let Some(pid) = session.pid else {
+        tracing::warn!(
+            "[codex_broker] broker state without pid skipped: {}",
+            broker_file.display()
+        );
+        return summary;
+    };
+    if is_alive(pid) {
+        summary.skipped_live = 1;
+        return summary;
+    }
+
+    let safe_session_dir = session
+        .session_dir
+        .as_deref()
+        .map(PathBuf::from)
+        .filter(|p| is_safe_broker_session_dir(p));
+
+    summary.removed_files += remove_file_if_exists(&broker_file);
+
+    if let Some(session_dir) = safe_session_dir.as_deref() {
+        summary.removed_files += remove_file_inside_dir(session.pid_file.as_deref(), session_dir);
+        summary.removed_files += remove_file_inside_dir(session.log_file.as_deref(), session_dir);
+        summary.removed_files +=
+            remove_unix_socket_inside_dir(session.endpoint.as_deref(), session_dir);
+        summary.removed_dirs += remove_empty_dir_if_exists(session_dir);
+    } else if session.session_dir.is_some() {
+        tracing::warn!(
+            "[codex_broker] unsafe broker sessionDir skipped: {:?}",
+            session.session_dir
+        );
+    }
+
+    summary
+}
+
+fn resolve_state_dirs(cwd: &str) -> Vec<PathBuf> {
+    let workspace_root = resolve_workspace_root(cwd);
+    let canonical = canonical_workspace_string(&workspace_root);
+    let dir_name = state_dir_name_for_workspace(&workspace_root, &canonical);
+    state_roots()
+        .into_iter()
+        .map(|root| root.join(&dir_name))
+        .collect()
+}
+
+fn state_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(plugin_data) = std::env::var(PLUGIN_DATA_ENV) {
+        if !plugin_data.trim().is_empty() {
+            roots.push(PathBuf::from(plugin_data).join("state"));
+        }
+    }
+    if let Some(home) = dirs::home_dir() {
+        roots.push(
+            home.join(".claude")
+                .join("plugins")
+                .join("data")
+                .join(CODEX_PLUGIN_DATA_DIR)
+                .join("state"),
+        );
+    }
+    roots.push(std::env::temp_dir().join(FALLBACK_STATE_ROOT_DIR));
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
+fn resolve_workspace_root(cwd: &str) -> PathBuf {
+    let cwd_path = PathBuf::from(cwd);
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(&cwd_path)
+        .output();
+    if let Ok(output) = output {
+        if output.status.success() {
+            let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !text.is_empty() {
+                return PathBuf::from(text);
+            }
+        }
+    }
+    cwd_path
+}
+
+fn canonical_workspace_string(path: &Path) -> String {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    strip_windows_verbatim_prefix(&canonical.to_string_lossy())
+}
+
+fn strip_windows_verbatim_prefix(raw: &str) -> String {
+    if let Some(rest) = raw.strip_prefix(r"\\?\UNC\") {
+        return format!(r"\\{rest}");
+    }
+    raw.strip_prefix(r"\\?\").unwrap_or(raw).to_string()
+}
+
+fn state_dir_name_for_workspace(workspace_root: &Path, canonical_workspace_root: &str) -> String {
+    let slug_source = workspace_root
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("workspace");
+    let slug = sanitize_slug(slug_source);
+    let mut hasher = Sha256::new();
+    hasher.update(canonical_workspace_root.as_bytes());
+    let hash = hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+    format!("{}-{}", slug, &hash[..16])
+}
+
+fn sanitize_slug(value: &str) -> String {
+    let mapped: String = value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let trimmed = mapped.trim_matches('-');
+    if trimmed.is_empty() {
+        "workspace".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn is_safe_broker_session_dir(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    if !name.starts_with(BROKER_SESSION_PREFIX) {
+        return false;
+    }
+    path_starts_with(path, &std::env::temp_dir())
+}
+
+fn path_starts_with(path: &Path, root: &Path) -> bool {
+    let normalize = |p: &Path| {
+        p.canonicalize()
+            .unwrap_or_else(|_| p.to_path_buf())
+            .to_string_lossy()
+            .replace('\\', "/")
+            .trim_end_matches('/')
+            .to_ascii_lowercase()
+    };
+    let path_s = normalize(path);
+    let root_s = normalize(root);
+    path_s == root_s || path_s.starts_with(&(root_s + "/"))
+}
+
+fn remove_file_if_exists(path: &Path) -> usize {
+    if path.is_file() {
+        match std::fs::remove_file(path) {
+            Ok(()) => return 1,
+            Err(e) => tracing::warn!("[codex_broker] remove file failed {}: {e}", path.display()),
+        }
+    }
+    0
+}
+
+fn remove_file_inside_dir(raw: Option<&str>, dir: &Path) -> usize {
+    let Some(raw) = raw else {
+        return 0;
+    };
+    let path = PathBuf::from(raw);
+    if path.is_file() && path_starts_with(&path, dir) {
+        remove_file_if_exists(&path)
+    } else {
+        0
+    }
+}
+
+fn remove_unix_socket_inside_dir(endpoint: Option<&str>, dir: &Path) -> usize {
+    let Some(endpoint) = endpoint.and_then(|e| e.strip_prefix("unix:")) else {
+        return 0;
+    };
+    let path = PathBuf::from(endpoint);
+    if path.exists() && path_starts_with(&path, dir) {
+        remove_file_if_exists(&path)
+    } else {
+        0
+    }
+}
+
+fn remove_empty_dir_if_exists(path: &Path) -> usize {
+    if path.is_dir() {
+        match std::fs::remove_dir(path) {
+            Ok(()) => return 1,
+            Err(e) => tracing::debug!(
+                "[codex_broker] broker session dir kept {}: {e}",
+                path.display()
+            ),
+        }
+    }
+    0
+}
+
+fn is_process_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    is_process_alive_platform(pid).unwrap_or(true)
+}
+
+#[cfg(windows)]
+fn is_process_alive_platform(pid: u32) -> Option<bool> {
+    let filter = format!("PID eq {pid}");
+    let output = Command::new("tasklist")
+        .args(["/FI", &filter, "/FO", "CSV", "/NH"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let needle = format!("\"{pid}\"");
+    Some(stdout.lines().any(|line| line.contains(&needle)))
+}
+
+#[cfg(not(windows))]
+fn is_process_alive_platform(pid: u32) -> Option<bool> {
+    let status = Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .status()
+        .ok()?;
+    Some(status.success())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_case(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "vibe-codex-broker-test-{name}-{}",
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_broker(state_dir: &Path, session_dir: &Path, pid: u32) {
+        fs::create_dir_all(state_dir).unwrap();
+        fs::create_dir_all(session_dir).unwrap();
+        fs::write(session_dir.join("broker.pid"), pid.to_string()).unwrap();
+        fs::write(session_dir.join("broker.log"), "log").unwrap();
+        let json = format!(
+            r#"{{
+  "endpoint": "pipe:\\\\.\\pipe\\cxc-test-codex-app-server",
+  "pidFile": "{}",
+  "logFile": "{}",
+  "sessionDir": "{}",
+  "pid": {}
+}}
+"#,
+            session_dir
+                .join("broker.pid")
+                .to_string_lossy()
+                .replace('\\', "\\\\"),
+            session_dir
+                .join("broker.log")
+                .to_string_lossy()
+                .replace('\\', "\\\\"),
+            session_dir.to_string_lossy().replace('\\', "\\\\"),
+            pid
+        );
+        fs::write(state_dir.join(BROKER_STATE_FILE), json).unwrap();
+    }
+
+    #[test]
+    fn state_dir_name_matches_codex_plugin_format() {
+        let name = state_dir_name_for_workspace(Path::new("vive-editor"), r"F:\vive-editor");
+        assert_eq!(name, "vive-editor-0878b76ff54a1305");
+    }
+
+    #[test]
+    fn dead_pid_removes_broker_files_and_safe_session_dir() {
+        let state_dir = temp_case("dead-state");
+        let session_dir =
+            std::env::temp_dir().join(format!("cxc-vibe-test-{}", uuid::Uuid::new_v4()));
+        write_broker(&state_dir, &session_dir, 999_999);
+
+        let summary = cleanup_stale_in_state_dir(&state_dir, |_| false);
+
+        assert_eq!(summary.checked, 1);
+        assert_eq!(summary.removed_files, 3);
+        assert_eq!(summary.removed_dirs, 1);
+        assert!(!state_dir.join(BROKER_STATE_FILE).exists());
+        assert!(!session_dir.exists());
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn live_pid_keeps_broker_state_intact() {
+        let state_dir = temp_case("live-state");
+        let session_dir =
+            std::env::temp_dir().join(format!("cxc-vibe-test-{}", uuid::Uuid::new_v4()));
+        write_broker(&state_dir, &session_dir, std::process::id());
+
+        let summary = cleanup_stale_in_state_dir(&state_dir, |_| true);
+
+        assert_eq!(summary.checked, 1);
+        assert_eq!(summary.skipped_live, 1);
+        assert!(state_dir.join(BROKER_STATE_FILE).exists());
+        assert!(session_dir.join("broker.pid").exists());
+        let _ = fs::remove_dir_all(state_dir);
+        let _ = fs::remove_dir_all(session_dir);
+    }
+
+    #[test]
+    fn malformed_broker_state_is_noop() {
+        let state_dir = temp_case("malformed");
+        fs::write(state_dir.join(BROKER_STATE_FILE), "{not-json").unwrap();
+
+        let summary = cleanup_stale_in_state_dir(&state_dir, |_| false);
+
+        assert_eq!(summary.checked, 1);
+        assert_eq!(summary.removed_files, 0);
+        assert!(state_dir.join(BROKER_STATE_FILE).exists());
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn unsafe_session_dir_does_not_remove_external_files() {
+        let state_dir = temp_case("unsafe-state");
+        let unsafe_dir = state_dir.join("not-temp-cxc");
+        write_broker(&state_dir, &unsafe_dir, 999_999);
+
+        let summary = cleanup_stale_in_state_dir(&state_dir, |_| false);
+
+        assert_eq!(summary.checked, 1);
+        assert_eq!(summary.removed_files, 1);
+        assert_eq!(summary.removed_dirs, 0);
+        assert!(!state_dir.join(BROKER_STATE_FILE).exists());
+        assert!(unsafe_dir.join("broker.pid").exists());
+        let _ = fs::remove_dir_all(state_dir);
+    }
+}

--- a/src-tauri/src/pty/codex_broker.rs
+++ b/src-tauri/src/pty/codex_broker.rs
@@ -11,6 +11,8 @@ use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::util::log_redact::redact_home;
+
 const PLUGIN_DATA_ENV: &str = "CLAUDE_PLUGIN_DATA";
 const CODEX_PLUGIN_DATA_DIR: &str = "codex-openai-codex";
 const BROKER_STATE_FILE: &str = "broker.json";
@@ -47,7 +49,7 @@ pub fn cleanup_stale_for_cwd(cwd: &str) -> CleanupSummary {
     if summary.removed_files > 0 || summary.removed_dirs > 0 || summary.skipped_live > 0 {
         tracing::info!(
             "[codex_broker] cleanup cwd={} checked={} removed_files={} removed_dirs={} skipped_live={}",
-            cwd,
+            redact_home(cwd),
             summary.checked,
             summary.removed_files,
             summary.removed_dirs,

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod batcher;
 pub mod claude_watcher;
+pub mod codex_broker;
 pub mod path_norm;
 pub mod registry;
 pub mod session;

--- a/src-tauri/src/pty/registry.rs
+++ b/src-tauri/src/pty/registry.rs
@@ -164,11 +164,7 @@ impl SessionRegistry {
     ///   - `Ok(())`: 採用された (id は registry に登録済み)
     ///   - `Err(handle)`: 既存 PTY と id が衝突。caller の handle はそのまま返却される
     ///     ので、caller 側で `handle.kill()` してから別 id で retry する責務がある。
-    pub fn insert_if_absent(
-        &self,
-        id: String,
-        handle: SessionHandle,
-    ) -> Result<(), SessionHandle> {
+    pub fn insert_if_absent(&self, id: String, handle: SessionHandle) -> Result<(), SessionHandle> {
         let mut g = recover(self.inner.lock());
         if g.by_id.contains_key(&id) {
             return Err(handle);
@@ -201,6 +197,7 @@ impl SessionRegistry {
                             "[registry] replacing session {prev_sid} with {id} — killing old PTY"
                         );
                         let _ = old.kill();
+                        old.cleanup_codex_broker_if_stale();
                     }
                 }
             }
@@ -281,40 +278,49 @@ impl SessionRegistry {
     }
 
     pub fn remove(&self, id: &str) -> Option<Arc<SessionHandle>> {
-        let mut g = recover(self.inner.lock());
-        if let Some(handle) = g.by_id.remove(id) {
-            if let Some(aid) = &handle.agent_id {
-                if g.by_agent.get(aid).map(String::as_str) == Some(id) {
-                    g.by_agent.remove(aid);
+        let removed = {
+            let mut g = recover(self.inner.lock());
+            if let Some(handle) = g.by_id.remove(id) {
+                if let Some(aid) = &handle.agent_id {
+                    if g.by_agent.get(aid).map(String::as_str) == Some(id) {
+                        g.by_agent.remove(aid);
+                    }
                 }
-            }
-            // Issue #271: session_key index も同期して掃除する。
-            if let Some(skey) = &handle.session_key {
-                if g.by_session_key.get(skey).map(String::as_str) == Some(id) {
-                    g.by_session_key.remove(skey);
+                // Issue #271: session_key index も同期して掃除する。
+                if let Some(skey) = &handle.session_key {
+                    if g.by_session_key.get(skey).map(String::as_str) == Some(id) {
+                        g.by_session_key.remove(skey);
+                    }
                 }
+                Some(handle)
+            } else {
+                None
             }
+        };
+        if let Some(handle) = &removed {
             // Issue #144: registry から外しただけだと、Arc の参照が他所に残っているとき
             // 子プロセス / reader thread が永久に生き続ける。明示的に kill を要求して、
             // PTY master 経由の read を EOF にし、reader thread を自然終了させる。
             // ※ Drop impl も kill するが「最後の Arc が drop されるまで」遅れるため、
             //   ここで早期 kill しておく。
             let _ = handle.kill();
-            Some(handle)
-        } else {
-            None
+            handle.cleanup_codex_broker_after_kill();
         }
+        removed
     }
 
     pub fn kill_all(&self) {
-        let mut g = recover(self.inner.lock());
-        g.by_agent.clear();
-        g.by_session_key.clear();
-        for (_, s) in g.by_id.drain() {
+        let sessions: Vec<Arc<SessionHandle>> = {
+            let mut g = recover(self.inner.lock());
+            g.by_agent.clear();
+            g.by_session_key.clear();
+            g.by_id.drain().map(|(_, s)| s).collect()
+        };
+        for s in sessions {
             let _ = s.kill();
+            s.cleanup_codex_broker_after_kill();
         }
     }
-
 }
 
 #[cfg(test)]
@@ -460,15 +466,14 @@ mod attach_lookup_tests {
         by_session_key.insert("k1".to_string(), "sid-dead".to_string());
         let by_agent = HashMap::new();
 
-        let (result, orphan_skey, orphan_agent) = lookup_attach_target_pure(
-            &by_id,
-            &by_session_key,
-            &by_agent,
-            Some("k1"),
-            None,
-        );
+        let (result, orphan_skey, orphan_agent) =
+            lookup_attach_target_pure(&by_id, &by_session_key, &by_agent, Some("k1"), None);
         assert!(result.is_none(), "by_id 空なら attach 不能");
-        assert_eq!(orphan_skey.as_deref(), Some("k1"), "孤立 session_key を返す");
+        assert_eq!(
+            orphan_skey.as_deref(),
+            Some("k1"),
+            "孤立 session_key を返す"
+        );
         assert!(orphan_agent.is_none());
     }
 
@@ -479,13 +484,8 @@ mod attach_lookup_tests {
         let mut by_agent = HashMap::new();
         by_agent.insert("a1".to_string(), "sid-dead".to_string());
 
-        let (result, orphan_skey, orphan_agent) = lookup_attach_target_pure(
-            &by_id,
-            &by_session_key,
-            &by_agent,
-            None,
-            Some("a1"),
-        );
+        let (result, orphan_skey, orphan_agent) =
+            lookup_attach_target_pure(&by_id, &by_session_key, &by_agent, None, Some("a1"));
         assert!(result.is_none());
         assert!(orphan_skey.is_none());
         assert_eq!(orphan_agent.as_deref(), Some("a1"));
@@ -509,13 +509,8 @@ mod attach_lookup_tests {
         let by_id = by_id_with(&[]);
         let by_session_key = HashMap::new();
         let by_agent = HashMap::new();
-        let (result, orphan_skey, orphan_agent) = lookup_attach_target_pure(
-            &by_id,
-            &by_session_key,
-            &by_agent,
-            Some("k1"),
-            Some("a1"),
-        );
+        let (result, orphan_skey, orphan_agent) =
+            lookup_attach_target_pure(&by_id, &by_session_key, &by_agent, Some("k1"), Some("a1"));
         assert!(result.is_none());
         assert!(orphan_skey.is_none());
         assert!(orphan_agent.is_none());
@@ -532,13 +527,8 @@ mod attach_lookup_tests {
         let mut by_agent = HashMap::new();
         by_agent.insert("a1".to_string(), "sid-dead-2".to_string());
 
-        let (result, orphan_skey, orphan_agent) = lookup_attach_target_pure(
-            &by_id,
-            &by_session_key,
-            &by_agent,
-            Some("k1"),
-            Some("a1"),
-        );
+        let (result, orphan_skey, orphan_agent) =
+            lookup_attach_target_pure(&by_id, &by_session_key, &by_agent, Some("k1"), Some("a1"));
         assert!(result.is_none());
         assert_eq!(orphan_skey.as_deref(), Some("k1"));
         assert_eq!(orphan_agent.as_deref(), Some("a1"));

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -55,6 +55,7 @@ pub struct SpawnOptions {
     pub command: String,
     pub args: Vec<String>,
     pub cwd: String,
+    pub is_codex: bool,
     pub cols: u16,
     pub rows: u16,
     pub env: HashMap<String, String>,
@@ -80,6 +81,8 @@ pub struct SessionHandle {
     pub session_key: Option<String>,
     pub team_id: Option<String>,
     pub role: Option<String>,
+    pub cwd: String,
+    pub is_codex: bool,
     /// Issue #153: prompt injection 中はユーザー入力を抑止する。
     /// `inject_codex_prompt_to_pty` 等が begin/end で立て下げる。
     /// renderer 側からの terminal_write は user_write 経由でこのフラグを見る。
@@ -220,6 +223,23 @@ impl SessionHandle {
         let _ = k.kill();
         Ok(())
     }
+
+    pub fn cleanup_codex_broker_if_stale(&self) {
+        if self.is_codex {
+            crate::pty::codex_broker::cleanup_stale_for_cwd(&self.cwd);
+        }
+    }
+
+    pub fn cleanup_codex_broker_after_kill(&self) {
+        if !self.is_codex {
+            return;
+        }
+        let summary = crate::pty::codex_broker::cleanup_stale_for_cwd(&self.cwd);
+        if summary.skipped_live > 0 {
+            std::thread::sleep(Duration::from_millis(250));
+            crate::pty::codex_broker::cleanup_stale_for_cwd(&self.cwd);
+        }
+    }
 }
 
 /// Issue #144: SessionHandle が drop されたタイミングで child プロセスを必ず kill する。
@@ -239,10 +259,7 @@ impl Drop for SessionHandle {
 
 /// `cwd` の検証 (旧 resolveValidCwd と同等)。
 /// 無効なら fallback → カレントディレクトリ。warning メッセージも返す。
-pub fn resolve_valid_cwd(
-    requested: &str,
-    fallback: Option<&str>,
-) -> (String, Option<String>) {
+pub fn resolve_valid_cwd(requested: &str, fallback: Option<&str>) -> (String, Option<String>) {
     let is_dir = |p: &str| !p.is_empty() && Path::new(p).is_dir();
     if is_dir(requested) {
         return (requested.to_string(), None);
@@ -253,7 +270,11 @@ pub fn resolve_valid_cwd(
                 fb.to_string(),
                 Some(format!(
                     "指定された作業ディレクトリが無効です: {} → {} で起動します",
-                    if requested.is_empty() { "(未設定)" } else { requested },
+                    if requested.is_empty() {
+                        "(未設定)"
+                    } else {
+                        requested
+                    },
                     fb
                 )),
             );
@@ -266,7 +287,11 @@ pub fn resolve_valid_cwd(
         cwd.clone(),
         Some(format!(
             "作業ディレクトリが無効です: {} → プロセス既定の {} で起動します",
-            if requested.is_empty() { "(未設定)" } else { requested },
+            if requested.is_empty() {
+                "(未設定)"
+            } else {
+                requested
+            },
             cwd
         )),
     )
@@ -594,6 +619,8 @@ pub fn spawn_session(
         session_key: opts.session_key,
         team_id: opts.team_id,
         role: opts.role,
+        cwd: opts.cwd,
+        is_codex: opts.is_codex,
         injecting: std::sync::atomic::AtomicBool::new(false),
         write_budget: Mutex::new(WriteBudget {
             window_started_at: Instant::now(),


### PR DESCRIPTION
## Summary
- Codex plugin の broker state を Rust 側で検査し、PID が死んでいる stale broker だけを削除する cleanup helper を追加
- Codex terminal の spawn 前、PTY の remove / kill_all 後に cleanup を実行
- live PID、壊れた broker.json、temp 外の sessionDir を削除しない回帰テストを追加

## Root cause
Codex worker が異常終了した場合、Codex plugin 側の SessionEnd hook が発火せず `broker.json` が残り、次回起動時に死んだ named pipe endpoint へ接続して handshake timeout になることがありました。

Closes #402

## Test plan
- [x] `cargo test --manifest-path src-tauri\Cargo.toml codex_broker -- --nocapture`
- [x] `cargo check --manifest-path src-tauri\Cargo.toml`
- [x] `npm run typecheck`
- [x] `git diff --check`
