### PR TITLE
fix(canvas): #397 Canvas zoom 下のターミナル範囲選択座標ずれを解消

### DIFF
--- a/src/renderer/src/components/TerminalView.tsx
+++ b/src/renderer/src/components/TerminalView.tsx
@@ -10,6 +10,7 @@ import {
 import { useTerminalClipboard } from '../lib/use-terminal-clipboard';
 import { useAutoInitialMessage } from '../lib/use-auto-initial-message';
 import { useFitToContainer } from '../lib/use-fit-to-container';
+import { useCanvasTerminalPointerNormalizer } from '../lib/use-canvas-terminal-pointer-normalizer';
 import type { CellSize } from '../lib/measure-cell-size';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 
@@ -331,6 +332,15 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
         window.requestAnimationFrame(() => term.focus());
       }
     }, []);
+
+    // Issue #397: Canvas zoom (transform: scale) 下では xterm の範囲選択座標がずれて
+    // 4 行ほど上を選択してしまうため、capture phase で MouseEvent を論理座標へ補正する。
+    // IDE モード (unscaledFit !== true) では何もしない。
+    useCanvasTerminalPointerNormalizer({
+      containerRef,
+      unscaledFit,
+      getZoom
+    });
 
     // --- 外部操作用ハンドル (public API は不変) ---
     useImperativeHandle(

--- a/src/renderer/src/lib/__tests__/canvas-terminal-pointer.test.ts
+++ b/src/renderer/src/lib/__tests__/canvas-terminal-pointer.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeCanvasTerminalClientPoint } from '../canvas-terminal-pointer';
+
+const rect = { left: 100, top: 200 };
+
+describe('normalizeCanvasTerminalClientPoint', () => {
+  it('zoom = 1 のときは元の値をそのまま返す', () => {
+    const out = normalizeCanvasTerminalClientPoint({
+      clientX: 250,
+      clientY: 380,
+      rect,
+      zoom: 1
+    });
+    expect(out).toEqual({ clientX: 250, clientY: 380 });
+  });
+
+  it('|zoom - 1| < 0.01 では no-op', () => {
+    const out = normalizeCanvasTerminalClientPoint({
+      clientX: 250,
+      clientY: 380,
+      rect,
+      zoom: 1.005
+    });
+    expect(out).toEqual({ clientX: 250, clientY: 380 });
+  });
+
+  it('zoom = 0.7 で container 内側の点を論理座標へ展開する', () => {
+    const out = normalizeCanvasTerminalClientPoint({
+      clientX: 100 + 70, // rect.left + 70 (visual px)
+      clientY: 200 + 35, // rect.top + 35 (visual px)
+      rect,
+      zoom: 0.7
+    });
+    // 論理 = rect + (visual / zoom)
+    expect(out.clientX).toBeCloseTo(100 + 70 / 0.7, 6); // = 200
+    expect(out.clientY).toBeCloseTo(200 + 35 / 0.7, 6); // = 250
+  });
+
+  it('zoom = 1.5 で container 内側の点を縮める', () => {
+    const out = normalizeCanvasTerminalClientPoint({
+      clientX: 100 + 150,
+      clientY: 200 + 75,
+      rect,
+      zoom: 1.5
+    });
+    expect(out.clientX).toBeCloseTo(100 + 150 / 1.5, 6); // = 200
+    expect(out.clientY).toBeCloseTo(200 + 75 / 1.5, 6); // = 250
+  });
+
+  it('zoom = 0 / NaN / 負値は no-op (異常値ガード)', () => {
+    for (const zoom of [0, -1, NaN, Number.POSITIVE_INFINITY]) {
+      const out = normalizeCanvasTerminalClientPoint({
+        clientX: 250,
+        clientY: 380,
+        rect,
+        zoom
+      });
+      expect(out).toEqual({ clientX: 250, clientY: 380 });
+    }
+  });
+
+  it('rect.left/top が 0 でも線形に正しく動く', () => {
+    const out = normalizeCanvasTerminalClientPoint({
+      clientX: 700,
+      clientY: 350,
+      rect: { left: 0, top: 0 },
+      zoom: 0.5
+    });
+    expect(out.clientX).toBeCloseTo(1400, 6);
+    expect(out.clientY).toBeCloseTo(700, 6);
+  });
+});

--- a/src/renderer/src/lib/canvas-terminal-pointer.ts
+++ b/src/renderer/src/lib/canvas-terminal-pointer.ts
@@ -1,0 +1,49 @@
+/**
+ * Issue #397: Canvas モード (React Flow `transform: scale(zoom)` 配下) の xterm では、
+ * pointer 座標が「スケール後の screen px」、cell 幅が「論理 px」として計算されているため、
+ * zoom != 1 のときに cell 位置がずれて 4 行ほど上を選択してしまう。
+ *
+ * 修正方針:
+ *   container 矩形 (rect) と zoom を使って、capture phase で受け取った clientX/clientY を
+ *   論理座標 (= zoom == 1 と等価な座標系) に変換する。xterm は変換後の座標で正しい cell を
+ *   計算できる。
+ */
+
+export interface NormalizeInput {
+  clientX: number;
+  clientY: number;
+  /** container (= `.terminal-view`) の `getBoundingClientRect()`。視覚スケール後の値。 */
+  rect: { left: number; top: number };
+  /** 現在の Canvas zoom (= `getZoom()`)。0 / 非有限 / |zoom - 1| < 0.01 のときは no-op。 */
+  zoom: number;
+}
+
+export interface NormalizedPoint {
+  clientX: number;
+  clientY: number;
+}
+
+const ZOOM_NEUTRAL_THRESHOLD = 0.01;
+
+/**
+ * `clientX/clientY` を論理座標に補正する。
+ * - zoom が 0 / 非有限 / |zoom - 1| < 0.01 のときは元の値をそのまま返す (no-op)。
+ * - container 矩形からの相対距離 `(clientX - rect.left)` を `1 / zoom` 倍して再構成する。
+ */
+export function normalizeCanvasTerminalClientPoint(
+  input: NormalizeInput
+): NormalizedPoint {
+  const { clientX, clientY, rect, zoom } = input;
+  if (!Number.isFinite(zoom) || zoom <= 0) {
+    return { clientX, clientY };
+  }
+  if (Math.abs(zoom - 1) < ZOOM_NEUTRAL_THRESHOLD) {
+    return { clientX, clientY };
+  }
+  return {
+    clientX: rect.left + (clientX - rect.left) / zoom,
+    clientY: rect.top + (clientY - rect.top) / zoom
+  };
+}
+
+export const __testables = { ZOOM_NEUTRAL_THRESHOLD };

--- a/src/renderer/src/lib/use-canvas-terminal-pointer-normalizer.ts
+++ b/src/renderer/src/lib/use-canvas-terminal-pointer-normalizer.ts
@@ -1,0 +1,143 @@
+/**
+ * Issue #397: Canvas モード (React Flow `transform: scale(zoom)` 配下) で xterm の
+ * 範囲選択座標がずれる問題を、capture phase で MouseEvent を論理座標へ変換した synthetic
+ * イベントに差し替えることで解消する hook。
+ *
+ * 仕様:
+ * - 適用条件: `unscaledFit === true` かつ `getZoom()` が 1 から十分離れている
+ *   (|zoom - 1| >= 0.01)。IDE モード (unscaledFit !== true) では何もしない。
+ * - 対象 event: 主ボタン (button === 0) の `mousedown` / `mousemove` / `mouseup` だけ。
+ *   wheel / contextmenu / keyboard / paste はパススルー。
+ * - 元イベント発火順: `capture phase` で握り潰し (`preventDefault` +
+ *   `stopImmediatePropagation`) → 論理座標に補正した `new MouseEvent` を target に
+ *   `dispatchEvent` で再投入。modifier / button / buttons / detail / view / movementX/Y は
+ *   全保持。
+ * - **document-level の追加 listener** (codex review #397 反映): xterm の
+ *   SelectionService と CoreBrowserTerminal.bindMouse はドラッグ開始後に
+ *   `document` 上で `mousemove` / `mouseup` を購読する。container だけだとドラッグが
+ *   端末外に出た瞬間に native 座標が xterm に届いて再びずれる。container 用と
+ *   document 用の 2 段で capture-phase listener を張り、どちらの経路でも論理座標化する。
+ * - 再帰防止: synthetic に `__vibeNormalized = true` を立て、capture phase 受信側で
+ *   それを見たら no-op で抜ける。
+ */
+import { useEffect, type RefObject } from 'react';
+import { normalizeCanvasTerminalClientPoint } from './canvas-terminal-pointer';
+
+interface NormalizedMouseEvent extends MouseEvent {
+  __vibeNormalized?: boolean;
+}
+
+interface PointerNormalizerOptions {
+  containerRef: RefObject<HTMLElement>;
+  unscaledFit: boolean | undefined;
+  getZoom: (() => number) | undefined;
+}
+
+const TRACKED_TYPES = ['mousedown', 'mousemove', 'mouseup'] as const;
+
+export function useCanvasTerminalPointerNormalizer({
+  containerRef,
+  unscaledFit,
+  getZoom
+}: PointerNormalizerOptions): void {
+  useEffect(() => {
+    if (!unscaledFit || !getZoom) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    /**
+     * ドラッグ中フラグ。container 内で primary mousedown を握り潰した瞬間に true、
+     * mouseup で false。document-level の mousemove/mouseup はこのフラグが true の
+     * ときだけ補正する (xterm 外の純粋な document mousemove を不必要に書き換えない)。
+     */
+    let dragging = false;
+
+    const computeNormalized = (
+      e: NormalizedMouseEvent
+    ): { x: number; y: number } | null => {
+      if (e.__vibeNormalized) return null;
+      if (e.button !== 0) return null;
+      const zoom = getZoom();
+      if (!Number.isFinite(zoom) || zoom <= 0) return null;
+      if (Math.abs(zoom - 1) < 0.01) return null;
+      const rect = container.getBoundingClientRect();
+      const out = normalizeCanvasTerminalClientPoint({
+        clientX: e.clientX,
+        clientY: e.clientY,
+        rect,
+        zoom
+      });
+      if (out.clientX === e.clientX && out.clientY === e.clientY) return null;
+      return { x: out.clientX, y: out.clientY };
+    };
+
+    const dispatchSynthetic = (
+      e: NormalizedMouseEvent,
+      x: number,
+      y: number
+    ): void => {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const target = (e.target as Element | null) ?? container;
+      const synthetic = new MouseEvent(e.type, {
+        bubbles: e.bubbles,
+        cancelable: e.cancelable,
+        composed: e.composed,
+        view: e.view,
+        detail: e.detail,
+        clientX: x,
+        clientY: y,
+        screenX: e.screenX,
+        screenY: e.screenY,
+        ctrlKey: e.ctrlKey,
+        shiftKey: e.shiftKey,
+        altKey: e.altKey,
+        metaKey: e.metaKey,
+        button: e.button,
+        buttons: e.buttons,
+        relatedTarget: e.relatedTarget,
+        movementX: e.movementX,
+        movementY: e.movementY
+      }) as NormalizedMouseEvent;
+      synthetic.__vibeNormalized = true;
+      target.dispatchEvent(synthetic);
+    };
+
+    const onContainerEvent = (event: MouseEvent): void => {
+      const e = event as NormalizedMouseEvent;
+      const normalized = computeNormalized(e);
+      if (!normalized) return;
+      if (e.type === 'mousedown') dragging = true;
+      else if (e.type === 'mouseup') dragging = false;
+      dispatchSynthetic(e, normalized.x, normalized.y);
+    };
+
+    const onDocumentEvent = (event: MouseEvent): void => {
+      const e = event as NormalizedMouseEvent;
+      // container 内のイベントは container listener (capture phase) が処理済み。
+      // document-level handler は「ドラッグが端末外に出た瞬間」だけが対象。
+      if (!dragging) return;
+      if (container.contains(e.target as Node)) return;
+      const normalized = computeNormalized(e);
+      if (!normalized) return;
+      if (e.type === 'mouseup') dragging = false;
+      dispatchSynthetic(e, normalized.x, normalized.y);
+    };
+
+    for (const type of TRACKED_TYPES) {
+      container.addEventListener(type, onContainerEvent, true);
+    }
+    // mousemove / mouseup を document でも capture して、xterm が
+    // document.addEventListener(...) で登録した bubble-phase listener より先に走らせる。
+    document.addEventListener('mousemove', onDocumentEvent, true);
+    document.addEventListener('mouseup', onDocumentEvent, true);
+
+    return () => {
+      for (const type of TRACKED_TYPES) {
+        container.removeEventListener(type, onContainerEvent, true);
+      }
+      document.removeEventListener('mousemove', onDocumentEvent, true);
+      document.removeEventListener('mouseup', onDocumentEvent, true);
+    };
+  }, [containerRef, unscaledFit, getZoom]);
+}


### PR DESCRIPTION
## Summary
- Issue #397: Canvas モード (React Flow `transform: scale(zoom)`) で xterm の範囲選択が約 4 行ずれる問題を解消
- 原因: xterm の cell は `unscaledFit` により論理 px で計算されるが、`MouseEvent.clientX/clientY` と `getBoundingClientRect()` はスケール後の screen px。zoom != 1 のとき差し引きで cell index がずれる
- 対策: capture phase で MouseEvent を握り潰し、論理座標 (`rect.left + (clientX - rect.left) / zoom`) に補正した synthetic event を再 dispatch

## 主要変更
- `src/renderer/src/lib/canvas-terminal-pointer.ts` (新規 pure) — 座標正規化
- `src/renderer/src/lib/use-canvas-terminal-pointer-normalizer.ts` (新規 hook) — container と document の両方で capture-phase listener
- `src/renderer/src/components/TerminalView.tsx` — hook 配線
- `src/renderer/src/lib/__tests__/canvas-terminal-pointer.test.ts` (新規) — 6 ケース

## codex 二次レビュー反映
xterm `SelectionService` / `CoreBrowserTerminal.bindMouse` がドラッグ開始後に `document` 上で mousemove/mouseup を listen するため、container だけだと「端末外までドラッグした瞬間」に native 座標が xterm に届いて再びずれる。container と document の両方に capture-phase listener を張り、`dragging` フラグで document-level は端末外ドラッグ中だけ補正するようにした。

## スコープ外
- IDE モードの座標 (`unscaledFit !== true` で effect が early return)
- wheel scrollback / contextmenu / keyboard / paste (mousedown/move/up のみ tracking)

## Test plan
- [x] `npx vitest run canvas-terminal-pointer.test.ts` → 6 passed
- [x] `npm run typecheck` → green
- [ ] `npm run dev` で Canvas zoom 0.7 / 1.0 / 1.5 で TerminalCard / AgentNodeCard の同じ行を選択し、ドラッグ開始位置と選択開始位置が一致すること
- [ ] ドラッグを端末外まで伸ばしても座標ずれがないこと
- [ ] wheel scrollback / 右クリックメニュー / 通常入力 / コピーが退行しないこと
- [ ] IDE モードのターミナルで挙動変更がないこと

Closes #397