### PR TITLE
fix(theme): #440 Glassテーマの白濁解消・Cyber Neonリブランド

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
         "resizable": true,
         "decorations": false,
         "transparent": true,
-        "backgroundColor": "#171716",
+        "backgroundColor": "#0A0A1A",
         "fullscreen": false
       }
     ],

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -105,7 +105,10 @@ body,
    #367: saturate(140%) は OS Acrylic の light tint を増幅して「白っぽい固定面」の主因
    になっていたため 110% へ下げる。blur も 18px は overblur 気味なので 14px に整える。
    テーマ palette 側 (themes.ts) の surface alpha を 0.38〜0.55 へ下げているため、
-   blur 強度を下げてもデスクトップ背景のぼかしは十分視認できる。 */
+   blur 強度を下げてもデスクトップ背景のぼかしは十分視認できる。
+   #440: ハードコードを CSS 変数参照に統一。tokens.css の `[data-theme='glass']` で
+   blur=12px / saturate=120% / brightness=0.7 を一元管理。brightness で背後の壁紙を
+   暗化し、Windows Terminal Cyber Neon と同じ「黒いすりガラス」感に揃える。 */
 :root[data-theme='glass'] .sidebar,
 :root[data-theme='glass'] .filetree,
 :root[data-theme='glass'] .rail,
@@ -114,8 +117,10 @@ body,
 :root[data-theme='glass'] .canvas-header,
 :root[data-theme='glass'] .main,
 :root[data-theme='glass'] .claude-code-panel {
-  backdrop-filter: blur(14px) saturate(110%);
-  -webkit-backdrop-filter: blur(14px) saturate(110%);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
 }
 
 /* ノイズオーバーレイは glass では控えめに (アクリル質感を邪魔しない) */
@@ -3967,8 +3972,10 @@ body.is-resizing * {
 [data-theme="glass"] .notes-panel,
 [data-theme="glass"] .filetree,
 [data-theme="glass"] .filetree__header {
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
 }
 
 /* glass テーマでは modal-backdrop / cmdp-backdrop の暗幕を弱め、

--- a/src/renderer/src/lib/themes.ts
+++ b/src/renderer/src/lib/themes.ts
@@ -129,42 +129,44 @@ export const THEMES: Record<ThemeName, ThemeVars> = {
   },
   glass: {
     /*
-     * Issue #16 / #367: アクリル風テーマ。OS 側 (Windows Acrylic / macOS vibrancy)
-     * が背後のぼかしを担い、アプリ側はそのブラーを「邪魔しない」最小限の半透明
-     * 黒サーフェスを重ねる。青くせず、claude-dark と同じテラコッタ accent に揃える。
+     * Issue #16 / #367 / #440: アクリル風テーマ (Cyber Neon ベース)。
      *
-     * 「背景がうっすらぼやけて映る」(= ユーザーが Glass に求めた本来の挙動) を
-     * 出すための原則 (#367 で再調整):
-     *   1. 主要 surface のオパシティを **40〜55% に下げる**。旧値 (60〜78%) だと
-     *      パネルが固定面になり、Win11 Acrylic の light-tint と相まって
-     *      「背景に関係なく白っぽい固定面」に見えた (#367 報告)。
-     *   2. 純黒 (0,0,0) ベースで Win11 Acrylic の白 tint を打ち消す方向に倒す。
-     *      旧値の (15,15,15) や (26,26,26) は dark gray で、Acrylic の白 tint と
-     *      混じって「milky」化していた。
-     *   3. 枠線・hover の白成分は引き続き 5% 以下に抑える。
-     *   4. saturate(180%) は tokens.css の `[data-theme='glass']` で 120% に下げ、
-     *      index.css の主要パネル backdrop も 110% まで下げる (#367)。
+     * Windows Terminal "Cyber Neon" と同じ世界観 — ダーク (#0A0A1A) ベース +
+     * ネオンシアン (#00FFFF) アクセント — に揃え、OS Acrylic の light tint で
+     * 白濁する問題を「surface 自体を暗化 + 高 opacity で確保」して解決する。
+     *
+     * 設計原則:
+     *   1. surface 色相は #0A0A1A 系 (ほぼ黒に微かなブルーバイオレット)。
+     *      backdrop-filter: brightness(0.7) と組み合わせて壁紙の白成分を抑える。
+     *   2. opacity は 0.78〜0.85 まで引き上げる。Glass の本質はパネル透過よりも
+     *      OS Acrylic 越しの「動く背景」感なので、surface 自体が薄すぎると逆に
+     *      壁紙が白く透けて milky 化する (#367 / #440)。
+     *   3. accent / border にはネオンシアンを採用。Cyber Neon の "蛍光差し色"
+     *      がないと全体が単調になり、dark surface でもくすんで見えた (#440)。
+     *   4. text は #E0E0FF (ラベンダー白) で「黒下地の上で光る」雰囲気を作る。
+     *   5. blur / saturate / brightness は tokens.css の `[data-theme='glass']`
+     *      で一元管理 (12px / 120% / 0.7)。
      */
     bg: 'rgba(0, 0, 0, 0)',
-    bgPanel: 'rgba(0, 0, 0, 0.45)',
-    bgSidebar: 'rgba(0, 0, 0, 0.42)',
-    bgToolbar: 'rgba(0, 0, 0, 0.38)',
-    bgElev: 'rgba(0, 0, 0, 0.55)',
-    border: 'rgba(255, 255, 255, 0.05)',
-    borderStrong: 'rgba(255, 255, 255, 0.10)',
-    bgHover: 'rgba(255, 255, 255, 0.04)',
-    bgActive: 'rgba(217, 119, 87, 0.18)',
-    accent: '#d97757',
-    accentHover: '#e88a6a',
-    accentSoft: '#d97757',
-    accentTint: 'rgba(217, 119, 87, 0.14)',
-    warning: '#d4a27f',
-    warningHover: '#e0b592',
-    text: '#f6f6f5',
-    textDim: '#c3c2b7',
-    textMute: '#97958c',
-    surfaceGlass: 'rgba(0, 0, 0, 0.40)',
-    focusRing: '0 0 0 3px rgba(217, 119, 87, 0.30)',
+    bgPanel: 'rgba(10, 10, 26, 0.82)',
+    bgSidebar: 'rgba(8, 8, 20, 0.80)',
+    bgToolbar: 'rgba(6, 6, 18, 0.78)',
+    bgElev: 'rgba(20, 20, 40, 0.85)',
+    border: 'rgba(0, 255, 255, 0.08)',
+    borderStrong: 'rgba(0, 255, 255, 0.15)',
+    bgHover: 'rgba(0, 255, 255, 0.06)',
+    bgActive: 'rgba(0, 255, 255, 0.14)',
+    accent: '#00FFFF',
+    accentHover: '#33FFFF',
+    accentSoft: '#00CCCC',
+    accentTint: 'rgba(0, 255, 255, 0.14)',
+    warning: '#FFD700',
+    warningHover: '#FFE033',
+    text: '#E0E0FF',
+    textDim: '#B0B8E0',
+    textMute: '#6070A0',
+    surfaceGlass: 'rgba(10, 10, 26, 0.68)',
+    focusRing: '0 0 0 2px rgba(0, 255, 255, 0.40)',
     monacoTheme: 'vs-dark'
   },
   light: {

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -807,8 +807,10 @@
   align-items: center;
   gap: 4px;
   background: var(--surface-glass, rgba(20, 20, 19, 0.62));
-  backdrop-filter: blur(14px) saturate(160%);
-  -webkit-backdrop-filter: blur(14px) saturate(160%);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
   border: 1px solid var(--border);
   border-radius: 999px;
   padding: 5px;
@@ -861,8 +863,10 @@
   gap: 2px;
   padding: 6px;
   background: var(--surface-glass, rgba(20, 20, 19, 0.86));
-  backdrop-filter: blur(14px) saturate(160%);
-  -webkit-backdrop-filter: blur(14px) saturate(160%);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
   border: 1px solid var(--border);
   border-radius: 12px;
   box-shadow: var(--shadow-md);

--- a/src/renderer/src/styles/components/shell.css
+++ b/src/renderer/src/styles/components/shell.css
@@ -138,8 +138,10 @@
   padding: 0 18px 0 16px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-toolbar);
-  backdrop-filter: blur(14px) saturate(160%);
-  -webkit-backdrop-filter: blur(14px) saturate(160%);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
   position: relative;
   z-index: var(--z-nav);
   -webkit-app-region: drag;

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -275,12 +275,15 @@ samp,
  * - glass-border / glass-highlight も白の主張を抑える (テーマ palette 側の border と
  *   合わせて全体の白浮きを断ち切る)。
  * - blur は OS Acrylic 主導なのでアプリ側は控えめ (12px) で十分。重ね過ぎると milky になる。
+ * - Issue #440: brightness(0.7) で背後の明るい壁紙を暗化し、Cyber Neon ベースの
+ *   「黒いすりガラス」質感を作る。非 Glass テーマでは fallback の 1 が効くため no-op。
  */
 :root[data-theme='glass'] {
   --glass-blur: 12px;
   --glass-saturate: 120%;
-  --glass-border: rgba(255, 255, 255, 0.04);
-  --glass-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  --glass-brightness: 0.7;
+  --glass-border: rgba(0, 255, 255, 0.10);
+  --glass-highlight: inset 0 1px 0 rgba(0, 255, 255, 0.05);
 }
 
 /*
@@ -301,8 +304,14 @@ samp,
  * 場合は親側の overflow と z-index を要確認。
  */
 [data-theme='glass'] .glass-surface {
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+  /* Issue #440: ネオンシアンの微発光で Cyber Neon 世界観の境界を表現 */
+  box-shadow:
+    0 0 1px rgba(0, 255, 255, 0.20),
+    inset 0 0 1px rgba(0, 255, 255, 0.08);
 }
 
 :root[data-theme='light'],


### PR DESCRIPTION
## Summary

Issue #440 の実装計画 (再計画 2026-05-03) に沿って、Glass テーマを Windows Terminal "Cyber Neon" と同じ世界観に揃える。

- `tokens.css` の `[data-theme='glass']` に `--glass-brightness: 0.7` を追加し、`.glass-surface` に Cyber Neon glow (シアンの微発光 box-shadow) を追加
- backdrop-filter のハードコード (`blur(14px) saturate(110%)` / `blur(14px) saturate(160%)`) を全て CSS 変数参照 (`blur(var(--glass-blur)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness, 1))`) に統一
  - `index.css` 117-118 (Glass 専用ホワイトリスト) と 3970-3971 (広域 Glass セレクタ)
  - `canvas.css` 810-811 / 864-865 (`.tc__hud` / `.tc__hud-arrange-pop`)
  - `shell.css` 141-142 (`.topbar`)
- `themes.ts` の `glass` パレットを Cyber Neon ベースに書き換え
  - 背景: `rgba(10, 10, 26, 0.78〜0.85)` (#0A0A1A 系の暗い surface を高 opacity で確保)
  - アクセント: `#00FFFF` (シアン) / hover `#33FFFF` / soft `#00CCCC`
  - 警告: `#FFD700` (ゴールド)
  - テキスト: `#E0E0FF` (ラベンダー白) / dim `#B0B8E0` / mute `#6070A0`
  - border / hover: ネオンシアン低 alpha
- `tauri.conf.json` の `backgroundColor` を `#171716` → `#0A0A1A` に変更し、`transparent: true` 時のフォールバック色を Cyber Neon 系に揃える

## なぜこれで白濁が消えるか

1. **brightness(0.7)** が backdrop-filter チェーンに加わり、Windows Acrylic の light tint で増幅された明るい壁紙画素を全体的に暗化する
2. **surface opacity を 0.78〜0.85 まで引き上げ**、低 opacity で壁紙が milky に透けてしまう問題を断ち切る
3. **surface の色相を #0A0A1A 系へ**振ることで Acrylic の白 tint と合成しても黒寄りに収まる
4. **ハードコード除去** により `tokens.css` の 1 箇所で blur / saturate / brightness を一括チューニング可能になり、二重適用 (`14px` と `12px` の併存) が解消

## 影響範囲

| ファイル | 変更 | リスク |
|---------|------|------|
| `src/renderer/src/styles/tokens.css` | `--glass-brightness` / glow 追加 + glass-border 色変更 | 低 (Glass 限定) |
| `src/renderer/src/index.css` | 2 セレクタブロックを var() に統一 | 低 (Glass 限定セレクタ) |
| `src/renderer/src/styles/components/canvas.css` | HUD / popover の backdrop-filter を var() 化 | 低 (`brightness(var(..., 1))` で非 Glass テーマは no-op) |
| `src/renderer/src/styles/components/shell.css` | `.topbar` の backdrop-filter を var() 化 | 低 (同上) |
| `src/renderer/src/lib/themes.ts` | `glass` パレット全面書き換え | 中 (Glass テーマの色全般が変わる — 意図通り) |
| `src-tauri/tauri.conf.json` | `backgroundColor` を `#0A0A1A` へ | 低 (`transparent: true` のフォールバックのみ) |

## Test plan

- [ ] `npm run typecheck` 通過 (済)
- [ ] Glass テーマに切り替えて、明るい壁紙でも白く濁らないことを目視確認
- [ ] パネル境界線・ボタン focus にネオンシアンのアクセントが見えること
- [ ] `claude-dark` / `claude-light` / `dark` / `midnight` / `light` に切り替えて非 Glass テーマで色崩れ・透過が起きないこと
- [ ] Canvas モードの `.tc__hud` / `.tc__hud-arrange-pop` で backdrop-filter が引き続き効くこと
- [ ] Windows Terminal Cyber Neon と並べて世界観が揃うこと
- [ ] `data-window-effect="native"` (Acrylic 適用成功時) と `"fallback"` (失敗時) の両方で見た目が成立すること

Closes #440