### PR TITLE
fix(theme): Glass テーマのアクセント文字色を改善

### DIFF
--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -393,7 +393,7 @@ body.is-resizing * {
 .sidebar-switcher__btn.is-active .sidebar-switcher__badge {
   background: var(--claude-brand, var(--accent));
   border-color: transparent;
-  color: #fffdf7;
+  color: var(--accent-foreground);
 }
 
 /* サイドバー個別ビュー */
@@ -644,7 +644,7 @@ body.is-resizing * {
 
 .toolbar__btn--primary {
   background: var(--accent);
-  color: #fffdf7;
+  color: var(--accent-foreground);
   font-weight: 600;
 }
 
@@ -2075,7 +2075,7 @@ body.is-resizing * {
   gap: 4px;
   padding: 3px 8px;
   background: var(--accent);
-  color: #fffdf7;
+  color: var(--accent-foreground);
   font-weight: 600;
   border: none;
   border-radius: 3px;
@@ -2615,7 +2615,7 @@ body.is-resizing * {
 :root[data-theme='claude-dark'] .toolbar__btn--primary {
   background: var(--accent);
   border-color: var(--accent);
-  color: #fffdf7;
+  color: var(--accent-foreground);
   font-weight: 500;
 }
 

--- a/src/renderer/src/lib/__tests__/theme-contrast.test.ts
+++ b/src/renderer/src/lib/__tests__/theme-contrast.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { applyTheme, THEMES } from '../themes';
+
+function hexChannelToLinear(channel: string): number {
+  const value = Number.parseInt(channel, 16) / 255;
+  return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(hex: string): number {
+  const normalized = hex.replace('#', '');
+  if (!/^[\da-f]{6}$/i.test(normalized)) {
+    throw new Error(`Expected 6-digit hex color, got ${hex}`);
+  }
+
+  const [r, g, b] = [0, 2, 4].map((start) =>
+    hexChannelToLinear(normalized.slice(start, start + 2))
+  );
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const fg = relativeLuminance(foreground);
+  const bg = relativeLuminance(background);
+  const lighter = Math.max(fg, bg);
+  const darker = Math.min(fg, bg);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe('theme accent foreground', () => {
+  it('keeps Glass accent buttons readable against cyan backgrounds', () => {
+    expect(contrastRatio(THEMES.glass.accentForeground, THEMES.glass.accent)).toBeGreaterThanOrEqual(
+      4.5
+    );
+    expect(
+      contrastRatio(THEMES.glass.accentForeground, THEMES.glass.accentHover)
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('publishes --accent-foreground when applying the Glass theme', () => {
+    applyTheme('glass', 'Inter', 14);
+
+    expect(document.documentElement.style.getPropertyValue('--accent-foreground')).toBe(
+      THEMES.glass.accentForeground
+    );
+  });
+});

--- a/src/renderer/src/lib/themes.ts
+++ b/src/renderer/src/lib/themes.ts
@@ -14,6 +14,7 @@ export interface ThemeVars {
   accentHover: string;
   accentSoft: string;
   accentTint: string;
+  accentForeground: string;
   warning: string;
   warningHover: string;
   text: string;
@@ -45,6 +46,7 @@ export const THEMES: Record<ThemeName, ThemeVars> = {
     accentHover: '#e88a6a',
     accentSoft: '#d97757',
     accentTint: 'rgba(217, 119, 87, 0.12)',
+    accentForeground: '#fffdf7',
     warning: '#d4a27f',
     warningHover: '#e0b592',
     text: '#f8f8f6',
@@ -72,6 +74,7 @@ export const THEMES: Record<ThemeName, ThemeVars> = {
     accentHover: '#c6613f',
     accentSoft: '#d97757',
     accentTint: 'rgba(217, 119, 87, 0.10)',
+    accentForeground: '#fffdf7',
     warning: '#a86b00',
     warningHover: '#8f5a00',
     text: '#141413',
@@ -95,6 +98,7 @@ export const THEMES: Record<ThemeName, ThemeVars> = {
     accentHover: '#6e7bdc',
     accentSoft: '#8a94eb',
     accentTint: 'rgba(94, 106, 210, 0.16)',
+    accentForeground: '#fffdf7',
     warning: '#f5a623',
     warningHover: '#f7b955',
     text: '#f7f8f8',
@@ -118,6 +122,7 @@ export const THEMES: Record<ThemeName, ThemeVars> = {
     accentHover: '#9072ff',
     accentSoft: '#a594ff',
     accentTint: 'rgba(124, 92, 255, 0.16)',
+    accentForeground: '#fffdf7',
     warning: '#f7b955',
     warningHover: '#f9c970',
     text: '#eef2ff',
@@ -160,6 +165,7 @@ export const THEMES: Record<ThemeName, ThemeVars> = {
     accentHover: '#33FFFF',
     accentSoft: '#00CCCC',
     accentTint: 'rgba(0, 255, 255, 0.14)',
+    accentForeground: '#050714',
     warning: '#FFD700',
     warningHover: '#FFE033',
     text: '#E0E0FF',
@@ -183,6 +189,7 @@ export const THEMES: Record<ThemeName, ThemeVars> = {
     accentHover: '#18181b',
     accentSoft: '#666666',
     accentTint: 'rgba(0, 0, 0, 0.06)',
+    accentForeground: '#ffffff',
     warning: '#f5a623',
     warningHover: '#d48806',
     text: '#000000',
@@ -225,6 +232,7 @@ function setThemeColorVars(root: HTMLElement, theme: ThemeVars): void {
     '--accent-hover': theme.accentHover,
     '--accent-soft': theme.accentSoft,
     '--accent-tint': theme.accentTint,
+    '--accent-foreground': theme.accentForeground,
     '--warning': theme.warning,
     '--warning-hover': theme.warningHover,
     '--text': theme.text,

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -181,7 +181,7 @@
 .canvas-btn--primary {
   background: var(--claude-brand, var(--accent));
   border-color: transparent;
-  color: #fffdf7;
+  color: var(--accent-foreground);
 }
 .canvas-btn--primary:hover {
   background: var(--claude-brand-strong, var(--accent-hover));
@@ -306,7 +306,7 @@
   font-size: 9px;
   font-weight: 700;
   line-height: 1;
-  color: var(--bg);
+  color: var(--accent-foreground);
   background: var(--claude-brand, var(--accent));
   border-radius: 999px;
 }

--- a/src/renderer/src/styles/components/onboarding.css
+++ b/src/renderer/src/styles/components/onboarding.css
@@ -169,7 +169,7 @@
   display: grid;
   place-items: center;
   background: var(--accent);
-  color: #fff;
+  color: var(--accent-foreground);
   margin-bottom: 28px;
   box-shadow:
     0 0 0 6px color-mix(in srgb, var(--accent) 14%, transparent),
@@ -587,7 +587,7 @@
 
 .onboarding__btn--primary {
   background: var(--accent);
-  color: #fff;
+  color: var(--accent-foreground);
   border-color: var(--accent);
 }
 .onboarding__btn--primary:hover {

--- a/src/renderer/src/styles/components/shell.css
+++ b/src/renderer/src/styles/components/shell.css
@@ -498,7 +498,7 @@
   padding: 0 3px;
   border-radius: 999px;
   background: var(--accent);
-  color: #fff;
+  color: var(--accent-foreground);
   font-size: 10px;
   font-weight: 700;
   line-height: 1;

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -152,6 +152,7 @@
   --accent-hover: #e88a6a;
   --accent-soft: #d97757;
   --accent-tint: rgba(217, 119, 87, 0.12);
+  --accent-foreground: #fffdf7;
   --warning: #d4a27f;
   --warning-hover: #e0b592;
   --danger: #ff6b6b;

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -148,3 +148,10 @@ codex exec --sandbox read-only --color never --ephemeral \
 - exit 127 が「Bash の command not found 規約」由来か Codex 自身の戻り値か未確定。Claude Code ハーネスのプロセス kill 後の表示の可能性が高い (codex 自体は通常 0 / 1 を返す)。
 - ConstrainedLanguage の影響度。1 回目は完走したことから「常に致命的」ではなく、「内部 fallback の停止点」と推定。
 - 2 回目失敗時のセッションファイルが `~/.codex/sessions/2026/04/28/` に**作られていない**ことから、Codex CLI 起動初期のプロンプト読み込み段階で詰まっており、rollout 機構には到達していない。
+
+## Glass テーマのアクセント背景に白文字を固定しない
+
+- Glass の `--accent` は `#00FFFF` のため、`#fff` / `#fffdf7` / Glass text `#E0E0FF` を重ねるとコントラストが約 1.0〜1.2:1 になり読めない。
+- Glass の `--bg` は透明なので、アクセント背景上の文字色として `var(--bg)` を流用しない。
+- ボタンやバッジで `background: var(--accent)` を使う場合は、テーマ側から `--accent-foreground` のような専用トークンを流し、Glass では濃色ネイビーを使う。
+- テーマ色を調整するときは `themes.ts` の `ThemeVars`、CSS 変数流し込み、対象 CSS、必要なコントラスト検証をセットで確認する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1096,3 +1096,41 @@ PR: https://github.com/yusei531642/vibe-editor/pull/459
 - [ ] Release PR を作成し、CI / reviewer を確認する。
 - [ ] PR merge 後、`v1.4.9` tag push で release workflow を起動する。
 - [ ] draft release の成果物確認後に publish 判断を行う。
+
+## Issue #466 Glass テーマのボタン文字コントラスト改善計画（2026-05-05 / Codex）
+
+### 計画
+- [x] Glass テーマの色定義と `var(--accent)` 背景を使うボタン CSS を調査する。
+- [x] 新規 Issue を起票し、調査結果と再現手順を記載する。
+- [x] Issue コメントに実装計画を投稿し、`planned` ラベルを付与する。
+- [x] 実装前にユーザー確認を受ける。
+- [x] `ThemeVars` にアクセント背景上の文字色トークンを追加し、全テーマへ値を設定する。
+- [x] `setThemeColorVars()` から `--accent-foreground` を公開する。
+- [x] `.toolbar__btn--primary` / `.onboarding__btn--primary` / `.canvas-btn--primary` などの白系固定文字色を `var(--accent-foreground)` へ置き換える。
+- [x] Glass の `#00FFFF` 背景と濃色 foreground のコントラストが 4.5:1 以上であることを確認する。
+- [x] `npm run typecheck` / `npm run test` / `npm run build:vite` / Vite smoke で動作と見た目を確認する。
+
+### Next Steps
+- [ ] ユーザー確認後、`feature/issue-466` ブランチを作成して最小差分で実装する。
+- [ ] PR を作成する場合は本文に `Closes #466` と検証結果を記載し、CodeRabbit と人間承認を待つ。自動マージはしない。
+
+### 進捗
+- [x] Issue: https://github.com/yusei531642/vibe-editor/issues/466
+- [x] Plan comment: https://github.com/yusei531642/vibe-editor/issues/466#issuecomment-4378224994
+- [x] Labels: `bug`, `ui`, `a11y`, `planned`
+- [x] `feature/issue-466` ブランチを作成し、Issue ラベルを `implementing` に更新。
+- [x] `src/renderer/src/lib/themes.ts` に `accentForeground` を追加し、Glass は `#050714` に設定。
+- [x] `src/renderer/src/lib/__tests__/theme-contrast.test.ts` を追加し、Glass accent / hover と foreground の 4.5:1 以上を検証。
+- [x] Vite smoke で `.toolbar__btn--primary` / `.onboarding__btn--primary` / `.canvas-btn--primary` / `.rail__badge` の計算コントラスト 16.0:1 を確認。
+
+### 検証結果
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test -- theme-contrast`: PASS（2 tests）
+- [x] `npm run test`: PASS（29 files / 196 tests）
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
+- [x] Browser smoke: `http://127.0.0.1:5173/` で Glass 変数を適用し、主要ボタン/バッジの文字色 `rgb(5, 7, 20)`、背景 `rgb(0, 255, 255)`、contrast `16.0` を確認。
+
+### Next Tasks
+- [x] 実装時は `--bg` が Glass で透明になる点を避け、アクセント背景専用の foreground token を使う。
+- [ ] PR を作成し、CodeRabbit / CI を確認する。


### PR DESCRIPTION
## Summary
- Glass テーマ用に `--accent-foreground` を追加し、水色アクセント背景上の文字色を濃色に変更
- toolbar / onboarding / canvas / rail badge など、固定白文字だったアクセント背景要素を新トークン参照へ変更
- Glass accent と foreground のコントラストを検証する回帰テストを追加

Closes #466

## Verification
- [x] `npm run typecheck`
- [x] `npm run test -- theme-contrast`
- [x] `npm run test`（29 files / 196 tests）
- [x] `npm run build:vite`
- [x] `git diff --check`
- [x] Browser smoke on `http://127.0.0.1:5173/`: Glass 変数適用後、`.toolbar__btn--primary` / `.onboarding__btn--primary` / `.canvas-btn--primary` / `.rail__badge` が foreground `rgb(5, 7, 20)`、background `rgb(0, 255, 255)`、contrast `16.0:1`

## Notes
- `--bg` は Glass で透明になるため、アクセント背景上の文字色には使わず専用トークン化しています。
- 非 Glass テーマは既存の白系 foreground 値を維持しています。