### PR TITLE
fix(canvas): Canvas sidebar widthをIDEに合わせる

### DIFF
--- a/src/renderer/src/styles/__tests__/canvas-css-contract.test.ts
+++ b/src/renderer/src/styles/__tests__/canvas-css-contract.test.ts
@@ -1,0 +1,34 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const stylesDir = dirname(testDir);
+const componentsDir = join(stylesDir, 'components');
+
+function readStyleFile(pathFromStylesDir: string): string {
+  return readFileSync(join(stylesDir, pathFromStylesDir), 'utf8');
+}
+
+function readComponentCss(fileName: string): string {
+  return readFileSync(join(componentsDir, fileName), 'utf8');
+}
+
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+describe('Canvas CSS contract', () => {
+  it('keeps the canvas sidebar width aligned with the redesign shell sidebar token', () => {
+    const tokens = stripCssComments(readStyleFile('tokens.css'));
+    const canvas = stripCssComments(readComponentCss('canvas.css'));
+
+    expect(tokens).toMatch(/--shell-sidebar-w\s*:\s*272px\s*;/);
+    expect(canvas).toMatch(
+      /\.canvas-layout__body\s*>\s*\.sidebar\s*\{[\s\S]*flex:\s*0\s+0\s+var\(--shell-sidebar-w\)\s*;[\s\S]*width:\s*var\(--shell-sidebar-w\)\s*;[\s\S]*min-width:\s*var\(--shell-sidebar-w\)\s*;[\s\S]*max-width:\s*var\(--shell-sidebar-w\)\s*;/
+    );
+  });
+});

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -30,6 +30,13 @@
   min-height: 0;
 }
 
+.canvas-layout__body > .sidebar {
+  flex: 0 0 var(--shell-sidebar-w);
+  width: var(--shell-sidebar-w);
+  min-width: var(--shell-sidebar-w);
+  max-width: var(--shell-sidebar-w);
+}
+
 .canvas-layout__stage {
   flex: 1;
   position: relative;

--- a/tasks/issue-469/plan.md
+++ b/tasks/issue-469/plan.md
@@ -1,0 +1,43 @@
+# Issue #469 - Canvas mode file tree width
+
+## 計画
+
+- 対象: https://github.com/yusei531642/vibe-editor/issues/469
+- Branch: `feature/issue-469`
+- Tier: C
+- RCA Mode: Root Cause Confirmed
+
+### RCA結果
+
+- 症状: Canvas モードのファイルツリー表示領域が IDE モードより広くなり、常時表示しづらい。
+- 再現根拠: Issue 本文と既存計画コメントで Canvas / IDE の表示幅差分が報告済み。
+- 原因箇所: `src/renderer/src/styles/components/canvas.css` の `.canvas-layout__body` 配下。
+- 原因経路: IDE モードは `.layout.layout--redesign` の grid column で `var(--shell-sidebar-w)` を使う一方、Canvas モードは `Rail` / `CanvasSidebar` / stage を flex 配置しており、`CanvasSidebar` が再利用する `.sidebar` に Canvas 限定の幅制約がない。
+- 修正方針: Canvas の親レイアウト側で `.canvas-layout__body > .sidebar` を `var(--shell-sidebar-w)` に固定する。`Sidebar` / `FileTreePanel` / `CanvasSidebar` のロジックは変更しない。
+
+### 実装ステップ
+
+- [x] `canvas.css` に Canvas 限定の Sidebar sizing contract を追加する。
+- [x] CSS contract test を追加し、Canvas sidebar が `--shell-sidebar-w` を参照することを固定する。
+- [x] `npm run typecheck` と対象 Vitest を実行する。
+- [x] Vite / browser smoke で Canvas レイアウトの描画を確認する。
+
+## 進捗
+
+- `.canvas-layout__body > .sidebar` を `flex: 0 0 var(--shell-sidebar-w)` / `width` / `min-width` / `max-width` で固定した。
+- `src/renderer/src/styles/__tests__/canvas-css-contract.test.ts` を追加し、IDE と Canvas が同じ `--shell-sidebar-w` token を使うことを検証した。
+- Vite 単体の browser smoke では Canvas モードへの切替と Canvas header / Rail / sidebar / stage の DOM 表示を確認した。Tauri API 未注入に由来する既存 console error は Vite 単体起動の制約として扱う。
+- Dev server: `http://127.0.0.1:5174/`
+
+## 検証結果
+
+- [x] `npx vitest run src/renderer/src/styles/__tests__/canvas-css-contract.test.ts`: PASS
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (30 files / 197 tests)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
+
+## Next Steps
+
+- PR を作成する場合は本文に `Closes #469` と検証結果を記載する。
+- CodeRabbit / CI / 人間レビューを待ち、自動マージは行わない。

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -155,3 +155,9 @@ codex exec --sandbox read-only --color never --ephemeral \
 - Glass の `--bg` は透明なので、アクセント背景上の文字色として `var(--bg)` を流用しない。
 - ボタンやバッジで `background: var(--accent)` を使う場合は、テーマ側から `--accent-foreground` のような専用トークンを流し、Glass では濃色ネイビーを使う。
 - テーマ色を調整するときは `themes.ts` の `ThemeVars`、CSS 変数流し込み、対象 CSS、必要なコントラスト検証をセットで確認する。
+
+## Issue #469 - Canvas sidebar width
+
+- IDE と Canvas で同じ `Sidebar` を再利用していても、親レイアウトが Grid から flex に変わると幅制約は引き継がれない。
+- 「IDE と同じ幅に合わせる」系の UI 修正では、既存 token の `--shell-sidebar-w` を参照し、別の px 値を直書きしない。
+- Canvas 固有の表示不具合は `canvas.css` 側へ局所化し、shared `.sidebar` や `FileTreePanel` へ波及させない。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1174,3 +1174,40 @@ PR: https://github.com/yusei531642/vibe-editor/pull/459
 - [ ] Release PR を作成し、CI / reviewer を確認する。
 - [ ] PR merge 後、`v1.4.10` tag push で release workflow を起動する。
 - [ ] draft release の成果物確認後に publish 判断を行う。
+
+## Issue #469 - Canvas mode file tree width (2026-05-06 / Codex)
+
+計画: `tasks/issue-469/plan.md`
+
+- [x] Issue #469 の本文、コメント、ラベル状態を確認
+- [x] IDE / Canvas の Sidebar 構造と幅定義を調査
+- [x] Root Cause Confirmed: Canvas の flex 配下で `.sidebar` 幅が `--shell-sidebar-w` に固定されていない
+- [x] 実装前計画と Next Steps を記録
+- [x] `src/renderer/src/styles/components/canvas.css` に Canvas 限定の Sidebar 幅制約を追加する
+- [x] CSS contract test / typecheck / UI smoke で動作を実証する
+
+### Next Steps
+
+- [x] Canvas の `.sidebar` を `var(--shell-sidebar-w)` に固定する。
+- [x] IDE 側の grid 幅定義と Canvas 側の flex 幅定義が同じ token を参照することをテストで固定する。
+- [x] 実装後に進捗、検証結果、Next Tasks を追記する。
+
+### 進捗
+
+- [x] `.canvas-layout__body > .sidebar` に `flex` / `width` / `min-width` / `max-width` の固定を追加。
+- [x] `canvas-css-contract.test.ts` で `--shell-sidebar-w` 参照を検証。
+- [x] Issue #469 の GitHub ラベルを `planned` から `implementing` に更新。
+
+### 検証結果
+
+- [x] `npx vitest run src/renderer/src/styles/__tests__/canvas-css-contract.test.ts`: PASS
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (30 files / 197 tests)
+- [x] `npm run build:vite`: PASS
+- [x] Browser smoke: `http://127.0.0.1:5174/` で Canvas モード表示、Rail/sidebar/stage の DOM 表示を確認。Vite 単体では Tauri API 未注入の既存 error が出る。
+- [x] `git diff --check`: PASS
+
+### Next Tasks
+
+- [ ] PR を作成する場合は本文に `Closes #469` と検証結果を記載する。
+- [ ] CodeRabbit / CI / 人間レビューを待ち、自動マージは行わない。


### PR DESCRIPTION
## 概要
- Canvas モードの Sidebar を `--shell-sidebar-w` に固定し、IDE モードのファイルツリー幅と揃えました。
- `CanvasSidebar` / `Sidebar` / `FileTreePanel` のロジックは変更せず、Canvas レイアウト CSS に責務を閉じています。
- Canvas sidebar の幅 contract を Vitest で固定しました。

Closes #469

## 検証
- [x] `npx vitest run src/renderer/src/styles/__tests__/canvas-css-contract.test.ts`
- [x] `npm run typecheck`
- [x] `npm run test` (30 files / 197 tests)
- [x] `npm run build:vite`
- [x] `git diff --check`
- [x] Browser smoke: `http://127.0.0.1:5174/` で Canvas モード表示、Rail/sidebar/stage の DOM 表示を確認

## 備考
- Vite 単体の browser smoke では Tauri API 未注入に由来する既存 console error が出ます。今回の CSS 修正とは独立の制約です。