### PR TITLE
fix(theme): #446 Glass canvas/IDEルートにdark tintを適用し白濁を解消

### DIFF
--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -94,11 +94,19 @@ body,
   visibility: hidden;
 }
 
-/* IDE / Canvas いずれのルートも透過。アプリ内の panel/sidebar/toolbar は
-   各自の rgba 背景を持っているので、下地にだけ OS アクリルが滲む。 */
+/* IDE / Canvas いずれのルートにも Cyber Neon ベースの半透明ダーク tint を載せる。
+   #440: 旧実装は `background: transparent` で OS Acrylic がそのまま壁紙を映し、
+   明るい壁紙だと canvas エリア (panel が無い空白) が白〜紫に濁って見えていた。
+   Windows Terminal Cyber Neon と同じ仕組み — dark bg を ~50% opacity で乗せて
+   acrylic の上から色を引き締める — に揃える。同時に brightness(0.7) を当てて
+   壁紙そのものの明るさも一段下げる。 */
 :root[data-theme='glass'] .layout,
 :root[data-theme='glass'] .canvas-layout {
-  background: transparent;
+  background: rgba(10, 10, 26, 0.55);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
 }
 
 /* Glass 時は panel / sidebar / toolbar に backdrop-blur を乗せてアクリル感を強化。


### PR DESCRIPTION
## Summary

#440 の Glass リブランドでは panel/sidebar/toolbar 個別に backdrop-filter brightness(0.7) を当てたが、`.canvas-layout` / `.layout` (各モードのルート) は `background: transparent` のままだった。このため:

- panel が存在する領域 (Sidebar / Topbar / Claude Code Panel 等) → dark tint 適用済み 👍
- **panel が存在しない空白領域 (Canvas モードの主エリア等)** → 親の透過がそのまま見え、OS Acrylic が壁紙をフル輝度で映す → milky 残留

Windows Terminal "Cyber Neon" と同じ手法 (dark bg を ~50% opacity で acrylic に重ねる) を `.canvas-layout` / `.layout` (Glass テーマ時のみ) に適用:

```css
:root[data-theme='glass'] .layout,
:root[data-theme='glass'] .canvas-layout {
  background: rgba(10, 10, 26, 0.55);
  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
    brightness(var(--glass-brightness, 1));
  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
    brightness(var(--glass-brightness, 1));
}
```

## なぜこれで治るか

1. `rgba(10, 10, 26, 0.55)` で navy 系 dark tint を ~55% で acrylic 上に乗せる → 壁紙の色は薄く透けつつも全体が dark に統一される
2. `brightness(0.7)` を canvas-layout の backdrop-filter にも適用 → 壁紙そのものを 70% の明るさまで暗化
3. blur / saturate は #440 と同じ `--glass-blur=12px` / `--glass-saturate=120%` を共有 (二重定義を避け、tokens.css 一元管理を維持)

## 影響範囲

- `src/renderer/src/index.css` 99-110 行のみ (1 ブロック)
- 他テーマには影響なし (`:root[data-theme='glass']` スコープ限定)
- IDE モードでも `.layout` に同じ tint が乗るが、もともと panel で埋まっているのでほぼ視覚的影響なし (整合性目的)

## Test plan

- [x] `npm run dev` で起動し、Glass テーマで Canvas モードに入る → 主エリアが dark navy のすりガラスに見えること (ユーザー確認済み: 「いい感じ」)
- [x] サイドバー / トップバー側の見た目が #445 と同じであること
- [ ] IDE モードに切り替えても極端に暗くなったり違和感が出ないこと
- [ ] `claude-dark` / `dark` / `midnight` / `light` に切り替えて非 Glass テーマで色崩れ・透過が起きないこと
- [ ] `data-window-effect="fallback"` (OS Acrylic 失敗時) でも CSS だけで dark tint が成立すること

Closes #446