### PR TITLE
fix(ui): #387 履歴バッジを「総件数」から「未確認件数」表示へ変更

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -39,6 +39,7 @@ import { ContextMenu, type ContextMenuItem } from './components/ContextMenu';
 import { MenuBar, MenuItem, MenuDivider, MenuSection } from './components/shell/MenuBar';
 import { useRecruitListener } from './lib/use-recruit-listener';
 import { useWindowFrameInsets } from './lib/use-window-frame-insets';
+import { useHistoryBadgeCount } from './lib/use-history-badge-count';
 import { ClaudeNotFound } from './components/ClaudeNotFound';
 import { getStatusMascotState } from './lib/status-mascot';
 import { useT } from './lib/i18n';
@@ -694,6 +695,13 @@ export function App(): JSX.Element {
   const toggleSidebar = useUiStore((s) => s.toggleSidebar);
   const availableUpdate = useUiStore((s) => s.availableUpdate);
 
+  // Issue #387: Rail の History バッジは「総件数」ではなく「未確認件数」。
+  // 履歴パネル表示中 (sidebarView === 'sessions' かつ折り畳まれていない) を確認済みとみなす。
+  const historyBadgeCount = useHistoryBadgeCount(
+    totalHistoryCount,
+    sidebarView === 'sessions' && !sidebarCollapsed
+  );
+
   // 「更新」ボタンクリック: 確認ダイアログ → DL → install → (Win 以外) relaunch。
   // 実行中タブ数を runningTaskCount に渡し、ダイアログで警告できるようにする。
   const handleClickUpdate = useCallback(() => {
@@ -856,7 +864,7 @@ export function App(): JSX.Element {
         sidebarView={sidebarView}
         onSidebarViewChange={setSidebarView}
         changeCount={gitChangeCount}
-        historyCount={totalHistoryCount}
+        historyBadgeCount={historyBadgeCount}
         onOpenSettings={() => setSettingsOpen(true)}
         hasGitRepo={hasGitRepo}
       />

--- a/src/renderer/src/components/shell/Rail.tsx
+++ b/src/renderer/src/components/shell/Rail.tsx
@@ -7,7 +7,9 @@ interface RailProps {
   sidebarView: SidebarView;
   onSidebarViewChange: (v: SidebarView) => void;
   changeCount: number;
-  historyCount: number;
+  /** Issue #387: 履歴ボタンに表示する「未確認件数」。総件数ではない。
+   *  履歴パネルを開いた時点で 0 になり、新規履歴が増えるまで再表示しない。 */
+  historyBadgeCount: number;
   onOpenSettings: () => void;
   /** プロジェクトが git リポジトリかどうか。false のとき Changes タブを Rail から外す。
    *  undefined / true は表示 (status 取得前に一瞬で消えるのを避けるためデフォルト表示)。 */
@@ -24,7 +26,7 @@ export function Rail({
   sidebarView,
   onSidebarViewChange,
   changeCount,
-  historyCount,
+  historyBadgeCount,
   onOpenSettings,
   hasGitRepo = true
 }: RailProps): JSX.Element {
@@ -70,7 +72,7 @@ export function Rail({
       view: 'sessions',
       label: t('sidebar.history'),
       icon: <History size={17} strokeWidth={2.2} />,
-      count: historyCount
+      count: historyBadgeCount
     },
     { view: 'notes', label: t('sidebar.notes'), icon: <StickyNote size={17} strokeWidth={2.2} /> }
   ];

--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -39,6 +39,7 @@ import type { SidebarView } from '../components/Sidebar';
 import { SettingsModal } from '../components/SettingsModal';
 import { useT } from '../lib/i18n';
 import { useUiStore } from '../stores/ui';
+import { useHistoryBadgeCount } from '../lib/use-history-badge-count';
 import { useCanvasStore } from '../stores/canvas';
 import {
   BUILTIN_PRESETS,
@@ -107,6 +108,13 @@ export function CanvasLayout(): JSX.Element {
   const [railChangeCount, setRailChangeCount] = useState(0);
   const [railHistoryCount, setRailHistoryCount] = useState(0);
   const [railHasGitRepo, setRailHasGitRepo] = useState(true);
+  // Issue #387: Rail の History バッジを「総件数」ではなく「未確認件数」へ。
+  // CanvasSidebar が unmount される (= sidebarCollapsed) と件数通知が止まるため、
+  // !sidebarCollapsed かつ sidebarView==='sessions' を確認済み条件にする。
+  const railHistoryBadgeCount = useHistoryBadgeCount(
+    railHistoryCount,
+    sidebarView === 'sessions' && !sidebarCollapsed
+  );
   // git リポジトリが無いと判明 + 現在 'changes' を見ている → 'files' に退避
   useEffect(() => {
     if (!railHasGitRepo && sidebarView === 'changes') {
@@ -537,7 +545,7 @@ export function CanvasLayout(): JSX.Element {
           sidebarView={sidebarView}
           onSidebarViewChange={setSidebarView}
           changeCount={railChangeCount}
-          historyCount={railHistoryCount}
+          historyBadgeCount={railHistoryBadgeCount}
           onOpenSettings={() => setSettingsOpen(true)}
           hasGitRepo={railHasGitRepo}
         />

--- a/src/renderer/src/lib/__tests__/history-badge-count.test.ts
+++ b/src/renderer/src/lib/__tests__/history-badge-count.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useHistoryBadgeCount } from '../use-history-badge-count';
+
+describe('useHistoryBadgeCount', () => {
+  it('履歴非表示の初回は totalCount をそのままバッジに出す', () => {
+    const { result } = renderHook(() => useHistoryBadgeCount(3, false));
+    expect(result.current).toBe(3);
+  });
+
+  it('履歴表示中はバッジを 0 にする', () => {
+    const { result } = renderHook(({ visible }) => useHistoryBadgeCount(3, visible), {
+      initialProps: { visible: true }
+    });
+    expect(result.current).toBe(0);
+  });
+
+  it('履歴表示中に件数が増えても 0 のまま追従する', () => {
+    const { result, rerender } = renderHook(
+      ({ total }) => useHistoryBadgeCount(total, true),
+      { initialProps: { total: 2 } }
+    );
+    expect(result.current).toBe(0);
+    rerender({ total: 5 });
+    expect(result.current).toBe(0);
+  });
+
+  it('履歴を一度開いて閉じてから件数が増えると増分のみ表示する', () => {
+    const { result, rerender } = renderHook(
+      ({ total, visible }) => useHistoryBadgeCount(total, visible),
+      { initialProps: { total: 2, visible: true } }
+    );
+    expect(result.current).toBe(0);
+
+    act(() => {
+      rerender({ total: 2, visible: false });
+    });
+    expect(result.current).toBe(0);
+
+    act(() => {
+      rerender({ total: 5, visible: false });
+    });
+    expect(result.current).toBe(3);
+  });
+
+  it('閉じたあと件数が減っても 0 に clamp する', () => {
+    const { result, rerender } = renderHook(
+      ({ total, visible }) => useHistoryBadgeCount(total, visible),
+      { initialProps: { total: 4, visible: true } }
+    );
+    expect(result.current).toBe(0);
+
+    act(() => {
+      rerender({ total: 4, visible: false });
+    });
+    expect(result.current).toBe(0);
+
+    act(() => {
+      rerender({ total: 1, visible: false });
+    });
+    expect(result.current).toBe(0);
+  });
+
+  it('閉じた状態で件数が増えてから開くとバッジが消える', () => {
+    const { result, rerender } = renderHook(
+      ({ total, visible }) => useHistoryBadgeCount(total, visible),
+      { initialProps: { total: 3, visible: false } }
+    );
+    expect(result.current).toBe(3);
+
+    act(() => {
+      rerender({ total: 3, visible: true });
+    });
+    expect(result.current).toBe(0);
+  });
+});

--- a/src/renderer/src/lib/use-history-badge-count.ts
+++ b/src/renderer/src/lib/use-history-badge-count.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Issue #387: Rail の History ボタンのバッジを「履歴総件数」ではなく
+ * 「未確認件数」として表示するための hook。
+ *
+ * 仕様:
+ * - 履歴パネル表示中は常に baseline = totalCount として扱い、バッジは 0。
+ * - 表示中に新規履歴が増えても、追従して 0 のまま。
+ * - 履歴を閉じたあとに新規履歴が増えたら、増分のみをバッジに表示する。
+ * - totalCount が減っても負数にならず 0 に clamp する。
+ *
+ * 永続化はしない (process 内 in-memory のみ)。再起動後の確認済み持続は別 issue。
+ */
+export function useHistoryBadgeCount(
+  totalCount: number,
+  isHistoryVisible: boolean
+): number {
+  const [seenCount, setSeenCount] = useState(0);
+
+  useEffect(() => {
+    if (isHistoryVisible) {
+      setSeenCount(totalCount);
+    }
+  }, [isHistoryVisible, totalCount]);
+
+  const baseline = isHistoryVisible ? totalCount : seenCount;
+  return Math.max(0, totalCount - baseline);
+}


### PR DESCRIPTION
## Summary
- Issue #387: Rail の History ボタンに付くバッジが「履歴総件数」だったため、履歴パネルを開いて確認してもバッジが消えなかった現象を解消
- 「未確認件数」を返す `useHistoryBadgeCount` hook を新設。履歴パネル表示中は 0、閉じている間に増えた件数だけをバッジに表示する
- IDE モード (App.tsx) と Canvas モード (CanvasLayout.tsx) の両方で同じ hook を使い、Canvas 折り畳み時 (`sidebarCollapsed`) は確認済みにしない

## 主要変更
- `src/renderer/src/lib/use-history-badge-count.ts` (新規) — pure hook
- `src/renderer/src/lib/__tests__/history-badge-count.test.ts` (新規) — 6 ケース
- `src/renderer/src/components/shell/Rail.tsx` — prop `historyCount` → `historyBadgeCount` 改名
- `src/renderer/src/App.tsx` — IDE モード Rail 接続を hook 経由に
- `src/renderer/src/layouts/CanvasLayout.tsx` — Canvas モード Rail 接続を hook 経由に

## スコープ外 (別 issue 候補)
- 確認済み状態のアプリ再起動後の永続化 (今回は in-memory のみ)
- 履歴パネル内の既読/未読表示

## Test plan
- [x] `npx vitest run src/renderer/src/lib/__tests__/history-badge-count.test.ts` → 6 passed
- [x] `npm run typecheck` → green
- [ ] `npm run dev` で IDE / Canvas 両方で「履歴あり → History を開く → バッジが消える → 履歴パネルを閉じる → 新しい履歴が増えるとバッジ再表示」を目視確認
- [ ] 既存の `Changes` バッジは未コミット変更件数のままであること

Closes #387