### PR TITLE
chore(release): bump version to 1.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-editor",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-editor",
-      "version": "1.4.10",
+      "version": "1.4.11",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/geist-mono": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5212,7 +5212,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.4.10"
+version = "1.4.11"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",

--- a/tasks/release-v1.4.11.md
+++ b/tasks/release-v1.4.11.md
@@ -1,0 +1,40 @@
+# Release v1.4.11
+
+## 計画
+
+- [x] Issue #470 / PR #472 / CI / Issue close 状態を確認する。
+- [x] 最新 release と tag を確認し、次の patch version を `v1.4.11` と判断する。
+- [x] `chore/release-1.4.11` で `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` / `src-tauri/Cargo.lock` を `1.4.11` に更新する。
+- [x] `npm run typecheck` / `npm run test` / `npm run build:vite` / `cargo check --manifest-path src-tauri/Cargo.toml` / `cargo check --locked --manifest-path src-tauri/Cargo.toml` / `git diff --check` を実行する。
+- [ ] Release PR を作成し、CI / reviewer を確認する。
+- [ ] Release PR merge 後に `v1.4.11` annotated tag を push して release workflow を起動する。
+- [ ] draft release と成果物を確認し、publish 可能な状態まで進める。
+
+## Next Steps
+
+- [x] バージョン bump を実施する。
+- [x] 品質ゲートを通す。
+- [ ] Release PR を作成する。
+- [ ] PR merge 後に tag push で release workflow を起動する。
+
+## 進捗
+
+- [x] `npm version 1.4.11 --no-git-tag-version` で npm 側を同期。
+- [x] `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` を `1.4.11` に更新。
+- [x] `cargo check --manifest-path src-tauri/Cargo.toml` で `src-tauri/Cargo.lock` の `vibe-editor` package version を `1.4.11` に更新。
+
+## 検証結果
+
+- [x] `cargo check --manifest-path src-tauri\Cargo.toml`: PASS
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (30 files / 199 tests)
+- [x] `npm run build:vite`: PASS
+- [x] `cargo check --locked --manifest-path src-tauri\Cargo.toml`: PASS
+- [x] `git diff --check`: PASS
+- [x] Note: 初回の `cargo check --locked` は `npm run build:vite` と並列実行したため `dist` asset 読み取り競合で失敗。`build:vite` 完了後の単独再実行で PASS。
+
+## Next Tasks
+
+- [ ] Release PR を作成し、CI / reviewer を確認する。
+- [ ] PR merge 後に `v1.4.11` annotated tag を作成して push する。
+- [ ] release workflow 完了後、draft release の成果物と `latest.json` を確認する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1256,3 +1256,42 @@ PR: https://github.com/yusei531642/vibe-editor/pull/459
 - [ ] PR を作成する場合は本文に `Closes #470` と検証結果を記載する。
 - [ ] CodeRabbit / CI / 人間レビューを待ち、自動マージは行わない。
 - [ ] 必要に応じて Tauri 実機起動で handoff 復元の手動 smoke を追加確認する。
+
+## Release v1.4.11 計画（2026-05-06 / Codex）
+
+計画: `tasks/release-v1.4.11.md`
+
+- [x] Issue #470 / PR #472 / CI / Issue close 状態を確認する
+- [x] 最新 release と tag を確認し、次の patch version を `v1.4.11` と判断する
+- [x] `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` / `src-tauri/Cargo.lock` を `1.4.11` に更新する
+- [x] 品質ゲートを通す
+- [ ] Release PR を作成し、CI / reviewer を確認する
+- [ ] PR merge 後に `v1.4.11` annotated tag を push して release workflow を起動する
+
+### Next Steps
+
+- [x] バージョン bump を実施する。
+- [x] `npm run typecheck` / `npm run test` / `npm run build:vite` / `cargo check --manifest-path src-tauri/Cargo.toml` / `cargo check --locked --manifest-path src-tauri/Cargo.toml` / `git diff --check` を実行する。
+- [ ] Release PR 作成後、CodeRabbit / CI / 人間レビューを確認する。
+- [ ] PR merge 後に tag push で release workflow を起動する。
+
+### 進捗
+
+- [x] `npm version 1.4.11 --no-git-tag-version` で npm 側を同期。
+- [x] `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` を `1.4.11` に更新。
+- [x] `cargo check --manifest-path src-tauri/Cargo.toml` で `src-tauri/Cargo.lock` の `vibe-editor` package version を `1.4.11` に更新。
+
+### 検証結果
+
+- [x] `cargo check --manifest-path src-tauri\Cargo.toml`: PASS
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (30 files / 199 tests)
+- [x] `npm run build:vite`: PASS
+- [x] `cargo check --locked --manifest-path src-tauri\Cargo.toml`: PASS
+- [x] `git diff --check`: PASS
+
+### Next Tasks
+
+- [ ] Release PR を作成し、CI / reviewer を確認する。
+- [ ] PR merge 後に `v1.4.11` annotated tag を作成して push する。
+- [ ] release workflow 完了後、draft release の成果物と `latest.json` を確認する。


### PR DESCRIPTION
## Summary
- Bump app version from `1.4.10` to `1.4.11` after #470 / #472.
- Sync npm, Tauri, and Cargo lock versions.
- Record release plan and verification in `tasks/release-v1.4.11.md` and `tasks/todo.md`.

## Release scope
- Includes #470 via merged PR #472.

## Test plan
- [x] `cargo check --manifest-path src-tauri\Cargo.toml`
- [x] `npm run typecheck`
- [x] `npm run test` (30 files / 199 tests)
- [x] `npm run build:vite`
- [x] `cargo check --locked --manifest-path src-tauri\Cargo.toml`
- [x] `git diff --check`

## Notes
- After this PR merges, create and push annotated tag `v1.4.11` to trigger `.github/workflows/release.yml`.