### PR TITLE
fix(canvas): #385 作業状態復元時に黒画面になる問題を解消

### DIFF
--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -265,9 +265,15 @@ export function CanvasLayout(): JSX.Element {
     const cards = entry.members.map((m, i) => {
       const agentId = `${m.role}-${i}-${entry.id}`;
       const saved = entry.canvasState?.nodes.find((s) => s.agentId === agentId);
-      const pos = saved
-        ? { x: saved.x, y: saved.y }
-        : presetPosition(i % 3, Math.floor(i / 3));
+      // Issue #385: 旧 team-history.json に NaN / Infinity / undefined な座標が残っていると、
+      // 復元直後に React Flow が render 例外を出して Canvas 全体が黒画面になる。
+      // 数値として有効でない場合は preset 配置にフォールバックする。
+      const savedX = typeof saved?.x === 'number' && Number.isFinite(saved.x) ? saved.x : null;
+      const savedY = typeof saved?.y === 'number' && Number.isFinite(saved.y) ? saved.y : null;
+      const pos =
+        savedX !== null && savedY !== null
+          ? { x: savedX, y: savedY }
+          : presetPosition(i % 3, Math.floor(i / 3));
       // Issue #69: 未知 role でも落ちないよう optional chain
       const label = ROLE_META[m.role]?.label ?? m.role ?? 'Agent';
       return {

--- a/src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Canvas store の正規化 (Issue #385) を直接テストする。
+ * - persist v3 → v4 の migration を経ても黒画面化しない
+ * - 同 version (v4 → v4) の rehydrate でも runtime に紛れ込んだ NaN viewport を補正する
+ * - 極端な座標 / zoom が起動時に修正される
+ */
+import { describe, expect, it } from 'vitest';
+import { __testables } from '../canvas';
+
+const { normalizeCanvasState, VIEWPORT_MIN_ZOOM, VIEWPORT_MAX_ZOOM, VIEWPORT_RESCUE_DISTANCE } =
+  __testables;
+
+describe('normalizeCanvasState (Issue #385)', () => {
+  it('null / 非オブジェクト入力は空 state にフォールバック', () => {
+    const out = normalizeCanvasState(null);
+    expect(out.nodes).toEqual([]);
+    expect(out.viewport).toEqual({ x: 0, y: 0, zoom: 1 });
+    expect(out.stageView).toBe('stage');
+    expect(out.teamLocks).toEqual({});
+    expect(out.arrangeGap).toBe('normal');
+  });
+
+  it('viewport.zoom が NaN / Infinity / 負値 / 上限超過のときクランプされる', () => {
+    expect(
+      normalizeCanvasState({ nodes: [], viewport: { x: 0, y: 0, zoom: NaN } })
+        .viewport.zoom
+    ).toBe(1);
+    expect(
+      normalizeCanvasState({ nodes: [], viewport: { x: 0, y: 0, zoom: 0 } })
+        .viewport.zoom
+    ).toBe(VIEWPORT_MIN_ZOOM);
+    expect(
+      normalizeCanvasState({
+        nodes: [],
+        viewport: { x: 0, y: 0, zoom: Number.POSITIVE_INFINITY }
+      }).viewport.zoom
+    ).toBe(VIEWPORT_MAX_ZOOM);
+    expect(
+      normalizeCanvasState({ nodes: [], viewport: { x: 0, y: 0, zoom: 100 } })
+        .viewport.zoom
+    ).toBe(VIEWPORT_MAX_ZOOM);
+    expect(
+      normalizeCanvasState({ nodes: [], viewport: { x: 0, y: 0, zoom: -2 } })
+        .viewport.zoom
+    ).toBe(VIEWPORT_MIN_ZOOM);
+  });
+
+  it('nodes ありで viewport が極端な値なら 0,0 へ復帰する', () => {
+    const node = {
+      id: 'a-1',
+      type: 'agent',
+      position: { x: 0, y: 0 },
+      data: { cardType: 'agent', title: 'Leader' },
+      style: { width: 640, height: 400 }
+    };
+    const out = normalizeCanvasState({
+      nodes: [node],
+      viewport: { x: VIEWPORT_RESCUE_DISTANCE + 1, y: 0, zoom: 1 }
+    });
+    expect(out.viewport.x).toBe(0);
+    expect(out.viewport.y).toBe(0);
+  });
+
+  it('nodes が空のときは極端な viewport 値はそのまま (= 操作で復帰可能)', () => {
+    const out = normalizeCanvasState({
+      nodes: [],
+      viewport: { x: VIEWPORT_RESCUE_DISTANCE + 1, y: 0, zoom: 1 }
+    });
+    expect(out.viewport.x).toBe(VIEWPORT_RESCUE_DISTANCE + 1);
+  });
+
+  it('壊れた node (type 不明 / position が NaN / style 欠損) は安全な形に直る', () => {
+    const out = normalizeCanvasState({
+      nodes: [
+        // type 不明 → 捨てられる
+        { id: 'broken', type: 'unknown', position: { x: 0, y: 0 } },
+        {
+          id: 'a-2',
+          type: 'agent',
+          position: { x: NaN, y: 'oops' },
+          data: { cardType: 'agent', title: '' },
+          style: { width: 'bad', height: undefined }
+        }
+      ],
+      viewport: { x: 0, y: 0, zoom: 1 }
+    });
+    expect(out.nodes).toHaveLength(1);
+    const n = out.nodes[0]!;
+    expect(Number.isFinite(n.position.x)).toBe(true);
+    expect(Number.isFinite(n.position.y)).toBe(true);
+    expect((n.style as { width: number }).width).toBe(640);
+    expect((n.style as { height: number }).height).toBe(400);
+    expect(n.data.title).toBe('Card'); // 空タイトル → 'Card'
+  });
+
+  it('node.id が無くても自動採番されて落ちない', () => {
+    const out = normalizeCanvasState({
+      nodes: [
+        {
+          type: 'terminal',
+          position: { x: 0, y: 0 },
+          data: { cardType: 'terminal', title: 'T' }
+        }
+      ]
+    });
+    expect(out.nodes).toHaveLength(1);
+    expect(typeof out.nodes[0]!.id).toBe('string');
+    expect(out.nodes[0]!.id.length).toBeGreaterThan(0);
+  });
+
+  it('teamLocks に boolean 以外の値が混じっていても落とす', () => {
+    const out = normalizeCanvasState({
+      nodes: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      teamLocks: { team1: true, team2: 'oops', team3: false }
+    });
+    expect(out.teamLocks).toEqual({ team1: true, team3: false });
+  });
+
+  it('stageView が不正値ならデフォルト stage に戻す', () => {
+    expect(
+      normalizeCanvasState({ stageView: 'evil' }).stageView
+    ).toBe('stage');
+    expect(
+      normalizeCanvasState({ stageView: 'list' }).stageView
+    ).toBe('list');
+  });
+
+  it('arrangeGap が不正値なら normal に戻す', () => {
+    expect(normalizeCanvasState({ arrangeGap: 999 }).arrangeGap).toBe('normal');
+    expect(normalizeCanvasState({ arrangeGap: 'tight' }).arrangeGap).toBe('tight');
+  });
+
+  it('node.position が有限でも rescue 距離超なら fallback grid に戻す (codex review #3)', () => {
+    const out = normalizeCanvasState({
+      nodes: [
+        {
+          id: 't-far',
+          type: 'terminal',
+          position: { x: VIEWPORT_RESCUE_DISTANCE + 100, y: 0 },
+          data: { cardType: 'terminal', title: 'Stranded' },
+          style: { width: 640, height: 400 }
+        }
+      ],
+      viewport: { x: 0, y: 0, zoom: 1 }
+    });
+    // index 0 → grid 0,0
+    expect(out.nodes[0]!.position.x).toBe(0);
+    expect(out.nodes[0]!.position.y).toBe(0);
+  });
+
+  it('node.position の片軸だけ極端なら片軸だけ rescue する', () => {
+    const out = normalizeCanvasState({
+      nodes: [
+        {
+          id: 't-half',
+          type: 'terminal',
+          position: { x: 50, y: -VIEWPORT_RESCUE_DISTANCE - 1 },
+          data: { cardType: 'terminal', title: 'HalfStranded' },
+          style: { width: 640, height: 400 }
+        }
+      ]
+    });
+    expect(out.nodes[0]!.position.x).toBe(50); // 維持
+    expect(out.nodes[0]!.position.y).toBe(0); // grid に戻す
+  });
+});

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -119,6 +119,132 @@ function finiteOr(value: unknown, fallback: number): number {
 }
 
 /**
+ * Issue #385: Canvas viewport の `zoom` を可視範囲にクランプし、
+ * `x` / `y` が極端な値 (= 全カードが viewport 外) のときは復帰用の値に戻す。
+ * これらは render 中に React Flow が黒画面化する/カードが見えなくなる主要因。
+ */
+const VIEWPORT_MIN_ZOOM = 0.1;
+const VIEWPORT_MAX_ZOOM = 4;
+/** nodes ありで viewport がここまで離れていたら「外れすぎ」と判定して復帰用 viewport にする */
+const VIEWPORT_RESCUE_DISTANCE = 1_000_000;
+
+function clampZoom(zoom: number): number {
+  // NaN は単位が無いので 1 (= 等倍) にフォールバック。±Infinity は Math.min/max で
+  // それぞれ MAX_ZOOM / MIN_ZOOM にクランプされる。
+  if (Number.isNaN(zoom)) return 1;
+  return Math.min(Math.max(zoom, VIEWPORT_MIN_ZOOM), VIEWPORT_MAX_ZOOM);
+}
+
+interface NormalizedCanvasState {
+  nodes: Node<CardData>[];
+  viewport: Viewport;
+  stageView: StageView;
+  teamLocks: Record<string, boolean>;
+  arrangeGap: ArrangeGap;
+}
+
+/**
+ * 永続化データ / merge 入力を React Flow が安全に描画できる形へ正規化する。
+ * - nodes: 必須プロパティの欠損 / 不正値を補い、type 不明な要素は捨てる
+ * - viewport.zoom: [VIEWPORT_MIN_ZOOM, VIEWPORT_MAX_ZOOM] にクランプ
+ * - viewport.x/y: 非有限なら 0、極端な値で nodes が完全に外れていれば nodes 中心へ復帰
+ * - stageView / teamLocks / arrangeGap: 不正な値ならデフォルトに戻す
+ */
+function normalizeCanvasState(input: unknown): NormalizedCanvasState {
+  const p = isRecord(input) ? input : {};
+  const nodes = Array.isArray(p.nodes)
+    ? p.nodes
+        .map((raw, index): Node<CardData> | null => {
+          if (!isRecord(raw)) return null;
+          const data = isRecord(raw.data) ? raw.data : {};
+          const type = isCardType(raw.type)
+            ? raw.type
+            : isCardType(data.cardType)
+              ? data.cardType
+              : null;
+          if (!type) return null;
+          const positionRaw = isRecord(raw.position) ? raw.position : {};
+          const styleRaw = isRecord(raw.style) ? raw.style : {};
+          const title =
+            typeof data.title === 'string' && data.title.trim()
+              ? data.title
+              : 'Card';
+          // Issue #385 (codex review #3): node.position が有限値でも極端 (|x|>1M 等)
+          // だと viewport が正常でもカードが viewport 外で見えず実質黒画面になる。
+          // rescue 距離を超える座標は fallback grid に戻して可視性を担保する。
+          const rawX = finiteOr(positionRaw.x, (index % 6) * (NODE_W + 32));
+          const rawY = finiteOr(positionRaw.y, Math.floor(index / 6) * (NODE_H + 32));
+          const safeX =
+            Math.abs(rawX) > VIEWPORT_RESCUE_DISTANCE
+              ? (index % 6) * (NODE_W + 32)
+              : rawX;
+          const safeY =
+            Math.abs(rawY) > VIEWPORT_RESCUE_DISTANCE
+              ? Math.floor(index / 6) * (NODE_H + 32)
+              : rawY;
+          return {
+            ...(raw as Partial<Node<CardData>>),
+            id: typeof raw.id === 'string' && raw.id ? raw.id : newId(type),
+            type,
+            position: { x: safeX, y: safeY },
+            data: {
+              ...data,
+              cardType: type,
+              title,
+              payload: data.payload
+            },
+            style: {
+              ...styleRaw,
+              width: finiteOr(styleRaw.width, NODE_W),
+              height: finiteOr(styleRaw.height, NODE_H)
+            }
+          };
+        })
+        .filter((n): n is Node<CardData> => n !== null)
+    : [];
+  const viewportRaw = isRecord(p.viewport) ? p.viewport : {};
+  let vpX = finiteOr(viewportRaw.x, 0);
+  let vpY = finiteOr(viewportRaw.y, 0);
+  // viewport.zoom は clampZoom 側で NaN→1 / ±Infinity→MAX/MIN を吸収する。
+  // finiteOr で潰すと Infinity が 1 にフォールバックされて clamp 仕様が崩れるので注意。
+  const vpZoom = clampZoom(
+    typeof viewportRaw.zoom === 'number' ? viewportRaw.zoom : 1
+  );
+  // nodes があるのに viewport がカード群から大きく外れていたら、nodes の中心 (= 0,0 周辺の代表点)
+  // へ寄せる。React Flow は座標を pan で表現するので、x/y が ±VIEWPORT_RESCUE_DISTANCE を
+  // 超えていたら現実的な操作で戻れない位置と判定。
+  if (
+    nodes.length > 0 &&
+    (Math.abs(vpX) > VIEWPORT_RESCUE_DISTANCE ||
+      Math.abs(vpY) > VIEWPORT_RESCUE_DISTANCE)
+  ) {
+    vpX = 0;
+    vpY = 0;
+  }
+  const teamLocks = isRecord(p.teamLocks)
+    ? Object.fromEntries(
+        Object.entries(p.teamLocks).filter(([, v]) => typeof v === 'boolean')
+      )
+    : {};
+  const stageView = STAGE_VIEWS.includes(p.stageView as StageView)
+    ? (p.stageView as StageView)
+    : 'stage';
+  const arrangeGap = ((): ArrangeGap => {
+    const gap = p.arrangeGap;
+    return gap === 'tight' || gap === 'normal' || gap === 'roomy'
+      ? gap
+      : 'normal';
+  })();
+  return {
+    nodes,
+    viewport: { x: vpX, y: vpY, zoom: vpZoom },
+    stageView,
+    teamLocks,
+    arrangeGap
+  };
+}
+
+/**
  * Issue #157: 旧 `Date.now() + counter` 方式は zustand persist 復元 + リロード後の
  * counter リセットで稀に衝突しうる。crypto.randomUUID() で衝突確率を実質ゼロに。
  * (Tauri WebView2 / 主要ブラウザでサポート済み。fallback 環境では Math.random ベースで補う)。
@@ -139,6 +265,16 @@ function newId(prefix: string): string {
  *  - 大量 handoff 時の保留 timer 蓄積を抑える
  */
 const pulseTimers = new Map<string, number>();
+
+/** Issue #385: テストから直接 normalize の挙動を検証するための export。
+ *  本体は zustand persist の migrate / merge から間接呼出しされるが、unit test では
+ *  この export を使って壊れた localStorage 入力 / 極端な viewport などの境界条件を確認する。 */
+export const __testables = {
+  normalizeCanvasState,
+  VIEWPORT_MIN_ZOOM,
+  VIEWPORT_MAX_ZOOM,
+  VIEWPORT_RESCUE_DISTANCE
+};
 
 export const useCanvasStore = create<CanvasState>()(
   /**
@@ -302,19 +438,16 @@ export const useCanvasStore = create<CanvasState>()(
     }),
     {
       name: 'vibe-editor:canvas',
-      version: 3,
+      // Issue #385: v4 へ bump し、persisted state は必ず normalizeCanvasState を経由
+      // させる。同 version の rehydrate でも `merge` で再正規化するため、runtime で
+      // 紛れ込んだ NaN viewport / 範囲外 zoom / 壊れた node も次回起動時には掃除される。
+      version: 4,
       migrate: (persisted, fromVersion) => {
         if (!isRecord(persisted)) {
-          return {
-            nodes: [],
-            viewport: { x: 0, y: 0, zoom: 1 },
-            stageView: 'stage',
-            teamLocks: {}
-          } as Partial<CanvasState>;
+          return normalizeCanvasState({}) as Partial<CanvasState>;
         }
+        const p: Record<string, unknown> = { ...persisted };
         // v1 → v2: payload.role を payload.roleProfileId にリネーム
-        // (role と roleProfileId 双方で参照される過渡期があるので、両方残す)
-        const p = { ...persisted } as Record<string, unknown>;
         if (fromVersion < 2 && Array.isArray(p.nodes)) {
           p.nodes = p.nodes.map((n) => {
             if (!isRecord(n)) return n;
@@ -326,11 +459,8 @@ export const useCanvasStore = create<CanvasState>()(
             return { ...n, data: { ...data, payload } };
           });
         }
-
-        // v2 → v3 (Issue #253): 旧 NODE_W/H (480x320) で永続化された小さいカードを
-        // NODE_W/H (640x400) に拡大する。ユーザーが手動でそれより大きくリサイズした
-        // 値は尊重するため、`<= LEGACY_*_THRESHOLD` のときだけ引き上げる。
-        // width/height は style に乗っているため style を直接書き換える。
+        // v2 → v3 (Issue #253): 旧 NODE_W/H (480x320) → 640x400。ユーザーが手動拡大した
+        // 値は尊重するため <= LEGACY_*_THRESHOLD のときだけ引き上げ。
         if (fromVersion < 3 && Array.isArray(p.nodes)) {
           p.nodes = p.nodes.map((n) => {
             if (!isRecord(n)) return n;
@@ -350,64 +480,17 @@ export const useCanvasStore = create<CanvasState>()(
             };
           });
         }
-
-        // 壊れた localStorage で ReactFlow が render 例外を出すと黒画面になるため、
-        // 永続化データはバージョンに関係なく最低限の形へ正規化してから復元する。
-        const nodes = Array.isArray(p.nodes)
-          ? p.nodes
-              .map((raw, index): Node<CardData> | null => {
-                if (!isRecord(raw)) return null;
-                const data = isRecord(raw.data) ? raw.data : {};
-                const type = isCardType(raw.type)
-                  ? raw.type
-                  : isCardType(data.cardType)
-                    ? data.cardType
-                    : null;
-                if (!type) return null;
-                const positionRaw = isRecord(raw.position) ? raw.position : {};
-                const styleRaw = isRecord(raw.style) ? raw.style : {};
-                const title = typeof data.title === 'string' && data.title.trim()
-                  ? data.title
-                  : 'Card';
-                return {
-                  ...(raw as Partial<Node<CardData>>),
-                  id: typeof raw.id === 'string' && raw.id ? raw.id : newId(type),
-                  type,
-                  position: {
-                    x: finiteOr(positionRaw.x, (index % 6) * (NODE_W + 32)),
-                    y: finiteOr(positionRaw.y, Math.floor(index / 6) * (NODE_H + 32))
-                  },
-                  data: {
-                    ...data,
-                    cardType: type,
-                    title,
-                    payload: data.payload
-                  },
-                  style: {
-                    ...styleRaw,
-                    width: finiteOr(styleRaw.width, NODE_W),
-                    height: finiteOr(styleRaw.height, NODE_H)
-                  }
-                };
-              })
-              .filter((n): n is Node<CardData> => n !== null)
-          : [];
-        const viewportRaw = isRecord(p.viewport) ? p.viewport : {};
-        return {
-          ...p,
-          nodes,
-          viewport: {
-            x: finiteOr(viewportRaw.x, 0),
-            y: finiteOr(viewportRaw.y, 0),
-            zoom: finiteOr(viewportRaw.zoom, 1)
-          },
-          stageView: STAGE_VIEWS.includes(p.stageView as StageView)
-            ? (p.stageView as StageView)
-            : 'stage',
-          teamLocks: isRecord(p.teamLocks) ? p.teamLocks : {}
-        } as Partial<CanvasState>;
+        // v3 → v4 (Issue #385): 構造変換は不要 (normalize で吸収する)。
+        return normalizeCanvasState(p) as Partial<CanvasState>;
       },
-      // 永続化: nodes / viewport / stageView / teamLocks。
+      // Issue #385: 同 version でも rehydrate のたびに normalize を走らせる。
+      // 旧実装は migrate 経由の正規化だけだったため、現バージョンで保存された
+      // 不正値 (極端な viewport 等) を起動時に拾えず、Canvas 真っ黒の症状を引き起こしていた。
+      merge: (persisted, current) => {
+        const normalized = normalizeCanvasState(persisted);
+        return { ...current, ...normalized };
+      },
+      // 永続化: nodes / viewport / stageView / teamLocks / arrangeGap。
       // edges は一時的な hand-off アニメに使うので含めない。
       partialize: (s) => ({
         nodes: s.nodes,


### PR DESCRIPTION
## Summary
- Issue #385: Canvas モードを閉じて開き直すと真っ黒になり前回の作業状態が見えない症状を解消
- 旧 zustand persist は migration 時しか正規化していなかったため、runtime に紛れ込んだ NaN viewport / 範囲外 zoom / 壊れた node / 極端な node position が次回起動でもそのまま通って React Flow の render 例外につながっていた
- `normalizeCanvasState()` を抽出して migrate と merge の両方で適用、同 version の rehydrate でも毎回サニタイズが走るようにした

## 主要変更
- `src/renderer/src/stores/canvas.ts`
  - `normalizeCanvasState()` 共通化 (nodes / viewport / stageView / teamLocks / arrangeGap)
  - persist `version: 3 → 4`、`merge` 追加で同 version 復元も再正規化
  - viewport.zoom を [0.1, 4] にクランプ、±Infinity も適切に頭打ち
  - nodes ありで |viewport| > 1M なら 0,0 に rescue
  - **node.position も rescue 距離超なら fallback grid に戻す** (codex 二次レビュー反映)
- `src/renderer/src/layouts/CanvasLayout.tsx`
  - `restoreRecent` で `saved.x` / `saved.y` が NaN / Infinity / undefined なら preset 配置にフォールバック (旧 team-history.json をガード)
- `src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts` (新規 11 ケース)

## Test plan
- [x] `npx vitest run stores/__tests__/` → 20 passed (既存 9 + 新規 11)
- [x] `npm run typecheck` → green
- [x] codex 二次レビュー → node.position の rescue を追加して再対応
- [ ] `npm run dev` で localStorage に壊れた viewport (NaN) を投入後に起動し、黒画面にならずカードが見えること
- [ ] 正常保存された Canvas 配置は過剰な fitView をされず前回状態として復元されること

## スコープ外
- 確認済み状態の永続化 / Recent 保存形式の構造的改修

Closes #385