### PR TITLE
fix(canvas): #372 recruit 後の viewport を新規 worker カード中心に寄せる

### DIFF
--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -36,6 +36,7 @@ import { LeaderGlow } from './LeaderGlow';
 import { StageHud } from './StageHud';
 import { useCanvasStore, NODE_W, NODE_H, type CardData } from '../../stores/canvas';
 import { colorOf } from '../../lib/team-roles';
+import { computeRecruitFocus } from '../../lib/canvas-recruit-focus';
 import { KEYS, useKeybinding } from '../../lib/keybindings';
 import { useUiStore } from '../../stores/ui';
 import { ContextMenu, type ContextMenuItem } from '../ContextMenu';
@@ -291,45 +292,45 @@ function FlowApp(): JSX.Element {
 
   const stageView = useCanvasStore((s) => s.stageView);
 
-  // Issue #253 review (#2 + #7): recruit 後に fitView({ padding, duration }) を発火させて、
-  // RECRUIT_RADIUS=NODE_W+80 で 6 名同心円配置時に端メンバーが viewport から外れる
-  // UX 退行を吸収する。lastRecruitAt は use-recruit-listener が card 追加直後に
-  // notifyRecruit() で書き、本 effect が変化を検知する。
-  // 200ms debounce: team_recruit が短時間に複数名 (Leader+5 等) を追加するケースで、
-  // fitView アニメーションが連続発火してカクつく問題を回避。最後の更新から 200ms 経過後に
-  // 1 回だけ fitView を呼ぶ。debounce 時間は新ノードのレンダー完了 (~16ms) より十分長く、
-  // ユーザーの体感遅延 (300ms 程度の許容) より短い実用値。
-  // Issue #259: fitView 後に zoom が極端に下がるとターミナル文字が判読困難になる UX 退行を防ぐ。
-  // 結果 zoom が MIN_RECRUIT_ZOOM を下回った場合は Leader (= recruit 直近の中心ノード) で
-  // setCenter のみ実行し zoom を確保する。一部メンバーは viewport 外になるが、ユーザーは pan で閲覧可能。
+  // Issue #253 / #372: recruit 後に viewport を「新規 worker カード」中心へ寄せる。
+  // lastRecruitFocus は use-recruit-listener が `notifyRecruit(newNodeId)` で書き、
+  // 本 effect が変化を検知して `setCenter` する。HR が worker を増やすケースでも
+  // Leader ではなく追加された worker を中心にできる。
+  //
+  // 200ms debounce: 新ノードの DOM 計測完了 (~16ms) を待ちつつ、連続 recruit (Leader+5 等)
+  // でアニメーションがカクつくのを回避。
+  //
+  // Issue #259 (継承): zoom が MIN_RECRUIT_ZOOM を下回ると TUI が読めなくなるため、
+  // 現在の zoom がそれより大きければ尊重し、下回っていれば minZoom にクランプして寄せる。
   const MIN_RECRUIT_ZOOM = 0.7;
-  const lastRecruitAt = useCanvasStore((s) => s.lastRecruitAt);
+  const lastRecruitFocus = useCanvasStore((s) => s.lastRecruitFocus);
   const reactFlow = useReactFlow();
   useEffect(() => {
-    if (!lastRecruitAt) return;
+    if (!lastRecruitFocus) return;
     const timer = window.setTimeout(() => {
       try {
-        // minZoom オプションで fitView 自体が極端に縮小しないようガード (@xyflow/react v12)
-        reactFlow.fitView({ padding: 0.15, duration: 300, minZoom: MIN_RECRUIT_ZOOM });
-        // 防衛的フォールバック: minZoom が反映されない paths があった場合に備えて、
-        // 結果 zoom を確認し閾値未満なら Leader を中心に setCenter で zoom を強制する。
+        const targetNode = reactFlow.getNode(lastRecruitFocus.nodeId);
+        // recruit cancel 等で対象ノードが消えていれば no-op
+        if (!targetNode) return;
         const vp = reactFlow.getViewport();
-        if (vp.zoom < MIN_RECRUIT_ZOOM) {
-          const leader = reactFlow.getNodes()[0];
-          if (leader) {
-            reactFlow.setCenter(
-              leader.position.x + NODE_W / 2,
-              leader.position.y + NODE_H / 2,
-              { zoom: MIN_RECRUIT_ZOOM, duration: 300 }
-            );
-          }
-        }
+        const focus = computeRecruitFocus({
+          node: targetNode,
+          currentZoom: vp.zoom,
+          minZoom: MIN_RECRUIT_ZOOM,
+          fallbackWidth: NODE_W,
+          fallbackHeight: NODE_H
+        });
+        if (!focus) return;
+        reactFlow.setCenter(focus.centerX, focus.centerY, {
+          zoom: focus.zoom,
+          duration: 300
+        });
       } catch {
         /* viewport 計算に失敗するレアケースは無視 */
       }
     }, 200);
     return () => window.clearTimeout(timer);
-  }, [lastRecruitAt, reactFlow]);
+  }, [lastRecruitFocus, reactFlow]);
 
   return (
     <div

--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -303,13 +303,23 @@ function FlowApp(): JSX.Element {
   // Issue #259 (継承): zoom が MIN_RECRUIT_ZOOM を下回ると TUI が読めなくなるため、
   // 現在の zoom がそれより大きければ尊重し、下回っていれば minZoom にクランプして寄せる。
   const MIN_RECRUIT_ZOOM = 0.7;
-  const lastRecruitFocus = useCanvasStore((s) => s.lastRecruitFocus);
+  // 旧 #372 review (vibe-editor-reviewer #418): selector で `lastRecruitFocus` を
+  // オブジェクトのまま購読すると、zustand が毎回新しい参照を返すため effect deps が
+  // 「object reference に敏感」になり、useReactFlow の参照変化と組み合わさって
+  // 過剰再実行に繋がりうる。primitive (`nodeId` / `requestedAt`) だけを deps に置き、
+  // 旧 trigger (`requestedAt`) が変化したときだけ effect を発火させる。
+  const recruitFocusNodeId = useCanvasStore(
+    (s) => s.lastRecruitFocus?.nodeId ?? null
+  );
+  const recruitFocusRequestedAt = useCanvasStore(
+    (s) => s.lastRecruitFocus?.requestedAt ?? 0
+  );
   const reactFlow = useReactFlow();
   useEffect(() => {
-    if (!lastRecruitFocus) return;
+    if (!recruitFocusNodeId || !recruitFocusRequestedAt) return;
     const timer = window.setTimeout(() => {
       try {
-        const targetNode = reactFlow.getNode(lastRecruitFocus.nodeId);
+        const targetNode = reactFlow.getNode(recruitFocusNodeId);
         // recruit cancel 等で対象ノードが消えていれば no-op
         if (!targetNode) return;
         const vp = reactFlow.getViewport();
@@ -330,7 +340,7 @@ function FlowApp(): JSX.Element {
       }
     }, 200);
     return () => window.clearTimeout(timer);
-  }, [lastRecruitFocus, reactFlow]);
+  }, [recruitFocusNodeId, recruitFocusRequestedAt, reactFlow]);
 
   return (
     <div

--- a/src/renderer/src/lib/__tests__/canvas-recruit-focus.test.ts
+++ b/src/renderer/src/lib/__tests__/canvas-recruit-focus.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { computeRecruitFocus } from '../canvas-recruit-focus';
+
+const NODE_W = 640;
+const NODE_H = 400;
+
+describe('computeRecruitFocus', () => {
+  it('node が null なら null を返す (no-op)', () => {
+    expect(
+      computeRecruitFocus({
+        node: null,
+        currentZoom: 1,
+        minZoom: 0.7,
+        fallbackWidth: NODE_W,
+        fallbackHeight: NODE_H
+      })
+    ).toBeNull();
+  });
+
+  it('measured を最優先して中心を計算する', () => {
+    const result = computeRecruitFocus({
+      node: {
+        position: { x: 100, y: 200 },
+        measured: { width: 400, height: 300 },
+        style: { width: NODE_W, height: NODE_H }
+      } as never,
+      currentZoom: 1,
+      minZoom: 0.7,
+      fallbackWidth: NODE_W,
+      fallbackHeight: NODE_H
+    });
+    expect(result).toEqual({
+      centerX: 100 + 400 / 2,
+      centerY: 200 + 300 / 2,
+      zoom: 1
+    });
+  });
+
+  it('measured 不在なら style の width/height を使う', () => {
+    const result = computeRecruitFocus({
+      node: {
+        position: { x: 0, y: 0 },
+        style: { width: 800, height: 600 }
+      } as never,
+      currentZoom: 0.9,
+      minZoom: 0.7,
+      fallbackWidth: NODE_W,
+      fallbackHeight: NODE_H
+    });
+    expect(result).toEqual({ centerX: 400, centerY: 300, zoom: 0.9 });
+  });
+
+  it('measured / style / props ともに無ければ fallback サイズで中心を計算する', () => {
+    const result = computeRecruitFocus({
+      node: {
+        position: { x: 1000, y: 2000 }
+      } as never,
+      currentZoom: 1,
+      minZoom: 0.7,
+      fallbackWidth: NODE_W,
+      fallbackHeight: NODE_H
+    });
+    expect(result).toEqual({
+      centerX: 1000 + NODE_W / 2,
+      centerY: 2000 + NODE_H / 2,
+      zoom: 1
+    });
+  });
+
+  it('現在 zoom が minZoom 未満でも minZoom にクランプされる', () => {
+    const result = computeRecruitFocus({
+      node: { position: { x: 0, y: 0 } } as never,
+      currentZoom: 0.3,
+      minZoom: 0.7,
+      fallbackWidth: NODE_W,
+      fallbackHeight: NODE_H
+    });
+    expect(result?.zoom).toBe(0.7);
+  });
+
+  it('現在 zoom が minZoom 以上ならそのまま使う (拡大は維持)', () => {
+    const result = computeRecruitFocus({
+      node: { position: { x: 0, y: 0 } } as never,
+      currentZoom: 1.4,
+      minZoom: 0.7,
+      fallbackWidth: NODE_W,
+      fallbackHeight: NODE_H
+    });
+    expect(result?.zoom).toBe(1.4);
+  });
+
+  it('measured / style に不正値 (0 / NaN) が混じっても fallback に逃げる', () => {
+    const result = computeRecruitFocus({
+      node: {
+        position: { x: 50, y: 60 },
+        measured: { width: NaN, height: 0 },
+        style: { width: 0, height: NaN }
+      } as never,
+      currentZoom: 1,
+      minZoom: 0.7,
+      fallbackWidth: NODE_W,
+      fallbackHeight: NODE_H
+    });
+    expect(result).toEqual({
+      centerX: 50 + NODE_W / 2,
+      centerY: 60 + NODE_H / 2,
+      zoom: 1
+    });
+  });
+});

--- a/src/renderer/src/lib/canvas-recruit-focus.ts
+++ b/src/renderer/src/lib/canvas-recruit-focus.ts
@@ -1,0 +1,76 @@
+/**
+ * Issue #372: recruit 後に viewport を新規 worker カード中心へ寄せるための
+ * 純粋計算関数。Canvas.tsx の useEffect でしか使わないが、ノードサイズが
+ * 実測サイズ / style / fallback のどこから来るかが多岐にわたるため pure 化して
+ * unit test しやすくする。
+ */
+import type { Node } from '@xyflow/react';
+
+export interface RecruitFocusInput {
+  /** 中心に置きたいノード (見つからなければ null)。 */
+  node: Pick<Node, 'position' | 'measured' | 'width' | 'height' | 'style'> | null;
+  /** 既存 zoom (= 現在の viewport.zoom)。 */
+  currentZoom: number;
+  /** ターゲット最小 zoom。`currentZoom` がこれを上回っていればそのまま維持する。 */
+  minZoom: number;
+  /** ノードサイズ取得に失敗したときの幅 / 高さ (NODE_W / NODE_H 想定)。 */
+  fallbackWidth: number;
+  fallbackHeight: number;
+}
+
+export interface RecruitFocusResult {
+  /** viewport 中心 (= reactFlow.setCenter の x). */
+  centerX: number;
+  /** viewport 中心 (= reactFlow.setCenter の y). */
+  centerY: number;
+  /** setCenter に渡す zoom (= 現在 zoom と min の max)。 */
+  zoom: number;
+}
+
+function pickNumber(...candidates: Array<unknown>): number | null {
+  for (const v of candidates) {
+    if (typeof v === 'number' && Number.isFinite(v) && v > 0) return v;
+  }
+  return null;
+}
+
+/**
+ * 対象ノードの中心座標と適用すべき zoom を計算する。
+ * - `node` が null のときは null を返す (呼び出し側で no-op にする)。
+ * - `node.measured` (React Flow が DOM を計測した値) を最優先。
+ *   無ければ `node.width` / `node.height` (props 直指定値)、
+ *   最後に `node.style.width` / `node.style.height` を見る。
+ *   どれも欠けていたら fallback (NODE_W / NODE_H) を使う。
+ * - zoom は `max(currentZoom, minZoom)`。手動で寄せた zoom を勝手に縮小しない。
+ */
+export function computeRecruitFocus(
+  input: RecruitFocusInput
+): RecruitFocusResult | null {
+  const { node, currentZoom, minZoom, fallbackWidth, fallbackHeight } = input;
+  if (!node) return null;
+
+  const measured = node.measured ?? null;
+  const styleW =
+    node.style && typeof (node.style as { width?: unknown }).width === 'number'
+      ? ((node.style as { width: number }).width)
+      : null;
+  const styleH =
+    node.style && typeof (node.style as { height?: unknown }).height === 'number'
+      ? ((node.style as { height: number }).height)
+      : null;
+
+  const width =
+    pickNumber(measured?.width, node.width, styleW) ?? fallbackWidth;
+  const height =
+    pickNumber(measured?.height, node.height, styleH) ?? fallbackHeight;
+
+  const zoom = Math.max(
+    currentZoom > 0 && Number.isFinite(currentZoom) ? currentZoom : minZoom,
+    minZoom
+  );
+  return {
+    centerX: node.position.x + width / 2,
+    centerY: node.position.y + height / 2,
+    zoom
+  };
+}

--- a/src/renderer/src/lib/use-recruit-listener.ts
+++ b/src/renderer/src/lib/use-recruit-listener.ts
@@ -215,7 +215,7 @@ export function useRecruitListener(): void {
         });
         const pos = findRecruitPosition(requester, teamNodes);
         const titleHint = p.agentLabelHint?.trim() || p.roleProfileId;
-        store.addCard({
+        const newNodeId = store.addCard({
           type: 'agent',
           title: titleHint,
           position: pos,
@@ -232,9 +232,10 @@ export function useRecruitListener(): void {
             customInstructions: p.customInstructions || undefined
           }
         });
-        // Issue #253: 新メンバー配置後に Canvas 側で fitView を発火させる。
-        // RECRUIT_RADIUS=NODE_W+80 で 6 名同心円配置時に端が viewport 外になる UX 退行を吸収。
-        store.notifyRecruit();
+        // Issue #253 / #372: 新メンバー配置後、Canvas 側で「新しい worker」を中心に
+        // viewport を寄せる。HR が worker を増やすケースでも Leader ではなく
+        // 追加されたばかりの worker が viewport の中央に来る。
+        store.notifyRecruit(newNodeId);
         // Issue #342 Phase 1: addCard 完了 (= spawn 開始) 時点で Hub に受領通知を返す。
         // handshake 完了は待たない (それは Hub 側 RECRUIT_TIMEOUT=30s 経路の責務)。
         // ack(true) だけでは MCP success にはならず、真の成功判定は handshake のみ。

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -63,14 +63,17 @@ interface CanvasState {
   setTeamLock: (teamId: string, locked: boolean) => void;
   isTeamLocked: (teamId: string) => boolean;
   /**
-   * Issue #253: recruit イベント (新規メンバー追加) で fitView を発火させるためのトリガー。
-   * use-recruit-listener が card 追加後に Date.now() を書き、Canvas component が
-   * useEffect で監視して `useReactFlow().fitView({ padding: 0.15, duration: 300 })` を呼ぶ。
-   * RECRUIT_RADIUS = NODE_W + 80 により論理幅 2080 px 超を要求する 6 名同心円配置でも、
-   * fitView で全員が viewport に収まるよう自動調整する。
+   * Issue #253 / #372: recruit イベント (新規メンバー追加) で viewport を新規 worker
+   * 中心へ寄せるためのトリガー。use-recruit-listener が card 追加後に
+   * `notifyRecruit(nodeId)` を呼び、Canvas component が useEffect でこの変化を検知して
+   * `useReactFlow().setCenter(...)` で対象ノードを中央に置く。
+   *
+   * `nodeId` を含めることで、HR から worker を増やすケース等でも「Leader ではなく
+   * 直前に追加された worker」を中心に置けるようにする (#372)。連続 recruit のうち
+   * 最後の 1 件だけが effect で消費される (古い trigger は debounce 内で上書き)。
    */
-  lastRecruitAt: number | null;
-  notifyRecruit: () => void;
+  lastRecruitFocus: { nodeId: string; requestedAt: number } | null;
+  notifyRecruit: (nodeId: string) => void;
   /**
    * Issue #369: Canvas 内の terminal / agent カードを一括整理整頓する。
    * 既存 PTY を維持するため node id / data / payload は触らず、
@@ -286,9 +289,11 @@ export const useCanvasStore = create<CanvasState>()(
         const v = get().teamLocks[teamId];
         return v === undefined ? true : v;
       },
-      // Issue #253: recruit 後の fitView トリガー (use-recruit-listener が書き、Canvas が監視)
-      lastRecruitAt: null,
-      notifyRecruit: () => set({ lastRecruitAt: Date.now() }),
+      // Issue #253 / #372: recruit 後の viewport 寄せトリガー
+      // (use-recruit-listener が書き、Canvas が監視して setCenter する)
+      lastRecruitFocus: null,
+      notifyRecruit: (nodeId) =>
+        set({ lastRecruitFocus: { nodeId, requestedAt: Date.now() } }),
       // Issue #369: terminal/agent カードの一括整理整頓
       arrangeGap: 'normal',
       setArrangeGap: (gap) => set({ arrangeGap: gap }),


### PR DESCRIPTION
## Summary
- Issue #372: HR が worker を recruit したときに viewport の中心が「新規 worker」ではなく「Leader」になるずれを解消
- recruit trigger に新規 node id を載せて、対象ノードを `setCenter` で確実に中央へ寄せる
- 既存 zoom が `MIN_RECRUIT_ZOOM` (0.7) より大きければ縮小しない (TUI が読める state を維持)

## 主要変更
- `src/renderer/src/stores/canvas.ts` — `lastRecruitAt` → `lastRecruitFocus: { nodeId, requestedAt }` 化、`notifyRecruit(nodeId)` API
- `src/renderer/src/lib/use-recruit-listener.ts` — `addCard()` の戻り値を `notifyRecruit` に渡す
- `src/renderer/src/lib/canvas-recruit-focus.ts` (新規 pure helper) — measured / props / style / fallback の優先順で中心座標と zoom を計算
- `src/renderer/src/components/canvas/Canvas.tsx` — 旧 `fitView` を撤去、`getNode(nodeId)` → `computeRecruitFocus()` → `setCenter` に置換
- `src/renderer/src/lib/__tests__/canvas-recruit-focus.test.ts` (新規) — 7 ケース

## レビュー
- codex (`codex:codex-rescue`) で二次レビュー実施 → approve、Critical / Major なし

## Test plan
- [x] `npx vitest run canvas-recruit-focus.test.ts` → 7 passed
- [x] `npm run typecheck` → green
- [ ] `npm run dev` で Canvas モードを開き、Leader → HR → worker recruit の流れで「新規 worker カード」が viewport 中央に来ることを目視確認
- [ ] zoom 1.4 まで寄せた状態で recruit したとき、zoom が縮小しないこと
- [ ] recruit cancel が起きたとき (例: timeout) に effect が no-op になり例外が出ないこと

Closes #372