### PR TITLE
Fix Canvas HUD, palette, card headers, and spawn placement

### DIFF
--- a/src/renderer/src/components/CommandPalette.tsx
+++ b/src/renderer/src/components/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Search } from 'lucide-react';
 import { filterCommands, type Command } from '../lib/commands';
 import { useT } from '../lib/i18n';
@@ -89,7 +90,7 @@ export function CommandPalette({
       onClose();
     }
   };
-  return (
+  return createPortal(
     <div
       className="cmdp-backdrop"
       data-state={dataState}
@@ -163,6 +164,7 @@ export function CommandPalette({
           )}
         </ul>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/renderer/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/renderer/src/components/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { CommandPalette } from '../CommandPalette';
+import { SettingsProvider } from '../../lib/settings-context';
+import type { Command } from '../../lib/commands';
+
+const commands: Command[] = [
+  {
+    id: 'test-command',
+    title: 'Test command',
+    category: 'Test',
+    run: vi.fn()
+  }
+];
+
+function installWindowApi(): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).api = {
+    settings: {
+      load: vi.fn(() => new Promise(() => undefined)),
+      save: vi.fn(() => Promise.resolve())
+    },
+    app: {
+      setProjectRoot: vi.fn(() => Promise.resolve()),
+      setZoomLevel: vi.fn(() => Promise.resolve())
+    }
+  };
+}
+
+describe('CommandPalette', () => {
+  beforeEach(() => {
+    installWindowApi();
+    Element.prototype.scrollIntoView = vi.fn();
+    window.requestAnimationFrame = vi.fn(() => 1);
+    window.cancelAnimationFrame = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders the backdrop through a body portal', () => {
+    const { container } = render(
+      <SettingsProvider>
+        <CommandPalette open commands={commands} onClose={vi.fn()} />
+      </SettingsProvider>
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveClass('cmdp-backdrop');
+    expect(dialog.parentElement).toBe(document.body);
+    expect(container.querySelector('.cmdp-backdrop')).toBeNull();
+  });
+});

--- a/src/renderer/src/components/canvas/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/CardFrame.tsx
@@ -4,7 +4,7 @@
  * - ボディ: 子要素 (TerminalView 等を直接埋める)
  * - リサイズハンドルは React Flow の NodeResizer を使う想定 (Phase 4)
  */
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { NodeResizer } from '@xyflow/react';
 import { useConfirmRemoveCard } from '../../lib/use-confirm-remove-card';
 
@@ -35,23 +35,13 @@ export function CardFrame({
   minHeight = DEFAULT_MIN_H
 }: CardFrameProps): JSX.Element {
   const confirmRemoveCard = useConfirmRemoveCard();
+  const cardStyle = {
+    ['--card-accent' as string]: accent ?? '#7a7afd'
+  } as CSSProperties;
   return (
     <div
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        background: 'var(--bg-elevated, #16161c)',
-        border: `1px solid ${accent ?? 'var(--border, #2a2a35)'}`,
-        borderRadius: 8,
-        overflow: 'hidden'
-        // boxShadow は付けない。
-        // React Flow viewport の `transform: scale()` 配下で
-        // `overflow:hidden + border-radius + box-shadow` が揃うと Chromium が
-        // 合成レイヤを作って xterm DOM テキストごとビットマップ化し、
-        // ズーム時にバイリニア補間で滲む。border だけで十分。
-      }}
+      className="canvas-card-frame"
+      style={cardStyle}
     >
       <NodeResizer
         minWidth={minWidth}
@@ -60,71 +50,29 @@ export function CardFrame({
         handleStyle={{ width: 8, height: 8, borderRadius: 2 }}
         lineStyle={{ borderWidth: 1 }}
       />
-      <header
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          padding: '6px 10px',
-          background: 'var(--bg-deep, #0d0d12)',
-          borderBottom: '1px solid var(--border, #2a2a35)',
-          fontSize: 12,
-          color: 'var(--fg-muted, #a8a8b8)',
-          userSelect: 'none',
-          cursor: 'grab'
-        }}
-      >
-        <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-          <span
-            style={{
-              width: 8,
-              height: 8,
-              borderRadius: '50%',
-              background: accent ?? '#7a7afd'
-            }}
-          />
-          {title}
+      <header className="canvas-card-frame__header">
+        <span className="canvas-card-frame__title-row">
+          <span aria-hidden="true" className="canvas-card-frame__accent-dot" />
+          <span className="canvas-card-frame__title" title={title}>
+            {title}
+          </span>
         </span>
         <button
           type="button"
-          className="nodrag"
+          className="nodrag canvas-card-frame__close"
           onClick={() => confirmRemoveCard(id)}
-          style={{
-            // 旧 padding 2/6 + font 14 は押しにくかったので 28x28 のヒット領域に拡大
-            width: 28,
-            height: 28,
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            background: 'transparent',
-            border: 0,
-            borderRadius: 6,
-            color: 'var(--fg-muted, #a8a8b8)',
-            cursor: 'pointer',
-            fontSize: 18,
-            lineHeight: 1
-          }}
           title="Close"
         >
           ×
         </button>
       </header>
       <div
-        className="nodrag nowheel"
+        className="nodrag nowheel canvas-card-frame__body"
         // React Flow は親の onMouseDown で node selection / drag 開始を拾うため、
         // body 内のクリックが選択に変換され、内部の xterm が focus を奪えないケースがある。
         // 選択フローを完全に遮断して、クリックはそのまま子 (xterm 等) に届ける。
         onMouseDown={(e) => e.stopPropagation()}
         onPointerDown={(e) => e.stopPropagation()}
-        style={{
-          flex: 1,
-          minHeight: 0,
-          minWidth: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-          position: 'relative'
-        }}
       >
         {children}
       </div>

--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -164,7 +164,10 @@ export function StageHud(): JSX.Element {
                   className={
                     'tc__hud-arrange-gap' + (arrangeGap === g.id ? ' is-active' : '')
                   }
-                  onClick={() => setArrangeGap(g.id)}
+                  onClick={() => {
+                    setArrangeGap(g.id);
+                    tidyTerminalCards(g.id);
+                  }}
                 >
                   {g.label}
                 </button>

--- a/src/renderer/src/components/shell/WindowControls.tsx
+++ b/src/renderer/src/components/shell/WindowControls.tsx
@@ -11,12 +11,24 @@ import { Minus, Square, Copy, X } from 'lucide-react';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { useT } from '../../lib/i18n';
 
+type TauriWindowHandle = ReturnType<typeof getCurrentWindow>;
+
+function getSafeCurrentWindow(): TauriWindowHandle | null {
+  try {
+    return getCurrentWindow();
+  } catch (err) {
+    console.warn('[window-controls] window API unavailable:', err);
+    return null;
+  }
+}
+
 export function WindowControls(): JSX.Element {
   const t = useT();
   const [isMaximized, setIsMaximized] = useState(false);
 
   useEffect(() => {
-    const win = getCurrentWindow();
+    const win = getSafeCurrentWindow();
+    if (!win) return undefined;
     let unlisten: (() => void) | undefined;
     let disposed = false;
     void (async () => {
@@ -45,13 +57,13 @@ export function WindowControls(): JSX.Element {
   }, []);
 
   const handleMinimize = (): void => {
-    void getCurrentWindow().minimize();
+    void getSafeCurrentWindow()?.minimize();
   };
   const handleToggleMaximize = (): void => {
-    void getCurrentWindow().toggleMaximize();
+    void getSafeCurrentWindow()?.toggleMaximize();
   };
   const handleClose = (): void => {
-    void getCurrentWindow().close();
+    void getSafeCurrentWindow()?.close();
   };
 
   return (

--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -59,6 +59,7 @@ import {
   formatCardCount,
   formatOrganizationAgentCount
 } from '../lib/canvas-layout-helpers';
+import { placeBatchAwayFromNodes } from '../lib/canvas-placement';
 import { useCanvasTeamRestore } from '../lib/hooks/use-canvas-team-restore';
 import { useCanvasAutoSave } from '../lib/hooks/use-canvas-auto-save';
 
@@ -91,6 +92,7 @@ export function CanvasLayout(): JSX.Element {
   const viewport = useCanvasStore((s) => s.viewport);
   const clear = useCanvasStore((s) => s.clear);
   const addCards = useCanvasStore((s) => s.addCards);
+  const notifyRecruit = useCanvasStore((s) => s.notifyRecruit);
   const { settings, update: updateSettings, reset: resetSettings } = useSettings();
   const t = useT();
   // プロジェクトルート: runtime の lastOpenedRoot を優先。ユーザー設定の
@@ -239,7 +241,9 @@ export function CanvasLayout(): JSX.Element {
         };
       })
     );
-    addCards(cards);
+    const placedCards = placeBatchAwayFromNodes(useCanvasStore.getState().nodes, cards);
+    const ids = addCards(placedCards);
+    if (ids[0]) notifyRecruit(ids[0]);
     setSpawnOpen(false);
     void loadRecent();
   };
@@ -294,7 +298,9 @@ export function CanvasLayout(): JSX.Element {
         }
       };
     });
-    addCards(cards);
+    const placedCards = placeBatchAwayFromNodes(useCanvasStore.getState().nodes, cards);
+    const ids = addCards(placedCards);
+    if (ids[0]) notifyRecruit(ids[0]);
     const updatedEntry: TeamHistoryEntry = {
       ...entry,
       lastUsedAt: new Date().toISOString()

--- a/src/renderer/src/lib/__tests__/canvas-placement.test.ts
+++ b/src/renderer/src/lib/__tests__/canvas-placement.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  placeBatchAwayFromNodes,
+  type BatchPlacementItem,
+  type CanvasPlacementNode
+} from '../canvas-placement';
+import { NODE_H, NODE_W } from '../../stores/canvas';
+import { GAP, presetPosition } from '../workspace-presets';
+
+const node = (
+  x: number,
+  y: number,
+  style?: CanvasPlacementNode['style']
+): CanvasPlacementNode => ({
+  position: { x, y },
+  style
+});
+
+const item = (x: number, y: number): BatchPlacementItem => ({
+  position: { x, y }
+});
+
+describe('canvas placement', () => {
+  it('moves a leader-only team spawn to the right of an existing card', () => {
+    const placed = placeBatchAwayFromNodes([node(0, 0)], [item(0, 0)], { gap: GAP });
+
+    expect(placed[0].position).toEqual({ x: NODE_W + GAP, y: 0 });
+  });
+
+  it('keeps batch-relative preset spacing when shifting multiple members', () => {
+    const existing = [node(0, 0), node(NODE_W + GAP, 0)];
+    const batch = [item(0, 0), item(NODE_W + GAP, 0)];
+    const placed = placeBatchAwayFromNodes(existing, batch, { gap: GAP });
+
+    expect(placed[0].position).toEqual({ x: (NODE_W + GAP) * 2, y: 0 });
+    expect(placed[1].position.x - placed[0].position.x).toBe(NODE_W + GAP);
+    expect(placed[1].position.y).toBe(placed[0].position.y);
+  });
+
+  it('does not move a batch that already avoids existing cards', () => {
+    const batch = [item(0, 0), item(NODE_W + GAP, 0)];
+    const placed = placeBatchAwayFromNodes([node(5000, 0)], batch, { gap: GAP });
+
+    expect(placed.map((card) => card.position)).toEqual(batch.map((card) => card.position));
+  });
+
+  it('uses existing node style dimensions for overlap checks', () => {
+    const placed = placeBatchAwayFromNodes(
+      [node(0, 0, { width: '800px', height: 500 })],
+      [item(NODE_W + GAP, 0)],
+      { gap: GAP }
+    );
+
+    expect(placed[0].position).toEqual({ x: 800 + GAP, y: 0 });
+  });
+
+  it('keeps presetPosition output usable as a relative batch layout', () => {
+    const batch = [presetPosition(0, 0), presetPosition(1, 0)].map((position) => ({
+      position
+    }));
+    const placed = placeBatchAwayFromNodes([node(0, 0)], batch, { gap: GAP });
+
+    expect(placed[1].position.x - placed[0].position.x).toBe(NODE_W + GAP);
+    expect(placed[1].position.y - placed[0].position.y).toBe(0);
+  });
+});

--- a/src/renderer/src/lib/canvas-placement.ts
+++ b/src/renderer/src/lib/canvas-placement.ts
@@ -1,0 +1,209 @@
+import { NODE_H, NODE_W } from '../stores/canvas';
+
+export interface CanvasPoint {
+  x: number;
+  y: number;
+}
+
+export interface CanvasPlacementNode {
+  position?: Partial<CanvasPoint>;
+  style?: {
+    width?: unknown;
+    height?: unknown;
+  };
+  measured?: {
+    width?: unknown;
+    height?: unknown;
+  };
+  width?: unknown;
+  height?: unknown;
+}
+
+export interface BatchPlacementItem {
+  position: CanvasPoint;
+  width?: number;
+  height?: number;
+}
+
+export interface BatchPlacementOptions {
+  gap?: number;
+  fallbackWidth?: number;
+  fallbackHeight?: number;
+}
+
+interface Rect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+const DEFAULT_GAP = 32;
+
+function finiteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function positiveDimension(value: unknown, fallback: number): number {
+  const parsed = finiteNumber(value);
+  return parsed !== null && parsed > 0 ? parsed : fallback;
+}
+
+function pointOrNull(position: Partial<CanvasPoint> | undefined): CanvasPoint | null {
+  const x = finiteNumber(position?.x);
+  const y = finiteNumber(position?.y);
+  return x === null || y === null ? null : { x, y };
+}
+
+function nodeRect(
+  node: CanvasPlacementNode,
+  fallbackWidth: number,
+  fallbackHeight: number
+): Rect | null {
+  const position = pointOrNull(node.position);
+  if (!position) return null;
+  const width = positiveDimension(
+    node.style?.width ?? node.measured?.width ?? node.width,
+    fallbackWidth
+  );
+  const height = positiveDimension(
+    node.style?.height ?? node.measured?.height ?? node.height,
+    fallbackHeight
+  );
+  return {
+    left: position.x,
+    top: position.y,
+    right: position.x + width,
+    bottom: position.y + height
+  };
+}
+
+function itemRect(item: BatchPlacementItem, fallbackWidth: number, fallbackHeight: number): Rect {
+  const width = positiveDimension(item.width, fallbackWidth);
+  const height = positiveDimension(item.height, fallbackHeight);
+  return {
+    left: item.position.x,
+    top: item.position.y,
+    right: item.position.x + width,
+    bottom: item.position.y + height
+  };
+}
+
+function bounds(rects: Rect[]): Rect {
+  return rects.reduce(
+    (acc, rect) => ({
+      left: Math.min(acc.left, rect.left),
+      top: Math.min(acc.top, rect.top),
+      right: Math.max(acc.right, rect.right),
+      bottom: Math.max(acc.bottom, rect.bottom)
+    }),
+    rects[0]
+  );
+}
+
+function overlaps(a: Rect, b: Rect): boolean {
+  return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+}
+
+function collides(rect: Rect, existing: Rect[]): boolean {
+  return existing.some((item) => overlaps(rect, item));
+}
+
+function translateRect(rect: Rect, dx: number, dy: number): Rect {
+  return {
+    left: rect.left + dx,
+    top: rect.top + dy,
+    right: rect.right + dx,
+    bottom: rect.bottom + dy
+  };
+}
+
+function normalizeBatch<T extends BatchPlacementItem>(batch: readonly T[]): T[] {
+  return batch.map((item) => {
+    const x = finiteNumber(item.position.x) ?? 0;
+    const y = finiteNumber(item.position.y) ?? 0;
+    return { ...item, position: { x, y } } as T;
+  });
+}
+
+function shiftBatch<T extends BatchPlacementItem>(
+  batch: readonly T[],
+  dx: number,
+  dy: number
+): T[] {
+  return batch.map(
+    (item) =>
+      ({
+        ...item,
+        position: {
+          x: item.position.x + dx,
+          y: item.position.y + dy
+        }
+      }) as T
+  );
+}
+
+/**
+ * Move only the new batch when team spawn positions would overlap existing cards.
+ * Existing user-arranged nodes are intentionally left untouched.
+ */
+export function placeBatchAwayFromNodes<T extends BatchPlacementItem>(
+  existingNodes: readonly CanvasPlacementNode[],
+  batch: readonly T[],
+  options: BatchPlacementOptions = {}
+): T[] {
+  const fallbackWidth = positiveDimension(options.fallbackWidth, NODE_W);
+  const fallbackHeight = positiveDimension(options.fallbackHeight, NODE_H);
+  const gap = positiveDimension(options.gap, DEFAULT_GAP);
+  const normalizedBatch = normalizeBatch(batch);
+  if (normalizedBatch.length === 0) return normalizedBatch;
+
+  const existingRects = existingNodes
+    .map((node) => nodeRect(node, fallbackWidth, fallbackHeight))
+    .filter((rect): rect is Rect => rect !== null);
+  if (existingRects.length === 0) return normalizedBatch;
+
+  const batchRect = bounds(
+    normalizedBatch.map((item) => itemRect(item, fallbackWidth, fallbackHeight))
+  );
+  if (!collides(batchRect, existingRects)) return normalizedBatch;
+
+  const occupied = bounds(existingRects);
+  const candidates: CanvasPoint[] = [
+    { x: occupied.right + gap, y: occupied.top },
+    { x: occupied.left, y: occupied.bottom + gap },
+    { x: occupied.right + gap, y: occupied.bottom + gap }
+  ];
+
+  for (const candidate of candidates) {
+    const dx = candidate.x - batchRect.left;
+    const dy = candidate.y - batchRect.top;
+    if (!collides(translateRect(batchRect, dx, dy), existingRects)) {
+      return shiftBatch(normalizedBatch, dx, dy);
+    }
+  }
+
+  const stepX = fallbackWidth + gap;
+  const stepY = fallbackHeight + gap;
+  const scanLimit = Math.max(12, existingRects.length + normalizedBatch.length + 6);
+  for (let row = 0; row <= scanLimit; row += 1) {
+    for (let col = 0; col <= scanLimit; col += 1) {
+      const candidate = {
+        x: occupied.left + col * stepX,
+        y: occupied.top + row * stepY
+      };
+      const dx = candidate.x - batchRect.left;
+      const dy = candidate.y - batchRect.top;
+      if (!collides(translateRect(batchRect, dx, dy), existingRects)) {
+        return shiftBatch(normalizedBatch, dx, dy);
+      }
+    }
+  }
+
+  return shiftBatch(normalizedBatch, occupied.right + gap - batchRect.left, 0);
+}

--- a/src/renderer/src/lib/use-window-frame-insets.ts
+++ b/src/renderer/src/lib/use-window-frame-insets.ts
@@ -13,6 +13,16 @@ import { useEffect } from 'react';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 
 const isWindows = /Windows/i.test(navigator.userAgent);
+type TauriWindowHandle = ReturnType<typeof getCurrentWindow>;
+
+function getSafeCurrentWindow(): TauriWindowHandle | null {
+  try {
+    return getCurrentWindow();
+  } catch (err) {
+    console.warn('[use-window-frame-insets] window API unavailable:', err);
+    return null;
+  }
+}
 
 export function useWindowFrameInsets(): void {
   useEffect(() => {
@@ -21,7 +31,8 @@ export function useWindowFrameInsets(): void {
     root.dataset.platform = 'windows';
     // 初期値を即時セットして flash を最小化
     root.dataset.windowMaximized = 'false';
-    const win = getCurrentWindow();
+    const win = getSafeCurrentWindow();
+    if (!win) return undefined;
     let unlisten: (() => void) | undefined;
     let disposed = false;
     void (async () => {

--- a/src/renderer/src/lib/webview-zoom.ts
+++ b/src/renderer/src/lib/webview-zoom.ts
@@ -19,11 +19,16 @@ let persistCallback: ((next: number) => void) | null = null;
 
 const clamp = (v: number): number => Math.max(MIN, Math.min(MAX, v));
 
+function applyHostZoom(value: number, label: string): void {
+  if (typeof window === 'undefined' || !window.api?.app?.setZoomLevel) return;
+  void window.api.app.setZoomLevel(value).catch((err) => {
+    console.warn(`[zoom] ${label} setZoomLevel failed:`, err);
+  });
+}
+
 const apply = (next: number): void => {
   current = clamp(next);
-  void window.api.app.setZoomLevel(current).catch((err) => {
-    console.warn('[zoom] setZoomLevel failed:', err);
-  });
+  applyHostZoom(current, 'apply');
   if (persistCallback) {
     try {
       persistCallback(current);
@@ -47,9 +52,7 @@ export const webviewZoom = {
   restoreFromSettings: (savedZoom: number | undefined): void => {
     const v = clamp(typeof savedZoom === 'number' && savedZoom > 0 ? savedZoom : 1.0);
     current = v;
-    void window.api.app.setZoomLevel(v).catch((err) => {
-      console.warn('[zoom] restore setZoomLevel failed:', err);
-    });
+    applyHostZoom(v, 'restore');
   },
   /** 永続化 callback を登録 (apply のたびに呼ばれる)。 */
   setPersistCallback: (cb: ((next: number) => void) | null): void => {

--- a/src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts
@@ -129,6 +129,8 @@ describe('normalizeCanvasState (Issue #385)', () => {
   it('arrangeGap が不正値なら normal に戻す', () => {
     expect(normalizeCanvasState({ arrangeGap: 999 }).arrangeGap).toBe('normal');
     expect(normalizeCanvasState({ arrangeGap: 'tight' }).arrangeGap).toBe('tight');
+    expect(normalizeCanvasState({ arrangeGap: 'wide' }).arrangeGap).toBe('wide');
+    expect(normalizeCanvasState({ arrangeGap: 'roomy' }).arrangeGap).toBe('normal');
   });
 
   it('node.position が有限でも rescue 距離超なら fallback grid に戻す (codex review #3)', () => {

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -234,7 +234,7 @@ function normalizeCanvasState(input: unknown): NormalizedCanvasState {
     : 'stage';
   const arrangeGap = ((): ArrangeGap => {
     const gap = p.arrangeGap;
-    return gap === 'tight' || gap === 'normal' || gap === 'roomy'
+    return gap === 'tight' || gap === 'normal' || gap === 'wide'
       ? gap
       : 'normal';
   })();

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -427,6 +427,100 @@
 }
 
 /* ----------
+ * Shared canvas card frame (TerminalCard / generic cards)
+ * ---------- */
+.canvas-card-frame {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated, var(--bg-panel));
+  border: 1px solid var(--card-accent, var(--border));
+  border-radius: 8px;
+  overflow: hidden;
+  /* box-shadow は付けない。
+     React Flow viewport の `transform: scale()` 配下で
+     `overflow:hidden + border-radius + box-shadow` が揃うと Chromium が
+     合成レイヤを作って xterm DOM テキストごとビットマップ化し、
+     ズーム時にバイリニア補間で滲む。border だけで十分。 */
+}
+
+.canvas-card-frame__header {
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 7px 10px 7px 12px;
+  background: var(--bg-deep, var(--bg-sidebar));
+  border-bottom: 1px solid var(--border);
+  font-size: var(--text-md, 14px);
+  font-weight: 600;
+  line-height: var(--leading-snug, 1.3);
+  color: var(--fg);
+  user-select: none;
+  cursor: grab;
+}
+
+.canvas-card-frame__header:active {
+  cursor: grabbing;
+}
+
+.canvas-card-frame__title-row {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 auto;
+}
+
+.canvas-card-frame__accent-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--card-accent, var(--accent));
+  flex-shrink: 0;
+}
+
+.canvas-card-frame__title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.canvas-card-frame__close {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.canvas-card-frame__close:hover {
+  background: var(--bg-hover);
+  color: var(--fg);
+}
+
+.canvas-card-frame__body {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+/* ----------
  * Agent card — Claude 公式風 (skill: claude-design 準拠)
  *
  *   - フラット (heavy shadow 禁止)、hairline border + 左端 2px ロール色バー
@@ -470,11 +564,13 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 6px 10px 6px 14px;
-  height: 34px;
+  gap: 10px;
+  padding: 7px 10px 7px 14px;
+  min-height: 42px;
   background: var(--bg-elev, var(--bg-panel));
   border-bottom: 1px solid var(--border);
-  font-size: 12px;
+  font-size: var(--text-md, 14px);
+  line-height: var(--leading-snug, 1.3);
   color: var(--fg);
   user-select: none;
   cursor: grab;
@@ -486,6 +582,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  flex: 1 1 auto;
   min-width: 0;
 }
 /*
@@ -493,15 +590,15 @@
  * 円形 + ロール色 + 微弱な glow リング。文字は role glyph (P/R/... 1 文字)。
  */
 .canvas-agent-card__avatar {
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
   background: var(--agent-accent, var(--accent));
   color: #0a0a0d;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 9px;
+  font-size: 11px;
   font-weight: 700;
   flex-shrink: 0;
   box-shadow: 0 0 0 3px
@@ -519,25 +616,31 @@
  */
 .canvas-agent-card__title {
   font-family: var(--font-claude-response, var(--ui-font));
-  font-weight: 500;
-  letter-spacing: var(--tracking-tight);
+  font-weight: 600;
+  letter-spacing: var(--tracking-normal);
+  flex: 1 1 auto;
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .canvas-agent-card__role {
-  font-size: 9px;
+  max-width: 96px;
+  font-size: var(--text-xs, 11px);
   color: color-mix(in srgb, var(--agent-accent, var(--fg-muted)) 80%, var(--fg-muted));
   text-transform: uppercase;
-  letter-spacing: 0.6px;
-  flex-shrink: 0;
+  letter-spacing: var(--tracking-wide, 0.02em);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 1;
 }
 .canvas-agent-card__organization {
   max-width: 120px;
   min-width: 0;
-  padding: 1px 6px;
+  padding: 2px 7px;
   border-radius: 999px;
-  font-size: 9px;
+  font-size: var(--text-xs, 11px);
   line-height: 1.4;
   color: color-mix(in srgb, var(--organization-accent, var(--fg)) 82%, var(--fg));
   background: color-mix(in srgb, var(--organization-accent, var(--accent)) 13%, transparent);
@@ -550,20 +653,20 @@
 .canvas-agent-card__actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   flex-shrink: 0;
 }
 .canvas-agent-card__status {
-  font-size: 10px;
+  font-size: var(--text-xs, 11px);
   color: var(--fg-subtle);
-  max-width: 140px;
+  max-width: 120px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .canvas-agent-card__tool {
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -584,9 +687,9 @@
 }
 .canvas-agent-card__close {
   /* 旧 20x20/14px は Fitts 的に小さすぎ (右クリックメニュー追加前は ×が唯一の閉じ手段)。
-     28x28 + 18px グリフへ拡大。ヘッダ高 (34px) を超えない範囲で最大化。 */
-  width: 28px;
-  height: 28px;
+     30x30 + 20px グリフへ拡大。 */
+  width: 30px;
+  height: 30px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -595,7 +698,7 @@
   border: 0;
   border-radius: 6px;
   cursor: pointer;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1;
   transition: background-color 100ms ease, color 100ms ease;
 }
@@ -681,10 +784,11 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 9px;
+  flex-shrink: 0;
+  font-size: 10px;
   color: var(--fg-subtle);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: var(--tracking-wide, 0.02em);
 }
 .canvas-agent-status__dot {
   width: 6px;

--- a/src/renderer/src/styles/components/palette.css
+++ b/src/renderer/src/styles/components/palette.css
@@ -1,4 +1,8 @@
 .cmdp-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-palette);
+  display: flex;
   align-items: flex-start;
   justify-content: center;
   padding: max(12vh, 72px) 20px 24px;
@@ -22,6 +26,7 @@
 
 .cmdp {
   /* Claude 公式風: フラットな bg (gradient 禁止)、radius-lg 相当 */
+  position: relative;
   width: min(640px, calc(100vw - 32px));
   max-height: min(72vh, 760px);
   border-radius: var(--radius-lg, 16px);

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -327,8 +327,8 @@ samp,
  * 小さな local stacking (1/2/5/10/20) は各コンポーネント内に留め、ここでは
  * "画面全体に対してどの層にいるか" が問題になるものだけを集約する。
  *
- * 9000 台は Canvas モード (常時最前面) とノイズオーバーレイ専用。
- * アプリ全体の最前面 (modal/palette/toast) は 1000〜3500 台。
+ * 9000 台は Canvas モード (常時最前面) と、その上に出る body portal UI 用。
+ * Canvas root より下でよい modal/toast は 1000〜3500 台に留める。
  *
  * Issue #356: ContextMenu は createPortal(document.body) で body 直下に出るため、
  * Canvas モード時は .canvas-layout (z-index: --z-canvas-root = 9200) と body の
@@ -342,7 +342,7 @@ samp,
   --z-nav: 600;
   --z-modal: 1000;
   --z-modal-elevated: 1500;
-  --z-palette: 2000;
+  --z-palette: 9600;
   --z-toast: 3000;
   --z-toast-top: 3200;
   --z-noise-overlay: 9000;

--- a/tasks/issue-autopilot-batch-handoff-2026-05-04.md
+++ b/tasks/issue-autopilot-batch-handoff-2026-05-04.md
@@ -152,3 +152,58 @@
 - [ ] 通常の `npm run dev` または人間の確認用環境で Canvas を開き、Terminal / Agent header、CommandPalette、gap変更の手動 smoke を行う。
 - [ ] PR を作成し、本文に自動検証 PASS と UI smoke 未完了理由を明記する。
 - [ ] CodeRabbit / reviewer / 人間承認 / QA 合意なしに merge しない。
+
+---
+
+## Issue #455 追補計画 (2026-05-04 / Codex)
+
+### 現状
+
+- PR #459 は Draft / CI `verify` SUCCESS / review・comments なし。
+- #455 は Tier C の Canvas 配置バグで、#441/#457 と同じ Draft PR に追補する方が未マージ差分との衝突を避けやすい。
+- 既存カードの手動レイアウトは維持し、新規チーム起動バッチだけを非衝突位置へ移す。
+
+### 実装方針
+
+- `src/renderer/src/lib/canvas-placement.ts` に batch 配置 helper を追加する。
+- `CanvasLayout.applyPreset()` と `restoreRecent()` の追加カード配列へ helper を適用する。
+- `addCards()` 後は先頭カード id を `notifyRecruit()` に渡し、viewport が新 Leader を見失わないようにする。
+- 手動 `+` 追加の `stagger()` は今回の対象外として維持する。
+
+### 検証コマンド
+
+- `npx vitest run src/renderer/src/lib/__tests__/canvas-placement.test.ts src/renderer/src/lib/__tests__/workspace-presets.test.ts`
+- `npm run typecheck`
+- `npm run build:vite`
+- `git diff --check`
+
+### Next Steps
+
+- [ ] helper と回帰テストを実装する。
+- [ ] 検証結果と残課題をこの引き継ぎ書と `tasks/todo.md` へ追記する。
+- [ ] PR #459 の title/body を #455 追補込みへ更新する。
+- [ ] merge は CodeRabbit / reviewer / 人間承認 / QA 合意後に人間が判断する。
+
+## Issue #455 実装結果 (2026-05-04 / Codex)
+
+### 変更内容
+
+- `src/renderer/src/lib/canvas-placement.ts` を追加し、既存カードと重なる新規チーム起動 batch だけを非衝突位置へ移す helper を実装。
+- `CanvasLayout.applyPreset()` と `restoreRecent()` で、プリセット相対配置 / saved position を保ったまま helper を適用。
+- `addCards()` 後に先頭カード id を `notifyRecruit()` へ渡し、新 Leader を viewport が見失わないようにした。
+- full Vitest の未処理 rejection 対策として、`webview-zoom.ts` の `setZoomLevel` 呼び出しを `window` 存在確認つきに安全化。
+- `src/renderer/src/lib/__tests__/canvas-placement.test.ts` を追加し、leader-only / 複数member / style寸法 / 相対距離維持を検証。
+
+### 検証結果
+
+- `npx vitest run src/renderer/src/lib/__tests__/canvas-placement.test.ts src/renderer/src/lib/__tests__/workspace-presets.test.ts`: PASS (2 files / 8 tests)
+- `npx vitest run src/renderer/src/lib/__tests__/canvas-arrange.test.ts src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts src/renderer/src/components/__tests__/CommandPalette.test.tsx src/renderer/src/lib/__tests__/canvas-placement.test.ts src/renderer/src/lib/__tests__/workspace-presets.test.ts`: PASS (5 files / 29 tests)
+- `npm run test`: PASS (28 files / 191 tests)。既存の jsdom `HTMLCanvasElement.getContext` stderr は継続するが exit 0。
+- `npm run typecheck`: PASS
+- `npm run build:vite`: PASS。既存の chunk size / ineffective dynamic import warning は継続。
+- `git diff --check`: PASS
+
+### 残課題
+
+- UI smoke は未実施。通常 Tauri 環境で「チーム起動」新カードの非重なりと viewport focus を手動確認する。
+- PR #459 の title/body を #455 追補込みへ更新し、commit / push 後に CI と CodeRabbit を再確認する。

--- a/tasks/issue-autopilot-batch-handoff-2026-05-04.md
+++ b/tasks/issue-autopilot-batch-handoff-2026-05-04.md
@@ -1,0 +1,154 @@
+# Issue Autopilot Batch 引き継ぎ書
+
+作成日: 2026-05-04  
+対象リポジトリ: `yusei531642/vibe-editor`  
+ローカルパス: `C:\Users\zooyo\Documents\Codex\2026-05-04\https-github-com-yusei531642-vibe-editor-3`
+
+## 計画
+
+- `planned` ラベル付き Issue から、低リスクかつ関連性の高い Canvas/UI グループを先に実施する。
+- 初回バッチは #457 / #453 / #441 の 3 件に限定する。
+- `main` 直接 push / 手動 merge は行わず、feature branch -> PR -> reviewer / CodeRabbit 相当確認 -> 人間承認の流れを守る。
+- 実装前計画は `tasks/todo.md` の「Issue Autopilot Batch: Canvas/UI 低リスクグループ計画（2026-05-04 / Codex）」に記録済み。
+
+## Next Steps
+
+- ユーザー確認後、`feature/issue-441-canvas-ui-batch` を作成する。
+- #457 / #453 / #441 の実装とテストを行う。
+- 実装後、この引き継ぎ書または `tasks/todo.md` に進捗・検証結果・残課題を追記する。
+
+## 現在の状態
+
+- リポジトリは指定フォルダへ clone 済み。
+- 現在ブランチは `main`、`origin/main` と同期状態。
+- 未コミット変更は `tasks/todo.md` の計画追記のみ。
+- コード変更、ブランチ作成、Issue ラベル変更、PR 作成は未実施。
+- `AGENTS.md`, `CLAUDE.md`, `.claude/skills/vibeeditor/SKILL.md`, `.claude/skills/pullrequest/SKILL.md`, issue-autopilot-batch skill を確認済み。
+
+## planned Issue 一覧と判断
+
+| Issue | 判断 | 理由 |
+|---|---|---|
+| #457 キャンバスモードの各ターミナルのヘッダー内コメントのフォントサイズがちいさすぎる | 初回対象 | Tier C。Canvas/UI/CSS 中心で低リスク。 |
+| #453 Canvas モードで Ctrl+Shift+P を押してもコマンドパレットが開かない | 初回対象 | Tier C。CommandPalette の描画レイヤ修正で Canvas UI 検証にまとめられる。 |
+| #441 キャンバスモードでサイズ統一ボタン、間隔ボタンが効かない | 初回対象 | Canvas HUD + store の小規模修正。#457/#453 と同じ画面で確認できる。 |
+| #455 チーム起動カードが既存カードと重なる | 後続候補 | Tier C だが配置 helper / preset / restore / viewport focus まで影響し、初回3件より少し広い。 |
+| #456 Codex-only チーム展開で HR が ClaudeCode になる | 後続 | Tier B。prompt / skill / schema 横断で #451 周辺差分との競合注意あり。 |
+| #454 スタンドアロン Codex / Claude タブで MCP startup failed | 後続 | Tier B。backend / bridge / MCP startup の変更を含む。 |
+| #451 team_send 成功後に worker が停止 | 除外 | `fortress-review-required` 付き。高リスク扱い。 |
+
+## 実装メモ
+
+### #457
+
+- 主な候補:
+  - `src/renderer/src/components/canvas/CardFrame.tsx`
+  - `src/renderer/src/styles/components/canvas.css`
+- 方針:
+  - CardFrame header の inline style を CSS クラス化する。
+  - header font を `var(--text-md)` 相当へ底上げする。
+  - AgentNodeCard header / avatar / role / organization / status / status badge の可読性を改善する。
+  - 長いタイトルは ellipsis で Close ボタンと衝突しないようにする。
+
+### #453
+
+- 主な候補:
+  - `src/renderer/src/components/CommandPalette.tsx`
+  - `src/renderer/src/styles/components/palette.css`
+  - 必要に応じて `src/renderer/src/styles/tokens.css`
+- 方針:
+  - `CommandPalette` を `createPortal(..., document.body)` で body 直下に描画する。
+  - `.cmdp-backdrop` に `position: fixed`, `inset: 0`, `display: flex`, `z-index: var(--z-palette)` を明示する。
+  - `--z-palette` が `--z-canvas-root` より上であることを確認する。
+  - Canvas 側に CommandPalette を複製しない。
+
+### #441
+
+- 主な候補:
+  - `src/renderer/src/components/canvas/StageHud.tsx`
+  - `src/renderer/src/stores/canvas.ts`
+  - `src/renderer/src/lib/__tests__/canvas-arrange.test.ts`
+  - `src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts`
+- 方針:
+  - `normalizeCanvasState()` の `arrangeGap` 正規化を `tight | normal | wide` に修正する。現在は `roomy` を許可して `wide` を落とす状態。
+  - HUD の gap ボタン押下時に `setArrangeGap(g.id)` だけでなく `tidyTerminalCards(g.id)` も実行し、即時に見た目へ反映する。
+  - サイズ統一は既存 `unifyTerminalCardSize()` の回帰テストで固定する。
+
+## 推奨検証
+
+- `npx vitest run src/renderer/src/lib/__tests__/canvas-arrange.test.ts src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts`
+- CommandPalette portal のテストを追加した場合は、その対象テストも実行する。
+- `npm run typecheck`
+- `npm run build:vite`
+- `git diff --check`
+- UI 変更後は `npm run dev` で Tauri 実機確認する。
+
+## UI 手動確認観点
+
+- Canvas モードで TerminalCard / AgentNodeCard のヘッダーが読みやすい。
+- Canvas ズーム 1.0 / 0.75 / 0.5 でタイトルやロール表示が破綻しない。
+- Canvas モードで `Ctrl+Shift+P` を押すと CommandPalette が Canvas より前面に出る。
+- IDE モードでも `Ctrl+Shift+P` が従来通り動く。
+- CommandPalette は Escape / backdrop click / command 実行で閉じる。
+- Canvas HUD の `tight / normal / wide` を押すたびに terminal / agent card の配置が即時に変わる。
+- `arrangeGap: "wide"` が reload 後も維持される。
+
+## 注意点
+
+- `rg.exe` がこの環境で一度 `Access is denied` になった。検索は PowerShell `Get-ChildItem` / `Select-String` へ fallback 可能。
+- `tasks/todo.md` には過去タスクが大量にあるため、今回の追記箇所だけを扱う。
+- 既存 `tasks/refactor-handoff.md` は今回の作業とは別件。上書きしない。
+- `.env*`、secret、既存未追跡ファイルは add しない。
+- `main` へ直接 push しない。PR の手動 merge もしない。
+
+## 進捗
+
+- [x] `planned` Issue 7 件を確認。
+- [x] 初回対象を #457 / #453 / #441 に絞った。
+- [x] `tasks/todo.md` に実装前計画と Next Steps を追記。
+- [x] 本引き継ぎ書を作成。
+- [x] feature branch 作成: `feature/issue-441-canvas-ui-batch`。
+- [x] 実装。
+- [x] テスト / build / 差分確認。
+- [ ] UI 確認。
+- [ ] PR 作成。
+
+## Next Tasks
+
+- [x] `git status --short --branch` で未コミット変更を確認する。
+- [x] `git switch -c feature/issue-441-canvas-ui-batch` で作業ブランチを作る。
+- [x] #441 の store / HUD 修正とテスト追加から着手する。
+- [x] #453 の portal / z-index 修正を行う。
+- [x] #457 の Canvas header 可読性改善を行う。
+- [x] 検証結果を `tasks/todo.md` とこの引き継ぎ書へ追記する。
+- [ ] PR 作成前に差分対象を再確認し、`Closes #441`, `Closes #453`, `Closes #457` を PR 本文へ入れる。
+- [ ] 通常の Tauri 起動環境で Canvas の手動 smoke を再実施する。
+
+## 実装結果 (2026-05-04)
+
+- #441: `normalizeCanvasState()` の `arrangeGap` 許可値を `tight | normal | wide` に修正し、legacy `roomy` は `normal` へ戻す回帰テストを追加。
+- #441: Stage HUD の gap ボタン押下時に `setArrangeGap(g.id)` と `tidyTerminalCards(g.id)` を連動させ、押下直後に配置へ反映するよう修正。
+- #453: CommandPalette を `document.body` 直下へ portal し、backdrop を fixed overlay 化。`--z-palette` を Canvas / context menu より上へ調整。
+- #453: CommandPalette portal の軽量テストを追加。
+- #457: Canvas の共通 `CardFrame` header を CSS クラス化し、Terminal / Agent header の文字サイズ・高さ・省略表示・ボタンサイズを底上げ。
+- 追加対応: dev/browser/custom Tauri smoke で `getCurrentWindow()` が Tauri metadata 不在時に render を落とさないよう、WindowControls と window frame inset hook を安全化。
+
+## 検証結果
+
+- `npx vitest run src/renderer/src/lib/__tests__/canvas-arrange.test.ts src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts src/renderer/src/components/__tests__/CommandPalette.test.tsx`: PASS (3 files / 21 tests)
+- `npm run typecheck`: PASS
+- `npm run build:vite`: PASS。既存の chunk size / ineffective dynamic import warning は継続。
+- `git diff --check`: PASS
+
+## UI確認結果
+
+- `npm run build:vite` 相当の production build は通過。
+- Vite 直表示では Tauri IPC がないため、アプリ全体の操作 smoke には不適。今回 `getCurrentWindow()` 由来の render crash は安全化済み。
+- 別 identifier の Tauri smoke は起動できたが、Tauri IPC injection が不完全で settings load が default へ落ちるため、#457/#453/#441 の完全な手動操作確認は未完了。
+- 検証用 Vite / Tauri プロセスは停止済み。`C:\Users\zooyo\.vibe-editor\settings.json` は事前バックアップから復元済み。
+
+## Next Tasks (更新)
+
+- [ ] 通常の `npm run dev` または人間の確認用環境で Canvas を開き、Terminal / Agent header、CommandPalette、gap変更の手動 smoke を行う。
+- [ ] PR を作成し、本文に自動検証 PASS と UI smoke 未完了理由を明記する。
+- [ ] CodeRabbit / reviewer / 人間承認 / QA 合意なしに merge しない。

--- a/tasks/issue-autopilot-batch-handoff-2026-05-04.md
+++ b/tasks/issue-autopilot-batch-handoff-2026-05-04.md
@@ -207,3 +207,30 @@
 
 - UI smoke は未実施。通常 Tauri 環境で「チーム起動」新カードの非重なりと viewport focus を手動確認する。
 - PR #459 の title/body を #455 追補込みへ更新し、commit / push 後に CI と CodeRabbit を再確認する。
+
+## 追加UI Smoke結果 (2026-05-04 / Playwright MCP)
+
+- `npm run dev:vite -- --host 127.0.0.1 --port 5177` で renderer を起動し、Playwright MCP で Canvas 画面へ遷移。
+- #453: Canvas 上で `Ctrl+Shift+P` を押下し、CommandPalette の body portal を確認。
+  - `.cmdp-backdrop`: 1
+  - `body > .cmdp-backdrop`: 1
+  - computed `z-index`: `9600`
+- #455: 「チーム起動」を 2 回実行し、React Flow node 2 件が重ならないことを bbox で確認。
+  - node boxes: `[-423,279,640,400]`, `[249,279,640,400]`
+  - overlap: `false`
+- #457: Agent header の computed style を確認。
+  - selector: `.canvas-agent-card__header`
+  - count: 2
+  - `font-size: 14px`, `min-height: 42px`, `height: 44.8px`
+- #441: HUD「整理」メニューで「広い」をクリックし、即時再配置を確認。
+  - before gap: `672px`
+  - after gap: `688px`
+  - `aria-checked=true`
+- screenshot: `issue-459-canvas-smoke.png`
+- 検証用 Vite port 5177 は停止済み。
+
+## 完了処理方針 (2026-05-04)
+
+- PR #459 を Ready for review に変更する。
+- #441 / #453 / #455 / #457 に完了コメントを投稿し、`completed` として close する。
+- merge は実施しない。人間承認とQA合意後に行う。

--- a/tasks/issue-autopilot-batch-handoff-2026-05-04.md
+++ b/tasks/issue-autopilot-batch-handoff-2026-05-04.md
@@ -234,3 +234,10 @@
 - PR #459 を Ready for review に変更する。
 - #441 / #453 / #455 / #457 に完了コメントを投稿し、`completed` として close する。
 - merge は実施しない。人間承認とQA合意後に行う。
+
+## 完了処理結果 (2026-05-04)
+
+- PR #459: Ready for review / OPEN / MERGEABLE。
+- 最新 GitHub Actions `verify`: PASS。
+- #441 / #453 / #455 / #457 は完了コメント投稿後、`completed` として close 済み。
+- Merge は未実施。CodeRabbit / reviewer / 人間承認 / QA 合意後に人間が判断する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -946,6 +946,12 @@ PR: https://github.com/yusei531642/vibe-editor/pull/459
 - [x] 検証用 Vite port 5177 は停止済み。
 
 ### 完了処理 Next Tasks (2026-05-04)
-- [ ] PR #459 を Ready for review に変更する。
-- [ ] #441 / #453 / #455 / #457 に完了コメントを投稿し、`completed` として close する。
-- [ ] 最終PR/Issue状態を確認する。
+- [x] PR #459 を Ready for review に変更する。
+- [x] 最新push後の GitHub Actions `verify`: PASS。
+- [x] #441 / #453 / #455 / #457 に完了コメントを投稿し、`completed` として close する。
+- [x] 最終PR/Issue状態を確認する。
+
+### 最終状態 (2026-05-04)
+- PR #459: Ready for review / OPEN / MERGEABLE / CI `verify` SUCCESS。
+- Closed: #441, #453, #455, #457。
+- Merge は未実施。CodeRabbit / reviewer / 人間承認 / QA 合意後に人間が判断する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -879,3 +879,59 @@ Branch: `feature/issue-452`
 - [ ] 通常の `npm run dev` または人間の確認用環境で Canvas を開き、#457/#453/#441 の手動 smoke を実施する。
 - [ ] PR 本文に `Closes #441`, `Closes #453`, `Closes #457` と検証結果、UI smoke 未完了理由を記載する。
 - [ ] CodeRabbit / reviewer / 人間承認 / QA 合意なしに merge しない。
+
+---
+
+## Issue #455 追補計画 (2026-05-04 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/455
+Branch: `feature/issue-441-canvas-ui-batch`
+PR: https://github.com/yusei531642/vibe-editor/pull/459
+
+### 判断
+- [x] PR #459 は Draft / CI `verify` SUCCESS / review・comments なし。
+- [x] #455 は Tier C で、#441/#457 と同じ Canvas 配置・表示領域に閉じる。
+- [x] 未マージの Canvas 差分と衝突しやすいため、別ブランチではなく現在の Draft PR #459 へ追補する。
+- [x] 既存カードは動かさず、新規チーム起動バッチだけを非衝突位置へ offset する。
+
+### 実装計画
+- [ ] `src/renderer/src/lib/canvas-placement.ts` を追加し、既存 node bbox と追加予定 batch bbox から非衝突 offset を決める helper を実装する。
+- [ ] helper は `NODE_W` / `NODE_H` を fallback にし、既存 node の `style.width` / `style.height` がある場合は bbox 計算へ反映する。
+- [ ] `CanvasLayout.applyPreset()` で `presetPosition()` の相対配置を維持したまま helper を通し、`addCards()` 後に先頭カードへ `notifyRecruit()` する。
+- [ ] `restoreRecent()` でも saved position / fallback position の batch 全体を同じ helper に通し、復元直後の重なりを避ける。
+- [ ] 手動 `+` 追加の `stagger()` は今回の対象外として維持する。
+
+### 検証計画
+- [ ] `npx vitest run src/renderer/src/lib/__tests__/canvas-placement.test.ts src/renderer/src/lib/__tests__/workspace-presets.test.ts`
+- [ ] `npm run typecheck`
+- [ ] `npm run build:vite`
+- [ ] `git diff --check`
+- [ ] UI smoke は PR #459 と同じ制約あり。可能なら通常 Tauri 環境で「チーム起動」新カードが既存カードと重ならず、viewport が新Leaderへ寄ることを確認する。
+
+### Next Steps
+- [ ] helper とテストを実装する。
+- [ ] 検証結果を `tasks/todo.md` と引き継ぎ書へ追記する。
+- [ ] PR #459 の本文・タイトルを #455 追補込みへ更新する。
+- [ ] CodeRabbit / reviewer / QA 合意なしに merge しない。
+
+### 進捗 (2026-05-04 / Codex)
+- [x] `src/renderer/src/lib/canvas-placement.ts` を追加。既存 node bbox と追加 batch bbox を比較し、重なる場合は既存 bbox の右側 / 下側 / grid scan の順で新規 batch だけを移動する。
+- [x] 既存 node の `style.width` / `style.height` を bbox 計算に反映。未指定時は `NODE_W` / `NODE_H` を fallback にする。
+- [x] `CanvasLayout.applyPreset()` と `restoreRecent()` に helper を接続し、`addCards()` 後に先頭カードへ `notifyRecruit()` を発火する。
+- [x] `src/renderer/src/lib/__tests__/canvas-placement.test.ts` を追加し、leader-only / 複数member / style寸法 / relative spacing の回帰を固定した。
+- [x] full Vitest の未処理 rejection を潰すため、`webview-zoom.ts` の host IPC 呼び出しを `window` 存在確認つきに安全化した。
+
+### 検証結果 (2026-05-04 / #455追補)
+- [x] `npx vitest run src/renderer/src/lib/__tests__/canvas-placement.test.ts src/renderer/src/lib/__tests__/workspace-presets.test.ts`: PASS (2 files / 8 tests)
+- [x] `npx vitest run src/renderer/src/lib/__tests__/canvas-arrange.test.ts src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts src/renderer/src/components/__tests__/CommandPalette.test.tsx src/renderer/src/lib/__tests__/canvas-placement.test.ts src/renderer/src/lib/__tests__/workspace-presets.test.ts`: PASS (5 files / 29 tests)
+- [x] `npm run test`: PASS (28 files / 191 tests)。既存の jsdom `HTMLCanvasElement.getContext` stderr は出るが exit 0。
+- [x] `npm run typecheck`: PASS
+- [x] `npm run build:vite`: PASS。既存の chunk size / ineffective dynamic import warning は継続。
+- [x] `git diff --check`: PASS
+- [ ] UI smoke: 未実施。PR #459 と同じく、通常 Tauri 環境での手動確認が必要。
+
+### Next Tasks (2026-05-04 / #455追補)
+- [ ] PR #459 の title/body を `Closes #455` と今回の検証結果込みへ更新する。
+- [ ] 変更を commit / push し、CI と CodeRabbit を確認する。
+- [ ] 通常 Tauri 環境で「チーム起動」新カードが既存カードと重ならず、viewport が新 Leader へ寄ることを手動 smoke する。
+- [ ] CodeRabbit / reviewer / QA 合意なしに merge しない。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -935,3 +935,17 @@ PR: https://github.com/yusei531642/vibe-editor/pull/459
 - [ ] 変更を commit / push し、CI と CodeRabbit を確認する。
 - [ ] 通常 Tauri 環境で「チーム起動」新カードが既存カードと重ならず、viewport が新 Leader へ寄ることを手動 smoke する。
 - [ ] CodeRabbit / reviewer / QA 合意なしに merge しない。
+
+### 追加UI Smoke (2026-05-04 / Playwright MCP)
+- [x] `npm run dev:vite -- --host 127.0.0.1 --port 5177` で renderer を起動し、Playwright MCP で Canvas へ遷移できることを確認。
+- [x] #453: Canvas 上で `Ctrl+Shift+P` を押下し、`.cmdp-backdrop` が 1 件、`body > .cmdp-backdrop` が 1 件、`z-index=9600` で表示されることを確認。
+- [x] #455: 「チーム起動」を 2 回実行し、React Flow node が 2 件、bbox は `[-423,279,640,400]` と `[249,279,640,400]`、overlap=false を確認。
+- [x] #457: `.canvas-agent-card__header` が 2 件、computed style は `font-size: 14px`, `min-height: 42px`, `height: 44.8px` を確認。
+- [x] #441: HUD「整理」メニューで「広い」をクリックし、`aria-checked=true`、カード間隔が 672px から 688px へ即時変化することを確認。
+- [x] screenshot: `issue-459-canvas-smoke.png`
+- [x] 検証用 Vite port 5177 は停止済み。
+
+### 完了処理 Next Tasks (2026-05-04)
+- [ ] PR #459 を Ready for review に変更する。
+- [ ] #441 / #453 / #455 / #457 に完了コメントを投稿し、`completed` として close する。
+- [ ] 最終PR/Issue状態を確認する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -810,3 +810,72 @@ Branch: `feature/issue-452`
 - [ ] PR 本文に「既存アプリ非停止のため完全な native hit-testing smoke は未実証」と明記する。
 - [ ] merge 前に人間が feature branch window で drag / clickability / PTY保持を確認する。
 - [ ] merge 前に Branch Protection `main.protected=false` の復旧を確認する。
+
+---
+
+## Issue Autopilot Batch: Canvas/UI 低リスクグループ計画（2026-05-04 / Codex）
+
+対象: https://github.com/yusei531642/vibe-editor/issues
+
+### 調査結果
+- [x] `planned` ラベル付き open Issue は 7 件: #457, #456, #455, #454, #453, #451, #441。
+- [x] #451 は `fortress-review-required` 付きの Tier A 相当で初回バッチから除外。
+- [x] #454 は backend / generated bridge / MCP startup を含む Tier B で初回バッチから除外。
+- [x] #456 は prompt / skill / schema を横断する Tier B で、#451 周辺差分との競合注意があるため初回バッチから除外。
+- [x] #455 は Canvas 配置ロジックの Tier C だが、spawn preset / restore / viewport focus まで見るため初回の最小グループからは後続候補にする。
+- [x] open PR は dependabot 系 #431-#439 のみで、Canvas/UI 対象ファイルとの直接競合は現時点で未検出。
+- [x] `vibeeditor` / `pullrequest` skill と `CLAUDE.md` を確認済み。リポジトリ方針に従い `main` 直接 push / 手動 merge はしない。
+
+### 初回バッチ対象
+- [ ] #457: Canvas モード各ターミナル/Agent ヘッダーのフォントサイズ・高さを改善する。
+- [ ] #453: Canvas モードで `Ctrl+Shift+P` の CommandPalette が見えるよう portal / z-index を修正する。
+- [ ] #441: Canvas HUD の「間隔」ボタンを押した直後に再配置し、`arrangeGap: "wide"` の永続化正規化を修正する。
+
+### 採用理由
+- [x] 3 件とも `canvas` / `ui` 中心で、renderer 側の CSS / React / zustand store に閉じる。
+- [x] Issue 計画上は #457, #453 が Tier C / score 4、#441 も小規模な Canvas HUD + store 修正で低リスク。
+- [x] 変更対象が Canvas 表示・HUD・global overlay にまとまり、検証を Canvas 起点で一括化できる。
+- [x] Rust / MCP / TeamHub / 外部プロセス起動の変更を含まないため、初回バッチとして安全。
+
+### 実装計画
+- [ ] ブランチは `feature/issue-441-canvas-ui-batch` を作成し、1 PR にまとめる場合は PR 本文に `Closes #441`, `Closes #453`, `Closes #457` を明記する。
+- [ ] #457: `CardFrame.tsx` の header inline style を CSS クラス化し、`canvas.css` の Agent header / role / status 周辺を `--text-md` / `--text-xs` ベースへ底上げする。
+- [ ] #453: `CommandPalette.tsx` を `createPortal(..., document.body)` で body 直下に描画し、`.cmdp-backdrop` を global overlay として `display:flex`, `position:fixed`, `z-index: var(--z-palette)` に揃える。
+- [ ] #453: `tokens.css` の `--z-palette` が `--z-canvas-root` より上か確認し、不足があれば最小修正する。
+- [ ] #441: `normalizeCanvasState()` の `arrangeGap` 許可値を `tight | normal | wide` に修正する。
+- [ ] #441: `StageHud.tsx` の gap ボタン押下で `setArrangeGap(g.id)` 後に `tidyTerminalCards(g.id)` を呼び、見た目を即時反映する。
+- [ ] #441: 既存 `canvas-arrange.test.ts` / `canvas-restore-normalize.test.ts` へ回帰テストを追加し、必要なら CommandPalette portal の軽量テストを追加する。
+
+### 検証計画
+- [ ] `npx vitest run src/renderer/src/lib/__tests__/canvas-arrange.test.ts src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts`
+- [ ] 追加した場合: `npx vitest run <CommandPalette portal test>`
+- [ ] `npm run typecheck`
+- [ ] `npm run build:vite`
+- [ ] UI 変更のため `npm run dev` で Canvas モードを起動し、#457/#453/#441 の操作フローを手動確認する。
+- [ ] `git diff --check`
+
+### Next Steps
+- [ ] ユーザー確認後、`feature/issue-441-canvas-ui-batch` を作成して実装する。
+- [ ] 実装完了後、このセクションへ「進捗」「検証結果」「Next Tasks」を追記する。
+- [ ] PR 作成前に差分対象を確認し、未関係の `tasks/*` や secret を混入させない。
+- [ ] PR 作成後はレビュー結果を確認し、人間承認・QA 合意なしに merge しない。
+
+### 進捗 (2026-05-04 / Codex 続き)
+- [x] `feature/issue-441-canvas-ui-batch` を作成。
+- [x] #441: `arrangeGap` 正規化を `tight | normal | wide` に修正し、HUD gap 押下で即時再配置するよう修正。
+- [x] #453: CommandPalette を body portal 化し、Canvas より前面の fixed overlay / z-index に修正。
+- [x] #457: Canvas card header の CSS 化と Terminal / Agent header の可読性改善を実装。
+- [x] dev/browser/custom Tauri smoke で `getCurrentWindow()` が metadata 不在時に render crash しないよう安全化。
+- [x] 検証用プロセス停止と `C:\Users\zooyo\.vibe-editor\settings.json` のバックアップ復元。
+
+### 検証結果 (2026-05-04)
+- [x] `npx vitest run src/renderer/src/lib/__tests__/canvas-arrange.test.ts src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts src/renderer/src/components/__tests__/CommandPalette.test.tsx`: PASS (3 files / 21 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run build:vite`: PASS。既存の chunk size / ineffective dynamic import warning は継続。
+- [x] `git diff --check`: PASS
+- [ ] UI smoke: PARTIAL。別 identifier Tauri 起動では IPC injection が不完全で settings load が default へ落ちるため、Canvas 操作の完全な手動確認は未完了。
+
+### Next Tasks (2026-05-04 更新)
+- [ ] 通常の `npm run dev` または人間の確認用環境で Canvas を開き、#457/#453/#441 の手動 smoke を実施する。
+- [ ] PR 本文に `Closes #441`, `Closes #453`, `Closes #457` と検証結果、UI smoke 未完了理由を記載する。
+- [ ] CodeRabbit / reviewer / 人間承認 / QA 合意なしに merge しない。


### PR DESCRIPTION
## Summary
- Closes #441
- Closes #453
- Closes #455
- Closes #457
- Fix Canvas HUD gap handling so `tight | normal | wide` is normalized and gap changes immediately re-run terminal card layout.
- Render CommandPalette through a body portal and raise its z-index above Canvas overlays.
- Improve Canvas terminal/agent card header readability and move shared card header styling into CSS.
- Keep new team-spawn / recent-restore card batches from overlapping existing Canvas cards while preserving preset-relative spacing, then focus the new Leader.
- Add defensive guards for browser/custom Tauri smoke: `getCurrentWindow()` metadata absence and `webviewZoom` host IPC absence no longer cause render/test crashes.

## Verification
- `npx vitest run src/renderer/src/lib/__tests__/canvas-placement.test.ts src/renderer/src/lib/__tests__/workspace-presets.test.ts` PASS (2 files / 8 tests)
- `npx vitest run src/renderer/src/lib/__tests__/canvas-arrange.test.ts src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts src/renderer/src/components/__tests__/CommandPalette.test.tsx src/renderer/src/lib/__tests__/canvas-placement.test.ts src/renderer/src/lib/__tests__/workspace-presets.test.ts` PASS (5 files / 29 tests)
- `npm run test` PASS (28 files / 191 tests; existing jsdom HTMLCanvasElement.getContext stderr remains)
- `npm run typecheck` PASS
- `npm run build:vite` PASS; existing chunk-size / ineffective dynamic import warnings remain
- `git diff --check` PASS
- GitHub Actions `verify` PASS on pushed branch

## UI Smoke
- `npm run dev:vite -- --host 127.0.0.1 --port 5177` + Playwright MCP Canvas smoke completed.
- #453: `Ctrl+Shift+P` on Canvas opens `.cmdp-backdrop`; `body > .cmdp-backdrop` count=1 and z-index=9600.
- #455: Team Launch twice creates 2 React Flow nodes with boxes `[-423,279,640,400]` and `[249,279,640,400]`; overlap=false.
- #457: `.canvas-agent-card__header` count=2 with computed `font-size: 14px`, `min-height: 42px`, `height: 44.8px`.
- #441: HUD Arrange menu `広い` changes spacing immediately from 672px to 688px and `aria-checked=true`.
- Test Vite process on port 5177 was stopped after verification.

## Merge Gate
- Ready for review, but do not auto-merge. Wait for CodeRabbit/reviewer feedback and human QA approval before merge.