### PR TITLE
fix(canvas): #442 プリセット/stagger のカードピッチを実カードサイズに揃え整頓後の重なりを解消

### DIFF
--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -25,6 +25,7 @@ import {
   History
 } from 'lucide-react';
 import type { CardData, CardType } from '../stores/canvas';
+import { NODE_H, NODE_W } from '../stores/canvas';
 import type {
   TeamHistoryEntry,
   TeamOrganizationMeta,
@@ -320,14 +321,16 @@ export function CanvasLayout(): JSX.Element {
   // ほぼ同じ x に積み重なって UI 上「追加されていない」ように見えていた。
   // 既存ノード数 (現在 viewport 内に限らずグローバル) を 6 列グリッドに展開して
   // staggered レイアウトを返す。
-  const stagger = (kind: CardType): { x: number; y: number } => {
+  // Issue #442: 旧実装は agent/terminal を 480+32 / 320+32、その他を 360+32 / 240+32 で
+  // 並べていたが、addCard / addCards は全 type に NODE_W/NODE_H (= 640x400, Issue #253)
+  // を style として付与するため、type 別ピッチは根拠が無くカードが重なっていた。
+  // ピッチを実カードサイズ NODE_W/NODE_H に統一する。
+  const stagger = (_kind: CardType): { x: number; y: number } => {
     const idx = nodes.length; // 全 type 共通の連番でも視覚的に十分散る
     const cols = 6;
-    const wrapTitle = ['agent', 'terminal'].includes(kind) ? 480 + 32 : 360 + 32;
-    const wrapH = ['agent', 'terminal'].includes(kind) ? 320 + 32 : 240 + 32;
     return {
-      x: (idx % cols) * wrapTitle,
-      y: Math.floor(idx / cols) * wrapH
+      x: (idx % cols) * (NODE_W + 32),
+      y: Math.floor(idx / cols) * (NODE_H + 32)
     };
   };
 

--- a/src/renderer/src/lib/__tests__/canvas-arrange.test.ts
+++ b/src/renderer/src/lib/__tests__/canvas-arrange.test.ts
@@ -118,6 +118,24 @@ describe('canvas-arrange / tidyTerminals', () => {
     const out = tidyTerminals(nodes);
     expect(out).toBe(nodes);
   });
+
+  // Issue #442: 整頓後に terminal-like カードが矩形上で重ならないこと。
+  // 隣接セル間の dx は (width + gap) >= NODE_W、dy は (height + gap) >= NODE_H を満たす。
+  it('places terminal-like cards without overlap (Issue #442 regression)', () => {
+    const nodes: Node<CardData>[] = [
+      makeNode('t1', 'terminal', { x: 0, y: 0 }),
+      makeNode('t2', 'terminal', { x: 50, y: 0 }),
+      makeNode('t3', 'terminal', { x: 0, y: 50 }),
+      makeNode('t4', 'terminal', { x: 50, y: 50 })
+    ];
+    const out = tidyTerminals(nodes, { gap: 'normal' });
+    const positions = out.map((n) => n.position).sort((a, b) => a.y - b.y || a.x - b.x);
+    expect(positions[1].x - positions[0].x).toBeGreaterThanOrEqual(NODE_W);
+    expect(positions[2].y - positions[0].y).toBeGreaterThanOrEqual(NODE_H);
+    // gap=normal は 32 なので厳密に NODE_W+32, NODE_H+32 と一致するはず
+    expect(positions[1].x - positions[0].x).toBe(NODE_W + ARRANGE_GAP_PX.normal);
+    expect(positions[2].y - positions[0].y).toBe(NODE_H + ARRANGE_GAP_PX.normal);
+  });
 });
 
 describe('canvas-arrange / unifyTerminalSize', () => {

--- a/src/renderer/src/lib/__tests__/workspace-presets.test.ts
+++ b/src/renderer/src/lib/__tests__/workspace-presets.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest';
 import {
   BUILTIN_PRESETS,
   expandPresetOrganizations,
+  GAP,
   presetMemberCount,
-  presetOrganizationCount
+  presetOrganizationCount,
+  presetPosition
 } from '../workspace-presets';
+import { NODE_H, NODE_W } from '../../stores/canvas';
 
 const t = (key: string): string => key;
 
@@ -38,5 +41,19 @@ describe('workspace presets', () => {
     expect(presetMemberCount(preset!)).toBe(1);
     expect(organizations).toHaveLength(1);
     expect(organizations[0].members[0]?.agent).toBe('codex');
+  });
+
+  // Issue #442: presetPosition のピッチは実カードサイズ NODE_W/NODE_H に追随する。
+  // 旧定数 (CARD_W=480 / CARD_H=340) のままだと 640x400 のカードが重なる。
+  it('presetPosition uses NODE_W/NODE_H pitch (Issue #442)', () => {
+    const a = presetPosition(0, 0);
+    const b = presetPosition(1, 0);
+    const c = presetPosition(0, 1);
+    expect(a).toEqual({ x: 0, y: 0 });
+    expect(b.x - a.x).toBe(NODE_W + GAP);
+    expect(c.y - a.y).toBe(NODE_H + GAP);
+    // 隣接セルの dx は必ず NODE_W 以上 (= カード同士が重ならない)
+    expect(b.x - a.x).toBeGreaterThanOrEqual(NODE_W);
+    expect(c.y - a.y).toBeGreaterThanOrEqual(NODE_H);
   });
 });

--- a/src/renderer/src/lib/workspace-presets.ts
+++ b/src/renderer/src/lib/workspace-presets.ts
@@ -10,6 +10,7 @@
  *   - Leader + HR (claude / codex)
  */
 import type { TeamOrganizationMeta, TeamRole, TerminalAgent } from '../../../types/shared';
+import { NODE_H, NODE_W } from '../stores/canvas';
 
 export interface PresetMember {
   role: TeamRole;
@@ -171,14 +172,15 @@ export const BUILTIN_PRESETS: WorkspacePreset[] = [
 /** 「チーム起動」ボタンのメイン部分が起動する既定プリセット (Leader-only Claude)。 */
 export const DEFAULT_SPAWN_PRESET: WorkspacePreset = BUILTIN_PRESETS[0];
 
-export const CARD_W = 480;
-export const CARD_H = 340;
 export const GAP = 32;
 
+// Issue #442: 実カードサイズ NODE_W/NODE_H (= 640x400, Issue #253) と乖離した
+// 旧定数 (CARD_W=480 / CARD_H=340) で並べていたためカードが重なっていた。
+// プリセット配置は Single Source of Truth として stores/canvas の NODE_W/NODE_H に追随させる。
 export function presetPosition(col: number, row: number): { x: number; y: number } {
   return {
-    x: col * (CARD_W + GAP),
-    y: row * (CARD_H + GAP)
+    x: col * (NODE_W + GAP),
+    y: row * (NODE_H + GAP)
   };
 }
 


### PR DESCRIPTION
Closes #442

## Summary

Canvas モードの「整頓」ボタンを押した直後や、Spawn Team / Add Card で複数のターミナル/エージェントカードを並べたときに **カード同士が重なって表示される** 不具合を修正します。

## Root cause

カードサイズの「真の値」と「並べるピッチで使う値」が乖離していました。

| 場所 | 旧値 | 正しい値 |
|------|------|----------|
| `lib/workspace-presets.ts` `CARD_W/CARD_H` | `480 / 340` | `NODE_W=640 / NODE_H=400` |
| `layouts/CanvasLayout.tsx` `stagger()` | agent/terminal: `480+32 / 320+32`, その他: `360+32 / 240+32` | 全 type 共通: `NODE_W+32 / NODE_H+32` |

実カードサイズは `stores/canvas.ts` の `NODE_W=640 / NODE_H=400` (Issue #253 で 480x320 → 640x400 に拡大) で、`addCard` / `addCards` は **全 type に対して** `style: { width: NODE_W, height: NODE_H }` を付与します。整頓本体 `tidyTerminals` は `NODE_W/NODE_H` を使っているため正しく動作していましたが、整頓後に新規カードを追加すると古いピッチで重ねて配置されるため「整頓してもターミナルが重なる」と見えていました。

## Changes

- `src/renderer/src/lib/workspace-presets.ts`
  - `NODE_W` / `NODE_H` を `stores/canvas` から import (Single Source of Truth)
  - `CARD_W` / `CARD_H` 定数を削除し、`presetPosition` を `NODE_W / NODE_H` ベースに書き換え
- `src/renderer/src/layouts/CanvasLayout.tsx`
  - `stagger()` のピッチを type 別 (`480+32` 等) から全 type 共通 `NODE_W+32 / NODE_H+32` に統一
- `__tests__/canvas-arrange.test.ts`, `__tests__/workspace-presets.test.ts`
  - Issue #442 回帰防止テストを追加 (整頓後の dx >= NODE_W / dy >= NODE_H、`presetPosition` のピッチ追随)

循環依存は無し: `stores/canvas.ts` は `workspace-presets` を import しないことを確認済み。

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npx vitest run src/renderer/src/lib/__tests__/canvas-arrange.test.ts src/renderer/src/lib/__tests__/workspace-presets.test.ts` (12/12 passed)
- [x] 全テスト suite 145/145 passed
- [ ] 実機 (`npm run dev`):
  - Spawn Team の `dual-claude-codex` プリセットでカードが横並びで重ならない
  - Add Card → Claude / Codex / Terminal を 4-5 回連打、6 列グリッドで全カード重ならず散る
  - 整頓ボタン押下後、terminal-like カードが grid 上で接触するが重ならない
  - 整頓直後に Add Card しても新規カードが既存カードと重ならない位置に追加される
  - 整頓ボタン後に既存 PTY セッションが切れない (id / payload 不変)