### PR TITLE
fix(settings): #449 引数の Unicode dash を ASCII '--' に正規化

### DIFF
--- a/src/renderer/src/components/settings/CommandOptionsSection.tsx
+++ b/src/renderer/src/components/settings/CommandOptionsSection.tsx
@@ -38,7 +38,7 @@ export function CommandOptionsSection({
 }: Props): JSX.Element {
   const t = useT();
   // Issue #76: 閉じクォート忘れを検出してユーザーに警告する
-  // Issue #449: 先頭が Unicode dash (U+2013 等) の token も警告する
+  // Issue #449: 先頭が Unicode dash (U+2013 等) の token についても警告する
   const argsParse = parseShellArgsStrict(draft[argsKey] as string);
   const hasParseWarning = argsParse.unterminatedQuote || argsParse.hasUnicodeDash;
   return (

--- a/src/renderer/src/components/settings/CommandOptionsSection.tsx
+++ b/src/renderer/src/components/settings/CommandOptionsSection.tsx
@@ -38,7 +38,9 @@ export function CommandOptionsSection({
 }: Props): JSX.Element {
   const t = useT();
   // Issue #76: 閉じクォート忘れを検出してユーザーに警告する
+  // Issue #449: 先頭が Unicode dash (U+2013 等) の token も警告する
   const argsParse = parseShellArgsStrict(draft[argsKey] as string);
+  const hasParseWarning = argsParse.unterminatedQuote || argsParse.hasUnicodeDash;
   return (
     <section className="modal__section">
       <h3>{title}</h3>
@@ -60,10 +62,13 @@ export function CommandOptionsSection({
           onChange={(e) => update(argsKey, e.target.value)}
           placeholder={argsPlaceholder}
           spellCheck={false}
-          aria-invalid={argsParse.unterminatedQuote}
+          aria-invalid={hasParseWarning}
         />
         {argsParse.unterminatedQuote && (
           <span className="modal__error">{t('settings.argsUnterminatedQuote')}</span>
+        )}
+        {argsParse.hasUnicodeDash && (
+          <span className="modal__error">{t('settings.argsUnicodeDash')}</span>
         )}
       </label>
       {cwdKey && (

--- a/src/renderer/src/components/settings/CustomAgentEditor.tsx
+++ b/src/renderer/src/components/settings/CustomAgentEditor.tsx
@@ -84,10 +84,13 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
           onChange={(e) => patchAgent({ args: e.target.value })}
           placeholder='--model opus --yes'
           spellCheck={false}
-          aria-invalid={argsParse.unterminatedQuote}
+          aria-invalid={argsParse.unterminatedQuote || argsParse.hasUnicodeDash}
         />
         {argsParse.unterminatedQuote && (
           <span className="modal__error">{t('settings.argsUnterminatedQuote')}</span>
+        )}
+        {argsParse.hasUnicodeDash && (
+          <span className="modal__error">{t('settings.argsUnicodeDash')}</span>
         )}
       </label>
 

--- a/src/renderer/src/lib/__tests__/parse-args.test.ts
+++ b/src/renderer/src/lib/__tests__/parse-args.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeLeadingDashes,
+  parseShellArgs,
+  parseShellArgsStrict
+} from '../parse-args';
+
+describe('parseShellArgs', () => {
+  it('splits on whitespace', () => {
+    expect(parseShellArgs('--model opus --add-dir foo')).toEqual([
+      '--model',
+      'opus',
+      '--add-dir',
+      'foo'
+    ]);
+  });
+
+  it('keeps quoted segments with spaces together', () => {
+    expect(parseShellArgs('--add-dir "D:/my projects/foo"')).toEqual([
+      '--add-dir',
+      'D:/my projects/foo'
+    ]);
+  });
+});
+
+describe('parseShellArgs Unicode dash normalization (Issue #449)', () => {
+  it('normalizes a leading EN DASH (U+2013) to "--"', () => {
+    // 入力: 1 文字の en dash + フラグ名 (Codex CLI の autocorrect ケース)
+    expect(parseShellArgs('–dangerously-bypass-approvals-and-sandbox')).toEqual([
+      '--dangerously-bypass-approvals-and-sandbox'
+    ]);
+  });
+
+  it('normalizes a leading EM DASH (U+2014) to "--"', () => {
+    expect(parseShellArgs('—foo')).toEqual(['--foo']);
+  });
+
+  it('collapses a mixed run of Unicode dash + ASCII hyphen at token start', () => {
+    // 例: en dash の直後に ASCII hyphen が混じっていてもまとめて "--" に潰す
+    expect(parseShellArgs('–-foo')).toEqual(['--foo']);
+    expect(parseShellArgs('––foo')).toEqual(['--foo']);
+  });
+
+  it('does not touch ASCII hyphens', () => {
+    expect(parseShellArgs('--foo -x')).toEqual(['--foo', '-x']);
+  });
+
+  it('does not touch Unicode dashes inside the value side', () => {
+    // option 名は ASCII '-' から始まるので、value 側に en dash があってもそのまま
+    expect(parseShellArgs('--foo=a–b')).toEqual(['--foo=a–b']);
+  });
+
+  it('normalizes within multi-token input', () => {
+    expect(parseShellArgs('–model opus ––yes')).toEqual([
+      '--model',
+      'opus',
+      '--yes'
+    ]);
+  });
+});
+
+describe('parseShellArgsStrict', () => {
+  it('reports unterminated quote', () => {
+    const result = parseShellArgsStrict('--foo "bar');
+    expect(result.unterminatedQuote).toBe(true);
+    expect(result.hasUnicodeDash).toBe(false);
+  });
+
+  it('reports hasUnicodeDash when a token starts with a Unicode dash', () => {
+    const result = parseShellArgsStrict('–dangerously-bypass-approvals-and-sandbox');
+    expect(result.hasUnicodeDash).toBe(true);
+    expect(result.args).toEqual(['--dangerously-bypass-approvals-and-sandbox']);
+  });
+
+  it('does not report hasUnicodeDash for ASCII-only input', () => {
+    const result = parseShellArgsStrict('--foo --bar');
+    expect(result.hasUnicodeDash).toBe(false);
+  });
+
+  it('reports both flags when both issues exist', () => {
+    const result = parseShellArgsStrict('–foo "unterminated');
+    expect(result.unterminatedQuote).toBe(true);
+    expect(result.hasUnicodeDash).toBe(true);
+  });
+});
+
+describe('normalizeLeadingDashes', () => {
+  it('returns empty string as-is', () => {
+    expect(normalizeLeadingDashes('')).toBe('');
+  });
+
+  it.each([
+    ['‐foo', '--foo'], // U+2010 HYPHEN
+    ['‑foo', '--foo'], // U+2011 NON-BREAKING HYPHEN
+    ['‒foo', '--foo'], // U+2012 FIGURE DASH
+    ['–foo', '--foo'], // U+2013 EN DASH
+    ['—foo', '--foo'], // U+2014 EM DASH
+    ['―foo', '--foo'], // U+2015 HORIZONTAL BAR
+    ['−foo', '--foo'], // U+2212 MINUS SIGN
+    ['﹘foo', '--foo'], // U+FE58 SMALL EM DASH
+    ['﹣foo', '--foo'], // U+FE63 SMALL HYPHEN-MINUS
+    ['－foo', '--foo'] // U+FF0D FULLWIDTH HYPHEN-MINUS
+  ])('normalizes leading %s to "--"', (input, expected) => {
+    expect(normalizeLeadingDashes(input)).toBe(expected);
+  });
+
+  it('leaves ASCII-leading tokens untouched', () => {
+    expect(normalizeLeadingDashes('--foo')).toBe('--foo');
+    expect(normalizeLeadingDashes('-x')).toBe('-x');
+    expect(normalizeLeadingDashes('foo')).toBe('foo');
+  });
+});

--- a/src/renderer/src/lib/__tests__/settings-migrate.test.ts
+++ b/src/renderer/src/lib/__tests__/settings-migrate.test.ts
@@ -35,4 +35,74 @@ describe('migrateSettings', () => {
 
     expect(migrated.statusMascotVariant).toBe('vibe');
   });
+
+  // ---------- Issue #449: v9 → v10 Unicode dash 正規化 ----------
+  describe('v9 → v10 Unicode dash normalization (Issue #449)', () => {
+    it('normalizes leading Unicode dash in codexArgs to ASCII "--"', () => {
+      const migrated = migrateSettings({
+        schemaVersion: 9,
+        language: 'ja',
+        theme: 'claude-dark',
+        codexArgs: '–dangerously-bypass-approvals-and-sandbox'
+      });
+
+      expect(migrated.codexArgs).toBe('--dangerously-bypass-approvals-and-sandbox');
+      expect(migrated.schemaVersion).toBe(APP_SETTINGS_SCHEMA_VERSION);
+    });
+
+    it('normalizes leading Unicode dash in claudeArgs', () => {
+      const migrated = migrateSettings({
+        schemaVersion: 9,
+        language: 'ja',
+        theme: 'claude-dark',
+        claudeArgs: '–model opus'
+      });
+
+      expect(migrated.claudeArgs).toBe('--model opus');
+    });
+
+    it('normalizes Unicode dash in customAgents[].args', () => {
+      const migrated = migrateSettings({
+        schemaVersion: 9,
+        language: 'ja',
+        theme: 'claude-dark',
+        customAgents: [
+          {
+            id: 'aider',
+            name: 'Aider',
+            command: 'aider',
+            args: '–model opus ––yes'
+          }
+        ]
+      });
+
+      expect(migrated.customAgents?.[0]?.args).toBe('--model opus --yes');
+    });
+
+    it('leaves ASCII-only args strings unchanged', () => {
+      const migrated = migrateSettings({
+        schemaVersion: 9,
+        language: 'ja',
+        theme: 'claude-dark',
+        claudeArgs: '--foo bar',
+        codexArgs: '--baz'
+      });
+
+      expect(migrated.claudeArgs).toBe('--foo bar');
+      expect(migrated.codexArgs).toBe('--baz');
+    });
+
+    it('does not run normalization when schemaVersion is already 10', () => {
+      // v10 以降の設定では migration は走らないため、Unicode dash を含んでいても
+      // そのまま保持される (ユーザーが UI で自分で直す or runtime parseShellArgs が救済する)
+      const migrated = migrateSettings({
+        schemaVersion: 10,
+        language: 'ja',
+        theme: 'claude-dark',
+        codexArgs: '–foo'
+      });
+
+      expect(migrated.codexArgs).toBe('–foo');
+    });
+  });
 });

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -444,6 +444,8 @@ const ja: Dict = {
   // ---------- Settings 補助 (Issue #76) ----------
   'settings.command': 'コマンド',
   'settings.argsUnterminatedQuote': 'ダブルクォート (") が閉じていません。引数が誤って解釈される可能性があります。',
+  'settings.argsUnicodeDash':
+    'Unicode ダッシュ (–, — など) が含まれています。実行時に ASCII の "--" に自動変換します。コピペや IME の自動変換が原因の可能性があります。',
 
   // ---------- Custom agents ----------
   'settings.customAgents.title': 'カスタムエージェント',
@@ -970,6 +972,8 @@ const en: Dict = {
   'settings.command': 'Command',
   'settings.argsUnterminatedQuote':
     'Unterminated double quote (") — arguments may be parsed incorrectly.',
+  'settings.argsUnicodeDash':
+    'Contains Unicode dashes (–, — etc.) — they will be normalized to ASCII "--" at runtime. Likely caused by paste or IME autocorrect.',
 
   // ---------- Custom agents ----------
   'settings.customAgents.title': 'Custom agents',

--- a/src/renderer/src/lib/parse-args.ts
+++ b/src/renderer/src/lib/parse-args.ts
@@ -12,26 +12,53 @@
  * Issue #76: 閉じクォートが無いまま入力が終わった場合、従来は silent に残りを
  * 1 つの token として詰め込んでいた。ユーザーの typo を検知できないため、
  * `parseShellArgsStrict` を別途公開し、settings 保存フローから呼び出せるようにする。
+ *
+ * Issue #449: 入力ソース (IME / コピペ / ハイフン自動補正) によっては U+2013 (en dash)
+ * 等の Unicode ダッシュが option token 先頭に混入する。Codex CLI / Claude CLI はこれを
+ * option として解釈しないため、`--dangerously-bypass-approvals-and-sandbox` のような
+ * 重要フラグが silent に無視され、ワーカー多重起動時に承認ダイアログが連発する。
+ * `parseShellArgs` では token 先頭の Unicode ダッシュを ASCII '-' に正規化して救済し、
+ * `parseShellArgsStrict` では正規化前の混入を warning として呼び出し側に通知する。
  */
 export function parseShellArgs(input: string): string[] {
-  return parseShellArgsInternal(input).args;
+  return parseShellArgsInternal(input).args.map(normalizeLeadingDashes);
 }
 
 /**
- * Issue #76: 閉じクォート忘れを error として返すバージョン。
- * 呼び出し側で UI 警告を出すのに使う。
+ * Issue #76 / #449: 閉じクォート忘れと Unicode dash 混入を呼び出し側に伝えるバージョン。
+ * UI で警告を出すのに使う。
  */
 export interface ParseShellArgsResult {
   args: string[];
   /** クォートが閉じずに入力が終わった場合 true */
   unterminatedQuote: boolean;
+  /**
+   * Issue #449: 先頭が Unicode ダッシュ (U+2013 / U+2014 / U+2212 等) の token が
+   * 1 つでもあった場合 true。`args` 自体は ASCII '-' に正規化済みなので、UI 警告だけ
+   * を出して値はそのまま使ってもらう想定。
+   */
+  hasUnicodeDash: boolean;
 }
 
 export function parseShellArgsStrict(input: string): ParseShellArgsResult {
-  return parseShellArgsInternal(input);
+  const internal = parseShellArgsInternal(input);
+  let hasUnicodeDash = false;
+  const normalized = internal.args.map((arg) => {
+    const next = normalizeLeadingDashes(arg);
+    if (next !== arg) hasUnicodeDash = true;
+    return next;
+  });
+  return {
+    args: normalized,
+    unterminatedQuote: internal.unterminatedQuote,
+    hasUnicodeDash
+  };
 }
 
-function parseShellArgsInternal(input: string): ParseShellArgsResult {
+function parseShellArgsInternal(input: string): {
+  args: string[];
+  unterminatedQuote: boolean;
+} {
   const args: string[] = [];
   let current = '';
   let inQuotes = false;
@@ -57,4 +84,34 @@ function parseShellArgsInternal(input: string): ParseShellArgsResult {
   }
   if (hasCurrent) args.push(current);
   return { args, unterminatedQuote: inQuotes };
+}
+
+/**
+ * Issue #449: token 先頭の Unicode dash 系文字を ASCII '--' (long option prefix) に置換する。
+ *
+ * 対象 Unicode ダッシュ (各種スマートクォート/全角):
+ *   - U+2010 HYPHEN          "‐"
+ *   - U+2011 NON-BREAKING H. "‑"
+ *   - U+2012 FIGURE DASH     "‒"
+ *   - U+2013 EN DASH         "–"
+ *   - U+2014 EM DASH         "—"
+ *   - U+2015 HORIZONTAL BAR  "―"
+ *   - U+2212 MINUS SIGN      "−"
+ *   - U+FE58 SMALL EM DASH   "﹘"
+ *   - U+FE63 SMALL HYPHEN-M. "﹣"
+ *   - U+FF0D FULLWIDTH HYP.  "－"
+ *
+ * macOS / iOS / MS Word の autocorrect は `--` を `–` (en dash) に変換するため、
+ * Unicode dash で始まる token は元々 `--` (long option) を意図していたケースがほぼ全て。
+ * カウント数に関係なく一律 `--` に正規化することで `--dangerously-bypass-approvals-and-sandbox`
+ * のような flag を救済する。短縮形 `-x` は Unicode dash に化けないので影響しない。
+ *
+ * `--foo=–value` のように option の value 側に Unicode dash が含まれていても、token 先頭
+ * (= ASCII '-' で始まる) には触らないので影響しない。
+ */
+const UNICODE_DASH_RE = /^[‐‑‒–—―−﹘﹣－][‐‑‒–—―−﹘﹣－\-]*/;
+
+export function normalizeLeadingDashes(token: string): string {
+  if (!token) return token;
+  return token.replace(UNICODE_DASH_RE, () => '--');
 }

--- a/src/renderer/src/lib/settings-migrate.ts
+++ b/src/renderer/src/lib/settings-migrate.ts
@@ -14,17 +14,37 @@
 import {
   APP_SETTINGS_SCHEMA_VERSION,
   DEFAULT_SETTINGS,
+  type AgentConfig,
   type AppSettings,
   type Language,
   type StatusMascotVariant,
   type ThemeName
 } from '../../../types/shared';
+import { parseShellArgsStrict } from './parse-args';
 
 type Raw = Record<string, unknown>;
 
 function isObject(v: unknown): v is Raw {
   return v !== null && typeof v === 'object' && !Array.isArray(v);
 }
+
+/**
+ * Issue #449: 引数文字列をパースして再構築することで、各 token 先頭の Unicode dash を
+ * ASCII '-' に正規化する。空白を含む値は再構築時に `"..."` で囲み直す。
+ *
+ * 注意: 既に ASCII hyphen のみの入力では parseShellArgs が冪等に文字列を返す保証は無く、
+ * 引用符の扱いが微妙に変わるため、Unicode dash を含むときだけ書き換える。
+ */
+function normalizeArgsString(raw: string): string {
+  if (!UNICODE_DASH_PROBE.test(raw)) return raw;
+  const tokens = parseShellArgsStrict(raw).args;
+  return tokens
+    .map((token) => (/[\s"]/.test(token) ? `"${token.replace(/"/g, '\\"')}"` : token))
+    .join(' ');
+}
+
+/** ASCII 比較で Unicode dash 系が含まれるかだけを高速チェックする (parse-args の正本パターンと同期) */
+const UNICODE_DASH_PROBE = /[‐‑‒–—―−﹘﹣－]/;
 
 export function migrateSettings(raw: unknown): AppSettings {
   if (!isObject(raw)) {
@@ -169,6 +189,29 @@ export function migrateSettings(raw: unknown): AppSettings {
     !validMascots.includes(data.statusMascotVariant as StatusMascotVariant)
   ) {
     data.statusMascotVariant = DEFAULT_SETTINGS.statusMascotVariant;
+  }
+
+  // --- Version 9 → 10: claudeArgs / codexArgs / customAgents[].args の Unicode dash 正規化 (Issue #449) ---
+  // U+2013 (en dash) などで保存された option (例: `–dangerously-bypass-approvals-and-sandbox`)
+  // を ASCII '-' に置き換える。Codex / Claude CLI は Unicode dash を option として解釈しないため、
+  // Codex worker でフラグが silent に無視され承認ダイアログが連発する原因になっていた。
+  if (version < 10) {
+    if (typeof data.claudeArgs === 'string') {
+      data.claudeArgs = normalizeArgsString(data.claudeArgs);
+    }
+    if (typeof data.codexArgs === 'string') {
+      data.codexArgs = normalizeArgsString(data.codexArgs);
+    }
+    if (Array.isArray(data.customAgents)) {
+      data.customAgents = (data.customAgents as unknown[]).map((entry) => {
+        if (!isObject(entry)) return entry;
+        const agent = entry as unknown as AgentConfig;
+        if (typeof agent.args === 'string') {
+          return { ...agent, args: normalizeArgsString(agent.args) };
+        }
+        return agent;
+      });
+    }
   }
 
   data.schemaVersion = APP_SETTINGS_SCHEMA_VERSION;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -14,8 +14,12 @@ export type Language = 'ja' | 'en';
 
 export type StatusMascotVariant = 'vibe' | 'spark' | 'mono';
 
-/** Issue #75: AppSettings の現在スキーマ。破壊変更時に上げる。 */
-export const APP_SETTINGS_SCHEMA_VERSION = 9;
+/**
+ * Issue #75: AppSettings の現在スキーマ。
+ * Issue #449 で claudeArgs / codexArgs / customAgents[].args の Unicode dash (U+2013 等)
+ * を ASCII '-' に正規化する migration を追加し v10。スキーマ自体のフィールド構成は v9 と同じ。
+ */
+export const APP_SETTINGS_SCHEMA_VERSION = 10;
 
 /**
  * ユーザーが自由に追加できるエージェントの設定。


### PR DESCRIPTION
Closes #449

## Summary
- macOS / iOS / MS Word 等の autocorrect で `--` が `–` (U+2013 EN DASH) に化け、`codexArgs` の `–dangerously-bypass-approvals-and-sandbox` が CLI 側で option として認識されず、Codex worker 起動のたびに承認ダイアログが連発していた問題を修正。
- 引数文字列の token 先頭にある Unicode dash 系文字 (`U+2010`〜`U+2015` / `U+2212` / `U+FE58` / `U+FE63` / `U+FF0D`) を ASCII `--` に正規化することで救済する。

## 変更内容
- `parse-args.ts`
  - `parseShellArgs` で各 token 先頭の Unicode dash run を ASCII `--` に正規化 (実行時救済)。
  - `parseShellArgsStrict` の戻り値に `hasUnicodeDash` を追加し、UI 警告に使えるようにした。
  - `normalizeLeadingDashes` を export して migration から再利用可能に。
- `settings-migrate.ts`
  - スキーマ v9 → v10 を追加。`claudeArgs` / `codexArgs` / `customAgents[].args` を解析して再構築し、保存済み設定の Unicode dash を恒久的に ASCII へ書き換える。
- `CommandOptionsSection.tsx` / `CustomAgentEditor.tsx`
  - 既存の閉じクォート警告と並べて Unicode dash 警告を表示 (`settings.argsUnicodeDash`)。
- `i18n.ts`
  - 日本語 / 英語の警告文言を追加。
- `shared.ts`
  - `APP_SETTINGS_SCHEMA_VERSION` を 10 に bump。
- ユニットテスト
  - `parse-args.test.ts`: 各種 Unicode dash の正規化、value 側不変性、`parseShellArgsStrict` の警告フラグを検証 (24 テスト)。
  - `settings-migrate.test.ts`: v9 → v10 の `claudeArgs` / `codexArgs` / `customAgents[].args` 正規化と冪等性を検証。

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/renderer/src/lib/__tests__/parse-args.test.ts src/renderer/src/lib/__tests__/settings-migrate.test.ts` — 32 PASS
- [x] `npm run test` — 174 PASS
- [x] `npm run build:vite` — built in 1.47s
- [ ] 手動: Codex worker 起動時の args ログで `--dangerously-bypass-approvals-and-sandbox` (ASCII) になっていることを目視確認 (PR レビュー後)