### PR TITLE
fix(canvas): Team復元時にセッションIDを保持

### DIFF
--- a/src/renderer/src/components/canvas/CanvasSidebar.tsx
+++ b/src/renderer/src/components/canvas/CanvasSidebar.tsx
@@ -189,6 +189,7 @@ export function CanvasSidebar({
             role: m.role,
             teamId: entry.id,
             agentId,
+            resumeSessionId: m.sessionId ?? null,
             cwd,
             organization: entry.organization
           }

--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -286,6 +286,7 @@ export function CanvasLayout(): JSX.Element {
           role: m.role,
           teamId: entry.id,
           agentId,
+          resumeSessionId: m.sessionId ?? null,
           cwd,
           organization: entry.organization,
           latestHandoff: entry.latestHandoff

--- a/src/renderer/src/lib/__tests__/canvas-layout-helpers.test.ts
+++ b/src/renderer/src/lib/__tests__/canvas-layout-helpers.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergeCanvasMembers,
+  serializeAutoSavePayload
+} from '../canvas-layout-helpers';
+import type { TeamHistoryEntry } from '../../../../types/shared';
+
+function entryWithSession(sessionId: string | null): TeamHistoryEntry {
+  return {
+    id: 'team-1',
+    name: 'Team',
+    projectRoot: 'F:\\vive-editor',
+    createdAt: '2026-05-03T00:00:00.000Z',
+    lastUsedAt: '2026-05-03T00:00:00.000Z',
+    members: [{ role: 'leader', agent: 'claude', sessionId }]
+  };
+}
+
+describe('canvas-layout-helpers', () => {
+  it('Canvas payload の新しい sessionId を Team 履歴メンバーへ反映する', () => {
+    const members = mergeCanvasMembers(
+      [{ role: 'leader', agent: 'claude', sessionId: 'new-session' }],
+      entryWithSession('old-session')
+    );
+
+    expect(members).toEqual([
+      { role: 'leader', agent: 'claude', sessionId: 'new-session' }
+    ]);
+  });
+
+  it('Canvas payload に sessionId が無いときは既存履歴の sessionId を保持する', () => {
+    const members = mergeCanvasMembers(
+      [{ role: 'leader', agent: 'claude', sessionId: null }],
+      entryWithSession('old-session')
+    );
+
+    expect(members).toEqual([
+      { role: 'leader', agent: 'claude', sessionId: 'old-session' }
+    ]);
+  });
+
+  it('sessionId の変更だけでも auto-save key が変わる', () => {
+    const makeKey = (sessionId: string | null): string =>
+      serializeAutoSavePayload({
+        byTeam: new Map([
+          [
+            'team-1',
+            {
+              name: 'Team',
+              members: [{ role: 'leader', agent: 'claude', sessionId }],
+              canvasNodes: [{ agentId: 'leader-0-team-1', x: 0, y: 0 }]
+            }
+          ]
+        ]),
+        viewport: { x: 0, y: 0, zoom: 1 }
+      });
+
+    expect(makeKey('session-a')).not.toBe(makeKey('session-b'));
+  });
+});

--- a/src/renderer/src/lib/canvas-layout-helpers.ts
+++ b/src/renderer/src/lib/canvas-layout-helpers.ts
@@ -37,7 +37,7 @@ export function formatOrganizationAgentCount(
 }
 
 export function mergeCanvasMembers(
-  currentMembers: { role: TeamRole; agent: TerminalAgent }[],
+  currentMembers: { role: TeamRole; agent: TerminalAgent; sessionId?: string | null }[],
   existingEntry?: TeamHistoryEntry
 ): TeamHistoryEntry['members'] {
   const sessionQueues = new Map<string, Array<string | null>>();
@@ -51,8 +51,9 @@ export function mergeCanvasMembers(
   return currentMembers.map((member) => {
     const key = `${member.role}:${member.agent}`;
     const queue = sessionQueues.get(key);
-    const sessionId = queue && queue.length > 0 ? queue.shift() ?? null : null;
-    return { ...member, sessionId };
+    const existingSessionId = queue && queue.length > 0 ? queue.shift() ?? null : null;
+    const sessionId = member.sessionId ?? existingSessionId;
+    return { role: member.role, agent: member.agent, sessionId };
   });
 }
 
@@ -62,6 +63,7 @@ export function serializeAutoSavePayload(payload: {
     {
       name: string;
       organization?: TeamOrganizationMeta;
+      members?: { role: TeamRole; agent: TerminalAgent; sessionId?: string | null }[];
       canvasNodes: { agentId: string; x: number; y: number; width?: number; height?: number }[];
       latestHandoff?: HandoffReference;
     }
@@ -73,6 +75,10 @@ export function serializeAutoSavePayload(payload: {
     parts.push(
       `${teamId}|${info.name}|` +
         `org:${info.organization?.id ?? ''}:${info.organization?.name ?? ''}:${info.organization?.color ?? ''}|` +
+        `members:${(info.members ?? [])
+          .map((m) => `${m.role}:${m.agent}:${m.sessionId ?? ''}`)
+          .sort()
+          .join(',')}|` +
         info.canvasNodes
           .map((c) => `${c.agentId}@${c.x},${c.y}:${c.width}x${c.height}`)
           .sort()

--- a/src/renderer/src/lib/hooks/use-canvas-auto-save.ts
+++ b/src/renderer/src/lib/hooks/use-canvas-auto-save.ts
@@ -60,7 +60,7 @@ export function useCanvasAutoSave(opts: UseCanvasAutoSaveOptions): void {
     interface TeamEntryInfo {
       name: string;
       organization?: TeamOrganizationMeta;
-      members: { role: TeamRole; agent: TerminalAgent }[];
+      members: { role: TeamRole; agent: TerminalAgent; sessionId?: string | null }[];
       canvasNodes: { agentId: string; x: number; y: number; width?: number; height?: number }[];
       latestHandoff?: HandoffReference;
     }
@@ -74,6 +74,7 @@ export function useCanvasAutoSave(opts: UseCanvasAutoSaveOptions): void {
         agent?: string;
         organization?: TeamOrganizationMeta;
         latestHandoff?: HandoffReference;
+        resumeSessionId?: string | null;
       };
       if (!p.teamId || !p.agentId) continue;
       const title = String(n.data?.title ?? 'Team');
@@ -86,7 +87,8 @@ export function useCanvasAutoSave(opts: UseCanvasAutoSaveOptions): void {
       if (!entry.organization && p.organization) entry.organization = p.organization;
       entry.members.push({
         role: (p.roleProfileId ?? p.role ?? 'leader') as TeamRole,
-        agent: (p.agent ?? 'claude') as TerminalAgent
+        agent: (p.agent ?? 'claude') as TerminalAgent,
+        sessionId: typeof p.resumeSessionId === 'string' ? p.resumeSessionId : null
       });
       entry.canvasNodes.push({
         agentId: p.agentId,


### PR DESCRIPTION
## Summary
- Canvas Team 自動保存でカード payload の `resumeSessionId` を Team 履歴メンバーへ反映
- Recent Teams / Canvas Sidebar から復元するとき、保存済み `sessionId` を `resumeSessionId` としてカードへ戻す
- sessionId 変更だけでも auto-save が走ることをユニットテストで固定

Closes #427

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/renderer/src/lib/__tests__/canvas-layout-helpers.test.ts`
- [x] `npx vitest run src/renderer/src/stores/__tests__/canvas-migrate.test.ts src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts src/renderer/src/stores/__tests__/canvas-subscribe.test.ts src/renderer/src/lib/__tests__/canvas-layout-helpers.test.ts`
- [x] `npm test`