### PR TITLE
chore(release): bump version to 1.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5212,7 +5212,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.4.7"
+version = "1.4.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.4.7"
+version = "1.4.8"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## Summary
v1.4.7 から 39 commits 蓄積した変更をまとめてリリース。`feat:` を含むが既存ユーザー向け patch として 1.4.8 を切る。

3 ファイル (`package.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json`) + `Cargo.lock` を 1.4.7 → 1.4.8 に同期。

## CHANGELOG (v1.4.8)

### ✨ Features (feat)
- ステータスバーのキャラクターを設定から選択可能に (#425, closes #422)
- Canvas: 引き継ぎボタンを統合し Leader 自身が MCP 経由で交代 (#424, closes #423)
- Canvas: 複数組織の同時起動と所属表示を追加 (#412, closes #370)
- Team Hub: 1 チームあたりのメンバー人数上限 (12 名) を撤廃 (#388, closes #386)
- Canvas: ターミナル/エージェントカードを一括整理整頓するボタンを追加 (#374, closes #369)
- vibe-team スキルパッケージを配布用に追加

### 🐛 Bug fixes (fix)
- Canvas: recruit 後の viewport を新規 worker カード中心に寄せる (#418, #372)
- Team Hub: delivered と read を分離し 1 回目の team_send を確実に拾えるよう (#421, #378)
- Canvas: 作業状態復元時に黒画面になる問題を解消 (#420, #385)
- Canvas: zoom 下のターミナル範囲選択座標ずれを解消 (#419, #397)
- UI: 履歴バッジを「総件数」から「未確認件数」表示へ変更 (#417, #387)
- Terminal: worker ターミナル IME stuck を解消する composition gate を追加 (#416, #398)
- Codex: system prompt の二重注入を解消し PTY 注入を fallback に降格 (#414, #413)
- PTY: Codex broker stale state を掃除 (#411)
- Team Hub: ワーカー無応答誤判定を防ぐ ACK / 進捗 / 生存判定ガード追加 (#410, #409)
- バンドル修正: open issues #379 / #368 / #367 の 3 件 (#383)
- Canvas: 引き継ぎ書作成ボタンのフィードバックを強化 (#377, #375)
- UI: 機能の無いヘッダー右上のユーザー初期文字アイコンを削除 (#376, #366)
- Terminal: IDE ターミナル黒画面 (Glass→Dark) を解消 (#371, #365)
- Terminal: IDE モード xterm 黒画面を解消 (#364, #363)

### ♻️ Refactor
- Rust: cargo clippy ベースライン 13 件を機械的に解消 (#415, #381)
- #373 大規模リファクタ (Phase 1-1 〜 Phase 5)
  - Phase 1-1〜1-9: `App.tsx` から hook / utility を順次切り出し (#384, #389-#396)
  - Phase 2: team-hub `protocol.rs` を機能別 module に分割 (#399)
  - Phase 3: `terminal.rs` から race 無関係 helper を sub-module に move (#403)
  - Phase 4-1: `commands/files.rs` を 3 sub-module に分割 (#404)
  - Phase 4-2: `SettingsModal.tsx` を 3 hook/utility に分割 (#405)
  - Phase 4-3: `CanvasLayout.tsx` を 3 hook/utility に分割 (#406)
  - Phase 5: `tauri-api.ts` を 11 領域別 sub-module に分割 (#408)

### 📝 Docs
- #373 引き継ぎ書の事実誤認・整合性指摘を反映 (#401)
- #373 Phase 2 完了時点の引き継ぎ書を更新 (#400)
- #373 clippy ベースラインのカテゴリ集計を修正 (#382)
- #373 Phase 0 ベースライン (smoke checklist + clippy 警告一覧) (#380)

## Test plan
- [ ] CI verify が pass する
- [ ] merge 後に main で `git tag -a v1.4.8` → push し release.yml が発火する
- [ ] tauri-action が Windows/macOS/Linux の全ビルドを完走し Releases draft に成果物が attach される
- [ ] `latest.json` (updater) が attach されている