### PR TITLE
fix(terminal): IDE初期ターミナルのフォント計測を安定化

### DIFF
--- a/src/renderer/src/lib/__tests__/use-pty-session-fonts.test.tsx
+++ b/src/renderer/src/lib/__tests__/use-pty-session-fonts.test.tsx
@@ -1,0 +1,149 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MutableRefObject } from 'react';
+import type { Terminal } from '@xterm/xterm';
+import type { FitAddon } from '@xterm/addon-fit';
+import { usePtySession } from '../use-pty-session';
+import type { PtySessionCallbacks, PtySpawnSnapshot } from '../use-pty-session';
+
+type TestWindow = Window &
+  typeof globalThis & {
+    api?: unknown;
+  };
+
+type TestTerminal = Terminal & {
+  textarea: HTMLTextAreaElement;
+};
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeRef<T>(current: T): MutableRefObject<T> {
+  return { current };
+}
+
+function makeTerminal(cols = 80, rows = 24): TestTerminal {
+  const term = {
+    cols,
+    rows,
+    textarea: document.createElement('textarea'),
+    write: vi.fn(),
+    writeln: vi.fn(),
+    resize: vi.fn((nextCols: number, nextRows: number) => {
+      term.cols = nextCols;
+      term.rows = nextRows;
+    }),
+    refresh: vi.fn(),
+    onData: vi.fn(() => ({ dispose: vi.fn() }))
+  } as unknown as TestTerminal;
+  return term;
+}
+
+describe('usePtySession font readiness', () => {
+  let originalApi: unknown;
+  let originalFontsDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalApi = (window as TestWindow).api;
+    originalFontsDescriptor = Object.getOwnPropertyDescriptor(document, 'fonts');
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    if (originalApi === undefined) {
+      delete (window as TestWindow).api;
+    } else {
+      (window as TestWindow).api = originalApi;
+    }
+    if (originalFontsDescriptor) {
+      Object.defineProperty(document, 'fonts', originalFontsDescriptor);
+    } else {
+      delete (document as Document & { fonts?: unknown }).fonts;
+    }
+  });
+
+  it('waits for document.fonts.ready before IDE-mode initial fit and terminal create', async () => {
+    const fontsReady = deferred();
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: { ready: fontsReady.promise } as Partial<FontFaceSet>
+    });
+
+    const term = makeTerminal();
+    const fit = {
+      fit: vi.fn(() => {
+        term.cols = 120;
+        term.rows = 36;
+      })
+    } as unknown as FitAddon;
+    const create = vi.fn(async (opts: { id?: string }) => ({
+      ok: true,
+      id: opts.id ?? 'pty-fonts'
+    }));
+
+    (window as TestWindow).api = {
+      terminal: {
+        onDataReady: vi.fn(async () => vi.fn()),
+        onExitReady: vi.fn(async () => vi.fn()),
+        onSessionIdReady: vi.fn(async () => vi.fn()),
+        onData: vi.fn(() => vi.fn()),
+        onExit: vi.fn(() => vi.fn()),
+        onSessionId: vi.fn(() => vi.fn()),
+        create,
+        write: vi.fn(async () => undefined),
+        resize: vi.fn(async () => undefined),
+        kill: vi.fn(async () => undefined)
+      }
+    };
+
+    const lastScheduledRef = makeRef<{ cols: number; rows: number } | null>(null);
+
+    renderHook(() =>
+      usePtySession({
+        cwd: 'C:/workspace',
+        command: 'claude',
+        termRef: makeRef<Terminal | null>(term),
+        fitRef: makeRef<FitAddon | null>(fit),
+        snapRef: makeRef<PtySpawnSnapshot>({}),
+        callbacksRef: makeRef<PtySessionCallbacks>({}),
+        ptyIdRef: makeRef<string | null>(null),
+        disposedRef: makeRef(false),
+        observeChunk: vi.fn(),
+        unscaledFit: false,
+        lastScheduledRef
+      })
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fit.fit).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fontsReady.resolve();
+      await fontsReady.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    expect(fit.fit).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0][0]).toMatchObject({ cols: 120, rows: 36 });
+    expect(lastScheduledRef.current).toEqual({ cols: 120, rows: 36 });
+  });
+});

--- a/src/renderer/src/lib/use-fit-to-container.ts
+++ b/src/renderer/src/lib/use-fit-to-container.ts
@@ -242,9 +242,8 @@ export function useFitToContainer(options: UseFitToContainerOptions): void {
   // Issue #253 sub (M2): webfont (JetBrains Mono Variable 等) のロード前に
   // measureCellSize が走ると system monospace のメトリクスを返すため、初回 spawn の
   // cellW がずれた grid で PTY が立つ。document.fonts.ready で全 webfont ロード完了を
-  // 待ち、unscaled モードなら 1 回だけ refit を発火して正しい寸法に上書きする。
+  // 待ち、Canvas / IDE のどちらでも 1 回だけ refit を発火して正しい寸法に上書きする。
   useEffect(() => {
-    if (!unscaledFit) return;
     if (typeof document === 'undefined' || !document.fonts) return;
     let cancelled = false;
     document.fonts.ready

--- a/src/renderer/src/lib/use-pty-session.ts
+++ b/src/renderer/src/lib/use-pty-session.ts
@@ -270,18 +270,24 @@ export function usePtySession(options: UsePtySessionOptions): void {
       return c[skey]?.generation === myGeneration;
     };
 
+    const seedLastScheduledSize = (cols: number, rows: number): void => {
+      const sharedRef = lastScheduledRefRef.current;
+      if (sharedRef) {
+        sharedRef.current = { cols, rows };
+      }
+    };
+
     // === Helper 1: loadInitialMetrics ===
     // Issue #253 review (W#1 + #3 + #4): web font (JetBrains Mono Variable 等) ロード前に
     // measureCellSize が走ると system monospace のメトリクスを返し、誤った cellW で
-    // PTY が立つ。Canvas モードでは fonts.ready を待ってから測ることで、Codex の
-    // banner も初回描画から正しい寸法で描画される。IDE モードでは fit.fit() が DOM
-    // メトリクスベースなので待つ必要なし。
+    // PTY が立つ。Canvas / IDE のどちらでも fonts.ready を待ってから測ることで、Codex の
+    // banner も初回描画から正しい寸法で描画される。
     // タイムアウト 300ms: コールドキャッシュ / 低速 I/O 環境で fonts.ready が秒オーダー
     // で resolve しないとき spawn が体感遅延する問題を回避。300ms 経過時は fallback
     // メトリクスで spawn し、後続の useFitToContainer の fonts.ready effect が ready 後
     // 1 回だけ refit を発火して補正するので、一瞬だけずれた表示も自動回復する。
     const loadInitialMetrics = async (): Promise<void> => {
-      if (unscaledFitRef.current && typeof document !== 'undefined' && document.fonts) {
+      if (typeof document !== 'undefined' && document.fonts) {
         let timedOut = false;
         try {
           await Promise.race([
@@ -329,16 +335,14 @@ export function usePtySession(options: UsePtySessionOptions): void {
               initialRows = grid.rows;
               // useFitToContainer の lastScheduledRef を seed して、30ms 後 visible-effect
               // の二重 IPC 発火を抑止する。
-              const sharedRef = lastScheduledRefRef.current;
-              if (sharedRef) {
-                sharedRef.current = { cols: grid.cols, rows: grid.rows };
-              }
+              seedLastScheduledSize(grid.cols, grid.rows);
             }
           }
         } else {
           fit?.fit();
           initialCols = term.cols;
           initialRows = term.rows;
+          seedLastScheduledSize(term.cols, term.rows);
         }
       } catch {
         /* 非表示マウント時は失敗してもOK */

--- a/src/renderer/src/lib/use-xterm-instance.ts
+++ b/src/renderer/src/lib/use-xterm-instance.ts
@@ -181,12 +181,15 @@ export function useXtermInstance(
   // マウント時の初期値を ref に退避。初回 Terminal 生成に使う。
   // 以後のフォント/テーマ変化はリアクティブ effect 側で反映する。
   const initialSettingsRef = useRef(settings);
+  const latestSettingsRef = useRef(settings);
+  latestSettingsRef.current = settings;
 
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
     const initial = initialSettingsRef.current;
+    let fontsReadyCancelled = false;
     const term = new Terminal({
       // ターミナル専用フォントを優先、未設定なら editor フォントに fallback。
       // applySafetyFallbacks (Issue #261 + #349): Canvas モードの DOM renderer で罫線/濃淡が
@@ -226,6 +229,37 @@ export function useXtermInstance(
     const fit = new FitAddon();
     term.loadAddon(fit);
     term.open(container);
+
+    if (typeof document !== 'undefined' && document.fonts) {
+      document.fonts.ready
+        .then(() => {
+          if (fontsReadyCancelled) return;
+          const current = latestSettingsRef.current;
+          term.options.fontFamily = applySafetyFallbacks(
+            current.terminalFontFamily || current.editorFontFamily
+          );
+          term.options.fontSize = current.terminalFontSize;
+          try {
+            webglRef.current?.clearTextureAtlas();
+          } catch {
+            /* WebGL context lost / dispose 済みなら無視 */
+          }
+          requestAnimationFrame(() => {
+            if (fontsReadyCancelled) return;
+            try {
+              if (!disableWebgl) {
+                fit.fit();
+              }
+              term.refresh(0, Math.max(0, term.rows - 1));
+            } catch {
+              /* dispose 直後などの再計測失敗は無視 */
+            }
+          });
+        })
+        .catch(() => {
+          /* fonts.ready は通常 reject しないが、念のため握りつぶす */
+        });
+    }
 
     /*
      * Issue #272 v4: Canvas モード限定で「ホイール → scrollback スクロール」を強制する。
@@ -307,6 +341,7 @@ export function useXtermInstance(
     fitRef.current = fit;
 
     return () => {
+      fontsReadyCancelled = true;
       webglRef.current?.dispose();
       webglRef.current = null;
       if (webglOwned) {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -468,6 +468,48 @@ _(未着手)_
 - `cargo test --manifest-path src-tauri\Cargo.toml team_hub -- --no-capture`: PASS（15 tests）
 - `git diff --check`: PASS
 
+---
+
+## Issue #443 IDEモード初期ターミナル表示修正
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/443
+
+### 計画
+- [x] Issue本文・plannedコメントを確認し、症状が IDE モード初期起動時の xterm/PTY サイズ決定レースであることを整理する。
+- [x] `src/renderer/src/lib/use-pty-session.ts` の `loadInitialMetrics` を確認し、IDE モードでは `document.fonts.ready` を待たずに `fit.fit()` と `terminal_create` が走る現状を確認する。
+- [x] `src/renderer/src/lib/use-fit-to-container.ts` の fonts.ready effect を確認し、`unscaledFit` のときだけ後追い refit する現状を確認する。
+- [x] `src/renderer/src/lib/use-xterm-instance.ts` の font/theme 反映経路を確認し、フォント実体ロード完了イベントでは同値再代入・再計測が走らない現状を確認する。
+- [x] `feature/issue-443` ブランチを作成して作業する。
+- [x] `use-pty-session.ts` で IDE モードも 300ms timeout 付き `document.fonts.ready` 待機後に初期 `fit.fit()` を実行する。
+- [x] `use-fit-to-container.ts` で IDE モードにも fonts.ready 後の 1 回 refit を許可し、初期フォントメトリクスずれを補正する。
+- [x] `use-xterm-instance.ts` で fonts.ready 後に `fontFamily` の同値再代入、必要な `fit()` / `refresh()` / WebGL atlas clear を行い、xterm のセル寸法キャッシュを再測定させる。
+- [x] Canvas モード (`unscaledFit=true`) の transform 対応経路は維持し、IDE 向け変更が Canvas の `computeUnscaledGrid` 経路に混入しないことを確認する。
+- [x] `npm run typecheck`、`npm run build:vite`、`git diff --check` を実行する。
+- [ ] 可能なら `npm run dev` で Tauri を起動し、IDE モード初期ターミナルの重複表示・初期崩れ・ドラッグ選択ずれを確認する。
+
+### Next Steps
+- ユーザー確認後、上記計画に沿って実装へ進む。
+- 実装完了後、このセクションへ「進捗」「検証」「Next Tasks」を追記する。
+
+### 進捗
+- `feature/issue-443` で実装。
+- `use-pty-session.ts` の初期サイズ算出で IDE モードも `document.fonts.ready` を最大 300ms 待つように変更。初期 `fit.fit()` 後の cols/rows を `lastScheduledRef` に seed し、初回 visible refit の重複 resize を抑止。
+- `use-fit-to-container.ts` の fonts.ready 後 refit を IDE モードにも展開。
+- `use-xterm-instance.ts` で fonts.ready 後に最新設定の fontFamily/fontSize を再代入し、WebGL atlas clear、IDE 経路の `fit()`、全行 refresh を行う補正パスを追加。
+- `use-pty-session-fonts.test.tsx` を追加し、IDE モードで fonts.ready 前に `terminal.create` が呼ばれないことと、初期サイズ seed が行われることを検証。
+
+### 検証
+- `npm ci`: PASS
+- `npm run typecheck`: PASS
+- `npx vitest run src/renderer/src/lib/__tests__/use-pty-session-fonts.test.tsx src/renderer/src/lib/__tests__/use-pty-session-hmr.test.ts`: PASS (2 files / 9 tests)
+- `npm run test`: PASS (23 files / 143 tests)。既存の jsdom canvas `getContext` 未実装 stderr は継続発生するが、テストは全件 PASS。
+- `npm run build:vite`: PASS。既存の chunk size / dynamic import warning は継続。
+- `git diff --check`: PASS
+
+### Next Tasks
+- Tauri 実機 (`npm run dev`) で IDE モード初期起動の Claude #1 banner が 1 回のみ、Team 作成後の残りペインも 1 回のみ、ドラッグ選択矩形ずれなしを手動 smoke する。
+- PR 作成後に CodeRabbit と人間レビューを待つ。自動マージは禁止。
+
 ### Next Tasks
 - 手動 smoke で worker -> leader の `team_send` / `team_read({ unread_only: false })` と dismiss -> re-recruit の挙動を確認する
 - PR 作成後に CodeRabbit と人間レビューを待つ


### PR DESCRIPTION
## Summary
- IDE モードの初期 PTY 作成前にも `document.fonts.ready` を最大 300ms 待ち、webfont ロード前の誤った xterm cell 計測を避けます
- fonts.ready 後の refit を IDE モードにも展開し、xterm の fontFamily 再代入・WebGL atlas clear・refresh でセル寸法キャッシュを補正します
- IDE モードで fonts.ready 前に `terminal.create` しないことを回帰テストで固定しました

## Verification
- `npm ci`
- `npm run typecheck`
- `npx vitest run src/renderer/src/lib/__tests__/use-pty-session-fonts.test.tsx src/renderer/src/lib/__tests__/use-pty-session-hmr.test.ts`
- `npm run test` (23 files / 143 tests; existing jsdom canvas getContext stderr remains)
- `npm run build:vite` (existing chunk size / dynamic import warnings remain)
- `git diff --check`

## Manual follow-up
- Tauri 実機 (`npm run dev`) で IDE モード初期起動の Claude #1 banner が 1 回のみ、Team 作成後の残りペインも 1 回のみ、ドラッグ選択矩形ずれなしを smoke してください。

Closes #443