### PR TITLE
refactor(renderer): Glass / drag-region CSSを集約

### DIFF
--- a/src/renderer/src/components/shell/Topbar.tsx
+++ b/src/renderer/src/components/shell/Topbar.tsx
@@ -53,7 +53,7 @@ export function Topbar({
       : 'var(--success)';
 
   return (
-    <div className="topbar" role="banner">
+    <div className="topbar" role="banner" data-tauri-drag-region>
       <div className="topbar__brand" data-tauri-drag-region title="vibe-editor">
         <img
           className="topbar__brand-logo"

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -80,12 +80,6 @@ body,
   background: var(--bg);
 }
 
-/* ---------- Glass テーマ: OS アクリルを透かす ---------- */
-:root[data-theme='glass'],
-:root[data-theme='glass'] body,
-:root[data-theme='glass'] #root {
-  background: transparent !important;
-}
 
 /* Canvas モード時は IDE レイヤを不可視化 (PTY / state は保持したまま)。
    これをやらないと、glass テーマで Canvas の背景が透明になって IDE が透けて見える。
@@ -94,48 +88,6 @@ body,
   visibility: hidden;
 }
 
-/* IDE / Canvas いずれのルートにも Cyber Neon ベースの半透明ダーク tint を載せる。
-   #440: 旧実装は `background: transparent` で OS Acrylic がそのまま壁紙を映し、
-   明るい壁紙だと canvas エリア (panel が無い空白) が白〜紫に濁って見えていた。
-   Windows Terminal Cyber Neon と同じ仕組み — dark bg を ~50% opacity で乗せて
-   acrylic の上から色を引き締める — に揃える。同時に brightness(0.7) を当てて
-   壁紙そのものの明るさも一段下げる。 */
-:root[data-theme='glass'] .layout,
-:root[data-theme='glass'] .canvas-layout {
-  background: rgba(10, 10, 26, 0.55);
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
-    brightness(var(--glass-brightness, 1));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
-    brightness(var(--glass-brightness, 1));
-}
-
-/* Glass 時は panel / sidebar / toolbar に backdrop-blur を乗せてアクリル感を強化。
-   #367: saturate(140%) は OS Acrylic の light tint を増幅して「白っぽい固定面」の主因
-   になっていたため 110% へ下げる。blur も 18px は overblur 気味なので 14px に整える。
-   テーマ palette 側 (themes.ts) の surface alpha を 0.38〜0.55 へ下げているため、
-   blur 強度を下げてもデスクトップ背景のぼかしは十分視認できる。
-   #440: ハードコードを CSS 変数参照に統一。tokens.css の `[data-theme='glass']` で
-   blur=12px / saturate=120% / brightness=0.7 を一元管理。brightness で背後の壁紙を
-   暗化し、Windows Terminal Cyber Neon と同じ「黒いすりガラス」感に揃える。 */
-:root[data-theme='glass'] .sidebar,
-:root[data-theme='glass'] .filetree,
-:root[data-theme='glass'] .rail,
-:root[data-theme='glass'] .topbar,
-:root[data-theme='glass'] .statusbar,
-:root[data-theme='glass'] .canvas-header,
-:root[data-theme='glass'] .main,
-:root[data-theme='glass'] .claude-code-panel {
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
-    brightness(var(--glass-brightness, 1));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
-    brightness(var(--glass-brightness, 1));
-}
-
-/* ノイズオーバーレイは glass では控えめに (アクリル質感を邪魔しない) */
-:root[data-theme='glass'] .layout::before,
-:root[data-theme='glass'] .canvas-layout::before {
-  opacity: 0;
-}
 
 /* ---------- グレイン/ノイズオーバーレイ (Linear / Notion 風) ---------- */
 .layout::before {
@@ -262,8 +214,6 @@ body.is-resizing * {
 
 .sidebar {
   background: var(--surface-glass);
-  backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-  -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -285,18 +235,12 @@ body.is-resizing * {
   display: flex;
   align-items: center;
   gap: 10px;
-  -webkit-app-region: drag;
   border-bottom: 1px solid var(--glass-border);
   /* NOTE: ここに overflow: hidden を付けると AppMenu のドロップダウンが
      親の境界で切り取られて表示されなくなる。ブランド文字列の省略は
      .sidebar__header .sidebar__brand の自前の overflow で処理する。 */
 }
 
-.sidebar__header .app-menu,
-.sidebar__header .app-menu__trigger,
-.sidebar__header .sidebar__brand {
-  -webkit-app-region: no-drag;
-}
 
 .sidebar__header .sidebar__brand {
   min-width: 0;
@@ -317,7 +261,6 @@ body.is-resizing * {
   font-weight: 500;
   color: var(--text);
   letter-spacing: -0.01em;
-  -webkit-app-region: no-drag;
 }
 
 .sidebar__brand-project {
@@ -632,8 +575,6 @@ body.is-resizing * {
   justify-content: space-between;
   padding: 0 10px;
   background: var(--surface-glass);
-  backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-  -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
   border-bottom: 1px solid var(--glass-border);
   box-shadow: var(--glass-highlight);
   gap: 8px;
@@ -641,18 +582,9 @@ body.is-resizing * {
   height: var(--toolbar-h);
   position: relative;
   z-index: 1;
-  -webkit-app-region: drag;
 }
 
 /* ツールバー内のインタラクティブ要素はドラッグ無効 */
-.toolbar__btn,
-.toolbar__path,
-.toolbar__right,
-.toolbar__left,
-.app-menu,
-.app-menu__trigger {
-  -webkit-app-region: no-drag;
-}
 
 .toolbar__left {
   display: flex;
@@ -1003,8 +935,6 @@ body.is-resizing * {
 .tabbar {
   display: flex;
   background: var(--surface-glass);
-  backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-  -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
   padding: 6px 16px 0;
   gap: 2px;
   position: relative;
@@ -1776,8 +1706,6 @@ body.is-resizing * {
   display: flex;
   flex-direction: column;
   background: var(--surface-glass);
-  backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-  -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
   min-height: 0;
   min-width: 0;
   box-shadow: inset 1px 0 0 var(--glass-border);
@@ -1797,13 +1725,10 @@ body.is-resizing * {
   justify-content: space-between;
   padding: 0 12px;
   background: var(--surface-glass);
-  backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
-  -webkit-backdrop-filter: saturate(var(--glass-saturate)) blur(var(--glass-blur));
   min-height: var(--toolbar-h);
   height: var(--toolbar-h);
   gap: 8px;
   box-shadow: 0 1px 0 var(--glass-border), var(--glass-highlight);
-  -webkit-app-region: drag;
   /* backdrop-filter がスタッキングコンテキストを生成するため、
      +ボタンのドロップダウンがターミナル本体の後ろに隠れる。
      z-index でヘッダーをターミナルより前面にする。 */
@@ -1811,11 +1736,6 @@ body.is-resizing * {
   z-index: 2;
 }
 
-.claude-code-panel__header .app-menu,
-.claude-code-panel__header .app-menu__trigger,
-.claude-code-panel__header-right {
-  -webkit-app-region: no-drag;
-}
 
 .claude-code-panel__title-wrap {
   display: flex;
@@ -3951,47 +3871,6 @@ body.is-resizing * {
 }
 
 
-/* ==========================================================================
-   Issue #16: Glass テーマ — すりガラス風 (半透明 + backdrop-filter)
-   data-theme=glass のときだけ主要パネルにブラーを適用する。
-   テーマ変数 (bg-panel/sidebar/toolbar/elev) は themes.ts 側で半透明に
-   設定済みなので、ここでは backdrop-filter を当てるだけで成立する。
-   ========================================================================== */
-[data-theme="glass"] .toolbar,
-[data-theme="glass"] .sidebar,
-[data-theme="glass"] .tabbar,
-[data-theme="glass"] .modal,
-[data-theme="glass"] .cmdp,
-[data-theme="glass"] .app-menu__dropdown,
-[data-theme="glass"] .user-menu__dropdown,
-[data-theme="glass"] .context-menu,
-[data-theme="glass"] .canvas-agent-card,
-[data-theme="glass"] .canvas-toolbar,
-[data-theme="glass"] .layout,
-[data-theme="glass"] .main,
-[data-theme="glass"] .content-area,
-[data-theme="glass"] .sidebar-view,
-[data-theme="glass"] .pane,
-[data-theme="glass"] .terminal-pane,
-[data-theme="glass"] .terminal-pane__header,
-[data-theme="glass"] .claude-code-panel,
-[data-theme="glass"] .claude-code-panel__header,
-[data-theme="glass"] .claude-code-panel__body,
-[data-theme="glass"] .notes-panel,
-[data-theme="glass"] .filetree,
-[data-theme="glass"] .filetree__header {
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
-    brightness(var(--glass-brightness, 1));
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
-    brightness(var(--glass-brightness, 1));
-}
-
-/* glass テーマでは modal-backdrop / cmdp-backdrop の暗幕を弱め、
-   背後のブラーが活きるようにする */
-[data-theme="glass"] .modal-backdrop,
-[data-theme="glass"] .cmdp-backdrop {
-  background: rgba(0, 0, 0, 0.18);
-}
 
 
 

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -41,6 +41,8 @@ import './styles/components/claude-not-found.css';
 import './styles/components/canvas.css';
 import './styles/components/claude-patterns.css';
 import './styles/components/shell.css';
+import './styles/components/glass.css';
+import './styles/components/drag-region.css';
 import './styles/components/tweaks.css';
 import './styles/components/image-preview.css';
 

--- a/src/renderer/src/styles/__tests__/drag-region-css-contract.test.ts
+++ b/src/renderer/src/styles/__tests__/drag-region-css-contract.test.ts
@@ -1,0 +1,128 @@
+/// <reference types="node" />
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const stylesDir = dirname(testDir);
+const rendererSrcDir = dirname(stylesDir);
+const componentsDir = join(stylesDir, 'components');
+
+function readRendererFile(pathFromRendererSrc: string): string {
+  return readFileSync(join(rendererSrcDir, pathFromRendererSrc), 'utf8');
+}
+
+function readComponentCss(fileName: string): string {
+  return readFileSync(join(componentsDir, fileName), 'utf8');
+}
+
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function importedCssPaths(mainTsx: string): string[] {
+  return Array.from(mainTsx.matchAll(/^import\s+['"]\.\/([^'"]+\.css)['"];?$/gm), (match) => match[1]);
+}
+
+function cssFilesUnder(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) return cssFilesUnder(fullPath);
+    return entry.isFile() && entry.name.endsWith('.css') ? [fullPath] : [];
+  });
+}
+
+function slashPath(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
+describe('Drag-region CSS contract', () => {
+  it('main.tsx imports drag-region.css after glass.css and before final tweaks', () => {
+    const imports = importedCssPaths(readRendererFile('main.tsx'));
+
+    const dragIndex = imports.indexOf('styles/components/drag-region.css');
+    expect(dragIndex).toBeGreaterThanOrEqual(0);
+    expect(dragIndex).toBeGreaterThan(imports.indexOf('styles/components/glass.css'));
+    expect(dragIndex).toBeLessThan(imports.indexOf('styles/components/tweaks.css'));
+    expect(dragIndex).toBeLessThan(imports.indexOf('styles/components/image-preview.css'));
+  });
+
+  it('drag-region.css defines drag and no-drag rules with no-drag after drag', () => {
+    const dragCss = stripCssComments(readComponentCss('drag-region.css'));
+    const dragRuleIndex = dragCss.indexOf('app-region: drag');
+    const webkitDragRuleIndex = dragCss.indexOf('-webkit-app-region: drag');
+    const noDragRuleIndex = dragCss.indexOf('app-region: no-drag');
+    const webkitNoDragRuleIndex = dragCss.indexOf('-webkit-app-region: no-drag');
+
+    expect(dragRuleIndex).toBeGreaterThanOrEqual(0);
+    expect(webkitDragRuleIndex).toBeGreaterThanOrEqual(0);
+    expect(noDragRuleIndex).toBeGreaterThanOrEqual(0);
+    expect(webkitNoDragRuleIndex).toBeGreaterThanOrEqual(0);
+    expect(noDragRuleIndex).toBeGreaterThan(dragRuleIndex);
+    expect(webkitNoDragRuleIndex).toBeGreaterThan(webkitDragRuleIndex);
+  });
+
+  it('drag-region.css keeps interactive controls in the no-drag allowlist', () => {
+    const dragCss = stripCssComments(readComponentCss('drag-region.css'));
+
+    for (const selector of [
+      'button',
+      'input',
+      'textarea',
+      'select',
+      'a',
+      "[role='button']",
+      '.menubar',
+      '.app-menu',
+      '.app-menu__trigger',
+      '.app-menu__dropdown',
+      '.user-menu__dropdown',
+      '.context-menu',
+      '.topbar__project',
+      '.topbar__search',
+      '.topbar__icons',
+      '.window-controls',
+      '.window-controls__btn',
+      '.canvas-btn',
+      '.canvas-btn-split',
+      '.canvas-btn-split__main',
+      '.canvas-btn-split__caret',
+      '.canvas-popover__wrap',
+      '.canvas-popover',
+      '.resize-handle'
+    ]) {
+      expect(dragCss).toContain(selector);
+    }
+  });
+
+  it('production CSS app-region declarations are centralized in drag-region.css', () => {
+    const offenders = cssFilesUnder(rendererSrcDir).flatMap((file) => {
+      const rel = slashPath(relative(rendererSrcDir, file));
+      if (rel === 'styles/components/drag-region.css') return [];
+
+      const css = stripCssComments(readFileSync(file, 'utf8'));
+      return /(?:^|[;{\s])-?webkit-app-region\s*:|(?:^|[;{\s])app-region\s*:/m.test(css)
+        ? [rel]
+        : [];
+    });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('Topbar root remains an explicit Tauri drag region', () => {
+    const topbar = readRendererFile('components/shell/Topbar.tsx');
+    const rootTag = topbar.match(/<div\s+[^>]*className="topbar"[^>]*>/)?.[0] ?? '';
+
+    expect(rootTag).toContain('data-tauri-drag-region');
+  });
+
+  it('Canvas header brand icon keeps pointer-events disabled for stable drag hit testing', () => {
+    const canvasCss = stripCssComments(readComponentCss('canvas.css'));
+
+    expect(canvasCss).toMatch(
+      /\.canvas-header__brand\s+svg\s*\{[\s\S]*pointer-events:\s*none\s*;/
+    );
+  });
+});

--- a/src/renderer/src/styles/__tests__/glass-css-contract.test.ts
+++ b/src/renderer/src/styles/__tests__/glass-css-contract.test.ts
@@ -1,0 +1,193 @@
+/// <reference types="node" />
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const stylesDir = dirname(testDir);
+const rendererSrcDir = dirname(stylesDir);
+const componentsDir = join(stylesDir, 'components');
+
+function readRendererFile(pathFromRendererSrc: string): string {
+  return readFileSync(join(rendererSrcDir, pathFromRendererSrc), 'utf8');
+}
+
+function readComponentCss(fileName: string): string {
+  return readFileSync(join(componentsDir, fileName), 'utf8');
+}
+
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function importedCssPaths(mainTsx: string): string[] {
+  return Array.from(mainTsx.matchAll(/^import\s+['"]\.\/([^'"]+\.css)['"];?$/gm), (match) => match[1]);
+}
+
+function cssFilesUnder(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) return cssFilesUnder(fullPath);
+    return entry.isFile() && entry.name.endsWith('.css') ? [fullPath] : [];
+  });
+}
+
+function slashPath(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
+function cssDeclarationsForProperty(
+  css: string,
+  property: 'backdrop-filter' | '-webkit-backdrop-filter'
+): Array<{ selector: string; property: string }> {
+  const code = stripCssComments(css);
+  const declarations: Array<{ selector: string; property: string }> = [];
+  const pattern = new RegExp(`${property.replace('-', '\\-')}\\s*:`, 'g');
+
+  for (const match of code.matchAll(pattern)) {
+    const index = match.index ?? 0;
+    const openBrace = code.lastIndexOf('{', index);
+    const previousCloseBrace = code.lastIndexOf('}', openBrace);
+    const selector = code.slice(previousCloseBrace + 1, openBrace).trim();
+    declarations.push({ selector, property });
+  }
+
+  return declarations;
+}
+
+describe('Glass CSS contract', () => {
+  it('main.tsx imports glass.css after component CSS and before final tweak/image CSS', () => {
+    const imports = importedCssPaths(readRendererFile('main.tsx'));
+
+    const glassIndex = imports.indexOf('styles/components/glass.css');
+    expect(glassIndex).toBeGreaterThanOrEqual(0);
+
+    // Glass effects must win over component base CSS, but tweaks/image-preview remain final overrides.
+    for (const componentCss of [
+      'styles/components/canvas.css',
+      'styles/components/claude-patterns.css',
+      'styles/components/shell.css'
+    ]) {
+      expect(glassIndex).toBeGreaterThan(imports.indexOf(componentCss));
+    }
+    expect(glassIndex).toBeLessThan(imports.indexOf('styles/components/tweaks.css'));
+    expect(glassIndex).toBeLessThan(imports.indexOf('styles/components/image-preview.css'));
+  });
+
+  it('tokens.css owns --glass-* values, not glass visual effects', () => {
+    const tokens = stripCssComments(readRendererFile('styles/tokens.css'));
+
+    for (const tokenName of [
+      '--glass-blur',
+      '--glass-saturate',
+      '--glass-border',
+      '--glass-highlight'
+    ]) {
+      expect(tokens).toMatch(new RegExp(`${tokenName}\\s*:`));
+    }
+
+    expect(tokens).not.toMatch(/backdrop-filter\s*:/);
+    expect(tokens).not.toMatch(/-webkit-backdrop-filter\s*:/);
+    expect(tokens).not.toMatch(/\[data-theme=['"]glass['"]\]\s+\.glass-surface/);
+  });
+
+  it('glass.css owns root transparency, root tint, glass-surface effects, and major surfaces', () => {
+    const glass = stripCssComments(readComponentCss('glass.css'));
+
+    expect(glass).toMatch(
+      /:root\[data-theme='glass'\][\s\S]*:root\[data-theme='glass'\]\s+body[\s\S]*:root\[data-theme='glass'\]\s+#root\s*\{[\s\S]*background:\s*transparent\s*!important/
+    );
+    expect(glass).toMatch(
+      /:root\[data-theme='glass'\]\s+\.layout,\s*:root\[data-theme='glass'\]\s+\.canvas-layout\s*\{[\s\S]*background:\s*rgba\([\s\S]*backdrop-filter:\s*blur\(var\(--glass-blur\)\)/
+    );
+    expect(glass).toMatch(
+      /:root\[data-theme='glass'\]\s+\.glass-surface[\s\S]*backdrop-filter:\s*blur\(var\(--glass-blur\)\)/
+    );
+
+    for (const selector of [
+      '.glass-surface',
+      '.sidebar',
+      '.filetree',
+      '.rail',
+      '.topbar',
+      '.statusbar',
+      '.canvas-header',
+      '.main',
+      '.toolbar',
+      '.tabbar',
+      '.modal',
+      '.cmdp',
+      '.app-menu__dropdown',
+      '.user-menu__dropdown',
+      '.content-area',
+      '.pane',
+      '.terminal-pane',
+      '.claude-code-panel',
+      '.canvas-agent-card',
+      '.canvas-toolbar'
+    ]) {
+      expect(glass).toContain(`:root[data-theme='glass'] ${selector}`);
+    }
+  });
+
+  it('index.css does not keep the legacy Issue #16 Glass surface whitelist', () => {
+    const indexCss = stripCssComments(readRendererFile('index.css'));
+
+    // A few narrow Glass exceptions may remain in index.css (for example xterm/filetree).
+    // The old regression-prone whitelist for broad surfaces must stay out of index.css.
+    for (const selector of [
+      '.toolbar',
+      '.sidebar',
+      '.topbar',
+      '.canvas-header',
+      '.main',
+      '.content-area',
+      '.pane',
+      '.terminal-pane',
+      '.claude-code-panel',
+      '.canvas-agent-card',
+      '.canvas-toolbar',
+      '.modal',
+      '.cmdp',
+      '.app-menu__dropdown',
+      '.user-menu__dropdown'
+    ]) {
+      expect(indexCss).not.toMatch(
+        new RegExp(`\\[data-theme=["']glass["']\\]\\s+\\${selector.replace('.', '.')}`)
+      );
+    }
+  });
+
+  it('remaining backdrop-filter declarations are limited to the documented allowlist', () => {
+    const cssFiles = cssFilesUnder(rendererSrcDir);
+    const unexpectedDeclarations = cssFiles.flatMap((file) => {
+      const rel = slashPath(relative(rendererSrcDir, file));
+      const css = readFileSync(file, 'utf8');
+      const declarations = [
+        ...cssDeclarationsForProperty(css, 'backdrop-filter'),
+        ...cssDeclarationsForProperty(css, '-webkit-backdrop-filter')
+      ];
+
+      return declarations
+        .filter(({ selector }) => {
+          if (rel === 'styles/components/glass.css') return false;
+          if (rel === 'styles/components/menu.css') return false;
+          if (rel === 'styles/components/modal.css') return false;
+          if (rel === 'styles/components/palette.css') return false;
+          if (rel === 'styles/components/canvas.css') return !selector.includes('.tc__hud');
+          if (rel === 'index.css') {
+            // index.css may keep local UI blur, but not broad Glass surface blur.
+            return /(\.toolbar|\.sidebar|\.topbar|\.canvas-header|\.main|\.claude-code-panel|\.canvas-agent-card|\.canvas-toolbar)/.test(
+              selector
+            );
+          }
+          return true;
+        })
+        .map(({ selector, property }) => `${rel} :: ${selector} :: ${property}`);
+    });
+
+    expect(unexpectedDeclarations).toEqual([]);
+  });
+});

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -100,11 +100,7 @@
 }
 
 /* ---------- top header ---------- */
-/* #318: IDE Topbar (.topbar) と同じ「親ヘッダー全体を drag、操作要素だけ no-drag」構造に揃える。
-   PR #311 の子要素のみ drag-region 付与は Tauri 公式の「直接ターゲット要件」を満たさず、
-   SVG が pointer target を奪うケースで drag が失敗していた。
-   `position: relative` は `z-index` を有効にするため、`-webkit-app-region` と `app-region`
-   は WebView2 / WebKit 両系統への互換のため両方併記する。 */
+/* Drag/no-drag hit testing is centralized in drag-region.css. */
 .canvas-header {
   display: flex;
   align-items: center;
@@ -115,25 +111,10 @@
   border-bottom: 1px solid var(--border);
   position: relative;
   z-index: 5;
-  app-region: drag;
-  -webkit-app-region: drag;
 }
 
-/* Canvas モードのボタン類はドラッグ領域から除外（#307 と同じパターンを #310 で適用）。
-   #318 で .canvas-header 全体を drag 化したため、操作要素は明示的に no-drag にする必要がある。
-   shell.css:247-345 の IDE Topbar 側の no-drag リストと同じ安全策。
-   `app-region` と `-webkit-app-region` を両方併記して WebView2 / WebKit 両系統に対応。 */
-.canvas-btn,
-.canvas-btn-split,
-.canvas-btn-split__main,
-.canvas-btn-split__caret,
-.canvas-popover__wrap,
-.canvas-popover,
-.window-controls,
-.window-controls__btn {
-  app-region: no-drag;
-  -webkit-app-region: no-drag;
-}
+
+
 
 .canvas-header__brand {
   display: inline-flex;

--- a/src/renderer/src/styles/components/drag-region.css
+++ b/src/renderer/src/styles/components/drag-region.css
@@ -1,0 +1,62 @@
+/* ===========================================================================
+ * Window drag regions
+ *
+ * Single source of truth for Tauri/WebView drag and no-drag hit testing.
+ * Keep no-drag rules after drag rules so interactive controls remain clickable.
+ * =========================================================================== */
+
+*[data-tauri-drag-region],
+.topbar,
+.sidebar__header,
+.toolbar,
+.claude-code-panel__header,
+.canvas-header {
+  app-region: drag;
+  -webkit-app-region: drag;
+}
+
+button,
+input,
+textarea,
+select,
+a,
+[role='button'],
+.menubar,
+.menubar *,
+.app-menu,
+.app-menu__trigger,
+.app-menu__dropdown,
+.user-menu__dropdown,
+.context-menu,
+.topbar__project,
+.topbar__modes,
+.topbar__search,
+.topbar__status,
+.topbar__icons,
+.topbar__update,
+.window-controls,
+.window-controls__btn,
+.toolbar__btn,
+.toolbar__path,
+.toolbar__right,
+.toolbar__left,
+.sidebar__header .app-menu,
+.sidebar__header .app-menu__trigger,
+.sidebar__header .sidebar__brand,
+.sidebar__brand,
+.claude-code-panel__header .app-menu,
+.claude-code-panel__header .app-menu__trigger,
+.claude-code-panel__header-right,
+.claude-code-panel__add-btn,
+.canvas-btn,
+.canvas-btn-split,
+.canvas-btn-split__main,
+.canvas-btn-split__caret,
+.canvas-popover__wrap,
+.canvas-popover,
+.resize-handle,
+.tab-create-menu,
+.tab-create-menu__item {
+  app-region: no-drag;
+  -webkit-app-region: no-drag;
+}

--- a/src/renderer/src/styles/components/glass.css
+++ b/src/renderer/src/styles/components/glass.css
@@ -1,0 +1,73 @@
+/* ===========================================================================
+ * Glass theme effects
+ *
+ * tokens.css owns the --glass-* values. This file owns the visual effects that
+ * should only apply while data-theme='glass' is active.
+ * =========================================================================== */
+
+:root[data-theme='glass'],
+:root[data-theme='glass'] body,
+:root[data-theme='glass'] #root {
+  background: transparent !important;
+}
+
+/* Keep the always-mounted IDE/Canvas roots dark enough over native Acrylic. */
+:root[data-theme='glass'] .layout,
+:root[data-theme='glass'] .canvas-layout {
+  background: rgba(10, 10, 26, 0.55);
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+}
+
+:root[data-theme='glass'] .layout::before,
+:root[data-theme='glass'] .canvas-layout::before {
+  opacity: 0;
+}
+
+:root[data-theme='glass'] .glass-surface,
+:root[data-theme='glass'] .sidebar,
+:root[data-theme='glass'] .filetree,
+:root[data-theme='glass'] .filetree__header,
+:root[data-theme='glass'] .rail,
+:root[data-theme='glass'] .topbar,
+:root[data-theme='glass'] .statusbar,
+:root[data-theme='glass'] .canvas-header,
+:root[data-theme='glass'] .main,
+:root[data-theme='glass'] .toolbar,
+:root[data-theme='glass'] .tabbar,
+:root[data-theme='glass'] .modal,
+:root[data-theme='glass'] .cmdp,
+:root[data-theme='glass'] .app-menu__dropdown,
+:root[data-theme='glass'] .user-menu__dropdown,
+:root[data-theme='glass'] .content-area,
+:root[data-theme='glass'] .sidebar-view,
+:root[data-theme='glass'] .pane,
+:root[data-theme='glass'] .terminal-pane,
+:root[data-theme='glass'] .terminal-pane__header,
+:root[data-theme='glass'] .claude-code-panel,
+:root[data-theme='glass'] .claude-code-panel__header,
+:root[data-theme='glass'] .claude-code-panel__body,
+:root[data-theme='glass'] .notes-panel,
+:root[data-theme='glass'] .canvas-agent-card,
+:root[data-theme='glass'] .canvas-toolbar {
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+}
+
+:root[data-theme='glass'] .glass-surface {
+  /* Issue #440: subtle neon edge to keep Cyber Neon glass from looking milky. */
+  box-shadow:
+    0 0 1px rgba(0, 255, 255, 0.20),
+    inset 0 0 1px rgba(0, 255, 255, 0.08);
+}
+
+/* Overlay/backdrop surfaces keep their component CSS behavior. This rule only
+   preserves the legacy Glass dim tint without moving modal/palette/menu CSS. */
+:where(:root[data-theme='glass']) .modal-backdrop,
+:where(:root[data-theme='glass']) .cmdp-backdrop {
+  background: rgba(0, 0, 0, 0.18);
+}

--- a/src/renderer/src/styles/components/shell.css
+++ b/src/renderer/src/styles/components/shell.css
@@ -9,7 +9,6 @@
 
 /* ==================== MENU BAR (Topbar 左側に並べるカスタムメニューバー) ==================== */
 .menubar {
-  -webkit-app-region: no-drag;
   display: flex;
   align-items: center;
   gap: 0;
@@ -138,13 +137,8 @@
   padding: 0 18px 0 16px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-toolbar);
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
-    brightness(var(--glass-brightness, 1));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
-    brightness(var(--glass-brightness, 1));
   position: relative;
   z-index: var(--z-nav);
-  -webkit-app-region: drag;
   flex-shrink: 0;
 }
 
@@ -178,7 +172,6 @@
 }
 
 .topbar__project {
-  -webkit-app-region: no-drag;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -215,7 +208,6 @@
 }
 
 .topbar__modes {
-  -webkit-app-region: no-drag;
   display: flex;
   align-items: center;
   gap: 2px;
@@ -247,7 +239,6 @@
 }
 
 .topbar__search {
-  -webkit-app-region: no-drag;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -289,7 +280,6 @@
 }
 
 .topbar__status {
-  -webkit-app-region: no-drag;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -313,7 +303,6 @@
 }
 
 .topbar__icons {
-  -webkit-app-region: no-drag;
   display: flex;
   align-items: center;
   /* 2px は Fitts's law 的に押しミスが増える。6px まで広げて "ゆとり" を演出 */
@@ -344,7 +333,6 @@
    accent 色のソフトな塗り (alpha) + 細線で「目立つけど押さなくても作業は止まらない」
    ニュアンス。ホバーで accent 強調 + 微小に持ち上がる。 */
 .topbar__update {
-  -webkit-app-region: no-drag;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -373,26 +361,15 @@
   white-space: nowrap;
 }
 
+/* Drag/no-drag hit testing is centralized in drag-region.css. */
+
 /* ==================== WINDOW CONTROLS (Issue #260 PR-2) ==================== */
 /* `decorations: false` でネイティブ chrome を外した代わりのカスタムボタン群。
-   .topbar の右端に座り、`-webkit-app-region: drag` の親領域から自身は no-drag に
    抜けることでクリック可能を保つ。 */
 
-/* Issue #307: Tauri 2 公式推奨の `data-tauri-drag-region` 属性が付いた要素を
-   ドラッグ可能領域として宣言する。Windows WebView2 では `-webkit-app-region` が
-   ほぼ無効なため、新仕様の `app-region` を併用する。 */
-*[data-tauri-drag-region] {
-  app-region: drag;
-  -webkit-app-region: drag;
-}
-.window-controls,
-.window-controls__btn {
-  app-region: no-drag;
-  -webkit-app-region: no-drag;
-}
+
 
 .window-controls {
-  -webkit-app-region: no-drag;
   display: flex;
   align-items: center;
   margin-left: 8px;
@@ -404,7 +381,6 @@
 }
 
 .window-controls__btn {
-  -webkit-app-region: no-drag;
   width: 46px;
   height: 100%;
   display: grid;

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -287,32 +287,11 @@ samp,
 }
 
 /*
- * Issue #260 PR-3: `.glass-surface` ユーティリティクラス。
+ * Issue #260 PR-3: `.glass-surface` utility class.
  *
- * 新規パネル / surface コンポーネントは ルート要素の className に `glass-surface` を
- * 付与するだけで、Glass テーマ時に自動的に backdrop-filter (blur + saturate) が
- * 適用される。Glass 以外のテーマでは何もしないので、付け得 (no-op)。
- *
- * 旧来の index.css 側 `[data-theme='glass'] .toolbar, .sidebar, ...` ホワイトリスト
- * 方式は、既存パネル互換のため当面残す。新規追加分は本ユーティリティで完結させる。
- *
- * 使い方:
- *   <div className="my-panel glass-surface">...</div>
- *
- * 注意: backdrop-filter は新しい stacking context を作るので、`position: relative`
- * と組み合わせると z-index が新規にスコープされる。modal/popover の上に重ねる
- * 場合は親側の overflow と z-index を要確認。
+ * Glass effect declarations live in styles/components/glass.css so this file can
+ * remain the single source of truth for values (`--glass-*`) only.
  */
-[data-theme='glass'] .glass-surface {
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
-    brightness(var(--glass-brightness, 1));
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
-    brightness(var(--glass-brightness, 1));
-  /* Issue #440: ネオンシアンの微発光で Cyber Neon 世界観の境界を表現 */
-  box-shadow:
-    0 0 1px rgba(0, 255, 255, 0.20),
-    inset 0 0 1px rgba(0, 255, 255, 0.08);
-}
 
 :root[data-theme='light'],
 :root[data-theme='claude-light'] {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -573,3 +573,240 @@ Issue: #361
 - `npm run build:vite`: PASS (既存の chunk size / dynamic import warning あり)
 - `cargo check --manifest-path src-tauri\Cargo.toml --all-targets`: PASS
 - `git diff --check`: PASS
+
+---
+
+
+## Issue #452 初回PR計画（QA No-Go差戻し修正 / 2026-05-04）
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/452
+Authoritative repo: `C:\Users\zooyo\Documents\GitHub\vibe-editor`
+Branch: `feature/issue-452`
+編集対象（計画タスク）: `tasks/todo.md` のみ
+
+### 調査結果サマリ
+- [x] Issue #452 は OPEN。ラベルは `ui` / `canvas` / `planned` / `refactor`。
+- [x] GitHub 上に Issue #452 紐づき PR / remote `feature/issue-452` は未検出。
+- [x] open PR #431-#439 は dependabot 系で、初回PR主要候補ファイルとの重複は未検出。
+- [x] authoritative repo は `C:\Users\zooyo\Documents\GitHub\vibe-editor`。`HEAD=abfde302ce4350ecfb0e378e748e7106638ff8f9` で `origin/main` と一致。
+- [x] `C:\Users\zooyo\Downloads\vibe-editor-dist` は fetch 後も `main...origin/main [behind 43]` の stale main のため実装対象 No-Go。
+- [x] `main.protected=false` を GitHub API で確認。merge 前ブロッカーとして Owner 確認・Branch Protection 復旧が必要。
+- [x] 既存未追跡 `tasks/*` は `git status --short` 表示で 18 entries、`--untracked-files=all` では 21 leaf files。未操作・PR混入 No-Go。
+
+### 採用スコープ（初回PR = Phase A+B のみ）
+- [x] Phase A: Glass CSS 集約。
+- [x] Phase B: drag-region CSS 集約。
+- [x] `src/renderer/src/index.css` を必須対象に含める。旧 Glass whitelist / root tint / drag-no-drag 残存を見落とすと再発するため No-Go。
+- [x] `tokens.css` は Glass 値、`glass.css` は Glass 効果、`drag-region.css` は drag/no-drag の SSOT とする。
+- [x] `glass.css` import 位置は component CSS 後、`tweaks.css` / `image-preview.css` 前を第一候補にする。
+- [x] `lint` / E2E script 追加や CI lint 導入は初回PRから除外する。
+
+### 明示的に除外する follow-up
+- [ ] `App.tsx` の 600 行以下化 / JSX 巨大分割。
+- [ ] `CanvasLayout.tsx` の header/menu/stage 分割。
+- [ ] `.claude/skills/theme-customization/SKILL.md` 更新、新規 `.claude/skills/drag-region/SKILL.md` など skill/docs 整備。
+- [ ] xterm / terminal 表示・scroll 共通化。
+- [ ] Rust / TeamHub / i18n / CI lint 導入。
+- [ ] 上記は別 PR / 別 Issue として Leader が別途割り当てる。
+
+### 計画
+- [ ] Phase 0: 変更前棚卸し
+  - [ ] `backdrop-filter` / `-webkit-backdrop-filter` / `glass-surface` / `data-theme='glass'` / `app-region` / `-webkit-app-region` / `data-tauri-drag-region` を全検索する。
+  - [ ] `index.css` の旧 Glass whitelist、root tint、drag/no-drag 残存を棚卸し対象に含める。
+  - [ ] `menu.css` / `modal.css` / `palette.css` と `canvas.css` の `.tc__hud-*` / arrange popover blur は意図的例外候補として理由を記録する。
+- [ ] Phase A: Glass CSS 集約（Implementation A）
+  - [ ] `src/renderer/src/styles/components/glass.css` を新設する。
+  - [ ] `tokens.css` に Glass の値を残し、root tint / `.glass-surface` / Glass 効果は `glass.css` に移動する。
+  - [ ] `index.css` の旧 Glass whitelist は撤去または `glass.css` へ移動する。
+  - [ ] `shell.css` / `canvas.css` の Glass 直書き blur は `glass.css` へ集約する。
+  - [ ] `canvas.css` の `.tc__hud-*` / arrange popover blur は非 Glass でも意図された表現の可能性があるため、初回PRでは例外として残すことを優先する。削る場合は理由と手動 smoke を必須にする。
+- [ ] Phase B: drag-region CSS 集約（Implementation A）
+  - [ ] `src/renderer/src/styles/components/drag-region.css` を新設する。
+  - [ ] `[data-tauri-drag-region]` / `.topbar` / `.canvas-header` と no-drag 対象を `drag-region.css` に集約する。
+  - [ ] no-drag は drag より後に置く。
+  - [ ] `button` / `input` / menu / WindowControls / popover trigger / resize handle 等を no-drag に明示登録する。
+  - [ ] `main.tsx` に `glass.css` / `drag-region.css` import を追加し、import 順を説明可能にする。
+  - [ ] `shell.css` / `canvas.css` / `index.css` の `app-region` / `-webkit-app-region` 重複を整理する。
+  - [ ] `Topbar.tsx` は必要最小の属性調整のみ対象にする。
+  - [ ] `CanvasLayout.tsx` は既存 `data-tauri-drag-region` の確認のみを基本とする。変更が必要な場合は理由・対象行・手動確認観点を PR に明記する。
+
+### A/B 分担（QA No-Go修正後の一本化）
+- [ ] Implementation A: production Phase A+B 担当。
+  - [ ] Glass production: `glass.css` 新設、`main.tsx` import、`tokens.css` / `index.css` / `shell.css` / `canvas.css` 整理。
+  - [ ] drag production: `drag-region.css` 新設、drag/no-drag SSOT、`main.tsx` import、`shell.css` / `canvas.css` / `index.css` の app-region 整理、必要最小 `Topbar.tsx` 属性調整。
+- [ ] Implementation B: 静的契約テストのみ担当。
+  - [ ] `src/renderer/src/styles/__tests__/glass-css-contract.test.ts`
+  - [ ] `src/renderer/src/styles/__tests__/drag-region-css-contract.test.ts`
+  - [ ] production CSS/TSX は編集しない。
+- [x] 古い B production 分担案（B が `drag-region.css` / `shell.css` / `canvas.css` / `index.css` / `Topbar.tsx` / `CanvasLayout.tsx` を編集する案）は obsolete。採用しない。
+
+### 変更候補ファイル（初回PR対象）
+- [ ] `src/renderer/src/styles/tokens.css` — Glass 値の SSOT。
+- [ ] `src/renderer/src/styles/components/glass.css` — 新規。Glass 効果の SSOT。
+- [ ] `src/renderer/src/styles/components/drag-region.css` — 新規。drag/no-drag の SSOT。
+- [ ] `src/renderer/src/index.css` — 旧 Glass whitelist、root tint、drag/no-drag 残存の整理対象。
+- [ ] `src/renderer/src/styles/components/shell.css` — topbar / Glass blur / drag 重複撤去対象。
+- [ ] `src/renderer/src/styles/components/canvas.css` — canvas header / Glass blur / drag 重複撤去対象。`.tc__hud-*` / arrange popover blur は例外候補。
+- [ ] `src/renderer/src/main.tsx` — CSS import 順の調整対象。
+- [ ] `src/renderer/src/components/shell/Topbar.tsx` — 必要最小の drag 属性調整が必要な場合のみ。
+- [ ] `src/renderer/src/layouts/CanvasLayout.tsx` — 原則確認のみ。変更が必要なら理由を明記して最小差分。
+- [ ] `src/renderer/src/styles/__tests__/glass-css-contract.test.ts` — B担当の契約テスト新規候補。
+- [ ] `src/renderer/src/styles/__tests__/drag-region-css-contract.test.ts` — B担当の契約テスト新規候補。
+
+### 変更候補ファイル（follow-up / 初回PR対象外）
+- [ ] `src/renderer/src/App.tsx` — JSX巨大分割は別PR。
+- [ ] `src/renderer/src/layouts/CanvasLayout.tsx` の header/menu/stage 分割 — 別PR。初回PRでは分割しない。
+- [ ] `.claude/skills/theme-customization/SKILL.md` — skill更新は別PR。
+- [ ] `.claude/skills/drag-region/SKILL.md` — skill新設は別PR。
+- [ ] `src/renderer/src/lib/themes.ts` — 原則読み取り / 例外判定のみ。最小変更では触らない。
+- [ ] `src/renderer/src/styles/components/menu.css` — 原則読み取り / 例外判定のみ。
+- [ ] `src/renderer/src/styles/components/modal.css` — 原則読み取り / 例外判定のみ。
+- [ ] `src/renderer/src/styles/components/palette.css` — 原則読み取り / 例外判定のみ。
+- [ ] xterm / Rust / TeamHub / i18n / CI lint 関連ファイル — 別Issue。
+
+### 初回PR 受け入れ条件
+- [ ] Glass 値は `tokens.css`、Glass 効果は `glass.css` に集約されている。
+- [ ] `index.css` の旧 Glass whitelist は撤去または `glass.css` へ移動済み。
+- [ ] `shell.css` / `canvas.css` / `index.css` に残る `backdrop-filter` は、`glass.css` または例外理由付きの意図的残存のみ。
+- [ ] `drag-region.css` が drag/no-drag の SSOT になっている。
+- [ ] no-drag が drag より後に定義され、button/input/menu/window controls/popover trigger/resize handle が no-drag 対象になっている。
+- [ ] `src/renderer/src/styles/__tests__/glass-css-contract.test.ts` と `drag-region-css-contract.test.ts` が追加され、SSOT・残存例外・import順の契約を検証している。
+- [ ] Glass smoke: `npm run dev` で IDE / Canvas の白濁・紫濁り・過剰 blur がないことを手動確認する。
+- [ ] Drag smoke: IDE Topbar と Canvas header の空白領域で window drag が効き、ボタン / input / menu / WindowControls / popover / resize handle がクリック可能なことを手動確認する。
+- [ ] 未追跡 `tasks/*` が PR 差分に混入していない。
+- [ ] Branch Protection `main.protected=false` の Owner確認・復旧方針が merge 前ブロッカーとして残っている。
+
+### 検証コマンド候補
+- [ ] `git status --short --branch`
+- [ ] `git diff --check`
+- [ ] `npm run typecheck`
+- [ ] `npm run test`
+- [ ] `npm run build:vite`
+- [ ] `cargo check --locked --manifest-path src-tauri\Cargo.toml --all-targets`
+- [ ] `cargo test --locked --manifest-path src-tauri\Cargo.toml`
+- [ ] `rg -n "backdrop-filter|-webkit-backdrop-filter|glass-surface|data-theme=['\"]glass|app-region|-webkit-app-region|data-tauri-drag-region" src/renderer/src`
+- [ ] `npm run dev`（Windows/Tauri 実機 smoke）
+- [ ] `lint` / E2E は現行 `package.json` に script 未定義のため、未実行を誤報告しない。必要なら別Issue / 別PRで script 整備を扱う。
+
+### No-Go / 安全制約
+- [ ] authoritative path 以外で実装しない: `C:\Users\zooyo\Documents\GitHub\vibe-editor` / `feature/issue-452` のみ。
+- [ ] `C:\Users\zooyo\Downloads\vibe-editor-dist` は stale main のため実装対象 No-Go。
+- [ ] `tasks/todo.md` 以外の計画タスク編集は禁止。
+- [ ] 未追跡 `tasks/*` を add / 編集 / 削除しない。
+- [ ] reset / clean / stash / drop / 削除は禁止。
+- [ ] 初回PRでは App/CanvasLayout分割、skill/docs、xterm/Rust/TeamHub/i18n/CI lint を混ぜない。
+
+### Next Steps
+- [ ] QA にこの修正版計画を再レビュー依頼する。
+- [ ] QA Go 後、Leader が Implementation A に production Phase A+B を割り当てる。
+- [ ] A の production 変更後、Leader が Implementation B に `styles/__tests__/*` の契約テスト追加を割り当てる。
+- [ ] 実装Go前に A/B とも `C:\Users\zooyo\Documents\GitHub\vibe-editor` / `feature/issue-452` であることを `git status --short --branch` で確認する。
+
+### 実装後進捗（最終状態反映 / 2026-05-04）
+- [x] Implementation A: production Phase A+B 実装完了。
+- [x] Implementation B: 静的契約テスト 2 件追加完了。
+- [x] QA A+B 差分レビュー: 条件付き Go。
+- [x] A Task #13: cargo 検証完了。
+- [x] QA Task #14: Tauri 実機 smoke は未実証として判定。
+- [x] QA Task #16: 既存アプリを閉じない前提の代替 smoke 整理完了。
+
+#### 変更ファイル概要
+- production 変更:
+  - `src/renderer/src/components/shell/Topbar.tsx`
+  - `src/renderer/src/index.css`
+  - `src/renderer/src/main.tsx`
+  - `src/renderer/src/styles/components/canvas.css`
+  - `src/renderer/src/styles/components/shell.css`
+  - `src/renderer/src/styles/tokens.css`
+  - `src/renderer/src/styles/components/glass.css`（新規）
+  - `src/renderer/src/styles/components/drag-region.css`（新規）
+- test 追加:
+  - `src/renderer/src/styles/__tests__/glass-css-contract.test.ts`
+  - `src/renderer/src/styles/__tests__/drag-region-css-contract.test.ts`
+
+#### 検証結果（代替で PASS 済み）
+- [x] `git diff --check`: PASS
+- [x] `npm run typecheck`: PASS
+- [x] `npm run build:vite`: PASS（既存警告あり）
+- [x] targeted Vitest: PASS（2 files / 11 tests）
+- [x] `npm run test`: PASS（26 files / 185 tests、既存 jsdom `getContext` stderr あり、exit 0）
+- [x] rg 残存確認: 実行済み（例外あり）
+- [x] `cargo check --locked --manifest-path src-tauri\Cargo.toml --all-targets`: PASS
+- [x] `cargo test --locked --manifest-path src-tauri\Cargo.toml`: PASS（93 passed / 0 failed、他ターゲット 0 tests も PASS）
+
+#### Tauri 実機 smoke の最終扱い
+- [ ] feature branch の Tauri 実機 smoke は未実行扱い。
+- [x] 既存 `vibe-editor  Downloads` が single-instance として稼働中。
+- [x] ユーザーが「閉じられない」と明示。
+- [x] repo 内にコード / config 変更なしで安全に single-instance を回避する既存 script / flag / 別 identifier 手順は確認できず。
+- [x] QA により `npm run dev` は Vite ready / Rust dev build / `target\debug\vibe-editor.exe` 起動試行まで到達。
+- [ ] feature branch window を検出できず、Glass / drag / clickability / PTY smoke は未実証。
+- [x] ユーザー作業中の可能性があるため、既存アプリは停止しない判断。
+
+#### 未実証項目
+- [ ] Native window drag / app-region hit testing。
+- [ ] Glass + WebView2 Acrylic 実視覚。
+- [ ] WindowControls / popover / resize handle clickability。
+- [ ] IDE / Canvas 切替時の PTY 保持。
+
+#### PR判断 / merge前ゲート
+- [x] 未実行理由を PR 本文に明記する条件で、条件付き PR 可能。
+- [ ] 完全 Go ではない。merge 前は Branch Protection 復旧、reviewer / CodeRabbit 相当レビュー、人間承認が必須。
+- [ ] Branch Protection `main.protected=false` は merge 前ブロッカー。Owner 確認・保護設定復旧が必要。
+- [ ] reviewer / CodeRabbit 相当レビュー + 人間承認まで merge 不可。
+- [ ] `lint` / E2E は package.json に script 未定義のため、未実行を誤報告しない。必要なら別Issue / 別PR。
+
+#### ユーザー目視チェックリスト（参考確認）
+- [ ] Glass 見た目。
+- [ ] window drag。
+- [ ] WindowControls / popover / resize handle clickability。
+- [ ] IDE / Canvas 切替時の PTY 保持。
+- [ ] 既存アプリのみ確認する場合は feature 差分の証跡ではなく参考確認として記録する。
+
+#### PR前 add 対象 / 禁止対象
+- [ ] add 対象候補:
+  - production 変更 6 件: `Topbar.tsx`, `index.css`, `main.tsx`, `canvas.css`, `shell.css`, `tokens.css`
+  - 新規 CSS 2 件: `glass.css`, `drag-region.css`
+  - 契約テスト 2 件: `glass-css-contract.test.ts`, `drag-region-css-contract.test.ts`
+  - ドキュメント: `tasks/todo.md`
+- [ ] add 禁止:
+  - 既存未追跡 `tasks/*`
+  - `.env*`
+  - secret / token / private key 類
+
+#### Next Tasks
+- [ ] PR 本文に Tauri 実機 smoke 未実行理由を明記する。
+- [ ] PR 本文に代替 PASS 済み検証（typecheck / build:vite / Vitest / cargo check / cargo test / diff check）を記録する。
+- [ ] PR 作成時に `git add` 対象を上記 add 対象候補に限定する。
+- [ ] 既存アプリで参考確認する場合は、feature 差分の証跡ではないことを明記する。
+- [ ] merge 前に Branch Protection `main.protected=false` の Owner 確認・復旧方針を明記する。
+
+### Issue #452 引き継ぎ対応計画（2026-05-04 / Codex）
+- [ ] `git status --short --branch` で対象が `feature/issue-452` か確認する。
+- [ ] 既存 `AppData\Local\vibe-editor\vibe-editor.exe` は停止せず、Tauri CLI の `--config` で一時 `identifier` / `productName` を差し替えた dev 起動を試す。
+- [ ] 別 identifier の feature branch window を起動できた場合のみ、Glass / drag / clickability / IDE-Canvas 切替 PTY 保持を Tauri 実機 smoke として記録する。
+- [ ] 別 identifier 起動でも実機確認できない場合は、その理由を `tasks/todo.md` と PR 本文に明記し、未実証ゲートとして残す。
+- [ ] `git diff --check` と `git status --short --branch` を再確認し、PR 対象ファイルだけを明示 `git add` する。
+- [ ] PR 作成・レビュー確認まで進める。merge は Branch Protection 復旧、reviewer / CodeRabbit 相当レビュー、actionable 指摘ゼロ、人間承認が揃うまで禁止。
+
+#### Next Steps
+- [ ] 一時 config を repo 外に作成し、`npm run dev -- --config <temp-config>` で起動する。
+- [ ] 起動ログ・window 検出・目視 / 操作確認の結果をこの TODO に追記する。
+- [ ] PR 本文には smoke の実施方法、通過項目、未実証項目、merge 前ブロッカーを明記する。
+
+### Tauri実機smoke結果（2026-05-04 / 既存アプリ非停止）
+- [x] 既存 `C:\Users\zooyo\AppData\Local\vibe-editor\vibe-editor.exe` は停止せず維持。
+- [x] repo 外の一時 config `tauri-issue452-glass-smoke.config.json` で `identifier` / `productName` を差し替え、single-instance を回避。
+- [x] `npm run dev -- --config <temp-config>`: PASS（Vite `http://localhost:5173/` ready、`target\debug\vibe-editor.exe` 起動）。
+- [x] feature branch window 検出: PASS（`target\debug\vibe-editor.exe`, title `vibe-editor — vibe-editor`）。
+- [x] feature UI表示: PASS（Git branch `feature/issue-452` と対象差分一覧が表示されることをスクリーンショットで確認）。
+- [ ] Glass見た目: PARTIAL。Glass透過は確認できるが、既存アプリが最大化され背面に写り込むため、Acrylic / blur の厳密な目視判定は保留。
+- [ ] IDE Topbar / Canvas header の手動 window drag: 未実証。
+- [ ] WindowControls / popover / resize handle clickability: 未実証。
+- [ ] IDE / Canvas 切替時の PTY 保持: 未実証（xterm focus がショートカットを吸う状態があり、確証なし）。
+- [x] 一時的に退避した `C:\Users\zooyo\.vibe-editor\settings.json` は元設定へ復元済み（first bytes `123,10,32`、BOMなし）。
+
+#### Next Tasks
+- [ ] PR 本文に「既存アプリ非停止のため完全な native hit-testing smoke は未実証」と明記する。
+- [ ] merge 前に人間が feature branch window で drag / clickability / PTY保持を確認する。
+- [ ] merge 前に Branch Protection `main.protected=false` の復旧を確認する。


### PR DESCRIPTION
﻿## Summary
- Glass効果を `styles/components/glass.css` に集約し、tokensは値のSSOTに整理
- drag/no-drag指定を `styles/components/drag-region.css` に集約し、Topbar rootへ `data-tauri-drag-region` を付与
- Glass / drag-region のCSS契約テストを追加し、import順・SSOT・例外条件を検証

Closes #452

## Verification
- `git diff --check`: PASS
- `npm run typecheck`: PASS（引き継ぎ済み結果）
- `npm run build:vite`: PASS（引き継ぎ済み結果、既存warningあり）
- `npm run test`: PASS（引き継ぎ済み結果）
- `cargo check --locked --manifest-path src-tauri\Cargo.toml --all-targets`: PASS（引き継ぎ済み結果）
- `cargo test --locked --manifest-path src-tauri\Cargo.toml`: PASS（引き継ぎ済み結果）

## Tauri smoke
- 既存 `C:\Users\zooyo\AppData\Local\vibe-editor\vibe-editor.exe` は停止せず維持
- repo外の一時Tauri configで `identifier` / `productName` を差し替え、single-instanceを回避
- `npm run dev -- --config <temp-config>`: PASS（Vite ready、`target\debug\vibe-editor.exe` 起動）
- feature UI表示: PASS（`feature/issue-452` と対象差分一覧をスクリーンショットで確認）
- Glass見た目: PARTIAL（既存アプリ最大化 + Glass透過の背面写り込みにより Acrylic / blur の厳密判定は保留）
- 未実証: IDE Topbar / Canvas header の手動drag、WindowControls / popover / resize handle clickability、IDE / Canvas切替時のPTY保持

## Merge blockers
- `main.protected=false` を 2026-05-04 に確認。merge前にBranch Protection復旧が必要
- reviewer / CodeRabbit相当レビューで actionable 指摘ゼロが必要
- 人間承認が必要
- AIによる自動/手動mergeは禁止
