### PR TITLE
fix(terminal): #398 worker ターミナル IME stuck を解消する composition gate を追加

### DIFF
--- a/src/renderer/src/components/TerminalView.tsx
+++ b/src/renderer/src/components/TerminalView.tsx
@@ -324,6 +324,14 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       [t]
     );
 
+    const focusTerminal = useCallback((): void => {
+      const term = termRef.current;
+      term?.focus();
+      if (term) {
+        window.requestAnimationFrame(() => term.focus());
+      }
+    }, []);
+
     // --- 外部操作用ハンドル (public API は不変) ---
     useImperativeHandle(
       ref,
@@ -335,7 +343,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
           void window.api.terminal.write(id, payload);
         },
         focus(): void {
-          termRef.current?.focus();
+          focusTerminal();
         },
         scrollToBottom(): void {
           termRef.current?.scrollToBottom();
@@ -352,9 +360,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
           return lines.join('\n').trim();
         }
       }),
-      // ptyIdRef / termRef は stable な ref なので deps 不要
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      []
+      [focusTerminal]
     );
 
     return (
@@ -364,7 +370,8 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
           ref={containerRef}
           // Canvas の TerminalCard 内では、xterm のテキストエリアに focus が入らず
           // キー入力が届かない現象がある。空白領域をクリックしても明示的に focus を奪う。
-          onMouseDown={() => termRef.current?.focus()}
+          onPointerDownCapture={focusTerminal}
+          onMouseDown={focusTerminal}
           onContextMenu={handleContextMenu}
         />
         {contextMenu && (

--- a/src/renderer/src/lib/__tests__/terminal-input-gate.test.ts
+++ b/src/renderer/src/lib/__tests__/terminal-input-gate.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { createTerminalInputGate } from '../terminal-input-gate';
+
+describe('terminal input gate', () => {
+  it('composition 中の入力を抑制し、compositionend 後に再開する', () => {
+    const gate = createTerminalInputGate();
+
+    expect(gate.shouldForward('a')).toBe(true);
+
+    gate.startComposition();
+    expect(gate.isComposing()).toBe(true);
+    expect(gate.shouldForward('k')).toBe(false);
+    expect(gate.getSuppressedCount()).toBe(1);
+
+    expect(gate.endComposition()).toBe(true);
+    expect(gate.isComposing()).toBe(false);
+    expect(gate.shouldForward('確定')).toBe(true);
+  });
+
+  it('compositioncancel / blur / focusout で stuck 状態を解除する', () => {
+    const gate = createTerminalInputGate();
+
+    gate.startComposition();
+    expect(gate.cancelComposition()).toBe(true);
+    expect(gate.shouldForward('a')).toBe(true);
+
+    gate.startComposition();
+    expect(gate.resetComposition('blur')).toBe(true);
+    expect(gate.shouldForward('b')).toBe(true);
+
+    gate.startComposition();
+    expect(gate.resetComposition('focusout')).toBe(true);
+    expect(gate.shouldForward('c')).toBe(true);
+  });
+
+  it('composition 中の stuck は端末インスタンス間で共有されない', () => {
+    const stuckGate = createTerminalInputGate();
+    const healthyGate = createTerminalInputGate();
+
+    stuckGate.startComposition();
+
+    expect(stuckGate.shouldForward('x')).toBe(false);
+    expect(healthyGate.shouldForward('y')).toBe(true);
+    expect(healthyGate.isComposing()).toBe(false);
+  });
+
+  it('composing でない reset は no-op として扱える', () => {
+    const gate = createTerminalInputGate();
+
+    expect(gate.resetComposition('blur')).toBe(false);
+    expect(gate.shouldForward('\r')).toBe(true);
+  });
+});

--- a/src/renderer/src/lib/terminal-input-gate.ts
+++ b/src/renderer/src/lib/terminal-input-gate.ts
@@ -1,0 +1,49 @@
+export type TerminalInputGateResetReason =
+  | 'compositionend'
+  | 'compositioncancel'
+  | 'blur'
+  | 'focusout'
+  | 'manual';
+
+export interface TerminalInputGate {
+  startComposition(): void;
+  endComposition(): boolean;
+  cancelComposition(): boolean;
+  resetComposition(reason: TerminalInputGateResetReason): boolean;
+  shouldForward(data: string): boolean;
+  isComposing(): boolean;
+  getSuppressedCount(): number;
+}
+
+export function createTerminalInputGate(): TerminalInputGate {
+  let composing = false;
+  let suppressedCount = 0;
+
+  return {
+    startComposition(): void {
+      composing = true;
+    },
+    endComposition(): boolean {
+      return this.resetComposition('compositionend');
+    },
+    cancelComposition(): boolean {
+      return this.resetComposition('compositioncancel');
+    },
+    resetComposition(_reason: TerminalInputGateResetReason): boolean {
+      const wasComposing = composing;
+      composing = false;
+      return wasComposing;
+    },
+    shouldForward(_data: string): boolean {
+      if (!composing) return true;
+      suppressedCount += 1;
+      return false;
+    },
+    isComposing(): boolean {
+      return composing;
+    },
+    getSuppressedCount(): number {
+      return suppressedCount;
+    }
+  };
+}

--- a/src/renderer/src/lib/use-pty-session.ts
+++ b/src/renderer/src/lib/use-pty-session.ts
@@ -5,6 +5,10 @@ import type { FitAddon } from '@xterm/addon-fit';
 import type { TerminalExitInfo } from '../../../types/shared';
 import { computeUnscaledGrid } from './compute-unscaled-grid';
 import type { CellSize } from './measure-cell-size';
+import {
+  createTerminalInputGate,
+  type TerminalInputGateResetReason
+} from './terminal-input-gate';
 
 export interface PtySpawnSnapshot {
   args?: string[];
@@ -672,17 +676,50 @@ export function usePtySession(options: UsePtySessionOptions): void {
       }
     })();
 
-    // IME composition 中は onData を抑制して候補ウィンドウの位置ジャンプを防ぐ
-    let composing = false;
+    // IME composition 中は onData を抑制して候補ウィンドウの位置ジャンプを防ぐ。
+    // compositionend を逃した場合は blur/focusout/cancel で端末単位の stuck を解除する。
+    const inputGate = createTerminalInputGate();
     const textarea = term.textarea;
-    const onCompStart = (): void => { composing = true; };
-    const onCompEnd = (): void => { composing = false; };
+    let lastSuppressedInputLogAt = 0;
+    const logInputGateReset = (reason: TerminalInputGateResetReason): void => {
+      if (!import.meta.env.DEV) return;
+      console.debug(
+        `[terminal:${ptyIdRef.current ?? 'pending'}] composition reset by ${reason}`
+      );
+    };
+    const logSuppressedInput = (): void => {
+      if (!import.meta.env.DEV) return;
+      const now = Date.now();
+      if (now - lastSuppressedInputLogAt < 1000) return;
+      lastSuppressedInputLogAt = now;
+      console.debug(
+        `[terminal:${ptyIdRef.current ?? 'pending'}] onData suppressed while composing`
+      );
+    };
+    const resetComposition = (reason: TerminalInputGateResetReason): void => {
+      if (inputGate.resetComposition(reason)) {
+        if (reason !== 'compositionend') {
+          logInputGateReset(reason);
+        }
+      }
+    };
+    const onCompStart = (): void => { inputGate.startComposition(); };
+    const onCompEnd = (): void => { resetComposition('compositionend'); };
+    const onCompCancel = (): void => { resetComposition('compositioncancel'); };
+    const onBlur = (): void => { resetComposition('blur'); };
+    const onFocusOut = (): void => { resetComposition('focusout'); };
     textarea?.addEventListener('compositionstart', onCompStart);
     textarea?.addEventListener('compositionend', onCompEnd);
+    textarea?.addEventListener('compositioncancel', onCompCancel);
+    textarea?.addEventListener('blur', onBlur);
+    textarea?.addEventListener('focusout', onFocusOut);
 
     // キー入力 → pty へ
     const dataSub = term.onData((data) => {
-      if (composing) return;
+      if (!inputGate.shouldForward(data)) {
+        logSuppressedInput();
+        return;
+      }
       if (ptyIdRef.current) {
         void window.api.terminal.write(ptyIdRef.current, data);
       }
@@ -699,6 +736,9 @@ export function usePtySession(options: UsePtySessionOptions): void {
       dataSub.dispose();
       textarea?.removeEventListener('compositionstart', onCompStart);
       textarea?.removeEventListener('compositionend', onCompEnd);
+      textarea?.removeEventListener('compositioncancel', onCompCancel);
+      textarea?.removeEventListener('blur', onBlur);
+      textarea?.removeEventListener('focusout', onFocusOut);
       // Issue #271: HMR cleanup と通常 unmount を厳密に区別する。
       //   - `hmrDisposeArmed.current === true` のとき: Vite が hot.dispose() の cb を
       //     呼んだ直後 (= HMR が module を捨てる経路) なので、kill せず cache に残す。


### PR DESCRIPTION
## Summary
- ワーカーターミナルだけ入力を受け付けなくなる現象 (Issue #398) を解消
- 旧実装は `compositionend` のみで `composing=false` に戻していたため、helper textarea の focus 移動などで `compositionend` を取りこぼすと特定端末だけ `composing=true` のまま全 `onData` を破棄していた
- 端末ごとに独立した `createTerminalInputGate()` を作り、`compositioncancel` / `blur` / `focusout` でも必ず stuck を解除する。focus 経路も `onPointerDownCapture` + `requestAnimationFrame` で強化

## 主要変更
- `src/renderer/src/lib/terminal-input-gate.ts` (新規) — composition gate factory
- `src/renderer/src/lib/__tests__/terminal-input-gate.test.ts` (新規) — 4 ケース
- `src/renderer/src/lib/use-pty-session.ts` — 旧 boolean を gate に置換、追加 listener と dev throttled log
- `src/renderer/src/components/TerminalView.tsx` — `focusTerminal` helper、pointer capture phase で focus 先取り

## Test plan
- [x] `npx vitest run src/renderer/src/lib/__tests__/terminal-input-gate.test.ts` → 4 passed
- [x] `npm run typecheck` → green
- [ ] `npm run dev` で Leader / 複数 Worker を起動し、IME 変換中に別カードへ focus 移動 → 元 Worker に戻ったときに入力が通ることを目視確認
- [ ] Leader / 他 Worker / IDE ターミナルの通常入力に退行がないこと

Closes #398