### PR TITLE
refactor(rust): #381 cargo clippy ベースライン 13 件を機械的に解消

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -663,6 +663,7 @@ pub fn app_get_user_info(app: tauri::AppHandle) -> AppUserInfo {
 /// Issue #49: 許可するスキームの allowlist。
 /// - `http`/`https`: 通常の Web ページ (Release ページ、ドキュメント等)
 /// - `mailto`: メール feedback
+///
 /// それ以外 (`file:`, `javascript:`, `data:`, OS カスタムプロトコル) は拒否する。
 const ALLOWED_EXTERNAL_SCHEMES: &[&str] = &["http", "https", "mailto"];
 

--- a/src-tauri/src/commands/files/encoding.rs
+++ b/src-tauri/src/commands/files/encoding.rs
@@ -110,11 +110,11 @@ pub fn detect_text_or_binary(bytes: &[u8]) -> (bool, String, String) {
                 || (b < 0x09)
                 || b == 0x0B
                 || b == 0x0C
-                || (b >= 0x0E && b < 0x20 && b != 0x1B) // ESC (0x1B) は xterm 系で許容
+                || ((0x0E..0x20).contains(&b) && b != 0x1B) // ESC (0x1B) は xterm 系で許容
         })
         .count();
     // 非テキスト率が 30% を超えるなら binary とみなす
-    if sample.len() > 0 && non_text * 100 / sample.len() >= 30 {
+    if !sample.is_empty() && non_text * 100 / sample.len() >= 30 {
         return (true, String::new(), "binary".to_string());
     }
     match std::str::from_utf8(bytes) {

--- a/src-tauri/src/commands/files/path_safety.rs
+++ b/src-tauri/src/commands/files/path_safety.rs
@@ -39,9 +39,7 @@ pub fn safe_join(root: &str, rel: &str) -> Option<PathBuf> {
             Component::CurDir => { /* "." は無視 */ }
             Component::ParentDir => {
                 // root 直下で ".." が来たら脱出なので拒否
-                if stack.pop().is_none() {
-                    return None;
-                }
+                stack.pop()?;
             }
             // RootDir / Prefix / ... は絶対パス要素 → 既に (1) で弾いているが念のため拒否
             _ => return None,

--- a/src-tauri/src/commands/terminal/command_validation.rs
+++ b/src-tauri/src/commands/terminal/command_validation.rs
@@ -54,6 +54,7 @@ pub fn configured_terminal_commands() -> HashSet<String> {
 /// renderer 由来の任意コマンド実行を避けるため、起動できるバイナリを
 /// 1. 組み込み allowlist (Claude / Codex / 代表的な対話シェル)
 /// 2. ユーザーが settings.json に保存した既知の command
+///
 /// に限定する。
 pub fn is_allowed_terminal_command(command: &str) -> bool {
     const SAFE_BASENAMES: &[&str] = &[

--- a/src-tauri/src/mcp_config/codex.rs
+++ b/src-tauri/src/mcp_config/codex.rs
@@ -62,10 +62,7 @@ pub async fn setup(bridge_path: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).await?;
     }
-    let mut content = match fs::read_to_string(&path).await {
-        Ok(s) => s,
-        Err(_) => String::new(),
-    };
+    let mut content: String = fs::read_to_string(&path).await.unwrap_or_default();
     content = remove_toml_section(&content, SECTION);
     content = remove_toml_section(&content, LEGACY_SECTION);
     // Issue #44: bridge_path を TOML basic string 用に正規 escape。

--- a/src-tauri/src/pty/claude_watcher.rs
+++ b/src-tauri/src/pty/claude_watcher.rs
@@ -232,7 +232,7 @@ pub fn spawn_watcher(
                     }
                     // まだ自分の番が来ていない → snapshot を更新して次イベントを待つ。
                     // (他の watcher が claim した id は snapshot に足し、次回の difference から除外する)
-                    snapshot.extend(current.into_iter());
+                    snapshot.extend(current);
                 }
                 Ok(Err(_)) | Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
                 Err(_) => break,

--- a/src-tauri/src/team_hub/inject.rs
+++ b/src-tauri/src/team_hub/inject.rs
@@ -43,6 +43,7 @@ const BP_END: &[u8] = b"\x1b[201~";
 /// - \x00 (NUL): pty バッファの不正切断要因
 /// - \x08 (BS) / \x7f (DEL): 受信側 readline の手前消し悪用防止
 /// - \x9b (CSI 単一バイト): 一部端末で ESC[ 相当に解釈される
+///
 /// 改行 (`\n`) と TAB (`\t`) は paste の意味的内容なので維持する。
 fn sanitize_for_paste(s: &str) -> String {
     let mut out = String::with_capacity(s.len());

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -217,6 +217,7 @@ fn reduce_home_prefix(s: &str) -> String {
 ///   - env var `VIBE_TEAM_LOG_PATH` が空でなければそれを優先 (絶対パス想定、空白 trim)
 ///   - そうでなければ起動時に記録したファイルパス
 ///   - どちらも無ければ `"<stderr>"` (= stderr-only モード)
+///
 /// 戻り値は home prefix を `~` に reduce 済み (Reviewer D Major 反映)。
 pub fn server_log_path_for_diagnostics() -> String {
     if let Ok(v) = std::env::var("VIBE_TEAM_LOG_PATH") {
@@ -553,6 +554,7 @@ impl TeamHub {
     /// Issue #183: client が送ってきた role が
     ///   1. pending recruit の予約 role と一致するか (新規 recruit 経路)
     ///   2. 既存 agent_role_bindings に bind 済み role と一致するか (再接続経路)
+    ///
     /// を照合する。どちらも不一致なら false を返してハンドラ側で接続切断。
     /// 初回 handshake が成功したら agent_id → role を bind する。
     ///
@@ -840,7 +842,7 @@ impl TeamHub {
             });
             tracing::info!("[teamhub] listening on local named pipe");
             tracing::debug!("[teamhub] endpoint={endpoint}");
-            return Ok(());
+            Ok(())
         }
     }
 

--- a/src-tauri/src/team_hub/protocol/tools/assign_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/assign_task.rs
@@ -195,6 +195,7 @@ pub async fn team_assign_task(
 ///   2) team_update_task(task_id, "in_progress") に変える
 ///   3) 長時間タスクでは team_status で進捗を残す
 ///   4) 完了時に team_send + team_update_task("done"/"blocked") を呼ぶ
+///
 /// ことで、Leader が `team_read` 0 件だけで「無応答」と誤判定するのを防ぐ。
 pub(super) fn build_task_notification(task_id: u32, description: &str) -> String {
     format!(

--- a/tasks/refactor-clippy-baseline.md
+++ b/tasks/refactor-clippy-baseline.md
@@ -6,6 +6,19 @@
 > リファクタ過程で **新規警告が増えていないこと** を判定する基準として使用する。
 > 解消は別 issue を切って独立 PR で実施 (Phase 1〜5 の中で自然に解消されるものは除く)。
 
+## 進捗 (2026-05-02 / Issue #381 解消後)
+
+| 区分 | 件数 | 備考 |
+|---|---|---|
+| Issue #381 で機械的に解消 | 13 | 下表 ✅ 印 |
+| #388 で構造変更により解消 | 1 | `team_hub/mod.rs:488 too_many_arguments` (`max_members` 引数削除) |
+| 残留 (Phase 3 で構造変更対象) | 1 | `pty/registry.rs:167 result_large_err` (`SessionHandle` の `Box<>` 化) |
+| 合計 | 15 | |
+
+> 残留 1 件があるため、`cargo clippy ... -D warnings` は依然 exit 1。
+> Phase 3 (PTY 境界整理) で `SessionHandle` を `Box<>` 化したら 0 件になる。それまでは
+> `result_large_err` のみが残ることを「green と等価」と扱う。
+
 ## 計測コマンド
 ```
 cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
@@ -17,23 +30,23 @@ cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 
 ## 警告一覧 (15 件)
 
-| # | ファイル:行 | lint | 種別 | リファクタで解消される見込み |
+| # | ファイル:行 (baseline 時点) | lint | 種別 | 状態 |
 |---|---|---|---|---|
-| 1 | `src/commands/app.rs:666` | `doc_lazy_continuation` | 日本語 doc コメントのインデント | — |
-| 2 | `src/commands/files.rs:201` | `manual_range_contains` | range の慣用化 | Phase 4 (`files.rs` 分割時に巻き取り可) |
-| 3 | `src/commands/files.rs:205` | `len_zero` (`sample.len() > 0`) | `!sample.is_empty()` 推奨 | Phase 4 |
-| 4 | `src/commands/files.rs:381` | `question_mark` (`.pop()?` で簡潔化) | `?` 演算子化 | Phase 4 |
-| 5 | `src/commands/terminal.rs:136` | `doc_lazy_continuation` | 日本語 doc コメントのインデント | Phase 3 (PTY 境界整理時に巻き取り可) |
-| 6 | `src/mcp_config/codex.rs:65` | `manual_unwrap_or_default` | `unwrap_or_default()` 推奨 | — |
-| 7 | `src/pty/claude_watcher.rs:235` | `useless_conversion` (`.into_iter()` 不要) | iterator 慣用化 | Phase 3 |
-| 8 | `src/pty/registry.rs:171` | `result_large_err` | `SessionHandle` の Err variant が 216 byte → `Box<>` 化推奨 | **Phase 3 (PTY 境界整理) で自然に再設計対象** |
-| 9 | `src/team_hub/inject.rs:46` | `doc_lazy_continuation` | 日本語 doc コメントのインデント | Phase 2 |
-| 10 | `src/team_hub/protocol.rs:881` | `doc_lazy_continuation` | 日本語 doc コメントのインデント | **Phase 2 (`protocol.rs` 分解) で消える** |
-| 11 | `src/team_hub/mod.rs:215` | `doc_lazy_continuation` | 日本語 doc コメントのインデント | — (Phase 2 では `mod.rs` を触らない方針) |
-| 12 | `src/team_hub/mod.rs:488` | `too_many_arguments` (8 引数、上限 7) | 関数シグネチャ変更必要 | — (Phase 2 では `mod.rs` を触らない方針) |
-| 13 | `src/team_hub/mod.rs:557` | `doc_lazy_continuation` | 日本語 doc コメントのインデント | — |
-| 14 | `src/team_hub/mod.rs:558` | `doc_lazy_continuation` | 日本語 doc コメントのインデント | — |
-| 15 | `src/team_hub/mod.rs:844` | `needless_return` | `return` の省略 | — |
+| 1 | `src/commands/app.rs:666` | `doc_lazy_continuation` | 日本語 doc コメントのインデント | ✅ #381 で解消 |
+| 2 | `src/commands/files.rs:201` (現 `commands/files/encoding.rs:113`) | `manual_range_contains` | range の慣用化 | ✅ #381 で解消 |
+| 3 | `src/commands/files.rs:205` (現 `commands/files/encoding.rs:117`) | `len_zero` (`sample.len() > 0`) | `!sample.is_empty()` 推奨 | ✅ #381 で解消 |
+| 4 | `src/commands/files.rs:381` (現 `commands/files/path_safety.rs:42`) | `question_mark` (`.pop()?` で簡潔化) | `?` 演算子化 | ✅ #381 で解消 |
+| 5 | `src/commands/terminal.rs:136` (現 `commands/terminal/command_validation.rs:57`) | `doc_lazy_continuation` | 日本語 doc コメントのインデント | ✅ #381 で解消 |
+| 6 | `src/mcp_config/codex.rs:65` | `manual_unwrap_or_default` | `unwrap_or_default()` 推奨 | ✅ #381 で解消 |
+| 7 | `src/pty/claude_watcher.rs:235` | `useless_conversion` (`.into_iter()` 不要) | iterator 慣用化 | ✅ #381 で解消 |
+| 8 | `src/pty/registry.rs:171` (現 `:167`) | `result_large_err` | `SessionHandle` の Err variant が 240 byte → `Box<>` 化推奨 | ⏳ **Phase 3 (PTY 境界整理) 残留** |
+| 9 | `src/team_hub/inject.rs:46` | `doc_lazy_continuation` | 日本語 doc コメントのインデント | ✅ #381 で解消 |
+| 10 | `src/team_hub/protocol.rs:881` (現 `protocol/tools/assign_task.rs:198`) | `doc_lazy_continuation` | 日本語 doc コメントのインデント | ✅ #381 で解消 |
+| 11 | `src/team_hub/mod.rs:215` (現 `:220`) | `doc_lazy_continuation` | 日本語 doc コメントのインデント | ✅ #381 で解消 |
+| 12 | `src/team_hub/mod.rs:488` | `too_many_arguments` (8 引数、上限 7) | 関数シグネチャ変更必要 | ✅ #388 で解消 (`max_members` 引数削除) |
+| 13 | `src/team_hub/mod.rs:557` (現 `:556`) | `doc_lazy_continuation` | 日本語 doc コメントのインデント | ✅ #381 で解消 |
+| 14 | `src/team_hub/mod.rs:558` (現 `:557`) | `doc_lazy_continuation` | 日本語 doc コメントのインデント | ✅ #381 で解消 |
+| 15 | `src/team_hub/mod.rs:844` (現 `:843`) | `needless_return` | `return` の省略 | ✅ #381 で解消 |
 
 ---
 


### PR DESCRIPTION
## Summary
- Issue #373 Phase 0 ベースライン (PR #380) で記録された clippy 既存警告 15 件のうち、構造変更不要な **13 件** を機械的に解消
- 挙動変更ゼロ (refactor 目的)
- 残留 1 件 (`pty/registry.rs:167 result_large_err`) は Issue #373 Phase 3 で `SessionHandle` を `Box<>` 化する際に解消する想定なのでスコープ外
- baseline 1 件 (`team_hub/mod.rs:488 too_many_arguments`) は #388 で解消済みのため進捗表で記録更新

## 修正内訳
| lint | 件数 |
|---|---|
| `doc_lazy_continuation` | 7 |
| `manual_range_contains` | 1 |
| `len_zero` | 1 |
| `question_mark` | 1 |
| `manual_unwrap_or_default` | 1 |
| `useless_conversion` | 1 |
| `needless_return` | 1 |

## Test plan
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` を実行し、対象 13 件が消滅、残留が `result_large_err` のみであることを確認
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` → 91 passed / 0 failed
- [x] `tasks/refactor-clippy-baseline.md` の進捗表を最新 main に整合 (#388 解消分含む)

Closes #381