### PR TITLE
fix(canvas): align list agent colors with stage

### DIFF
--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -5,7 +5,7 @@
  * Rust 側 TeamHub から `team:handoff` event が来たら、from→to エッジを
  * 一時的に追加して 10 秒で自動 fade (#379)。
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
 // Controls (zoom/+/-、fit、lock 4 ボタン) はデフォルトで白くアプリのテーマと合わないため import しない。
 import {
   ReactFlow,
@@ -35,13 +35,16 @@ import { QuickNav } from './QuickNav';
 import { LeaderGlow } from './LeaderGlow';
 import { StageHud } from './StageHud';
 import { useCanvasStore, NODE_W, NODE_H, type CardData } from '../../stores/canvas';
-import { colorOf } from '../../lib/team-roles';
 import { computeRecruitFocus } from '../../lib/canvas-recruit-focus';
 import { KEYS, useKeybinding } from '../../lib/keybindings';
 import { useUiStore } from '../../stores/ui';
 import { ContextMenu, type ContextMenuItem } from '../ContextMenu';
 import { useT } from '../../lib/i18n';
 import { useConfirmRemoveCard } from '../../lib/use-confirm-remove-card';
+import { useRoleProfiles } from '../../lib/role-profiles-context';
+import { useSettings } from '../../lib/settings-context';
+import { resolveAgentVisual, type AgentVisualPayload } from '../../lib/agent-visual';
+import type { TeamOrganizationMeta } from '../../../../types/shared';
 
 const nodeTypes = {
   terminal: TerminalCard,
@@ -68,6 +71,13 @@ function FlowApp(): JSX.Element {
   const confirmRemoveCard = useConfirmRemoveCard();
   const pulseEdge = useCanvasStore((s) => s.pulseEdge);
   const setTeamLock = useCanvasStore((s) => s.setTeamLock);
+  const { settings } = useSettings();
+  const { byId: profilesById } = useRoleProfiles();
+  const resolveAccent = useCallback(
+    (payload: AgentVisualPayload | undefined): string =>
+      resolveAgentVisual(payload, profilesById, settings.language).agentAccent,
+    [profilesById, settings.language]
+  );
   // 個別の getter は store から都度引く (selector は使わない: teamLocks 全体購読すると
   // ロック切替で全カード再レンダーになるため、必要時に getState で参照する)。
   const isTeamLocked = useCallback((teamId: string): boolean => {
@@ -268,18 +278,17 @@ function FlowApp(): JSX.Element {
       source: fromNode.id,
       target: toNode.id,
       type: 'handoff',
-      data: { color: colorOf(p.fromRole), preview: p.preview, fromRole: p.fromRole }
+      data: { color: resolveAccent({ roleProfileId: p.fromRole }), preview: p.preview, fromRole: p.fromRole }
     });
   });
 
   const minimapColor = useCallback((node: Node) => {
     const data = node.data as CardData | undefined;
     if (data?.cardType === 'agent') {
-      const role = (data.payload as { role?: string } | undefined)?.role;
-      return colorOf(role);
+      return resolveAccent(data.payload as AgentVisualPayload | undefined);
     }
     return '#7a7afd';
-  }, []);
+  }, [resolveAccent]);
 
   const initialViewport = useMemo(() => useCanvasStore.getState().viewport, []);
 
@@ -422,6 +431,8 @@ function FlowApp(): JSX.Element {
  *  Canvas 上の agent ノードを一覧化する。 */
 function StageListOverlay(): JSX.Element {
   const nodes = useCanvasStore((s) => s.nodes);
+  const { settings } = useSettings();
+  const { byId: profilesById } = useRoleProfiles();
   const agentNodes = nodes.filter((n) => (n.data as CardData | undefined)?.cardType === 'agent');
   return (
     <div className="tc-list-overlay">
@@ -435,17 +446,28 @@ function StageListOverlay(): JSX.Element {
         ) : (
           agentNodes.map((n) => {
             const payload = (n.data as CardData | undefined)?.payload as
-              | { role?: string; agentId?: string; agent?: string }
+              | {
+                  roleProfileId?: string;
+                  role?: string;
+                  agentId?: string;
+                  agent?: string;
+                  organization?: TeamOrganizationMeta;
+                }
               | undefined;
-            const color = colorOf(payload?.role);
+            const visual = resolveAgentVisual(payload, profilesById, settings.language);
+            const rowStyle = {
+              ['--agent-accent' as string]: visual.agentAccent,
+              ['--organization-accent' as string]: visual.organizationAccent,
+              ['--role-color' as string]: visual.agentAccent
+            } as CSSProperties;
             return (
-              <div key={n.id} className="tc-list-row" style={{ ['--role-color' as string]: color }}>
+              <div key={n.id} className="tc-list-row" style={rowStyle}>
                 <span className="tc-list-row__avatar">
-                  {(payload?.role ?? '?').charAt(0).toUpperCase()}
+                  {visual.glyph}
                 </span>
                 <div className="tc-list-row__id">
                   <span className="tc-list-row__name">{(n.data as CardData | undefined)?.title}</span>
-                  <span className="tc-list-row__role">{payload?.role ?? 'unassigned'}</span>
+                  <span className="tc-list-row__role">{visual.label}</span>
                 </div>
                 <span className="tc-list-row__status">
                   <span className="tc-list-row__status-dot" aria-hidden="true" />

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
@@ -18,7 +18,8 @@ import { useCanvasStore, NODE_MIN_W, NODE_MIN_H } from '../../../stores/canvas';
 import { useCanvasTerminalFit } from '../../../lib/use-canvas-terminal-fit';
 import { useConfirmRemoveCard } from '../../../lib/use-confirm-remove-card';
 import { useXtermScrollToBottomOnResize } from '../../../lib/use-xterm-scroll-on-resize';
-import { fallbackProfile, profileText, renderSystemPrompt, useRoleProfiles } from '../../../lib/role-profiles-context';
+import { renderSystemPrompt, useRoleProfiles } from '../../../lib/role-profiles-context';
+import { resolveAgentVisual } from '../../../lib/agent-visual';
 import { parseShellArgs } from '../../../lib/parse-args';
 import { resolveAgentConfig } from '../../../lib/agent-resolver';
 import { useRecruitSpawnAck } from '../../../lib/use-terminal-spawn';
@@ -175,14 +176,15 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   const fit = useCanvasTerminalFit(settings);
   const payload = (data?.payload ?? {}) as AgentPayload;
   // 新スキーマ roleProfileId を優先、無ければ legacy role を読む
-  const roleProfileId = payload.roleProfileId ?? payload.role ?? 'leader';
-  const profilesById = useRoleProfiles().byId;
-  const globalPreamble = useRoleProfiles().file.globalPreamble;
-  const profile = profilesById[roleProfileId] ?? fallbackProfile(roleProfileId);
-  const accent = profile.visual.color;
-  const organizationAccent = payload.organization?.color;
-  const meta = profileText(profile, settings.language);
-  const title = (data?.title as string) ?? meta.label;
+  const roleProfiles = useRoleProfiles();
+  const profilesById = roleProfiles.byId;
+  const globalPreamble = roleProfiles.file.globalPreamble;
+  const visual = resolveAgentVisual(payload, profilesById, settings.language);
+  const roleProfileId = visual.roleProfileId;
+  const profile = visual.profile;
+  const accent = visual.agentAccent;
+  const organizationAccent = visual.organizationAccent;
+  const title = (data?.title as string) ?? visual.label;
   const [handoffBusy, setHandoffBusy] = useState(false);
   // Issue #342 Phase 1: recruit 経路の spawn 失敗を Hub に ack するためのコールバック。
   // payload.agentId / payload.teamId が揃っているとき (= 通常の AgentNode は常に揃う)
@@ -395,7 +397,7 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
       retireAfterAck: true,
       trigger: 'manual',
       content: {
-        summary: `${title} (${meta.label}) の Canvas handoff。保存時点の terminal snapshot と次アクションを含みます。`,
+        summary: `${title} (${visual.label}) の Canvas handoff。保存時点の terminal snapshot と次アクションを含みます。`,
         decisions: ['この handoff は既存セッションを --resume せず、新しいセッションへ注入するための継続メモとして保存されました。'],
         filesTouched: [],
         openTasks: ['handoff markdown を読み、現在の作業目的・未完了タスク・次アクションを確認する。'],
@@ -414,7 +416,7 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   }, [
     cwd,
     id,
-    meta.label,
+    visual.label,
     payload.agent,
     payload.agentId,
     payload.cwd,
@@ -536,7 +538,7 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
                 {payload.organization.name}
               </span>
             )}
-            <span className="canvas-agent-card__role">{meta.label}</span>
+            <span className="canvas-agent-card__role">{visual.label}</span>
           </span>
           <span className="canvas-agent-card__actions">
             <StatusBadge state={activity} label={t(`agentStatus.${activity}`)} />

--- a/src/renderer/src/lib/__tests__/agent-visual.test.ts
+++ b/src/renderer/src/lib/__tests__/agent-visual.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { RoleProfile } from '../../../../types/shared';
+import { resolveAgentVisual } from '../agent-visual';
+
+function profile(id: string, color: string, glyph: string, label = id): RoleProfile {
+  return {
+    schemaVersion: 1,
+    id,
+    source: 'user',
+    i18n: {
+      en: { label, description: `${label} role` },
+      ja: { label: `${label} ja`, description: `${label} role ja` }
+    },
+    visual: { color, glyph },
+    prompt: { template: '' },
+    permissions: {
+      canRecruit: false,
+      canDismiss: false,
+      canAssignTasks: false,
+      canCreateRoleProfile: false
+    },
+    defaultEngine: 'claude'
+  };
+}
+
+describe('resolveAgentVisual', () => {
+  const profiles = {
+    leader: profile('leader', '#a78bfa', 'L', 'Leader'),
+    reviewer: profile('reviewer', '#22c55e', 'R', 'Reviewer'),
+    custom_operator: profile('custom_operator', '#f97316', 'O', 'Operator')
+  };
+
+  it('uses roleProfileId before the legacy role field', () => {
+    const visual = resolveAgentVisual(
+      { roleProfileId: 'reviewer', role: 'leader' },
+      profiles,
+      'en'
+    );
+
+    expect(visual.roleProfileId).toBe('reviewer');
+    expect(visual.agentAccent).toBe('#22c55e');
+    expect(visual.glyph).toBe('R');
+    expect(visual.label).toBe('Reviewer');
+  });
+
+  it('keeps custom and dynamic role profile colors instead of falling back to builtin colors', () => {
+    const visual = resolveAgentVisual(
+      { roleProfileId: 'custom_operator' },
+      profiles,
+      'en'
+    );
+
+    expect(visual.agentAccent).toBe('#f97316');
+    expect(visual.organizationAccent).toBe('#f97316');
+  });
+
+  it('falls back to the legacy role field for old canvas payloads', () => {
+    const visual = resolveAgentVisual({ role: 'leader' }, profiles, 'en');
+
+    expect(visual.roleProfileId).toBe('leader');
+    expect(visual.agentAccent).toBe('#a78bfa');
+  });
+
+  it('uses organization color only for the organization accent', () => {
+    const visual = resolveAgentVisual(
+      {
+        roleProfileId: 'reviewer',
+        organization: {
+          id: 'org-1',
+          name: 'Org',
+          color: '#0ea5e9'
+        }
+      },
+      profiles,
+      'en'
+    );
+
+    expect(visual.agentAccent).toBe('#22c55e');
+    expect(visual.organizationAccent).toBe('#0ea5e9');
+  });
+});

--- a/src/renderer/src/lib/agent-visual.ts
+++ b/src/renderer/src/lib/agent-visual.ts
@@ -1,0 +1,43 @@
+import type {
+  Language,
+  RoleProfile,
+  TeamOrganizationMeta
+} from '../../../types/shared';
+import { fallbackProfile, profileText } from './role-profiles-context';
+
+export interface AgentVisualPayload {
+  roleProfileId?: string;
+  role?: string;
+  organization?: TeamOrganizationMeta;
+}
+
+export interface AgentVisual {
+  roleProfileId: string;
+  profile: RoleProfile;
+  label: string;
+  description: string;
+  glyph: string;
+  agentAccent: string;
+  organizationAccent: string;
+}
+
+export function resolveAgentVisual(
+  payload: AgentVisualPayload | undefined,
+  profilesById: Record<string, RoleProfile>,
+  language: Language
+): AgentVisual {
+  const roleProfileId = payload?.roleProfileId ?? payload?.role ?? 'leader';
+  const profile = profilesById[roleProfileId] ?? fallbackProfile(roleProfileId);
+  const text = profileText(profile, language);
+  const agentAccent = profile.visual.color;
+
+  return {
+    roleProfileId,
+    profile,
+    label: text.label,
+    description: text.description,
+    glyph: profile.visual.glyph,
+    agentAccent,
+    organizationAccent: payload?.organization?.color ?? agentAccent
+  };
+}

--- a/src/renderer/src/styles/__tests__/canvas-css-contract.test.ts
+++ b/src/renderer/src/styles/__tests__/canvas-css-contract.test.ts
@@ -31,4 +31,21 @@ describe('Canvas CSS contract', () => {
       /\.canvas-layout__body\s*>\s*\.sidebar\s*\{[\s\S]*flex:\s*0\s+0\s+var\(--shell-sidebar-w\)\s*;[\s\S]*width:\s*var\(--shell-sidebar-w\)\s*;[\s\S]*min-width:\s*var\(--shell-sidebar-w\)\s*;[\s\S]*max-width:\s*var\(--shell-sidebar-w\)\s*;/
     );
   });
+
+  it('keeps canvas list rows wired to the same agent and organization accent variables as stage cards', () => {
+    const canvas = stripCssComments(readComponentCss('canvas.css'));
+
+    expect(canvas).toMatch(
+      /\.tc-list-row\s*\{[\s\S]*box-shadow:\s*inset\s+3px\s+0\s+0\s+var\(--organization-accent,\s*var\(--agent-accent,\s*var\(--accent\)\)\)\s*;/
+    );
+    expect(canvas).toMatch(
+      /\.tc-list-row__avatar\s*\{[\s\S]*var\(--agent-accent,\s*var\(--role-color,\s*var\(--accent\)\)\)/
+    );
+    expect(canvas).toMatch(
+      /\.tc-list-row__role\s*\{[\s\S]*color:\s*var\(--agent-accent,\s*var\(--role-color,\s*var\(--text-mute\)\)\)\s*;/
+    );
+    expect(canvas).toMatch(
+      /\.tc-list-row__status-dot\s*\{[\s\S]*background:\s*var\(--agent-accent,\s*var\(--role-color,\s*var\(--success\)\)\)\s*;/
+    );
+  });
 });

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -1121,10 +1121,11 @@
   background: var(--bg-panel);
   border: 1px solid var(--border);
   border-radius: var(--radius);
+  box-shadow: inset 3px 0 0 var(--organization-accent, var(--agent-accent, var(--accent)));
   transition: border-color 180ms, transform 180ms var(--ease-out);
 }
 .tc-list-row:hover {
-  border-color: var(--border-strong);
+  border-color: color-mix(in srgb, var(--organization-accent, var(--agent-accent, var(--accent))) 35%, var(--border));
   transform: translateX(2px);
 }
 .tc-list-row__avatar {
@@ -1133,9 +1134,9 @@
   border-radius: 10px;
   display: grid;
   place-items: center;
-  background: color-mix(in oklab, var(--role-color, var(--accent)) 14%, transparent);
-  border: 1px solid color-mix(in oklab, var(--role-color, var(--accent)) 30%, transparent);
-  color: var(--role-color, var(--accent));
+  background: color-mix(in oklab, var(--agent-accent, var(--role-color, var(--accent))) 14%, transparent);
+  border: 1px solid color-mix(in oklab, var(--agent-accent, var(--role-color, var(--accent))) 30%, transparent);
+  color: var(--agent-accent, var(--role-color, var(--accent)));
   font-family: var(--font-claude-response);
   font-size: 16px;
   font-weight: 500;
@@ -1159,7 +1160,7 @@
   font-size: 9.5px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--role-color, var(--text-mute));
+  color: var(--agent-accent, var(--role-color, var(--text-mute)));
 }
 .tc-list-row__status {
   display: inline-flex;
@@ -1177,5 +1178,5 @@
   width: 6px;
   height: 6px;
   border-radius: 999px;
-  background: var(--role-color, var(--success));
+  background: var(--agent-accent, var(--role-color, var(--success)));
 }

--- a/tasks/issue-474/plan.md
+++ b/tasks/issue-474/plan.md
@@ -1,0 +1,70 @@
+## 実装計画
+
+### ゴール
+Canvas モードの「リスト」表示で、各エージェント端末の色・ロール表記・アバターが「ステージ」上の端末カードと同じロールプロファイル由来になるようにする。動的ロール、カスタムロール、組織色つきチームでも、リスト表示だけ既定紫へ落ちない状態を完了条件にする。
+
+### 調査メモ / 根本原因
+- `src/renderer/src/components/canvas/cards/AgentNodeCard.tsx` は `payload.roleProfileId ?? payload.role` を使い、`useRoleProfiles().byId` から `profile.visual.color` と `profile.visual.glyph` を解決している。
+- `src/renderer/src/components/canvas/Canvas.tsx` の `StageListOverlay` は `payload.role` のみを読み、互換 shim の `colorOf(payload?.role)` を使っている。
+- `colorOf()` は `src/renderer/src/lib/team-roles.ts` の builtin 互換 API で、動的ロールやユーザー定義ロールを解決できず `#7a7afd` に fallback する。
+- そのため、ステージ上の `AgentNodeCard` は現在のロールプロファイル色、リスト上の行は旧 builtin 色または fallback 色になり、配色がずれる。
+
+### 影響範囲 / 触るファイル
+- `src/renderer/src/components/canvas/Canvas.tsx` — `StageListOverlay` のロール解決を `roleProfileId` 優先 + `RoleProfilesContext` ベースへ変更する。
+- `src/renderer/src/components/canvas/cards/AgentNodeCard.tsx` — 必要ならリストと共有できる視覚情報解決 helper を使う形に薄く寄せる。
+- `src/renderer/src/lib/agent-visual.ts` (新規候補) — `roleProfileId` / legacy `role` / profile / label / glyph / color / organization color の解決を小さく共通化する。
+- `src/renderer/src/lib/__tests__/agent-visual.test.ts` (新規候補) — `roleProfileId` が legacy `role` より優先され、custom/dynamic profile color が使われることを固定する。
+- `src/renderer/src/styles/components/canvas.css` — リスト行の CSS 変数を stage 側と同じ意味に揃える。必要に応じて `--agent-accent` / `--organization-accent` を使う。
+- `src/renderer/src/styles/__tests__/canvas-css-contract.test.ts` — リスト行が role/profile 色変数を参照する契約を追加する。
+
+### 実装ステップ
+- [ ] Step 1: `StageListOverlay` の payload 型を `roleProfileId` / `role` / `organization` 対応にし、`useRoleProfiles` と `profileText` / `fallbackProfile` で `AgentNodeCard` と同じロール表示情報を解決する。
+- [ ] Step 2: リスト行に渡す CSS 変数を `--role-color` だけに閉じず、stage 側と同じ `agentAccent` / `organizationAccent` の意味へ揃える。
+- [ ] Step 3: 変更が重複する場合は小さな `agent-visual` helper に抽出し、`AgentNodeCard` と `StageListOverlay` から同じ解決ロジックを使う。
+- [ ] Step 4: 動的ロール、custom profile、legacy `role` の fallback を単体テストで固定する。
+- [ ] Step 5: CSS contract test でリスト行が role/profile 色を使い続けることを固定する。
+- [ ] Step 6: Canvas の Stage/List 切替で、同じ端末のロール色・アバター・ロール名が一致することを手動 smoke する。
+
+### 検証方法
+- `npm run typecheck`
+- `npx vitest run src/renderer/src/lib/__tests__/agent-visual.test.ts src/renderer/src/styles/__tests__/canvas-css-contract.test.ts`
+- `npm run test`
+- `npm run build:vite`
+- 手動テスト: `npm run dev` で Canvas モードを開き、動的ロールまたはカスタムロール色の agent を配置する。HUD の「ステージ」と「リスト」を切り替え、同じ端末のアクセント色・アバター・ロール名が一致することを確認する。
+
+### リスク・代替案
+- リスク: `StageListOverlay` が `useRoleProfiles` を読むことで、profile 更新時の再描画が増える。ただし表示対象は list view のみで、影響は限定的。
+- リスク: 組織色をどの UI 要素に反映するかを間違えると、role 色との意味が逆転する。stage 側の `--agent-accent` と `--organization-accent` の役割を基準に合わせる。
+- 代替案: helper を作らず `Canvas.tsx` に同等ロジックを局所実装する。差分は小さくなるが、同じズレが再発しやすい。
+
+### 想定 PR 構成
+- branch: `fix/issue-474-canvas-list-terminal-colors`
+- commit 粒度: 1 commit で十分。helper 抽出とテスト追加を同時に含める。
+- PR title 案: `fix(canvas): リスト表示の端末配色をステージ表示と揃える`
+- 本文に `Closes #474` を含める。
+
+### Next Steps
+- 実装フェーズに進む場合は、上記 branch を切って renderer 側の Canvas 表示修正から始める。
+- PR 前に typecheck、対象 vitest、全体 test、build:vite、Canvas Stage/List の手動 smoke を実施する。
+
+### 実装進捗
+
+- [x] `src/renderer/src/lib/agent-visual.ts` を追加し、`roleProfileId` 優先、legacy `role` fallback、profile label/glyph/color、organization color の解決を共通化。
+- [x] `AgentNodeCard` と `StageListOverlay` を同じ `resolveAgentVisual()` 経由に変更し、Stage/List/MiniMap/handoff edge の色解決を揃えた。
+- [x] リスト行 CSS を `--agent-accent` / `--organization-accent` ベースへ変更し、Stage 側の意味と一致させた。
+- [x] `agent-visual.test.ts` と `canvas-css-contract.test.ts` で、`roleProfileId` 優先、custom/dynamic profile、legacy fallback、CSS 変数契約を固定。
+
+### 検証結果
+
+- [x] `npm run typecheck`: PASS
+- [x] `npx vitest run src/renderer/src/lib/__tests__/agent-visual.test.ts src/renderer/src/styles/__tests__/canvas-css-contract.test.ts`: PASS (2 files / 6 tests)
+- [x] `npm run test`: PASS (31 files / 204 tests)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
+- [x] Playwright smoke: `http://127.0.0.1:5175/` に `roleProfileId=hr` / legacy `role=leader` の agent を注入し、Stage と List の両方で agent accent `#22c55e`、organization accent `#0ea5e9`、role label `人事`、glyph `H` を確認。
+
+### Next Tasks
+
+- [ ] PR を作成する場合は本文に `Closes #474` と上記検証結果を記載する。
+- [ ] CodeRabbit / CI / 人間レビューを待ち、自動マージは行わない。
+- [ ] 必要に応じて Tauri 実行環境で追加 smoke を行う。Vite 単体 smoke では Tauri API 未注入由来の既存 console error が出る。

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -161,3 +161,10 @@ codex exec --sandbox read-only --color never --ephemeral \
 - IDE と Canvas で同じ `Sidebar` を再利用していても、親レイアウトが Grid から flex に変わると幅制約は引き継がれない。
 - 「IDE と同じ幅に合わせる」系の UI 修正では、既存 token の `--shell-sidebar-w` を参照し、別の px 値を直書きしない。
 - Canvas 固有の表示不具合は `canvas.css` 側へ局所化し、shared `.sidebar` や `FileTreePanel` へ波及させない。
+
+## Issue #474 - Canvas list / stage color parity
+
+- Canvas の複数ビューで同じ agent / terminal を描く場合は、`roleProfileId` と `RoleProfilesContext` を色・glyph・label の single source of truth にする。
+- `src/renderer/src/lib/team-roles.ts` の `colorOf()` は builtin 互換 shim であり、動的 role、custom role profile、ユーザー override の色を解決できない。新規 UI で使い回さない。
+- Stage/List のような並列表現は、片方だけ CSS 変数名を変えると drift しやすい。`--agent-accent` / `--organization-accent` など意味が同じ変数を揃える。
+- List 本体だけでなく MiniMap や handoff edge など周辺表示も旧 `colorOf()` 参照が残りやすい。表示系の source of truth を変えるときは関連する補助表示まで検索する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1295,3 +1295,55 @@ PR: https://github.com/yusei531642/vibe-editor/pull/459
 - [ ] Release PR を作成し、CI / reviewer を確認する。
 - [ ] PR merge 後に `v1.4.11` annotated tag を作成して push する。
 - [ ] release workflow 完了後、draft release の成果物と `latest.json` を確認する。
+
+## Issue #474 - Canvas list terminal colors (2026-05-06 / Codex)
+
+計画: `tasks/issue-474/plan.md`
+
+- [x] Issue #474 の本文、コメント、ラベル状態を確認
+- [x] `issue-planner` / `issue-plan` / `vibeeditor` の該当手順を確認
+- [x] Canvas の Stage/List 表示、AgentNodeCard、role profile 解決、CSS を調査
+- [x] Root Cause Confirmed: List 表示が旧 `payload.role` + builtin shim `colorOf()` を使い、Stage 表示の `roleProfileId` + `RoleProfilesContext` と同じ色解決になっていない
+- [x] 実装前計画と Next Steps を `tasks/issue-474/plan.md` に記録
+- [x] Issue #474 に実装計画コメントを投稿する
+- [x] Issue #474 に `planned` と種別/領域ラベルを付与する
+- [x] 実装開始時に状態ラベルを `planned` から `implementing` へ遷移する
+- [x] `tasks/batch-pipeline-state.json` に Issue #474 の Phase A 状態を記録する
+
+### Next Steps
+
+- [x] `StageListOverlay` を `roleProfileId` 優先 + `RoleProfilesContext` ベースの色解決へ変更する。
+- [x] リスト行の CSS 変数を Stage 側の `AgentNodeCard` と同じ意味に揃える。
+- [x] 動的ロール / custom profile / legacy role fallback をテストで固定する。
+- [x] `npm run typecheck`、対象 vitest、`npm run test`、`npm run build:vite`、Canvas Stage/List smoke で確認する。
+
+### 進捗
+
+- [x] Issue #474 は OPEN、コメントなし、ラベルなしであることを確認。
+- [x] 調査対象は Renderer の Canvas 表示に限定できると判断。Rust / IPC / PTY 起動処理は変更不要。
+- [x] `AgentNodeCard` は `profile.visual.color`、List は `colorOf(payload.role)` で、色の source of truth が分岐していることを確認。
+- [x] `fix/issue-474-canvas-list-terminal-colors` ブランチを作成し、Issue #474 を `implementing` に更新。
+- [x] `agent-visual` helper を追加し、Stage/List/MiniMap/handoff edge の色解決を `resolveAgentVisual()` に統一。
+- [x] `agent-visual.test.ts` と `canvas-css-contract.test.ts` を追加/更新し、roleProfileId 優先と list CSS 変数契約を固定。
+- [x] Playwright smoke で Stage/List とも `roleProfileId=hr` の agent accent `#22c55e`、organization accent `#0ea5e9`、role label `人事`、glyph `H` を確認。
+
+### Next Tasks
+
+- [x] GitHub Issue コメント投稿後、コメント URL とラベル状態を確認する。
+- [x] 実装フェーズへ進む場合は `fix/issue-474-canvas-list-terminal-colors` を切る。
+- [ ] PR を作成する場合は本文に `Closes #474` と検証結果を記載する。
+- [ ] CodeRabbit / CI / 人間レビューを待ち、自動マージは行わない。
+
+### 投稿結果
+
+- [x] Issue comment: https://github.com/yusei531642/vibe-editor/issues/474#issuecomment-4384844892
+- [x] Labels: `planned`, `bug`, `canvas`, `ui`
+
+### 検証結果
+
+- [x] `npm run typecheck`: PASS
+- [x] `npx vitest run src/renderer/src/lib/__tests__/agent-visual.test.ts src/renderer/src/styles/__tests__/canvas-css-contract.test.ts`: PASS (2 files / 6 tests)
+- [x] `npm run test`: PASS (31 files / 204 tests)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
+- [x] Browser smoke: `http://127.0.0.1:5175/` で Stage/List の DOM/CSS 変数を確認。Vite 単体のため Tauri API 未注入由来の既存 console error は発生。


### PR DESCRIPTION
## Summary
- Add a shared `resolveAgentVisual()` helper for roleProfileId/legacy role/profile visual resolution.
- Use the same resolver from Stage agent cards, List rows, MiniMap colors, and handoff edge colors.
- Update List row CSS to use `--agent-accent` / `--organization-accent`, matching Stage semantics.

Closes #474

## Verification
- [x] `npm run typecheck`
- [x] `npx vitest run src/renderer/src/lib/__tests__/agent-visual.test.ts src/renderer/src/styles/__tests__/canvas-css-contract.test.ts`
- [x] `npm run test` (31 files / 204 tests)
- [x] `npm run build:vite`
- [x] `git diff --check`
- [x] Playwright smoke on `http://127.0.0.1:5175/`: injected `roleProfileId=hr` with legacy `role=leader`; confirmed Stage/List both used agent accent `#22c55e`, organization accent `#0ea5e9`, role label `人事`, glyph `H`.

## Notes
- Vite-only browser smoke shows existing Tauri API injection console errors because it is not running inside the Tauri shell; the Canvas color parity DOM/CSS checks passed.
- No automatic merge requested; waiting for CodeRabbit/CI/human review.