### PR TITLE
fix(team_hub): #378 delivered と read を分離し 1 回目の team_send を確実に拾えるようにする

### DIFF
--- a/src-tauri/src/team_hub/inject.rs
+++ b/src-tauri/src/team_hub/inject.rs
@@ -196,7 +196,21 @@ pub async fn inject(
     }
     sleep(Duration::from_millis(CHUNK_DELAY_MS)).await;
     let s = session.clone();
-    let _ = tokio::task::spawn_blocking(move || s.write(b"\r")).await;
+    // Issue #378: 最終 Enter (`\r`) の書き込み結果を必ず検証する。
+    // 旧実装は結果を捨てており、本文 paste は成功しても Enter 送信だけ失敗したケースを
+    // delivered と扱ってしまっていた。Leader から見ると「届いたつもり」だが worker は
+    // bracketed paste の入力欄表示のままで confirm されず、再送指示でようやく実行される。
+    match tokio::task::spawn_blocking(move || s.write(b"\r")).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            tracing::warn!("[inject] write(\\r) failed for agent {agent_id}: {e}");
+            return false;
+        }
+        Err(e) => {
+            tracing::warn!("[inject] spawn_blocking(\\r) failed for agent {agent_id}: {e}");
+            return false;
+        }
+    }
     tracing::debug!("[inject] -> agent {agent_id} delivered");
     true
 }

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -387,9 +387,21 @@ pub struct TeamMessage {
     pub timestamp: String,
     pub read_by: Vec<String>,
     /// Issue #342 Phase 3 (3.7 / 3.8): 各 agent_id が `read_by` に追加された ISO8601 時刻。
-    /// `team_read` 戻り値の `receivedAt` と `team_send` 戻り値の `receivedAtPerRecipient`
-    /// で参照される。in-memory only (TeamMessage 自体が永続化対象でないため)。
+    /// `team_read` 戻り値の `receivedAt` で参照される。
+    /// Issue #378 以降、`team_send` の `receivedAtPerRecipient` / `deliveredAtPerRecipient` は
+    /// `delivered_at` を正本とするため、ここから直接参照されることはなくなった。
+    /// in-memory only (TeamMessage 自体が永続化対象でないため)。
     pub read_at: HashMap<String, String>,
+    /// Issue #378: 「PTY への inject (= 配達) が成功した」事実を `read_by` (= 受信側
+    /// agent が認識して `team_read` を呼んだ) と分離して保持する。
+    /// 旧実装は inject 成功で sender に加えて recipient まで `read_by` に追加していたため、
+    /// worker が実際には Enter を確認していない 1 回目の指示を「既読」として扱い、
+    /// `team_read({unread_only: true})` でも 0 件しか返さなかった (= 再送指示までユーザーが
+    /// 異変に気付けない)。delivered_to / delivered_at を別 channel として持ち、`read_by` は
+    /// sender 自己印 + `team_read` 実行のときだけ更新する。
+    /// in-memory only (永続化対象ではないため migration 不要)。
+    pub delivered_to: Vec<String>,
+    pub delivered_at: HashMap<String, String>,
 }
 
 #[derive(Clone)]

--- a/src-tauri/src/team_hub/protocol/tools/read.rs
+++ b/src-tauri/src/team_hub/protocol/tools/read.rs
@@ -36,24 +36,34 @@ pub async fn team_read(
         if !(is_for_me && from_someone_else) {
             continue;
         }
+        // Issue #378: unread 判定は `read_by` のみを SSOT とする。`delivered_to` は
+        // 「PTY に届いた」事実だけを示し、worker が認識/処理したことの証拠ではないため、
+        // unread fallback の対象から外してはならない (= 1 回目の指示を確実に拾えるように)。
         if unread_only && m.read_by.contains(&ctx.agent_id) {
             continue;
         }
         if !m.read_by.contains(&ctx.agent_id) {
             m.read_by.push(ctx.agent_id.clone());
         }
-        // Issue #342 Phase 3 (3.8): 自分が読んだ時刻を記録 (既に inject 経由で値が入って
-        // いれば後勝ちで上書きせず保持する。最初の "received" 時刻を尊重するため)。
+        // Issue #342 Phase 3 (3.8): 自分が読んだ時刻を記録。
+        // 旧実装では inject 成功で read_at に値が入ることがあり、それを尊重する optional 設計
+        // だった。Issue #378 で inject 成功は delivered_at に分離したので、read_at は本当に
+        // 「team_read 経由で読んだ瞬間」を指す。互換のため or_insert は残す
+        // (sender 自身の send 時刻が初期値として入っているケースを潰さないため)。
         m.read_at
             .entry(ctx.agent_id.clone())
             .or_insert_with(|| now_iso.clone());
         let received_at = m.read_at.get(&ctx.agent_id).cloned();
+        // Issue #378: delivered_at を payload に含めることで、UI / 診断側が
+        // 「配達済みだが未読」と「読了」を区別できるようにする。
+        let delivered_at = m.delivered_at.get(&ctx.agent_id).cloned();
         out.push(json!({
             "id": m.id,
             "from": m.from,
             "message": m.message,
             "timestamp": m.timestamp,
             "receivedAt": received_at,
+            "deliveredAt": delivered_at,
         }));
     }
     let count = out.len();
@@ -64,4 +74,86 @@ pub async fn team_read(
         .or_default();
     reader_diag.last_seen_at = Some(now_iso);
     Ok(json!({ "messages": out, "count": count }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pty::SessionRegistry;
+    use crate::team_hub::{TeamHub, TeamInfo, TeamMessage};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    /// Issue #378: PTY inject (= delivered) は成功したが worker が認識していない 1 回目の
+    /// メッセージを `team_read({unread_only: true})` で必ず取得できることを確認する。
+    /// 旧実装は inject 成功で recipient を read_by に追加していたため、unread fallback で
+    /// 0 件になり、worker が「再送」を要求するまで Leader 側からは異常を検知できなかった。
+    #[tokio::test]
+    async fn unread_only_returns_delivered_but_not_yet_read_message() {
+        let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+        let team_id = "team-test".to_string();
+        let leader_aid = "leader-1".to_string();
+        let worker_aid = "worker-1".to_string();
+
+        {
+            let mut state = hub.state.lock().await;
+            let team = state.teams.entry(team_id.clone()).or_insert_with(TeamInfo::default);
+            // Leader → Worker への 1 通: delivered_to に worker、read_by には sender 自身のみ
+            let mut delivered_at = HashMap::new();
+            delivered_at.insert(worker_aid.clone(), "2026-05-02T12:00:00Z".to_string());
+            team.messages.push_back(TeamMessage {
+                id: 1,
+                from: "leader".into(),
+                from_agent_id: leader_aid.clone(),
+                to: "worker".into(),
+                resolved_recipient_ids: vec![worker_aid.clone()],
+                message: "first instruction".into(),
+                timestamp: "2026-05-02T12:00:00Z".into(),
+                read_by: vec![leader_aid.clone()],
+                read_at: HashMap::from([(leader_aid.clone(), "2026-05-02T12:00:00Z".into())]),
+                delivered_to: vec![worker_aid.clone()],
+                delivered_at: delivered_at.clone(),
+            });
+        }
+
+        let ctx = CallContext {
+            team_id: team_id.clone(),
+            role: "worker".into(),
+            agent_id: worker_aid.clone(),
+        };
+        let res = team_read(&hub, &ctx, &json!({ "unread_only": true }))
+            .await
+            .expect("team_read ok");
+        let messages = res
+            .get("messages")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(messages.len(), 1, "1 件目の指示が unread として取得できるべき");
+        let m = &messages[0];
+        assert_eq!(m["id"].as_u64(), Some(1));
+        assert_eq!(m["from"].as_str(), Some("leader"));
+        assert_eq!(
+            m["deliveredAt"].as_str(),
+            Some("2026-05-02T12:00:00Z"),
+            "deliveredAt が payload に含まれるべき"
+        );
+
+        // 2 回目を呼ぶと既読印が付いて 0 件になる
+        let res2 = team_read(&hub, &ctx, &json!({ "unread_only": true }))
+            .await
+            .expect("team_read ok");
+        assert_eq!(
+            res2.get("count").and_then(|v| v.as_u64()),
+            Some(0),
+            "team_read 2 回目は unread が空であるべき"
+        );
+
+        // 既読印が message.read_by に worker_aid を追加していること
+        let state = hub.state.lock().await;
+        let team = state.teams.get(&team_id).unwrap();
+        let m = team.messages.iter().find(|m| m.id == 1).unwrap();
+        assert!(m.read_by.contains(&worker_aid));
+        assert!(m.read_at.contains_key(&worker_aid));
+    }
 }

--- a/src-tauri/src/team_hub/protocol/tools/send.rs
+++ b/src-tauri/src/team_hub/protocol/tools/send.rs
@@ -115,8 +115,13 @@ pub async fn team_send(
         resolved_recipient_ids: resolved_recipient_ids.clone(),
         message: message.to_string(),
         timestamp: timestamp.clone(),
+        // Issue #378: sender 自身は送信時点で既読扱いを継続。recipient は inject が成功
+        // しても自動で read_by に入れない (= worker が `team_read` を実行する経路でしか
+        // 既読印が付かない) ことで、未確認指示を unread fallback で再取得できるようにする。
         read_by: vec![ctx.agent_id.clone()],
         read_at: initial_read_at,
+        delivered_to: Vec::new(),
+        delivered_at: HashMap::new(),
     });
     // Issue #107 / #216: 上限超過分は古い順に破棄してメモリ青天井を防ぐ。
     // VecDeque::pop_front() で O(1) eviction にする。
@@ -175,10 +180,12 @@ pub async fn team_send(
         });
     }
 
-    // Issue #342 Phase 3 (3.7): 受領時刻を recipient agent_id ごとに追跡。
-    // 全 target は最初 None で初期化し、inject 成功した瞬間に Some(now) を入れる。
-    // 未配信 (inject 失敗) の target はそのまま None で戻り値に乗る。
-    let mut received_at_per_recipient: HashMap<String, Option<String>> = targets
+    // Issue #342 Phase 3 (3.7) / Issue #378:
+    // - `delivered_at_per_recipient` は inject (= PTY 配達) が成功した瞬間の timestamp を持つ。
+    //   旧 `receivedAtPerRecipient` は意味的に「PTY に届いた」≒「読まれた」を混同させていたため、
+    //   Issue #378 では `deliveredAtPerRecipient` を新設して payload の正本にする。
+    //   `receivedAtPerRecipient` は legacy alias として同じ値を残し、外部 UI / 解析ツールの後方互換を保つ。
+    let mut delivered_at_per_recipient: HashMap<String, Option<String>> = targets
         .iter()
         .map(|(aid, _)| (aid.clone(), None))
         .collect();
@@ -193,15 +200,23 @@ pub async fn team_send(
             } else {
                 target_role.clone()
             });
-            let received_at = Utc::now().to_rfc3339();
-            received_at_per_recipient.insert(target_aid.clone(), Some(received_at.clone()));
-            // read_by / read_at に追加 + 受信側 diagnostics 更新
+            let delivered_at = Utc::now().to_rfc3339();
+            delivered_at_per_recipient
+                .insert(target_aid.clone(), Some(delivered_at.clone()));
+            // Issue #378: read_by/read_at は触らない。delivered_to/delivered_at だけを更新する。
+            // (旧実装は inject 成功で recipient まで read_by に入れていたため、worker が実際に
+            //  Enter を確認していない 1 回目の指示も「既読」扱いになり、`team_read({unread_only: true})`
+            //  fallback で再取得できなかった。delivered/read を分離することで、worker が処理した
+            //  ことの真の証拠 (= team_read 呼び出し) でしか read_by に印が付かなくなる。)
             {
                 let mut state = hub.state.lock().await;
                 if let Some(t) = state.teams.get_mut(&ctx.team_id) {
                     if let Some(m) = t.messages.iter_mut().find(|m| m.id == msg_id) {
-                        m.read_by.push(target_aid.clone());
-                        m.read_at.insert(target_aid.clone(), received_at.clone());
+                        if !m.delivered_to.iter().any(|id| id == &target_aid) {
+                            m.delivered_to.push(target_aid.clone());
+                        }
+                        m.delivered_at
+                            .insert(target_aid.clone(), delivered_at.clone());
                     }
                 }
                 // Issue #342 Phase 3 (3.3): 受信側 diagnostics 更新
@@ -209,8 +224,8 @@ pub async fn team_send(
                     .member_diagnostics
                     .entry(target_aid.clone())
                     .or_default();
-                recipient_diag.last_message_in_at = Some(received_at.clone());
-                recipient_diag.last_seen_at = Some(received_at.clone());
+                recipient_diag.last_message_in_at = Some(delivered_at.clone());
+                recipient_diag.last_seen_at = Some(delivered_at.clone());
                 recipient_diag.messages_in_count =
                     recipient_diag.messages_in_count.saturating_add(1);
             }
@@ -262,6 +277,11 @@ pub async fn team_send(
         "delivered": delivered,
         "note": note,
         "sentAt": timestamp,
-        "receivedAtPerRecipient": received_at_per_recipient,
+        // Issue #378: delivered と read を分離した正本フィールド。inject (= PTY 配達) 成功時刻だけを持つ。
+        "deliveredAtPerRecipient": delivered_at_per_recipient,
+        // legacy alias: 旧 UI / 診断ツールが `receivedAtPerRecipient` を読むため同値を残す。
+        // 名前が「受信して読まれた時刻」を連想させやすいが、現行は `deliveredAtPerRecipient` と同義
+        // (= inject 成功時刻)。読了印は `team_read` が呼ばれた瞬間に message.read_at に書かれる別経路。
+        "receivedAtPerRecipient": delivered_at_per_recipient,
     }))
 }


### PR DESCRIPTION
## Summary
- Issue #378: Leader → Worker への 1 回目の `team_send` が worker 側で認識されず、ユーザーが「再送」を明示するまで通らない症状を解消
- 旧実装は `inject` 成功で recipient を `read_by` に追加していたため `team_read({unread_only: true})` で fallback 取得できず、worker が処理し忘れた指示が静かに消えていた
- `delivered_to / delivered_at` を `read_by / read_at` から分離し、PTY 配達成功と worker 認識を別 channel で扱う

## 主要変更
- `src-tauri/src/team_hub/inject.rs` — 最終 `\r` 書き込み結果を必ず検証、失敗で `false` を返す
- `src-tauri/src/team_hub/mod.rs` — `TeamMessage` に `delivered_to` / `delivered_at` 追加 (in-memory only)
- `src-tauri/src/team_hub/protocol/tools/send.rs`
  - inject 成功で `delivered_to` / `delivered_at` を更新 (旧 `read_by` 追加経路は削除)
  - 戻り値 payload に **新キー `deliveredAtPerRecipient`** を正本として追加。`receivedAtPerRecipient` は同値の legacy alias として後方互換維持
- `src-tauri/src/team_hub/protocol/tools/read.rs`
  - unread 判定は `read_by` のみ参照 (worker が `team_read` を呼んだ瞬間だけが既読印)
  - payload に `deliveredAt` を追加し UI / 診断側で「配達済みだが未読」「読了」を区別可能に
- `read.rs` に `#[tokio::test]` を追加: delivered_to=worker / read_by=leader のみで `team_read(unread_only: true)` → 1 件取得、deliveredAt 含有、再呼出しで 0 件 + read_by 印確認

## codex 二次レビュー
- Critical / Major なし
- Minor 指摘 (doc コメントが旧仕様を参照) は反映済み

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml team_hub` → 20 passed (新規 1 件含む)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --all-targets` → green
- [x] `npm run typecheck` → green
- [ ] `npm run dev` で Canvas モードに leader / worker を起動し、leader から worker への 1 回目の team_send が再送なしで認識されることを目視確認
- [ ] worker が `team_read({unread_only: true})` を呼ぶと delivered 済みかつ未確認のメッセージが取れること、2 回目で 0 件になること

## スコープ外
- LLM からの明示 ack protocol 新設
- Canvas hand-off edge の表示時間調整 (#379 で扱う)
- `team_recruit` の handshake 再設計

Closes #378