### PR TITLE
feat(settings): #422 ステータスバーのキャラクターを設定から選択可能にする

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -94,6 +94,7 @@ export function App(): JSX.Element {
     language: useSettingsValue('language'),
     theme: useSettingsValue('theme'),
     density: useSettingsValue('density'),
+    statusMascotVariant: useSettingsValue('statusMascotVariant'),
     hasCompletedOnboarding: useSettingsValue('hasCompletedOnboarding'),
     mcpAutoSetup: useSettingsValue('mcpAutoSetup')
   };

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -11,6 +11,7 @@ import { useSettingsKeydown } from '../lib/hooks/use-settings-keydown';
 import { useSettingsNav } from '../lib/hooks/use-settings-nav';
 import { LanguageSection } from './settings/LanguageSection';
 import { ThemeSection } from './settings/ThemeSection';
+import { MascotSection } from './settings/MascotSection';
 import { FontFamilySection } from './settings/FontFamilySection';
 import { TerminalSection } from './settings/TerminalSection';
 import { RoleProfilesSection } from './settings/RoleProfilesSection';
@@ -220,7 +221,12 @@ export function SettingsModal({
           </>
         );
       case 'appearance':
-        return <ThemeSection draft={draft} update={update} />;
+        return (
+          <>
+            <ThemeSection draft={draft} update={update} />
+            <MascotSection draft={draft} update={update} />
+          </>
+        );
       case 'fonts':
         return (
           <>

--- a/src/renderer/src/components/settings/MascotSection.tsx
+++ b/src/renderer/src/components/settings/MascotSection.tsx
@@ -1,0 +1,43 @@
+import { DEFAULT_SETTINGS, type AppSettings } from '../../../../types/shared';
+import { STATUS_MASCOT_OPTIONS } from '../../lib/settings-options';
+import { StatusMascot } from '../shell/StatusMascot';
+import type { UpdateSetting } from './types';
+
+interface Props {
+  draft: AppSettings;
+  update: UpdateSetting;
+}
+
+export function MascotSection({ draft, update }: Props): JSX.Element {
+  const isJa = draft.language === 'ja';
+  const selected = draft.statusMascotVariant ?? DEFAULT_SETTINGS.statusMascotVariant;
+
+  return (
+    <section className="modal__section">
+      <h3>{isJa ? 'キャラクター' : 'Character'}</h3>
+      <div className="mascot-grid">
+        {STATUS_MASCOT_OPTIONS.map((opt) => (
+          <label
+            key={opt.value}
+            className={`mascot-card ${selected === opt.value ? 'is-selected' : ''}`}
+          >
+            <input
+              type="radio"
+              name="statusMascotVariant"
+              value={opt.value}
+              checked={selected === opt.value}
+              onChange={() => update('statusMascotVariant', opt.value)}
+            />
+            <span className="mascot-card__preview" aria-hidden="true">
+              <StatusMascot state="idle" label={opt.label} variant={opt.value} />
+            </span>
+            <span className="mascot-card__meta">
+              <strong>{opt.label}</strong>
+              <span>{isJa ? opt.descJa : opt.descEn}</span>
+            </span>
+          </label>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/renderer/src/components/shell/StatusBar.tsx
+++ b/src/renderer/src/components/shell/StatusBar.tsx
@@ -45,7 +45,11 @@ export function StatusBar({
     <div className="status" role="contentinfo">
       <span className="status__item status__item--mode">
         <span className="status__mascot-track">
-          <StatusMascot state={mascotState} label={t(`status.mascot.${mascotState}`)} />
+          <StatusMascot
+            state={mascotState}
+            label={t(`status.mascot.${mascotState}`)}
+            variant={settings.statusMascotVariant ?? 'vibe'}
+          />
         </span>
         <span className="status__mode-label">{viewMode === 'canvas' ? 'canvas' : 'ide'}</span>
       </span>

--- a/src/renderer/src/components/shell/StatusMascot.tsx
+++ b/src/renderer/src/components/shell/StatusMascot.tsx
@@ -1,18 +1,25 @@
+import type { StatusMascotVariant } from '../../../../types/shared';
 import type { StatusMascotState } from '../../lib/status-mascot';
 
 interface StatusMascotProps {
   state: StatusMascotState;
   label: string;
+  variant?: StatusMascotVariant;
 }
 
-export function StatusMascot({ state, label }: StatusMascotProps): JSX.Element {
+export function StatusMascot({
+  state,
+  label,
+  variant = 'vibe'
+}: StatusMascotProps): JSX.Element {
   return (
     <span
-      className={`status-mascot status-mascot--${state}`}
+      className={`status-mascot status-mascot--${state} status-mascot--variant-${variant}`}
       role="img"
       aria-label={label}
       title={label}
       data-state={state}
+      data-variant={variant}
     >
       <span className="status-mascot__motion" aria-hidden="true">
         <span className="status-mascot__viewport">
@@ -24,12 +31,12 @@ export function StatusMascot({ state, label }: StatusMascotProps): JSX.Element {
             focusable="false"
             shapeRendering="crispEdges"
           >
-            <MascotFrame x={0} />
-            <MascotFrame x={16} tool="pencil" arm="up" />
-            <MascotFrame x={32} tool="paper" sparkle />
-            <MascotFrame x={48} arm="run" legs="run" sparkle />
-            <MascotFrame x={64} tool="lens" arm="up" />
-            <MascotFrame x={80} alert legs="flat" />
+            <MascotFrame x={0} variant={variant} />
+            <MascotFrame x={16} variant={variant} tool="pencil" arm="up" />
+            <MascotFrame x={32} variant={variant} tool="paper" sparkle />
+            <MascotFrame x={48} variant={variant} arm="run" legs="run" sparkle />
+            <MascotFrame x={64} variant={variant} tool="lens" arm="up" />
+            <MascotFrame x={80} variant={variant} alert legs="flat" />
           </svg>
         </span>
       </span>
@@ -41,6 +48,7 @@ type Tool = 'pencil' | 'paper' | 'lens';
 
 interface MascotFrameProps {
   x: number;
+  variant: StatusMascotVariant;
   tool?: Tool;
   arm?: 'up' | 'run';
   legs?: 'run' | 'flat';
@@ -50,6 +58,7 @@ interface MascotFrameProps {
 
 function MascotFrame({
   x,
+  variant,
   tool,
   arm,
   legs,
@@ -71,14 +80,39 @@ function MascotFrame({
         </>
       ) : null}
 
-      <rect className={bodyClass} x="7" y="3" width="3" height="1" />
-      <rect className={bodyClass} x="6" y="4" width="5" height="1" />
-      <rect className={bodyClass} x="5" y="5" width="7" height="1" />
-      <rect className={bodyClass} x="4" y="6" width="9" height="1" />
-      <rect className={bodyClass} x="5" y="7" width="7" height="1" />
-      <rect className={bodyClass} x="6" y="8" width="5" height="2" />
-      <rect className={bodyClass} x="7" y="10" width="3" height="1" />
-      <rect className="status-mascot__body-shade" x="6" y="9" width="5" height="1" />
+      {variant === 'mono' ? (
+        <>
+          <rect className={bodyClass} x="4" y="3" width="9" height="8" />
+          <rect className="status-mascot__panel" x="5" y="4" width="7" height="4" />
+          <rect className="status-mascot__body-shade" x="5" y="9" width="7" height="1" />
+          <rect className="status-mascot__antenna" x="8" y="1" width="1" height="2" />
+          <rect className="status-mascot__antenna" x="7" y="0" width="3" height="1" />
+        </>
+      ) : variant === 'spark' ? (
+        <>
+          <rect className="status-mascot__antenna" x="8" y="1" width="1" height="1" />
+          <rect className={bodyClass} x="7" y="2" width="3" height="1" />
+          <rect className={bodyClass} x="5" y="3" width="7" height="1" />
+          <rect className={bodyClass} x="4" y="4" width="9" height="1" />
+          <rect className={bodyClass} x="3" y="5" width="11" height="2" />
+          <rect className={bodyClass} x="4" y="7" width="9" height="1" />
+          <rect className={bodyClass} x="5" y="8" width="7" height="1" />
+          <rect className={bodyClass} x="6" y="9" width="5" height="1" />
+          <rect className={bodyClass} x="7" y="10" width="3" height="1" />
+          <rect className="status-mascot__body-shade" x="5" y="8" width="7" height="1" />
+        </>
+      ) : (
+        <>
+          <rect className={bodyClass} x="7" y="3" width="3" height="1" />
+          <rect className={bodyClass} x="6" y="4" width="5" height="1" />
+          <rect className={bodyClass} x="5" y="5" width="7" height="1" />
+          <rect className={bodyClass} x="4" y="6" width="9" height="1" />
+          <rect className={bodyClass} x="5" y="7" width="7" height="1" />
+          <rect className={bodyClass} x="6" y="8" width="5" height="2" />
+          <rect className={bodyClass} x="7" y="10" width="3" height="1" />
+          <rect className="status-mascot__body-shade" x="6" y="9" width="5" height="1" />
+        </>
+      )}
 
       {tool === 'lens' ? (
         <>
@@ -86,6 +120,18 @@ function MascotFrame({
           <rect className="status-mascot__review" x="9" y="5" width="2" height="1" />
           <rect className="status-mascot__eye" x="8" y="6" width="1" height="1" />
           <rect className="status-mascot__eye" x="11" y="7" width="1" height="1" />
+        </>
+      ) : variant === 'mono' ? (
+        <>
+          <rect className="status-mascot__eye" x="6" y="5" width="1" height="1" />
+          <rect className="status-mascot__eye" x="10" y="5" width="1" height="1" />
+          <rect className="status-mascot__shine" x="7" y="7" width="3" height="1" />
+        </>
+      ) : variant === 'spark' ? (
+        <>
+          <rect className="status-mascot__eye" x="6" y="5" width="2" height="1" />
+          <rect className="status-mascot__eye" x="10" y="5" width="2" height="1" />
+          <rect className="status-mascot__shine" x="8" y="7" width="2" height="1" />
         </>
       ) : (
         <>

--- a/src/renderer/src/lib/__tests__/settings-migrate.test.ts
+++ b/src/renderer/src/lib/__tests__/settings-migrate.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { APP_SETTINGS_SCHEMA_VERSION } from '../../../../types/shared';
+import { migrateSettings } from '../settings-migrate';
+
+describe('migrateSettings', () => {
+  it('adds the default status mascot variant for older settings', () => {
+    const migrated = migrateSettings({
+      schemaVersion: 8,
+      language: 'ja',
+      theme: 'claude-dark'
+    });
+
+    expect(migrated.schemaVersion).toBe(APP_SETTINGS_SCHEMA_VERSION);
+    expect(migrated.statusMascotVariant).toBe('vibe');
+  });
+
+  it('keeps a valid status mascot variant', () => {
+    const migrated = migrateSettings({
+      schemaVersion: APP_SETTINGS_SCHEMA_VERSION,
+      language: 'ja',
+      theme: 'claude-dark',
+      statusMascotVariant: 'mono'
+    });
+
+    expect(migrated.statusMascotVariant).toBe('mono');
+  });
+
+  it('replaces an invalid status mascot variant with the default', () => {
+    const migrated = migrateSettings({
+      schemaVersion: APP_SETTINGS_SCHEMA_VERSION,
+      language: 'ja',
+      theme: 'claude-dark',
+      statusMascotVariant: 'unknown'
+    });
+
+    expect(migrated.statusMascotVariant).toBe('vibe');
+  });
+});

--- a/src/renderer/src/lib/settings-migrate.ts
+++ b/src/renderer/src/lib/settings-migrate.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_SETTINGS,
   type AppSettings,
   type Language,
+  type StatusMascotVariant,
   type ThemeName
 } from '../../../types/shared';
 
@@ -159,6 +160,15 @@ export function migrateSettings(raw: unknown): AppSettings {
     if (data.terminalFontFamily === OLD_TERMINAL_FONT_DEFAULT_V7) {
       data.terminalFontFamily = DEFAULT_SETTINGS.terminalFontFamily;
     }
+  }
+
+  // --- Version 8 → 9: ステータスバー mascot の選択設定を追加 (Issue #422) ---
+  const validMascots: StatusMascotVariant[] = ['vibe', 'spark', 'mono'];
+  if (
+    version < 9 ||
+    !validMascots.includes(data.statusMascotVariant as StatusMascotVariant)
+  ) {
+    data.statusMascotVariant = DEFAULT_SETTINGS.statusMascotVariant;
   }
 
   data.schemaVersion = APP_SETTINGS_SCHEMA_VERSION;

--- a/src/renderer/src/lib/settings-options.ts
+++ b/src/renderer/src/lib/settings-options.ts
@@ -1,4 +1,4 @@
-import type { Density, ThemeName } from '../../../types/shared';
+import type { Density, StatusMascotVariant, ThemeName } from '../../../types/shared';
 
 export const THEME_OPTIONS: { value: ThemeName; label: string; desc: string }[] = [
   {
@@ -15,6 +15,32 @@ export const THEME_OPTIONS: { value: ThemeName; label: string; desc: string }[] 
   { value: 'midnight', label: 'Midnight', desc: '深い青紫ベース、紫アクセント' },
   { value: 'glass', label: 'Glass', desc: 'すりガラス風 — 半透明パネル + ブラー' },
   { value: 'light', label: 'Light', desc: '明るい背景、暗い文字' }
+];
+
+export const STATUS_MASCOT_OPTIONS: {
+  value: StatusMascotVariant;
+  label: string;
+  descJa: string;
+  descEn: string;
+}[] = [
+  {
+    value: 'vibe',
+    label: 'Vibe',
+    descJa: '既定の小さな相棒',
+    descEn: 'Default tiny companion'
+  },
+  {
+    value: 'spark',
+    label: 'Spark',
+    descJa: '明るめで軽い印象',
+    descEn: 'Brighter and lighter'
+  },
+  {
+    value: 'mono',
+    label: 'Mono',
+    descJa: '端末になじむ角ばった見た目',
+    descEn: 'A terminal-friendly angular look'
+  }
 ];
 
 /* ★ = アプリに同梱 (variable webfont)。OS 未インストールでも常に同じルックで描画される。 */

--- a/src/renderer/src/lib/settings-section-meta.tsx
+++ b/src/renderer/src/lib/settings-section-meta.tsx
@@ -53,7 +53,7 @@ export function iconFor(id: SectionId): JSX.Element {
 export type FixedLabelEntry = { label: string; title: string; desc: string };
 export const FIXED_LABELS_JA: Record<string, FixedLabelEntry> = {
   general: { label: '一般', title: '一般', desc: '言語と密度設定' },
-  appearance: { label: '表示', title: '表示', desc: 'テーマと配色' },
+  appearance: { label: '表示', title: '表示', desc: 'テーマ、配色、キャラクター' },
   fonts: { label: 'フォント', title: 'フォント', desc: 'UI / エディタ / ターミナルのフォント' },
   claude: { label: 'Claude Code', title: 'Claude Code', desc: '起動コマンドと引数' },
   codex: { label: 'Codex', title: 'Codex', desc: '起動コマンドと引数' },
@@ -63,7 +63,7 @@ export const FIXED_LABELS_JA: Record<string, FixedLabelEntry> = {
 };
 export const FIXED_LABELS_EN: Record<string, FixedLabelEntry> = {
   general: { label: 'General', title: 'General', desc: 'Language and density' },
-  appearance: { label: 'Appearance', title: 'Appearance', desc: 'Theme and surfaces' },
+  appearance: { label: 'Appearance', title: 'Appearance', desc: 'Theme, surfaces, and character' },
   fonts: { label: 'Fonts', title: 'Typography', desc: 'UI / editor / terminal fonts' },
   claude: { label: 'Claude Code', title: 'Claude Code', desc: 'Launch command and args' },
   codex: { label: 'Codex', title: 'Codex', desc: 'Launch command and args' },

--- a/src/renderer/src/styles/components/modal.css
+++ b/src/renderer/src/styles/components/modal.css
@@ -610,7 +610,8 @@
 
 .modal--settings .modal__theme-grid,
 .modal--settings .lang-grid,
-.modal--settings .density-grid {
+.modal--settings .density-grid,
+.modal--settings .mascot-grid {
   gap: 10px;
 }
 
@@ -625,7 +626,8 @@
  */
 .modal--settings .theme-card,
 .modal--settings .lang-card,
-.modal--settings .density-card {
+.modal--settings .density-card,
+.modal--settings .mascot-card {
   position: relative;
   padding: 12px 14px;
   border: 1px solid var(--border);
@@ -644,7 +646,8 @@
 @media (hover: hover) {
   .modal--settings .theme-card:hover,
   .modal--settings .lang-card:hover,
-  .modal--settings .density-card:hover {
+  .modal--settings .density-card:hover,
+  .modal--settings .mascot-card:hover {
     background: var(--bg-elev);
     border-color: var(--border-strong);
     transform: translateY(-1px);
@@ -661,14 +664,16 @@
    tap 後の sticky transform を確実にリセットする保険として役立つ。 */
 .modal--settings .theme-card:active,
 .modal--settings .lang-card:active,
-.modal--settings .density-card:active {
+.modal--settings .density-card:active,
+.modal--settings .mascot-card:active {
   transform: translateY(0);
   box-shadow: none;
 }
 
 .modal--settings .theme-card.is-selected,
 .modal--settings .lang-card.is-selected,
-.modal--settings .density-card.is-selected {
+.modal--settings .density-card.is-selected,
+.modal--settings .mascot-card.is-selected {
   /* 選択は「ほんの少し明るい背景 + やや強い境界」だけで示し、
      accent はカード右上の dot にのみ用いる */
   background: var(--bg-elev);
@@ -679,7 +684,8 @@
 /* 選択カード右上の accent dot (アクセント色を 1 ヶ所に集約) */
 .modal--settings .theme-card.is-selected::after,
 .modal--settings .lang-card.is-selected::after,
-.modal--settings .density-card.is-selected::after {
+.modal--settings .density-card.is-selected::after,
+.modal--settings .mascot-card.is-selected::after {
   content: '';
   position: absolute;
   top: 10px;
@@ -694,15 +700,61 @@
 /* タイポグラフィ階層: ラベル (主表記) を 1px 強く、補足はより dim に。
    モーダル内のカード共通 (lang / density) で揃える */
 .modal--settings .lang-card strong,
-.modal--settings .density-card strong {
+.modal--settings .density-card strong,
+.modal--settings .mascot-card__meta strong {
   font-weight: 600;
   letter-spacing: -0.005em;
 }
 
 .modal--settings .lang-card span,
-.modal--settings .density-card span {
+.modal--settings .density-card span,
+.modal--settings .mascot-card__meta span {
   color: var(--text-mute);
   opacity: 0.85;
+}
+
+.modal--settings .mascot-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.modal--settings .mascot-card {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+}
+
+.modal--settings .mascot-card input[type='radio'] {
+  display: none;
+}
+
+.modal--settings .mascot-card__preview {
+  --mascot-size: 32px;
+  --mascot-track-width: 32px;
+  --mascot-run-distance: 0px;
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  position: relative;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--bg-sidebar) 74%, transparent);
+  border: 1px solid var(--border);
+}
+
+.modal--settings .mascot-card__preview .status-mascot {
+  position: relative;
+  left: auto;
+  top: auto;
+}
+
+.modal--settings .mascot-card__meta {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
 /* 「適用して保存」ボタン: 押下時の ✓ フィードバック幅をチラつかせない */

--- a/src/renderer/src/styles/components/shell.css
+++ b/src/renderer/src/styles/components/shell.css
@@ -622,6 +622,20 @@
   top: 0;
   z-index: 1;
 }
+.status-mascot--variant-spark {
+  --mascot-body: var(--success);
+  --mascot-body-shade: color-mix(in srgb, var(--success) 68%, var(--bg-sidebar));
+  --mascot-eye: color-mix(in srgb, var(--bg-sidebar) 84%, black);
+  --mascot-shine: color-mix(in srgb, var(--warning) 75%, white);
+  --mascot-tool: var(--accent);
+}
+.status-mascot--variant-mono {
+  --mascot-body: color-mix(in srgb, var(--text-dim) 78%, var(--bg-panel));
+  --mascot-body-shade: color-mix(in srgb, var(--border-strong) 72%, var(--bg-panel));
+  --mascot-eye: var(--accent);
+  --mascot-shine: color-mix(in srgb, var(--accent) 72%, var(--text));
+  --mascot-tool: var(--claude-accent-blue, #3886e5);
+}
 .status-mascot--idle {
   --mascot-offset: 0px;
 }
@@ -681,6 +695,12 @@
 }
 .status-mascot__body-shade {
   fill: var(--mascot-body-shade);
+}
+.status-mascot__panel {
+  fill: color-mix(in srgb, var(--bg-sidebar) 84%, black);
+}
+.status-mascot__antenna {
+  fill: var(--mascot-tool);
 }
 .status-mascot__eye {
   fill: var(--mascot-eye);

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -12,8 +12,10 @@ export type Density = 'compact' | 'normal' | 'comfortable';
 
 export type Language = 'ja' | 'en';
 
+export type StatusMascotVariant = 'vibe' | 'spark' | 'mono';
+
 /** Issue #75: AppSettings の現在スキーマ。破壊変更時に上げる。 */
-export const APP_SETTINGS_SCHEMA_VERSION = 8;
+export const APP_SETTINGS_SCHEMA_VERSION = 9;
 
 /**
  * ユーザーが自由に追加できるエージェントの設定。
@@ -49,6 +51,8 @@ export interface AppSettings {
   terminalFontFamily?: string;
   terminalFontSize: number;
   density: Density;
+  /** ステータスバー左側に表示するキャラクターの見た目 */
+  statusMascotVariant?: StatusMascotVariant;
   // ---------- Claude Code 起動オプション ----------
   claudeCommand: string;
   claudeArgs: string;
@@ -162,6 +166,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     "'JetBrainsMono Nerd Font Mono', 'JetBrains Mono Variable', 'Cascadia Mono', 'Cascadia Code', Consolas, 'Lucida Console', 'Segoe UI Symbol', monospace",
   terminalFontSize: 13,
   density: 'normal',
+  statusMascotVariant: 'vibe',
   claudeCommand: 'claude',
   claudeArgs: '',
   claudeCwd: '',


### PR DESCRIPTION
## Summary
- Issue #422 対応: ステータスバー左下に表示する mascot を 3 種から選択できるように
- 設定モーダルに `Character` セクション (`MascotSection.tsx`) を追加。プレビュー付きの 3 択 (Vibe / Spark / Mono)
- `AppSettings.statusMascotVariant` を追加し、schema version 8 → 9 にマイグレーション (不正値や旧設定は `vibe` にフォールバック)
- `StatusMascot` / `StatusBar` を variant 対応にリファクタ
- `settings-migrate.test.ts` でマイグレーション挙動を回帰テスト

Closes #422

## Test plan
- [ ] 設定モーダル → Character セクションが表示され、3 択をプレビュー付きで切り替えられる
- [ ] 選択した mascot が StatusBar 左下に即時反映される
- [ ] 設定を保存して再起動後も選択が保持される
- [ ] schema v8 以前の設定 JSON を読ませても `statusMascotVariant: 'vibe'` で起動する
- [ ] 不正値 (例: `"hoge"`) を持つ設定でも default に矯正される