### PR TITLE
refactor(build): clean test and vite warnings

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { listen } from '@tauri-apps/api/event';
 import {
   Clock,
   Command as CommandIcon,
@@ -280,7 +281,6 @@ export function App(): JSX.Element {
     let unlisten: (() => void) | null = null;
     let cancelled = false;
     void (async () => {
-      const { listen } = await import('@tauri-apps/api/event');
       const u = await listen<string>('project:files-changed', () => {
         const h = fsWatchHandlersRef.current;
         if (!h) return;

--- a/src/renderer/src/lib/use-files-changed.ts
+++ b/src/renderer/src/lib/use-files-changed.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { listen } from '@tauri-apps/api/event';
 
 /**
  * Issue #128: Rust 側 fs_watch が emit する `project:files-changed` を購読し、
@@ -17,7 +18,6 @@ export function useFilesChanged(callback: () => void, debounceMs = 250): void {
     let timer: number | null = null;
 
     void (async () => {
-      const { listen } = await import('@tauri-apps/api/event');
       const u = await listen<string>('project:files-changed', () => {
         if (timer !== null) window.clearTimeout(timer);
         timer = window.setTimeout(() => {

--- a/src/renderer/src/test-setup.ts
+++ b/src/renderer/src/test-setup.ts
@@ -1,5 +1,14 @@
 import '@testing-library/jest-dom/vitest';
 
+if (typeof HTMLCanvasElement !== 'undefined') {
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: function getContext(_contextId: string): null {
+      return null;
+    }
+  });
+}
+
 // jsdom には ResizeObserver が無い。Canvas/xterm 系のフックが
 // マウント直後に observe を呼ぶため、最低限の no-op polyfill を入れる。
 class ResizeObserverPolyfill {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1023,3 +1023,37 @@ PR: https://github.com/yusei531642/vibe-editor/pull/459
 - [ ] 承認後、#456 -> #454 -> #451 の順に Red/Green で実装する。
 - [ ] 実装後、本セクションに進捗・検証結果・残課題を追記する。
 - [ ] PR を作成する場合は `Closes #451`, `Closes #454`, `Closes #456` を本文に含め、CodeRabbit と人間承認を待つ。自動マージはしない。
+## Issue #460 ビルド/テスト時の既存警告整理 計画（2026-05-05 / Codex）
+
+### Fortress Review
+- 対象: https://github.com/yusei531642/vibe-editor/issues/460
+- Tier: C（スコア 3）
+- 判定根拠: DB migration / 認証 / 課金 / 公開 API 契約変更なし。対象は Vitest setup、`@tauri-apps/api/event` import 整理、Vite chunk warning 設定または分割方針の調整に限定する。
+- RCA 判定: PASS。`npm run test` で `HTMLCanvasElement.prototype.getContext` stderr、`npm run build:vite` で chunk size / ineffective dynamic import / plugin timings warning を再現済み。
+- 判定: 条件付き Go。実装前に本計画の確認を受ける。
+
+### 計画
+- [x] Issue #460 の内容を確認し、`feature/issue-460` ブランチを作成する。
+- [x] `npm ci`、`npm run test`、`npm run build:vite` で現状警告を再現する。
+- [x] `src/renderer/src/test-setup.ts` に jsdom 用の Canvas 2D mock を追加し、`measureCellSize` の fallback 挙動を stderr なしで維持する。
+- [x] `src/renderer/src/App.tsx` と `src/renderer/src/lib/use-files-changed.ts` の `@tauri-apps/api/event` import 経路を静的 import に統一し、ineffective dynamic import warning を解消する。
+- [x] `vite.config.ts` の chunk warning を確認し、Monaco 等の意図的な大型 vendor chunk は分割または明示的な warning limit で扱う。警告抑止だけに見える変更にしないよう、理由をコメントに残す。
+- [x] `npm run test` と `npm run build:vite` を再実行し、成功かつ対象警告が消えていることを確認する。
+- [x] 実装後に本節へ進捗、検証結果、残課題を追記する。
+
+### Next Steps
+- [x] ユーザー確認後、上記計画に沿って最小差分で実装する。
+- [ ] 実装後、必要なら PR 本文に `Closes #460` と検証結果を記載する。
+
+### 進捗
+- [x] `src/renderer/src/test-setup.ts` で `HTMLCanvasElement.prototype.getContext` を jsdom 用に no-op 化し、未実装 stderr を抑止。
+- [x] `src/renderer/src/App.tsx` / `src/renderer/src/lib/use-files-changed.ts` の `@tauri-apps/api/event` を静的 import に統一。
+- [x] `vite.config.ts` を `rolldownOptions` に移行し、Monaco の既知大型 chunk 向けに `chunkSizeWarningLimit` を明示。plugin timing warning は `checks.pluginTimings=false` で抑止し、ineffective dynamic import などの意味的チェックは維持。
+
+### 検証結果
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS（28 files / 194 tests、`HTMLCanvasElement.getContext` stderr なし）
+- [x] `npm run build:vite`: PASS（chunk size / ineffective dynamic import / plugin timings warning なし）
+
+### Next Tasks
+- [ ] PR を作成する場合は本文に `Closes #460` と上記検証結果を記載し、CodeRabbit と人間承認を待つ。自動マージはしない。

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,13 @@ export default defineConfig(async () => ({
     target: 'chrome120',
     minify: !process.env.TAURI_ENV_DEBUG ? 'esbuild' : false,
     sourcemap: !!process.env.TAURI_ENV_DEBUG,
-    rollupOptions: {
+    // Monaco is intentionally isolated below; app-owned JS stays below 500 kB.
+    chunkSizeWarningLimit: 4000,
+    rolldownOptions: {
+      checks: {
+        // Keep semantic checks enabled, but suppress timing noise from CSS/transpile-heavy builds.
+        pluginTimings: false
+      },
       input: resolve(__dirname, 'src/renderer/index.html'),
       output: {
         // Issue #110: main chunk が 4.7MB あり起動時間と WebView メモリに響くため、


### PR DESCRIPTION
## 概要
- jsdom テスト環境の Canvas `getContext` stderr を test setup で抑止
- `@tauri-apps/api/event` の import 経路を静的 import に統一し、ineffective dynamic import warning を解消
- Vite / Rolldown 設定を明示し、Monaco の既知大型 vendor chunk と plugin timing warning の扱いを整理
- `tasks/todo.md` に計画、進捗、検証結果、Next Tasks を記録

## 検証
- [x] `npm run typecheck`
- [x] `npm run test`（28 files / 194 tests、`HTMLCanvasElement.getContext` stderr なし）
- [x] `npm run build:vite`（chunk size / ineffective dynamic import / plugin timings warning なし）
- [x] `git diff --check`

## 運用メモ
- CodeRabbit / 人間承認 / QA 合意を待つ。自動マージはしない。

Closes #460