### PR TITLE
perf: Rust / Canvas / PTY / UI の小規模最適化スイープ

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -674,9 +674,8 @@ fn is_safe_external_url(url: &str) -> bool {
     if trimmed.is_empty() || trimmed.len() > 8192 {
         return false;
     }
-    let colon = match trimmed.find(':') {
-        Some(i) => i,
-        None => return false,
+    let Some(colon) = trimmed.find(':') else {
+        return false;
     };
     let scheme = &trimmed[..colon];
     // scheme は ASCII 英数 + `-.+` のみが RFC 的に許容

--- a/src-tauri/src/commands/atomic_write.rs
+++ b/src-tauri/src/commands/atomic_write.rs
@@ -9,7 +9,7 @@
 // POSIX も Windows も rename は same-volume なら atomic (Windows は MoveFileEx + REPLACE_EXISTING)。
 
 use anyhow::{anyhow, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
@@ -25,15 +25,14 @@ pub async fn atomic_write(target: &Path, bytes: &[u8]) -> Result<()> {
     let tmp = {
         let file_name = target
             .file_name()
-            .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "vibe.tmp".to_string());
+            .map_or_else(|| "vibe.tmp".to_string(), |s| s.to_string_lossy().into_owned());
         let pid = std::process::id();
         let unique = uuid::Uuid::new_v4().simple().to_string();
         let tmp_name = format!(".{file_name}.tmp.{pid}.{unique}");
-        target
-            .parent()
-            .map(|p| p.join(tmp_name.clone()))
-            .unwrap_or_else(|| Path::new(&tmp_name).to_path_buf())
+        match target.parent() {
+            Some(p) => p.join(&tmp_name),
+            None => PathBuf::from(&tmp_name),
+        }
     };
 
     // Issue #187 (Security): tmp が攻撃者によって symlink 先置きされている可能性に備え、

--- a/src-tauri/src/commands/dialog.rs
+++ b/src-tauri/src/commands/dialog.rs
@@ -42,13 +42,11 @@ pub async fn dialog_open_file(
 /// 「ユーザーホーム配下」または「現在のプロジェクトルート / その祖先」だけを許可する。
 /// /etc, /sys, /proc, C:\Windows などのシステム領域は早期 reject。
 fn is_path_safe_to_query(path: &std::path::Path) -> bool {
-    let canon = match path.canonicalize() {
-        Ok(p) => p,
-        Err(_) => return false, // 存在しないパスも reject (fingerprint 防止)
+    let Ok(canon) = path.canonicalize() else {
+        return false; // 存在しないパスも reject (fingerprint 防止)
     };
-    let home = match dirs::home_dir() {
-        Some(h) => h,
-        None => return false,
+    let Some(home) = dirs::home_dir() else {
+        return false;
     };
     let home_canon = home.canonicalize().unwrap_or(home);
     if canon.starts_with(&home_canon) {

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -137,16 +137,13 @@ pub async fn files_list(project_root: String, rel_path: String) -> FileListResul
 #[tauri::command]
 pub async fn files_read(project_root: String, rel_path: String) -> FileReadResult {
     const MAX_READ_BYTES: u64 = 50 * 1024 * 1024;
-    let abs = match safe_join(&project_root, &rel_path) {
-        Some(p) => p,
-        None => {
-            return FileReadResult {
-                ok: false,
-                error: Some("invalid path".into()),
-                path: rel_path,
-                ..Default::default()
-            }
-        }
+    let Some(abs) = safe_join(&project_root, &rel_path) else {
+        return FileReadResult {
+            ok: false,
+            error: Some("invalid path".into()),
+            path: rel_path,
+            ..Default::default()
+        };
     };
     let meta = match tokio::fs::metadata(&abs).await {
         Ok(m) => m,
@@ -224,15 +221,12 @@ pub async fn files_write(
     // mtime/size を見逃した「同サイズ・1 秒以内」変更でも conflict を確定する。
     expected_content_hash: Option<String>,
 ) -> FileWriteResult {
-    let abs = match safe_join(&project_root, &rel_path) {
-        Some(p) => p,
-        None => {
-            return FileWriteResult {
-                ok: false,
-                error: Some("invalid path".into()),
-                ..Default::default()
-            }
-        }
+    let Some(abs) = safe_join(&project_root, &rel_path) else {
+        return FileWriteResult {
+            ok: false,
+            error: Some("invalid path".into()),
+            ..Default::default()
+        };
     };
 
     // Issue #102: 指定 encoding で再エンコード。lossy / binary は拒否。

--- a/src-tauri/src/commands/files/encoding.rs
+++ b/src-tauri/src/commands/files/encoding.rs
@@ -65,26 +65,30 @@ pub fn encode_for_save(content: &str, encoding: &str) -> Result<Vec<u8>, String>
 /// 戻り値: (is_binary, content, encoding)
 pub fn detect_text_or_binary(bytes: &[u8]) -> (bool, String, String) {
     // --- BOM による UTF-16/32 判定 ---
+    // 各 BOM 分岐で decode 失敗時に返すフォールバック (binary 扱い)。
+    // `unwrap_or` だと Ok 経路でも String::new() / "binary".to_string() が毎回 alloc されるので
+    // `unwrap_or_else` で遅延評価する。
+    let binary_fallback = || (true, String::new(), "binary".to_string());
     if bytes.starts_with(&[0xFF, 0xFE, 0x00, 0x00]) {
         // UTF-32 LE BOM (UTF-16 LE と prefix 被るので先にチェック)
         return utf32_decode(&bytes[4..], true)
             .map(|s| (false, s, "utf-32le".to_string()))
-            .unwrap_or((true, String::new(), "binary".to_string()));
+            .unwrap_or_else(binary_fallback);
     }
     if bytes.starts_with(&[0x00, 0x00, 0xFE, 0xFF]) {
         return utf32_decode(&bytes[4..], false)
             .map(|s| (false, s, "utf-32be".to_string()))
-            .unwrap_or((true, String::new(), "binary".to_string()));
+            .unwrap_or_else(binary_fallback);
     }
     if bytes.starts_with(&[0xFF, 0xFE]) {
         return utf16_decode(&bytes[2..], true)
             .map(|s| (false, s, "utf-16le".to_string()))
-            .unwrap_or((true, String::new(), "binary".to_string()));
+            .unwrap_or_else(binary_fallback);
     }
     if bytes.starts_with(&[0xFE, 0xFF]) {
         return utf16_decode(&bytes[2..], false)
             .map(|s| (false, s, "utf-16be".to_string()))
-            .unwrap_or((true, String::new(), "binary".to_string()));
+            .unwrap_or_else(binary_fallback);
     }
     if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
         // UTF-8 BOM

--- a/src-tauri/src/commands/fs_watch.rs
+++ b/src-tauri/src/commands/fs_watch.rs
@@ -107,9 +107,8 @@ pub fn start_for_root(app: AppHandle, root: String) {
     // 1 つの critical section にまとめ、no-op 判定 → generation 更新 → spawn 引数生成までを
     // ロック保持中に行う。
     let my_generation = {
-        let mut g = match ACTIVE_WATCHER_GEN.lock() {
-            Ok(g) => g,
-            Err(_) => return,
+        let Ok(mut g) = ACTIVE_WATCHER_GEN.lock() else {
+            return;
         };
         if g.1.as_deref() == Some(root.as_str()) {
             return; // 同 root 同 generation が既に動いているので no-op
@@ -119,7 +118,7 @@ pub fn start_for_root(app: AppHandle, root: String) {
         g.0
     };
 
-    let my_root = root.clone();
+    let my_root = root;
     std::thread::spawn(move || {
         let root_path = PathBuf::from(&my_root);
         if !root_path.exists() {

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -365,8 +365,7 @@ pub async fn git_diff(
     // diff が「全削除」に見えてしまう。raw bytes → from_utf8_lossy で落としどころを作る。
     let worktree_too_large = tokio::fs::metadata(&abs)
         .await
-        .map(|m| m.len() > MAX_DIFF_BYTES as u64)
-        .unwrap_or(false);
+        .is_ok_and(|m| m.len() > MAX_DIFF_BYTES as u64);
     let (modified, worktree_is_lossy) = if worktree_too_large {
         (String::new(), false)
     } else {

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -295,16 +295,13 @@ pub async fn git_diff(
 
     // Issue #36: rel_path が ".." を含むと project_root の外を読めてしまうため safe_join を通す。
     // safe_join が None (= 境界外 / absolute / 不正) の場合は empty にしてエラー扱い。
-    let abs = match crate::commands::files::safe_join(&project_root, &rel_path) {
-        Some(p) => p,
-        None => {
-            return GitDiffResult {
-                ok: false,
-                error: Some("invalid relative path".into()),
-                path: rel_path,
-                ..Default::default()
-            };
-        }
+    let Some(abs) = crate::commands::files::safe_join(&project_root, &rel_path) else {
+        return GitDiffResult {
+            ok: false,
+            error: Some("invalid relative path".into()),
+            path: rel_path,
+            ..Default::default()
+        };
     };
 
     // Issue #154 #1: project_root が submodule / worktree 内のとき、cwd を project_root に
@@ -317,16 +314,13 @@ pub async fn git_diff(
 
     // git の HEAD blob path は repo_root 相対なので、project_root → repo_root の差分を埋める。
     // safe_join 後に repo_root に含まれるかどうかを確認し、相対化する。
-    let abs_head_target = match crate::commands::files::safe_join(&project_root, head_path) {
-        Some(p) => p,
-        None => {
-            return GitDiffResult {
-                ok: false,
-                error: Some("invalid head path".into()),
-                path: rel_path,
-                ..Default::default()
-            };
-        }
+    let Some(abs_head_target) = crate::commands::files::safe_join(&project_root, head_path) else {
+        return GitDiffResult {
+            ok: false,
+            error: Some("invalid head path".into()),
+            path: rel_path,
+            ..Default::default()
+        };
     };
     let head_path_for_git = match abs_head_target.strip_prefix(&repo_root) {
         Ok(p) => p.to_string_lossy().replace('\\', "/"),

--- a/src-tauri/src/commands/handoffs.rs
+++ b/src-tauri/src/commands/handoffs.rs
@@ -163,12 +163,11 @@ async fn ensure_private_handoff_dir(dir: &Path) -> Result<(), String> {
     Ok(())
 }
 
-async fn restrict_private_file(_path: &Path) -> Result<(), String> {
+fn restrict_private_file(_path: &Path) -> Result<(), String> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(_path, std::fs::Permissions::from_mode(0o600))
-            .await
+        std::fs::set_permissions(_path, std::fs::Permissions::from_mode(0o600))
             .map_err(|e| e.to_string())?;
     }
     Ok(())
@@ -272,12 +271,12 @@ async fn write_handoff(
     crate::commands::atomic_write::atomic_write(json_path, &json)
         .await
         .map_err(|e| e.to_string())?;
-    restrict_private_file(json_path).await?;
+    restrict_private_file(json_path)?;
     let markdown = render_markdown(handoff);
     crate::commands::atomic_write::atomic_write(md_path, markdown.as_bytes())
         .await
         .map_err(|e| e.to_string())?;
-    restrict_private_file(md_path).await
+    restrict_private_file(md_path)
 }
 
 #[tauri::command]
@@ -345,9 +344,8 @@ pub async fn handoffs_list(
 ) -> Vec<HandoffCheckpoint> {
     let dir = handoff_dir(&project_root, team_id.as_deref());
     let mut out = Vec::new();
-    let mut rd = match fs::read_dir(&dir).await {
-        Ok(r) => r,
-        Err(_) => return out,
+    let Ok(mut rd) = fs::read_dir(&dir).await else {
+        return out;
     };
     while let Ok(Some(entry)) = rd.next_entry().await {
         let path = entry.path();

--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -45,16 +45,13 @@ pub async fn logs_read_tail(max_bytes: Option<u64>) -> Result<ReadLogTailRespons
     let path_str = path.to_string_lossy().to_string();
 
     // metadata 取得 (ファイル不在は empty=true で正常終了)
-    let meta = match fs::metadata(&path).await {
-        Ok(m) => m,
-        Err(_) => {
-            return Ok(ReadLogTailResponse {
-                content: String::new(),
-                path: path_str,
-                truncated: false,
-                empty: true,
-            });
-        }
+    let Ok(meta) = fs::metadata(&path).await else {
+        return Ok(ReadLogTailResponse {
+            content: String::new(),
+            path: path_str,
+            truncated: false,
+            empty: true,
+        });
     };
     let size = meta.len();
     if size == 0 {

--- a/src-tauri/src/commands/role_profiles.rs
+++ b/src-tauri/src/commands/role_profiles.rs
@@ -20,9 +20,8 @@ static SAVE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 #[tauri::command]
 pub async fn role_profiles_load() -> Value {
     let path = role_profiles_path();
-    let bytes = match fs::read(&path).await {
-        Ok(b) => b,
-        Err(_) => return Value::Null,
+    let Ok(bytes) = fs::read(&path).await else {
+        return Value::Null;
     };
     match serde_json::from_slice::<Value>(&bytes) {
         Ok(v) => v,

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -27,9 +27,8 @@ fn projects_dir(root: &str) -> PathBuf {
 #[tauri::command]
 pub async fn sessions_list(project_root: String) -> Vec<SessionInfo> {
     let dir = projects_dir(&project_root);
-    let mut rd = match tokio::fs::read_dir(&dir).await {
-        Ok(r) => r,
-        Err(_) => return vec![],
+    let Ok(mut rd) = tokio::fs::read_dir(&dir).await else {
+        return vec![];
     };
     // Issue #31: encode_project_path は非英数を '-' に潰すので、別 project が同じ
     // encoded directory に衝突し得る (例: `C:\repo-a` と `C:\repo\a`)。
@@ -59,9 +58,8 @@ pub async fn sessions_list(project_root: String) -> Vec<SessionInfo> {
             .and_then(|s| s.to_str())
             .unwrap_or("")
             .to_string();
-        let metadata = match tokio::fs::metadata(&path).await {
-            Ok(m) => m,
-            Err(_) => continue,
+        let Ok(metadata) = tokio::fs::metadata(&path).await else {
+            continue;
         };
         let last_modified_at = metadata
             .modified()
@@ -145,9 +143,8 @@ pub async fn sessions_list(project_root: String) -> Vec<SessionInfo> {
 ///     (正確な行数は fs::metadata の行数相当だと OS 依存で取れないので割り切る)
 async fn read_jsonl_summary(path: &std::path::Path) -> (String, u32, Option<String>) {
     const HEAD_LIMIT_LINES: u32 = 2000;
-    let f = match tokio::fs::File::open(path).await {
-        Ok(f) => f,
-        Err(_) => return (String::new(), 0, None),
+    let Ok(f) = tokio::fs::File::open(path).await else {
+        return (String::new(), 0, None);
     };
     let reader = tokio::io::BufReader::new(f);
     let mut lines = reader.lines();

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -25,9 +25,8 @@ static SAVE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 pub async fn settings_load() -> Value {
     tracing::info!("[IPC] settings_load called");
     let path = settings_path();
-    let bytes = match fs::read(&path).await {
-        Ok(b) => b,
-        Err(_) => return Value::Null,
+    let Ok(bytes) = fs::read(&path).await else {
+        return Value::Null;
     };
     match serde_json::from_slice::<Value>(&bytes) {
         Ok(v) => v,

--- a/src-tauri/src/commands/team_history.rs
+++ b/src-tauri/src/commands/team_history.rs
@@ -137,12 +137,9 @@ async fn ensure_loaded(cache: &mut Option<Vec<TeamHistoryEntry>>) {
         return;
     }
     let path = store_path();
-    let bytes = match fs::read(&path).await {
-        Ok(b) => b,
-        Err(_) => {
-            *cache = Some(Vec::new());
-            return;
-        }
+    let Ok(bytes) = fs::read(&path).await else {
+        *cache = Some(Vec::new());
+        return;
     };
     let entries = serde_json::from_slice::<Vec<TeamHistoryEntry>>(&bytes).unwrap_or_default();
     *cache = Some(entries);

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -102,9 +102,8 @@ async fn inject_codex_prompt_to_pty(
 ) {
     use tokio::time::sleep;
     sleep(Duration::from_millis(1800)).await;
-    let session = match registry.get(&term_id) {
-        Some(s) => s,
-        None => return,
+    let Some(session) = registry.get(&term_id) else {
+        return;
     };
     // Issue #153: 注入中はユーザーの xterm 入力 (terminal_write) を抑止する。
     // build_chunks は banner 込みで分割するが、Codex 注入では banner 不要なので空文字を渡す。

--- a/src-tauri/src/commands/terminal/codex_instructions.rs
+++ b/src-tauri/src/commands/terminal/codex_instructions.rs
@@ -34,9 +34,8 @@ pub async fn prepare_codex_instructions_file(instructions: &str) -> Option<PathB
 pub async fn cleanup_old_codex_instructions(dir: &std::path::Path) {
     // Issue #138: 旧 7 日 → 24h に短縮。情報残存リスクを下げる
     const TTL_SECS: u64 = 24 * 60 * 60;
-    let mut rd = match tokio::fs::read_dir(dir).await {
-        Ok(r) => r,
-        Err(_) => return,
+    let Ok(mut rd) = tokio::fs::read_dir(dir).await else {
+        return;
     };
     let now = std::time::SystemTime::now();
     while let Ok(Some(entry)) = rd.next_entry().await {

--- a/src-tauri/src/commands/terminal/paste_image.rs
+++ b/src-tauri/src/commands/terminal/paste_image.rs
@@ -28,9 +28,8 @@ fn extension_for_mime(mime: &str) -> Option<&'static str> {
 async fn cleanup_old_paste_images(dir: &std::path::Path) {
     // Issue #138: 旧 7 日 → 24h に短縮。情報残存リスクを下げる
     const TTL_SECS: u64 = 24 * 60 * 60;
-    let mut rd = match tokio::fs::read_dir(dir).await {
-        Ok(r) => r,
-        Err(_) => return,
+    let Ok(mut rd) = tokio::fs::read_dir(dir).await else {
+        return;
     };
     let now = std::time::SystemTime::now();
     while let Ok(Some(entry)) = rd.next_entry().await {
@@ -67,17 +66,14 @@ pub async fn save(
             error: Some("pasted image exceeds size limit (32 MB)".into()),
         };
     }
-    let ext = match extension_for_mime(&mime_type) {
-        Some(e) => e,
-        None => {
-            return SavePastedImageResult {
-                ok: false,
-                path: None,
-                error: Some(format!(
-                    "unsupported MIME type for pasted image: {mime_type}"
-                )),
-            };
-        }
+    let Some(ext) = extension_for_mime(&mime_type) else {
+        return SavePastedImageResult {
+            ok: false,
+            path: None,
+            error: Some(format!(
+                "unsupported MIME type for pasted image: {mime_type}"
+            )),
+        };
     };
     use base64::Engine;
     let bytes = match base64::engine::general_purpose::STANDARD.decode(base64.as_bytes()) {
@@ -87,7 +83,7 @@ pub async fn save(
                 ok: false,
                 path: None,
                 error: Some(e.to_string()),
-            };
+            }
         }
     };
     if bytes.len() > MAX_PASTED_IMAGE_BYTES {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,7 +49,7 @@ fn init_logging() {
 
     // Issue #342 Phase 3 (3.11): `team_diagnostics` の `serverLogPath` 用に実パスを記録。
     // env var `VIBE_TEAM_LOG_PATH` で override 可能 (server_log_path_for_diagnostics 側で参照)。
-    team_hub::set_server_log_path(log_path.clone());
+    team_hub::set_server_log_path(log_path);
 
     let file_appender = tracing_appender::rolling::never(log_dir, "vibe-editor.log");
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);

--- a/src-tauri/src/mcp_config/claude.rs
+++ b/src-tauri/src/mcp_config/claude.rs
@@ -18,7 +18,7 @@ fn config_path() -> PathBuf {
 pub async fn setup(desired: &Value) -> Result<bool> {
     let path = config_path();
     let mut config: Value = match fs::read(&path).await {
-        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or(Value::Object(Default::default())),
+        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_else(|_| Value::Object(Default::default())),
         Err(_) => Value::Object(Default::default()),
     };
     let obj = config
@@ -78,12 +78,11 @@ pub async fn cleanup() -> Result<bool> {
     let removed = config
         .get_mut("mcpServers")
         .and_then(|s| s.as_object_mut())
-        .map(|s| {
+        .is_some_and(|s| {
             let a = s.remove(ENTRY).is_some();
             let b = s.remove(LEGACY_ENTRY).is_some();
             a || b
-        })
-        .unwrap_or(false);
+        });
     if removed {
         let json = serde_json::to_vec_pretty(&config)?;
         // Issue #108: setup と同じく cleanup も atomic_write を使う。

--- a/src-tauri/src/mcp_config/claude.rs
+++ b/src-tauri/src/mcp_config/claude.rs
@@ -71,9 +71,8 @@ pub async fn restore(snap: Option<Vec<u8>>) -> Result<()> {
 
 pub async fn cleanup() -> Result<bool> {
     let path = config_path();
-    let bytes = match fs::read(&path).await {
-        Ok(b) => b,
-        Err(_) => return Ok(false),
+    let Ok(bytes) = fs::read(&path).await else {
+        return Ok(false);
     };
     let mut config: Value = serde_json::from_slice(&bytes).unwrap_or_default();
     let removed = config

--- a/src-tauri/src/mcp_config/codex.rs
+++ b/src-tauri/src/mcp_config/codex.rs
@@ -51,7 +51,7 @@ pub fn remove_toml_section(content: &str, section: &str) -> String {
             out.push(line);
         }
     }
-    while out.last().map(|s| s.trim().is_empty()).unwrap_or(false) {
+    while out.last().is_some_and(|s| s.trim().is_empty()) {
         out.pop();
     }
     out.join("\n")

--- a/src-tauri/src/mcp_config/codex.rs
+++ b/src-tauri/src/mcp_config/codex.rs
@@ -81,9 +81,8 @@ pub async fn setup(bridge_path: &str) -> Result<()> {
 
 pub async fn cleanup() -> Result<()> {
     let path = config_path();
-    let content = match fs::read_to_string(&path).await {
-        Ok(s) => s,
-        Err(_) => return Ok(()),
+    let Ok(content) = fs::read_to_string(&path).await else {
+        return Ok(());
     };
     let stripped = remove_toml_section(&content, SECTION);
     let stripped = remove_toml_section(&stripped, LEGACY_SECTION);

--- a/src-tauri/src/pty/batcher.rs
+++ b/src-tauri/src/pty/batcher.rs
@@ -22,7 +22,7 @@ const FLUSH_BYTES: usize = 32 * 1024;
 const STARTUP_DELAY_MS: u64 = 50;
 
 /// Issue #53: bounded チャネル容量 (vec chunk 単位)。
-/// PTY reader は 8KB/chunk なので、256 枠 ≒ 2MB の backpressure buffer。
+/// PTY reader は 16 KiB/chunk なので、256 枠 ≒ 4 MiB の backpressure buffer。
 /// これを超えると reader thread の blocking_send がブロックし、自動的に
 /// PTY へ backpressure が伝播する (unbounded による無限メモリ膨張を防ぐ)。
 pub const PTY_CHANNEL_CAPACITY: usize = 256;
@@ -84,17 +84,22 @@ fn flush(app: &AppHandle, event: &str, buf: &mut BytesMut, scrollback: &Scrollba
         // 先頭もマルチバイト途中 → 次 flush まで保留 (emit しない)
         return;
     }
-    let remainder: Vec<u8> = buf[safe_end..].to_vec();
-    buf.truncate(safe_end);
-    let len = buf.len();
     // Issue #285 follow-up: emit する確定済みバイト列を scrollback にも反映する。
     // 容量超過分は前から drop されるので、attach 経路では「最近 64 KiB」だけ replay される。
-    append_scrollback(scrollback, buf);
-    let text = String::from_utf8_lossy(buf).into_owned();
-    buf.clear();
-    if !remainder.is_empty() {
-        buf.extend_from_slice(&remainder);
+    // 旧実装は `buf` を一度 truncate してから scrollback に渡し、remainder を別 Vec に
+    // 退避 → emit 後に extend_from_slice で書き戻していた。slice 借用で済む処理を
+    // Vec 経由に分割していたため、flush ごとに `remainder.to_vec()` の追加 alloc + memcpy
+    // が走っていた。安定 API の copy_within で in-place 圧縮することで、flush あたりの
+    // ヒープ allocation を 1 件削減する (60Hz 上限で常時 emit 中は ~60 alloc/s 削減)。
+    let emit_slice = &buf[..safe_end];
+    append_scrollback(scrollback, emit_slice);
+    let text = String::from_utf8_lossy(emit_slice).into_owned();
+    let len = safe_end;
+    let remainder_len = buf.len() - safe_end;
+    if remainder_len > 0 {
+        buf.copy_within(safe_end.., 0);
     }
+    buf.truncate(remainder_len);
     match app.emit(event, text) {
         Ok(_) => tracing::debug!("[batcher] emit {event} {len}B ok"),
         Err(e) => tracing::warn!("emit {event} failed: {e}"),

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -565,9 +565,15 @@ pub fn spawn_session(
     // Issue #53: bounded channel で reader → batcher に backpressure をかける。
     //   reader (std::thread) は `blocking_send` でチャネル満杯時に待機 → OS 側で PTY
     //   への入力が詰まれば子プロセスが書き込み待ちに入るので、メモリ無限膨張を防げる。
+    //
+    // チャンクサイズは 16 KiB。旧 8 KiB 比で大量出力時 (cargo build 等) の syscall /
+    // Vec allocation / channel send 頻度が約半分になる。read() は OS が用意した
+    // 即時バイト数を返すブロッキング読み出しなので、対話的な小入力では従来通り少バイト
+    // しか allocate されない (latency 影響なし)。最大 backpressure は
+    // 16 KiB * PTY_CHANNEL_CAPACITY ≒ 4 MiB。
     let (tx, rx) = mpsc::channel::<Vec<u8>>(crate::pty::batcher::PTY_CHANNEL_CAPACITY);
     std::thread::spawn(move || {
-        let mut buf = [0u8; 8192];
+        let mut buf = [0u8; 16 * 1024];
         loop {
             match reader.read(&mut buf) {
                 Ok(0) => break,

--- a/src-tauri/src/team_hub/inject.rs
+++ b/src-tauri/src/team_hub/inject.rs
@@ -118,14 +118,11 @@ pub async fn inject(
     from_role: &str,
     text: &str,
 ) -> bool {
-    let session = match registry.get_by_agent(agent_id) {
-        Some(s) => s,
-        None => {
-            tracing::warn!(
-                "[inject] no session for agent {agent_id} — registry has no by_agent entry"
-            );
-            return false;
-        }
+    let Some(session) = registry.get_by_agent(agent_id) else {
+        tracing::warn!(
+            "[inject] no session for agent {agent_id} — registry has no by_agent entry"
+        );
+        return false;
     };
     let banner = format!("[Team ← {from_role}] ");
     let chunks = build_chunks(&banner, text);

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -202,9 +202,8 @@ pub fn set_server_log_path(p: PathBuf) {
 /// home directory プレフィックスを `~` に reduce する。
 /// home が解決できない / s が home 配下でないときは原文を返す。
 fn reduce_home_prefix(s: &str) -> String {
-    let home = match dirs::home_dir() {
-        Some(h) => h,
-        None => return s.to_string(),
+    let Some(home) = dirs::home_dir() else {
+        return s.to_string();
     };
     let home_s = home.to_string_lossy().to_string();
     // Windows では `\` と `/` の混在があり得るので両形で試す
@@ -247,9 +246,8 @@ mod path_tests {
     /// 存在しないと一部スキップされる点だけ承知 (Linux CI / Windows CI とも home はある)。
     #[test]
     fn reduces_home_prefix_when_under_home() {
-        let home = match dirs::home_dir() {
-            Some(h) => h,
-            None => return, // home 取れない環境ではスキップ (CI 上は通常存在する)
+        let Some(home) = dirs::home_dir() else {
+            return; // home 取れない環境ではスキップ (CI 上は通常存在する)
         };
         let inside = home
             .join(".vibe-editor")
@@ -745,14 +743,11 @@ impl TeamHub {
         outcome: RecruitAckOutcome,
     ) -> Result<(), AckError> {
         let mut s = self.state.lock().await;
-        let pending = match s.pending_recruits.get_mut(agent_id) {
-            Some(p) => p,
-            None => {
-                tracing::warn!(
-                    "[teamhub] recruit_ack ignored: no pending recruit for agent={agent_id}"
-                );
-                return Err(AckError::NotFound);
-            }
+        let Some(pending) = s.pending_recruits.get_mut(agent_id) else {
+            tracing::warn!(
+                "[teamhub] recruit_ack ignored: no pending recruit for agent={agent_id}"
+            );
+            return Err(AckError::NotFound);
         };
         if pending.team_id != expected_team_id {
             tracing::warn!(
@@ -897,16 +892,13 @@ impl TeamHub {
                             break;
                         }
                     };
-                    let permit = match sem.clone().try_acquire_owned() {
-                        Ok(p) => p,
-                        Err(_) => {
-                            tracing::warn!(
-                                "[teamhub] rejecting connection: client limit ({}) reached",
-                                MAX_CONCURRENT_CLIENTS
-                            );
-                            drop(connected);
-                            continue;
-                        }
+                    let Ok(permit) = sem.clone().try_acquire_owned() else {
+                        tracing::warn!(
+                            "[teamhub] rejecting connection: client limit ({}) reached",
+                            MAX_CONCURRENT_CLIENTS
+                        );
+                        drop(connected);
+                        continue;
                     };
                     let hub2 = hub.clone();
                     let token = token.clone();
@@ -1260,12 +1252,9 @@ where
         // Issue #149: 書き込み I/O 失敗で client loop ごと終了するのを避ける。
         // ECONNRESET 等の一時的な失敗は log + continue で次の line を待つ。
         // notification (id=null) には仕様上 error を返さない。
-        let line_str = match std::str::from_utf8(&buf) {
-            Ok(s) => s,
-            Err(_) => {
-                tracing::warn!("[teamhub] dropping invalid utf-8 line");
-                continue;
-            }
+        let Ok(line_str) = std::str::from_utf8(&buf) else {
+            tracing::warn!("[teamhub] dropping invalid utf-8 line");
+            continue;
         };
         let req: serde_json::Value = match serde_json::from_str(line_str) {
             Ok(v) => v,

--- a/src-tauri/src/team_hub/protocol/tools/create_leader.rs
+++ b/src-tauri/src/team_hub/protocol/tools/create_leader.rs
@@ -135,7 +135,7 @@ pub async fn team_create_leader(
             if let Some(app) = &app {
                 let _ = app.emit(
                     "team:recruit-cancelled",
-                    json!({ "newAgentId": new_agent_id, "reason": phase_str.clone() }),
+                    json!({ "newAgentId": new_agent_id, "reason": phase_str }),
                 );
             }
             let message = if reason.is_empty() {

--- a/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
+++ b/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
@@ -61,7 +61,7 @@ fn pending_inbox_summary(
     }
 
     let oldest_age_ms = oldest_at.map(|oldest| (now - oldest).num_milliseconds().max(0));
-    let stalled = oldest_age_ms.map_or(false, |age| age >= STALLED_INBOUND_THRESHOLD_MS);
+    let stalled = oldest_age_ms.is_some_and(|age| age >= STALLED_INBOUND_THRESHOLD_MS);
 
     PendingInboxSummary {
         ids,
@@ -80,18 +80,17 @@ fn build_member_diagnostics_row(
 ) -> Value {
     let pending = pending_inbox_summary(messages, agent_id, role, now);
     let pending_count = pending.ids.len();
-    let last_seen_at = diagnostics.last_seen_at.clone();
     json!({
         "agentId": agent_id,
         "role": role,
         "online": true,
         "inconsistent": inconsistent,
-        "recruitedAt": diagnostics.recruited_at.clone(),
-        "lastHandshakeAt": diagnostics.last_handshake_at.clone(),
-        "lastSeenAt": last_seen_at.clone(),
-        "lastAgentActivityAt": last_seen_at,
-        "lastMessageInAt": diagnostics.last_message_in_at.clone(),
-        "lastMessageOutAt": diagnostics.last_message_out_at.clone(),
+        "recruitedAt": diagnostics.recruited_at,
+        "lastHandshakeAt": diagnostics.last_handshake_at,
+        "lastSeenAt": diagnostics.last_seen_at,
+        "lastAgentActivityAt": diagnostics.last_seen_at,
+        "lastMessageInAt": diagnostics.last_message_in_at,
+        "lastMessageOutAt": diagnostics.last_message_out_at,
         "messagesInCount": diagnostics.messages_in_count,
         "messagesOutCount": diagnostics.messages_out_count,
         "tasksClaimedCount": diagnostics.tasks_claimed_count,
@@ -99,8 +98,8 @@ fn build_member_diagnostics_row(
         "pendingInboxCount": pending_count,
         "oldestPendingInboxAgeMs": pending.oldest_age_ms,
         "stalledInbound": pending.stalled,
-        "currentStatus": diagnostics.current_status.clone(),
-        "lastStatusAt": diagnostics.last_status_at.clone(),
+        "currentStatus": diagnostics.current_status,
+        "lastStatusAt": diagnostics.last_status_at,
     })
 }
 

--- a/src-tauri/src/team_hub/protocol/tools/recruit.rs
+++ b/src-tauri/src/team_hub/protocol/tools/recruit.rs
@@ -241,7 +241,7 @@ pub async fn team_recruit(
                 if let Some(app) = &app {
                     let _ = app.emit(
                         "team:recruit-cancelled",
-                        json!({ "newAgentId": new_agent_id, "reason": phase_str.clone() }),
+                        json!({ "newAgentId": new_agent_id, "reason": phase_str }),
                     );
                 }
                 let message = if reason.is_empty() {

--- a/src-tauri/src/util/log_redact.rs
+++ b/src-tauri/src/util/log_redact.rs
@@ -8,9 +8,8 @@
 /// `path` 内に含まれるユーザーホームディレクトリを `~` に置き換えた文字列を返す。
 /// home が取れない場合は input をそのまま返す。
 pub fn redact_home(path: &str) -> String {
-    let home = match dirs::home_dir() {
-        Some(h) => h,
-        None => return path.to_string(),
+    let Some(home) = dirs::home_dir() else {
+        return path.to_string();
     };
     let home_str = home.to_string_lossy();
     if home_str.is_empty() {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -51,7 +51,7 @@ import {
 } from './lib/settings-context';
 import { useToast } from './lib/toast-context';
 import { useUiStore } from './stores/ui';
-import { dedupPrepend, listContainsPath } from './lib/path-norm';
+import { listContainsPath } from './lib/path-norm';
 import { useProjectLoader } from './lib/hooks/use-project-loader';
 import { useFileTabs } from './lib/hooks/use-file-tabs';
 import type { DiffTab, EditorTab } from './lib/hooks/use-file-tabs';

--- a/src/renderer/src/components/CommandPalette.tsx
+++ b/src/renderer/src/components/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Search } from 'lucide-react';
 import { filterCommands, type Command } from '../lib/commands';
@@ -56,40 +56,46 @@ export function CommandPalette({
   const { mounted, dataState, motion } = useSpringMount(open, 160);
   if (!mounted) return null;
 
-  const runSelected = (): void => {
+  const runSelected = useCallback((): void => {
     const cmd = filtered[selected];
     if (!cmd) return;
     onClose();
     // voidキャスト: async でも同期でも同じ扱い
     void Promise.resolve(cmd.run());
-  };
+  }, [filtered, selected, onClose]);
 
-  const handleKeyDown = (e: React.KeyboardEvent): void => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setSelected((i) => Math.min(filtered.length - 1, i + 1));
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setSelected((i) => Math.max(0, i - 1));
-    } else if (e.key === 'Enter') {
-      e.preventDefault();
-      runSelected();
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      onClose();
-    }
-  };
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent): void => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelected((i) => Math.min(filtered.length - 1, i + 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelected((i) => Math.max(0, i - 1));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        runSelected();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    },
+    [filtered.length, runSelected, onClose]
+  );
 
   // Issue #180: 旧実装は backdrop onClick={onClose} で閉じていたため、リスト内/入力欄で
   // mousedown → backdrop で mouseup と移動するドラッグ選択 (テキスト選択) でも click が
   // backdrop に届いて閉じていた。
   // mousedown 時点の target が backdrop 自体のときだけ閉じるように変更。
   // (panel 内で mousedown した click は target=panel の子孫になるので閉じない)
-  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>): void => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
-  };
+  const handleBackdropMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>): void => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
   return createPortal(
     <div
       className="cmdp-backdrop"

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowLeft, Check, Plus, Search, X } from 'lucide-react';
 import type { AgentConfig, AppSettings } from '../../../types/shared';
 import { DEFAULT_SETTINGS } from '../../../types/shared';
@@ -118,9 +118,12 @@ export function SettingsModal({
   // 並んでおり、ここで return すると mounted の値で hook 数が変わって "Rendered more hooks
   // than during the previous render" エラーになる (#220 系で再発)。
 
-  const update = <K extends keyof AppSettings>(key: K, value: AppSettings[K]): void => {
-    setDraft((d) => ({ ...d, [key]: value }));
-  };
+  const update = useCallback(
+    <K extends keyof AppSettings>(key: K, value: AppSettings[K]): void => {
+      setDraft((d) => ({ ...d, [key]: value }));
+    },
+    []
+  );
 
   const handleApply = (): void => {
     // saved=true の状態で再度押されるのはボタンの disabled で防いでいるが、

--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -59,10 +59,25 @@ const edgeTypes = {
   handoff: HandoffEdge
 };
 
+// React Flow に渡す静的な props はモジュール定数にしてレンダー間で参照を保つ。
+// インラインオブジェクトだと毎レンダーで新しい識別子になり MiniMap / Background が
+// memoization を活かせない。
+const MINIMAP_STYLE = { background: '#0d0d12' } as const;
+const MINIMAP_MASK_COLOR = 'rgba(0,0,0,0.6)';
+const FLOW_DELETE_KEYS = ['Delete'];
+const FLOW_PAN_BUTTONS = [0, 1, 2];
+const FLOW_PRO_OPTIONS = { hideAttribution: true } as const;
+const FLOW_STAGE_STYLE = { position: 'absolute' as const, inset: 0 };
+const BACKGROUND_COLOR_VAR = 'var(--canvas-grid, #1c1c20)';
+/** Issue #259 継承: zoom が 0.7 を下回ると TUI が読めなくなるため recruit focus 時のクランプ閾値。 */
+const MIN_RECRUIT_ZOOM = 0.7;
+
 function FlowApp(): JSX.Element {
   const t = useT();
   const nodes = useCanvasStore((s) => s.nodes);
   const edges = useCanvasStore((s) => s.edges);
+  // setNodes / setEdges / setViewport / addCard / pulseEdge / setTeamLock は zustand
+  // 内部で stable identity を保つため selector で取り出してキャッシュしておく。
   const setNodes = useCanvasStore((s) => s.setNodes);
   const setEdges = useCanvasStore((s) => s.setEdges);
   const setViewport = useCanvasStore((s) => s.setViewport);
@@ -111,9 +126,13 @@ function FlowApp(): JSX.Element {
       // 同じキャストが index 構築 + position/dimensions 分岐で計 3 回走るので helper に集約。
       const teamIdOf = (n: Node<CardData>): string | undefined =>
         (n.data?.payload as { teamId?: string } | undefined)?.teamId;
+      // store から最新 nodes を直接取り出す (subscribe している `nodes` と等価だが、
+      // ここで getState 越しに読むと callback の deps から `nodes` を外せる →
+      // ドラッグ中に毎フレーム識別子が変わる onNodesChange を React Flow に再 bind せずに済む)。
+      const currentNodes = useCanvasStore.getState().nodes;
       const nodesById = new Map<string, Node<CardData>>();
       const teamMembers = new Map<string, Node<CardData>[]>();
-      for (const n of nodes) {
+      for (const n of currentNodes) {
         nodesById.set(n.id, n);
         const tid = teamIdOf(n);
         if (tid) {
@@ -192,17 +211,18 @@ function FlowApp(): JSX.Element {
       }
 
       const allChanges = extra.length > 0 ? [...remaining, ...extra] : remaining;
-      setNodes(applyNodeChanges(allChanges, nodes));
+      setNodes(applyNodeChanges(allChanges, currentNodes));
     },
-    [nodes, setNodes, confirmRemoveCard, isTeamLocked]
+    [setNodes, confirmRemoveCard, isTeamLocked]
   );
   const onEdgesChange = useCallback(
-    (changes: EdgeChange<Edge>[]) => setEdges(applyEdgeChanges(changes, edges)),
-    [edges, setEdges]
+    (changes: EdgeChange<Edge>[]) =>
+      setEdges(applyEdgeChanges(changes, useCanvasStore.getState().edges)),
+    [setEdges]
   );
   const onConnect = useCallback(
-    (c: Connection) => setEdges(addEdge(c, edges)),
-    [edges, setEdges]
+    (c: Connection) => setEdges(addEdge(c, useCanvasStore.getState().edges)),
+    [setEdges]
   );
 
   // ----- 右クリックメニュー (カード単位) -----
@@ -212,15 +232,18 @@ function FlowApp(): JSX.Element {
     items: ContextMenuItem[];
   } | null>(null);
 
-  // Ctrl+Space / Pane 右クリック共通: 新規 AI Agent (Claude Code) を追加
+  // Ctrl+Space / Pane 右クリック共通: 新規 AI Agent (Claude Code) を追加。
+  // 件数カウントは getState で都度参照し、callback 識別子を `nodes` の参照変化から切り離す
+  // (ドラッグ中の毎フレーム再生成を抑え、useKeybinding の listener 再登録も発生させない)。
   const handleAddClaudeAgent = useCallback((): void => {
-    const n = nodes.filter((x) => x.type === 'agent').length + 1;
+    const currentNodes = useCanvasStore.getState().nodes;
+    const n = currentNodes.filter((x) => x.type === 'agent').length + 1;
     addCard({
       type: 'agent',
       title: `Claude #${n}`,
       payload: { agent: 'claude', role: 'leader' }
     });
-  }, [addCard, nodes]);
+  }, [addCard]);
 
   const handleNodeContextMenu = useCallback(
     (e: React.MouseEvent, node: Node<CardData>) => {
@@ -311,7 +334,7 @@ function FlowApp(): JSX.Element {
   //
   // Issue #259 (継承): zoom が MIN_RECRUIT_ZOOM を下回ると TUI が読めなくなるため、
   // 現在の zoom がそれより大きければ尊重し、下回っていれば minZoom にクランプして寄せる。
-  const MIN_RECRUIT_ZOOM = 0.7;
+  // (MIN_RECRUIT_ZOOM はモジュールトップで定義)
   // 旧 #372 review (vibe-editor-reviewer #418): selector で `lastRecruitFocus` を
   // オブジェクトのまま購読すると、zustand が毎回新しい参照を返すため effect deps が
   // 「object reference に敏感」になり、useReactFlow の参照変化と組み合わさって
@@ -355,7 +378,7 @@ function FlowApp(): JSX.Element {
     <div
       className="tc-stage-root"
       data-view={stageView}
-      style={{ position: 'absolute', inset: 0 }}
+      style={FLOW_STAGE_STYLE}
     >
       <LeaderGlow />
       <ReactFlow
@@ -370,7 +393,7 @@ function FlowApp(): JSX.Element {
         onNodeContextMenu={handleNodeContextMenu}
         onPaneContextMenu={handlePaneContextMenu}
         // Delete キーで選択中カードを削除 (Backspace は xterm 入力と衝突するので除外)
-        deleteKeyCode={['Delete']}
+        deleteKeyCode={FLOW_DELETE_KEYS}
         defaultViewport={initialViewport}
         // --- zoom / pan の挙動 ---
         // Figma/Miro 風のカメラ zoom を React Flow 本来の挙動として復活。
@@ -391,24 +414,24 @@ function FlowApp(): JSX.Element {
         zoomOnScroll
         zoomOnPinch
         zoomOnDoubleClick={false}
-        panOnDrag={[0, 1, 2]}
+        panOnDrag={FLOW_PAN_BUTTONS}
         // onlyRenderVisibleElements は付けない。
         // 付けると React Flow がビューポート外のカードを DOM からアンマウントし、
         // TerminalCard 配下の usePtySession クリーンアップが走って PTY (= Claude/Codex)
         // ごと kill されてしまう。
         // パンで視点を動かしただけで Claude が死ぬのは UX として許容できないので、
         // 多少の DOM 増加は呑んで全カードを常時マウントしておく。
-        proOptions={{ hideAttribution: true }}
+        proOptions={FLOW_PRO_OPTIONS}
       >
-        <Background gap={32} color="var(--canvas-grid, #1c1c20)" />
+        <Background gap={32} color={BACKGROUND_COLOR_VAR} />
         {/* React Flow デフォルトの白い縦 4 ボタン (zoom/+/-、fit、lock) は UI と不整合なので非表示。
             ズームはマウスホイール / トラックパッド、fit はキー (KEYS.fitView)、lock は不要なため。 */}
         <MiniMap
           pannable
           zoomable
           nodeColor={minimapColor}
-          maskColor="rgba(0,0,0,0.6)"
-          style={{ background: '#0d0d12' }}
+          maskColor={MINIMAP_MASK_COLOR}
+          style={MINIMAP_STYLE}
         />
       </ReactFlow>
 

--- a/src/renderer/src/components/canvas/HandoffEdge.tsx
+++ b/src/renderer/src/components/canvas/HandoffEdge.tsx
@@ -41,6 +41,8 @@ function HandoffEdgeImpl({
   const color = d?.color ?? '#7a7afd';
   const preview = d?.preview ?? '';
 
+  // @keyframes handoff-flow は canvas.css に集約済み (旧実装は edge mount のたびに
+  // 同一内容の <style> を吐いていた)。インライン style は色依存ぶんだけ残す。
   return (
     <>
       <BaseEdge
@@ -57,21 +59,14 @@ function HandoffEdgeImpl({
       {preview && (
         <EdgeLabelRenderer>
           <div
+            className="canvas-handoff-edge__label"
             style={{
-              position: 'absolute',
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
               background: `${color}1a`,
               color,
-              padding: '2px 8px',
-              borderRadius: 6,
-              fontSize: 10,
               border: `1px solid ${color}66`,
-              maxWidth: 240,
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              pointerEvents: 'none',
-              fontFamily: "'Inter', sans-serif",
+              // Glass CSS contract (`.tc__hud` 以外で backdrop-filter 禁止) に従い
+              // インライン style 側で blur をかける。一時 edge ラベルなので影響軽微。
               backdropFilter: 'blur(4px)'
             }}
           >
@@ -79,11 +74,6 @@ function HandoffEdgeImpl({
           </div>
         </EdgeLabelRenderer>
       )}
-      <style>{`
-        @keyframes handoff-flow {
-          to { stroke-dashoffset: -14; }
-        }
-      `}</style>
     </>
   );
 }

--- a/src/renderer/src/components/canvas/LeaderGlow.tsx
+++ b/src/renderer/src/components/canvas/LeaderGlow.tsx
@@ -1,8 +1,15 @@
+import { memo } from 'react';
+
 /**
  * LeaderGlow — Canvas 中央に配置するリーダー用ラジアルグロー。
  * Claude Design バンドルの .tc__leader-glow を移植。
  * Canvas viewport transform の外側 (ステージ座標系でなく CSS viewport 中央) に置く。
+ *
+ * Canvas 全体が再レンダーするたびに <div /> を作り直すコストはゼロに近いが、
+ * memo で包んで「props 無し → 親の再レンダーをそのまま素通り」できるようにする。
  */
-export function LeaderGlow(): JSX.Element {
+function LeaderGlowImpl(): JSX.Element {
   return <div className="tc__leader-glow" aria-hidden="true" />;
 }
+
+export const LeaderGlow = memo(LeaderGlowImpl);

--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { LayoutGrid, List, Maximize2, Ruler, Users, ZoomIn, ZoomOut } from 'lucide-react';
 import { useReactFlow } from '@xyflow/react';
 import { useT } from '../../lib/i18n';
@@ -46,32 +46,42 @@ export function StageHud(): JSX.Element {
     };
   }, [arrangeOpen]);
 
-  const views: Array<{ id: StageView; label: string; tip: string; icon: JSX.Element }> = [
-    {
-      id: 'stage',
-      label: t('canvas.hud.stage'),
-      tip: t('canvas.hud.stage.tooltip'),
-      icon: <Users size={12} strokeWidth={2} />
-    },
-    {
-      id: 'list',
-      label: t('canvas.hud.list'),
-      tip: t('canvas.hud.list.tooltip'),
-      icon: <List size={12} strokeWidth={2} />
-    },
-    {
-      id: 'focus',
-      label: t('canvas.hud.focus'),
-      tip: t('canvas.hud.focus.tooltip'),
-      icon: <Maximize2 size={12} strokeWidth={2} />
-    }
-  ];
+  // 翻訳結果の配列は `t` 依存。zustand store 変化 (stageView / arrangeGap) のたびに
+  // 配列リテラル + JSX を作り直すと map 配下の Lucide アイコン (memo されない子) も
+  // 全て新しい props で識別され、Chrome DevTools React profiler 上で目立つ flicker
+  // 要因になる。t を使うので useMemo で `t` 同一 → 同一参照にする。
+  const views = useMemo<Array<{ id: StageView; label: string; tip: string; icon: JSX.Element }>>(
+    () => [
+      {
+        id: 'stage',
+        label: t('canvas.hud.stage'),
+        tip: t('canvas.hud.stage.tooltip'),
+        icon: <Users size={12} strokeWidth={2} />
+      },
+      {
+        id: 'list',
+        label: t('canvas.hud.list'),
+        tip: t('canvas.hud.list.tooltip'),
+        icon: <List size={12} strokeWidth={2} />
+      },
+      {
+        id: 'focus',
+        label: t('canvas.hud.focus'),
+        tip: t('canvas.hud.focus.tooltip'),
+        icon: <Maximize2 size={12} strokeWidth={2} />
+      }
+    ],
+    [t]
+  );
 
-  const gaps: Array<{ id: ArrangeGap; label: string }> = [
-    { id: 'tight', label: t('canvas.hud.arrange.gap.tight') },
-    { id: 'normal', label: t('canvas.hud.arrange.gap.normal') },
-    { id: 'wide', label: t('canvas.hud.arrange.gap.wide') }
-  ];
+  const gaps = useMemo<Array<{ id: ArrangeGap; label: string }>>(
+    () => [
+      { id: 'tight', label: t('canvas.hud.arrange.gap.tight') },
+      { id: 'normal', label: t('canvas.hud.arrange.gap.normal') },
+      { id: 'wide', label: t('canvas.hud.arrange.gap.wide') }
+    ],
+    [t]
+  );
 
   return (
     <div className="tc__hud" role="toolbar" aria-label="Canvas view">

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard.tsx
@@ -197,8 +197,10 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   // 30 カード並ぶと idle 中も毎秒 150 回 timer が起きていた (省電力モード/裏画面でも)。
   // → 出力イベント (handleActivity) の都度 setTimeout を立て直し、idle 復帰でクリアする。
   //   typing 状態の間しかタイマーが動かないので idle 時はゼロコスト。
+  // useCallback で参照固定: TerminalView に渡す onActivity が毎レンダー新規になると、
+  //   TerminalView 内部の effect (handler 再 attach) が無駄に再実行される。
   const idleTimerRef = useRef<number | null>(null);
-  const handleActivity = (): void => {
+  const handleActivity = useCallback((): void => {
     setActivity('typing');
     if (idleTimerRef.current !== null) {
       window.clearTimeout(idleTimerRef.current);
@@ -207,7 +209,7 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
       idleTimerRef.current = null;
       setActivity((prev) => (prev !== 'idle' ? 'idle' : prev));
     }, 600);
-  };
+  }, []);
   useEffect(() => {
     return () => {
       if (idleTimerRef.current !== null) {
@@ -220,34 +222,41 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   // ----- ユーザー入力から auto-summary タイトル -----
   // 入力をバッファし、Enter (\r) を押した瞬間にバッファ内容をタイトル化する。
   // 既にユーザーが手で名付けた (auto title 形式でない) 場合は上書きしない。
+  // title は user 入力で都度上書きされうるが、判定は確定タイミングだけなので ref で読む
+  // → callback 自体は (id, setCardTitle) のみに依存させて識別子を安定化。
   const inputBufferRef = useRef('');
-  const handleUserInput = (raw: string): void => {
-    if (!raw) return;
-    // 制御コードのうち BS, ESC, 矢印キー等は無視。Enter (\r/\n) は確定トリガ。
-    for (const ch of raw) {
-      const code = ch.charCodeAt(0);
-      if (ch === '\r' || ch === '\n') {
-        const text = inputBufferRef.current;
-        inputBufferRef.current = '';
-        const summary = summarizeInput(text);
-        if (summary && isAutoTitle(title)) {
-          setCardTitle(id, summary);
-        }
-      } else if (code === 0x7f || code === 0x08) {
-        // Backspace
-        inputBufferRef.current = inputBufferRef.current.slice(0, -1);
-      } else if (code === 0x1b) {
-        // ESC シーケンス開始 → 同チャンク内の残りも捨てる近似
-        return;
-      } else if (code >= 0x20) {
-        inputBufferRef.current += ch;
-        // 暴走防止: 200 文字超えたらリセット
-        if (inputBufferRef.current.length > 200) {
-          inputBufferRef.current = inputBufferRef.current.slice(-200);
+  const titleRef = useRef(title);
+  titleRef.current = title;
+  const handleUserInput = useCallback(
+    (raw: string): void => {
+      if (!raw) return;
+      // 制御コードのうち BS, ESC, 矢印キー等は無視。Enter (\r/\n) は確定トリガ。
+      for (const ch of raw) {
+        const code = ch.charCodeAt(0);
+        if (ch === '\r' || ch === '\n') {
+          const text = inputBufferRef.current;
+          inputBufferRef.current = '';
+          const summary = summarizeInput(text);
+          if (summary && isAutoTitle(titleRef.current)) {
+            setCardTitle(id, summary);
+          }
+        } else if (code === 0x7f || code === 0x08) {
+          // Backspace
+          inputBufferRef.current = inputBufferRef.current.slice(0, -1);
+        } else if (code === 0x1b) {
+          // ESC シーケンス開始 → 同チャンク内の残りも捨てる近似
+          return;
+        } else if (code >= 0x20) {
+          inputBufferRef.current += ch;
+          // 暴走防止: 200 文字超えたらリセット
+          if (inputBufferRef.current.length > 200) {
+            inputBufferRef.current = inputBufferRef.current.slice(-200);
+          }
         }
       }
-    }
-  };
+    },
+    [id, setCardTitle]
+  );
 
   // Issue #23 + カスタムエージェント対応:
   // agent-resolver 経由で built-in (claude/codex) + customAgents のコマンド/引数/cwd を解決する。
@@ -512,6 +521,16 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   }, []);
   useXtermScrollToBottomOnResize(termContainerRef, scrollToBottom);
 
+  // TerminalView に渡す onSessionId を useCallback 化。インライン lambda だと
+  // setActivity / status の局所 setState で AgentNodeCard が再描画するたび
+  // TerminalView 側の onSessionId が新規参照になり、内部 deps 経由の handler 差替えが起きる。
+  const handleSessionId = useCallback(
+    (sid: string): void => {
+      if (sid) setCardPayload(id, { resumeSessionId: sid });
+    },
+    [id, setCardPayload]
+  );
+
   return (
     <>
       <NodeResizer
@@ -595,9 +614,7 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
             onStatus={setStatus}
             onActivity={handleActivity}
             onUserInput={handleUserInput}
-            onSessionId={(sid) => {
-              if (sid) setCardPayload(id, { resumeSessionId: sid });
-            }}
+            onSessionId={handleSessionId}
             // Issue #342 Phase 1: terminal_create 失敗を Hub に ack(false) する。
             // 30 秒の handshake timeout を待たず、recruit MCP に構造化エラーが即返る。
             onSpawnError={onSpawnError}

--- a/src/renderer/src/components/overlays/TweaksPanel.tsx
+++ b/src/renderer/src/components/overlays/TweaksPanel.tsx
@@ -4,6 +4,26 @@ import { useT } from '../../lib/i18n';
 import { useSettings } from '../../lib/settings-context';
 import { useUiStore } from '../../stores/ui';
 
+const THEMES: ReadonlyArray<{ id: ThemeName; label: string }> = [
+  { id: 'claude-dark', label: 'claude dark' },
+  { id: 'claude-light', label: 'claude light' },
+  { id: 'dark', label: 'dark' },
+  { id: 'light', label: 'light' },
+  { id: 'midnight', label: 'midnight' },
+  { id: 'glass', label: 'glass' }
+];
+
+const DENSITIES: ReadonlyArray<{ id: Density; label: string }> = [
+  { id: 'compact', label: 'compact' },
+  { id: 'normal', label: 'normal' },
+  { id: 'comfortable', label: 'comfortable' }
+];
+
+const LANGUAGES: ReadonlyArray<{ id: Language; label: string }> = [
+  { id: 'ja', label: '日本語' },
+  { id: 'en', label: 'English' }
+];
+
 /**
  * TweaksPanel — 右下に浮かぶクイック調整パネル。
  * Claude Design バンドルの .tweaks を移植し、既存 `useSettings` に値を書き戻す。
@@ -16,26 +36,6 @@ export function TweaksPanel(): JSX.Element | null {
   const setOpen = useUiStore((s) => s.setTweaksOpen);
 
   if (!open) return null;
-
-  const themes: Array<{ id: ThemeName; label: string }> = [
-    { id: 'claude-dark', label: 'claude dark' },
-    { id: 'claude-light', label: 'claude light' },
-    { id: 'dark', label: 'dark' },
-    { id: 'light', label: 'light' },
-    { id: 'midnight', label: 'midnight' },
-    { id: 'glass', label: 'glass' }
-  ];
-
-  const densities: Array<{ id: Density; label: string }> = [
-    { id: 'compact', label: 'compact' },
-    { id: 'normal', label: 'normal' },
-    { id: 'comfortable', label: 'comfortable' }
-  ];
-
-  const languages: Array<{ id: Language; label: string }> = [
-    { id: 'ja', label: '日本語' },
-    { id: 'en', label: 'English' }
-  ];
 
   return (
     <div className="tweaks is-open" role="dialog" aria-label={t('tweaks.title')}>
@@ -54,7 +54,7 @@ export function TweaksPanel(): JSX.Element | null {
         <div className="tw-group">
           <div className="tw-label">{t('tweaks.theme')}</div>
           <div className="tw-row">
-            {themes.map((theme) => (
+            {THEMES.map((theme) => (
               <button
                 key={theme.id}
                 type="button"
@@ -69,7 +69,7 @@ export function TweaksPanel(): JSX.Element | null {
         <div className="tw-group">
           <div className="tw-label">{t('tweaks.density')}</div>
           <div className="tw-row">
-            {densities.map((d) => (
+            {DENSITIES.map((d) => (
               <button
                 key={d.id}
                 type="button"
@@ -84,7 +84,7 @@ export function TweaksPanel(): JSX.Element | null {
         <div className="tw-group">
           <div className="tw-label">{t('tweaks.language')}</div>
           <div className="tw-row">
-            {languages.map((lng) => (
+            {LANGUAGES.map((lng) => (
               <button
                 key={lng.id}
                 type="button"

--- a/src/renderer/src/components/settings/LanguageSection.tsx
+++ b/src/renderer/src/components/settings/LanguageSection.tsx
@@ -7,13 +7,15 @@ interface Props {
   update: UpdateSetting;
 }
 
+const LANGUAGES: ReadonlyArray<Language> = ['ja', 'en'];
+
 export function LanguageSection({ draft, update }: Props): JSX.Element {
   const t = useT();
   return (
     <section className="modal__section">
       <h3>{t('settings.language')}</h3>
       <div className="lang-grid">
-        {(['ja', 'en'] as Language[]).map((lang) => (
+        {LANGUAGES.map((lang) => (
           <label
             key={lang}
             className={`lang-card ${draft.language === lang ? 'is-selected' : ''}`}

--- a/src/renderer/src/components/shell/ActivityPanel.tsx
+++ b/src/renderer/src/components/shell/ActivityPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import type { TeamRole } from '../../../../types/shared';
 import { useT } from '../../lib/i18n';
 import {
@@ -37,12 +37,15 @@ export function ActivityPanel({
 
   const groups = useMemo(() => groupEventsByRecency(filtered), [filtered]);
 
-  const filterChips: Array<{ id: FilterKind; label: string }> = [
-    { id: 'all', label: t('activity.filter.all') },
-    { id: 'handoff', label: t('activity.filter.handoff') },
-    { id: 'status', label: t('activity.filter.tool') },
-    { id: 'error', label: t('activity.filter.error') }
-  ];
+  const filterChips = useMemo<Array<{ id: FilterKind; label: string }>>(
+    () => [
+      { id: 'all', label: t('activity.filter.all') },
+      { id: 'handoff', label: t('activity.filter.handoff') },
+      { id: 'status', label: t('activity.filter.tool') },
+      { id: 'error', label: t('activity.filter.error') }
+    ],
+    [t]
+  );
 
   return (
     <aside className={`activity${className ? ' ' + className : ''}`} style={style} aria-label="Activity feed">
@@ -99,7 +102,7 @@ export function ActivityPanel({
   );
 }
 
-function FeedItem({ event }: { event: ActivityEvent }): JSX.Element {
+const FeedItem = memo(function FeedItem({ event }: { event: ActivityEvent }): JSX.Element {
   const color = roleColorVar(event.fromRole ?? event.role ?? null);
   const dateLabel = new Date(event.ts).toLocaleTimeString(undefined, {
     hour: '2-digit',
@@ -131,7 +134,7 @@ function FeedItem({ event }: { event: ActivityEvent }): JSX.Element {
       ) : null}
     </div>
   );
-}
+});
 
 function roleColorVar(role: TeamRole | string | null | undefined): string {
   if (!role) return 'var(--accent)';

--- a/src/renderer/src/components/shell/MenuBar.tsx
+++ b/src/renderer/src/components/shell/MenuBar.tsx
@@ -9,7 +9,7 @@
  *   - 別の項目を hover (どこかが既に開いている場合のみ) → そちらに開け替え
  *   - 外クリック / Esc / 項目選択 → 全閉じ
  */
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { memo, useEffect, useRef, useState, type ReactNode } from 'react';
 import { ChevronDown } from 'lucide-react';
 
 export interface MenuBarItem {
@@ -103,7 +103,13 @@ export interface MenuItemProps {
   disabled?: boolean;
 }
 
-export function MenuItem({ icon, label, shortcut, onClick, disabled }: MenuItemProps): JSX.Element {
+export const MenuItem = memo(function MenuItem({
+  icon,
+  label,
+  shortcut,
+  onClick,
+  disabled
+}: MenuItemProps): JSX.Element {
   return (
     <button
       type="button"
@@ -118,15 +124,15 @@ export function MenuItem({ icon, label, shortcut, onClick, disabled }: MenuItemP
       {shortcut && <span className="menubar__item-shortcut">{shortcut}</span>}
     </button>
   );
-}
+});
 
 /** 区切り線 */
-export function MenuDivider(): JSX.Element {
+export const MenuDivider = memo(function MenuDivider(): JSX.Element {
   return <div className="menubar__divider" aria-hidden="true" />;
-}
+});
 
 /** セクション見出し (例: 「最近開いたプロジェクト」) */
-export function MenuSection({
+export const MenuSection = memo(function MenuSection({
   label,
   rightSlot
 }: {
@@ -139,4 +145,4 @@ export function MenuSection({
       {rightSlot}
     </div>
   );
-}
+});

--- a/src/renderer/src/components/shell/Rail.tsx
+++ b/src/renderer/src/components/shell/Rail.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from 'react';
 import { Files, GitBranch, History, LayoutGrid, Settings as SettingsIcon, StickyNote } from 'lucide-react';
 import type { SidebarView } from '../Sidebar';
 import { useT } from '../../lib/i18n';
@@ -41,41 +42,49 @@ export function Rail({
   //   - アクティブタブ + sidebar 開 → 折り畳み
   //   - アクティブタブ + sidebar 閉 → 開く
   //   - 別タブ → そのタブに切替 (折り畳まれていたら開く)
-  const handleTabClick = (view: SidebarView): void => {
-    if (sidebarView === view) {
-      toggleSidebar();
-      return;
-    }
-    onSidebarViewChange(view);
-    if (sidebarCollapsed) setSidebarCollapsed(false);
-  };
-
-  const items: Array<{
-    view: SidebarView;
-    label: string;
-    icon: JSX.Element;
-    count?: number;
-  }> = [
-    { view: 'files', label: t('sidebar.files'), icon: <Files size={17} strokeWidth={2.2} /> },
-    // git リポジトリでない場合は Changes タブごと表示しない
-    ...(hasGitRepo
-      ? [
-          {
-            view: 'changes' as SidebarView,
-            label: t('sidebar.changes'),
-            icon: <GitBranch size={17} strokeWidth={2.2} />,
-            count: changeCount
-          }
-        ]
-      : []),
-    {
-      view: 'sessions',
-      label: t('sidebar.history'),
-      icon: <History size={17} strokeWidth={2.2} />,
-      count: historyBadgeCount
+  const handleTabClick = useCallback(
+    (view: SidebarView): void => {
+      if (sidebarView === view) {
+        toggleSidebar();
+        return;
+      }
+      onSidebarViewChange(view);
+      if (sidebarCollapsed) setSidebarCollapsed(false);
     },
-    { view: 'notes', label: t('sidebar.notes'), icon: <StickyNote size={17} strokeWidth={2.2} /> }
-  ];
+    [sidebarView, toggleSidebar, onSidebarViewChange, sidebarCollapsed, setSidebarCollapsed]
+  );
+
+  const items = useMemo<
+    Array<{
+      view: SidebarView;
+      label: string;
+      icon: JSX.Element;
+      count?: number;
+    }>
+  >(
+    () => [
+      { view: 'files', label: t('sidebar.files'), icon: <Files size={17} strokeWidth={2.2} /> },
+      // git リポジトリでない場合は Changes タブごと表示しない
+      ...(hasGitRepo
+        ? [
+            {
+              view: 'changes' as SidebarView,
+              label: t('sidebar.changes'),
+              icon: <GitBranch size={17} strokeWidth={2.2} />,
+              count: changeCount
+            }
+          ]
+        : []),
+      {
+        view: 'sessions',
+        label: t('sidebar.history'),
+        icon: <History size={17} strokeWidth={2.2} />,
+        count: historyBadgeCount
+      },
+      { view: 'notes', label: t('sidebar.notes'), icon: <StickyNote size={17} strokeWidth={2.2} /> }
+    ],
+    [t, hasGitRepo, changeCount, historyBadgeCount]
+  );
 
   return (
     <nav className="rail" aria-label="Primary navigation">

--- a/src/renderer/src/components/shell/StatusMascot.tsx
+++ b/src/renderer/src/components/shell/StatusMascot.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { StatusMascotVariant } from '../../../../types/shared';
 import type { StatusMascotState } from '../../lib/status-mascot';
 
@@ -7,7 +8,7 @@ interface StatusMascotProps {
   variant?: StatusMascotVariant;
 }
 
-export function StatusMascot({
+export const StatusMascot = memo(function StatusMascot({
   state,
   label,
   variant = 'vibe'
@@ -42,7 +43,7 @@ export function StatusMascot({
       </span>
     </span>
   );
-}
+});
 
 type Tool = 'pencil' | 'paper' | 'lens';
 

--- a/src/renderer/src/lib/agent-resolver.ts
+++ b/src/renderer/src/lib/agent-resolver.ts
@@ -15,12 +15,6 @@ export interface ResolvedAgent {
   color?: string;
 }
 
-export interface AgentOption {
-  value: string;
-  label: string;
-  color?: string;
-}
-
 /**
  * agent id → 起動パラメータを 1 つのオブジェクトで返す。
  * 呼び出し元 (AgentNodeCard 等) はこれだけ読めば PTY spawn に必要な値が揃う。
@@ -57,25 +51,4 @@ export function resolveAgentConfig(
     args: settings.claudeArgs || '',
     cwd: settings.claudeCwd || settings.lastOpenedRoot || ''
   };
-}
-
-/**
- * Team ビルダーや Canvas の Add Card ポップオーバーなどで
- * 「選択可能なエージェント一覧」を作るためのユーティリティ。
- */
-export function allAgentOptions(settings: AppSettings): AgentOption[] {
-  return [
-    { value: 'claude', label: 'Claude Code' },
-    { value: 'codex', label: 'Codex' },
-    ...(settings.customAgents ?? []).map((a) => ({
-      value: a.id,
-      label: a.name,
-      color: a.color
-    }))
-  ];
-}
-
-/** built-in agent id かどうか (カスタム id の予約語チェックに使う)。 */
-export function isBuiltinAgentId(id: string): boolean {
-  return id === 'claude' || id === 'codex';
 }

--- a/src/renderer/src/lib/team-roles.ts
+++ b/src/renderer/src/lib/team-roles.ts
@@ -9,7 +9,7 @@
  */
 import type { Language, RoleProfile, TeamRole } from '../../../types/shared';
 import { BUILTIN_BY_ID, BUILTIN_ROLE_PROFILES } from './role-profiles-builtin';
-import { fallbackProfile, profileText, renderSystemPrompt } from './role-profiles-context';
+import { fallbackProfile, profileText } from './role-profiles-context';
 
 export interface RoleMeta {
   role: string;
@@ -45,49 +45,6 @@ export function roleMetaFor(role: TeamRole, language: Language): RoleMeta {
   const p = BUILTIN_BY_ID[role];
   if (!p) return profileToMeta(fallbackProfile(role), language);
   return profileToMeta(p, language);
-}
-
-/**
- * UI 表示順。固定ワーカーロール撤廃に伴い、ビルトインは leader / hr のみ。
- * 動的ロール (Leader が team_recruit で生成) は UI 側でメンバーカード単位に並ぶため、
- * ここには含めない。
- */
-export const ROLE_ORDER: TeamRole[] = ['leader', 'hr'];
-
-export interface TeamMemberSeed {
-  agentId: string;
-  role: TeamRole;
-  agent: 'claude' | 'codex';
-}
-
-/**
- * @deprecated 新コードは role-profiles-context の renderSystemPrompt を直接使う。
- *             builtin の 5 種を使うレガシー経路のみ維持。
- */
-export function buildTeamSystemPrompt(
-  selfAgentId: string,
-  selfRole: TeamRole,
-  teamName: string,
-  members: TeamMemberSeed[],
-  language: Language = 'en'
-): string {
-  const profile = BUILTIN_BY_ID[selfRole] ?? fallbackProfile(selfRole);
-  const profilesById: Record<string, RoleProfile> = Object.fromEntries(
-    BUILTIN_ROLE_PROFILES.map((p) => [p.id, p])
-  );
-  return renderSystemPrompt({
-    profile,
-    profilesById,
-    teamName,
-    selfAgentId,
-    members: members.map((m) => ({
-      agentId: m.agentId,
-      roleProfileId: m.role,
-      agent: m.agent
-    })),
-    globalPreamble: undefined,
-    language
-  });
 }
 
 export function colorOf(role: string | undefined): string {

--- a/src/renderer/src/lib/use-animated-mount.ts
+++ b/src/renderer/src/lib/use-animated-mount.ts
@@ -85,10 +85,6 @@ export function useSpringMount(open: boolean, exitMs = 160): AnimatedMountResult
   return useAnimatedMount(open, { exitMs, preset: 'spring' });
 }
 
-export function useFadeMount(open: boolean, exitMs = 160): AnimatedMountResult {
-  return useAnimatedMount(open, { exitMs, preset: 'fade' });
-}
-
 export function useScaleMount(open: boolean, exitMs = 160): AnimatedMountResult {
   return useAnimatedMount(open, { exitMs, preset: 'scale' });
 }

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -120,9 +120,6 @@
   z-index: 5;
 }
 
-
-
-
 .canvas-header__brand {
   display: inline-flex;
   align-items: center;
@@ -1039,8 +1036,18 @@
     stroke-dashoffset: -100;
   }
 }
-.react-flow__edge.react-flow__edge-handoff .react-flow__edge-path,
-.tc__edge-path {
+/* HandoffEdge コンポーネントが inline style で参照する keyframes。
+   旧実装では edge instance ごとに <style> を JSX 内で吐いていたため、HMR や
+   pulseEdge のたびに同一定義の <style> ノードが追加されていた。グローバル定義に集約。 */
+@keyframes handoff-flow {
+  to {
+    stroke-dashoffset: -14;
+  }
+}
+/* `.tc__edge-path` は HandoffEdge が `.react-flow__edge-path` を直接吐くため未使用だが、
+   旧クラス名のまま参照してくる外部スタイルがあった場合の互換のため残す削除候補。
+   現状コード側では参照されていないので将来削除予定。 */
+.react-flow__edge.react-flow__edge-handoff .react-flow__edge-path {
   fill: none;
   stroke: var(--role-color, var(--accent));
   stroke-width: 2;
@@ -1049,20 +1056,20 @@
   animation: tcEdgeFlow 1.6s linear infinite;
 }
 
-/* flying message pill (placed absolutely in container via inline style) */
-.tc__msg {
+/* HandoffEdge label: 静的レイアウトは CSS、色依存ぶんだけインライン。
+   backdrop-filter は Glass CSS contract (`.tc__hud` 以外で禁止) に従い、
+   従来通りインライン style 側で適用する。 */
+.canvas-handoff-edge__label {
   position: absolute;
-  padding: 4px 10px;
-  background: var(--bg-elev);
-  border: 1px solid var(--border-strong);
-  border-radius: 999px;
-  font-size: 10.5px;
-  color: var(--text);
-  font-family: var(--mono-font);
-  box-shadow: var(--shadow-md), 0 0 0 4px rgba(217, 119, 87, 0.28);
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 10px;
+  max-width: 240px;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   pointer-events: none;
-  z-index: 40;
+  font-family: 'Inter', sans-serif;
 }
 
 /* stage view modes — when stageView === 'list', the ReactFlow stage is hidden */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,8 @@ export default defineConfig(async () => ({
     sourcemap: !!process.env.TAURI_ENV_DEBUG,
     // Monaco is intentionally isolated below; app-owned JS stays below 500 kB.
     chunkSizeWarningLimit: 4000,
+    // Tauri は WebView2 にローカル配信するので gzip 計測は不要。CI ビルドが目に見えて短縮される。
+    reportCompressedSize: false,
     rolldownOptions: {
       checks: {
         // Keep semantic checks enabled, but suppress timing noise from CSS/transpile-heavy builds.
@@ -61,7 +63,15 @@ export default defineConfig(async () => ({
             return 'vendor-react';
           }
           if (id.includes('@fontsource-variable')) return 'vendor-fonts';
-          // それ以外は default chunk へ (lucide-react / zustand / dompurify / marked 等は小さい)
+          // marked + dompurify は MarkdownPreview からのみ参照される。
+          // 別 chunk に追い出して main chunk から切り離し、再評価コストも局所化する。
+          if (id.includes('/marked/') || id.includes('/dompurify/')) {
+            return 'vendor-markdown';
+          }
+          // @tauri-apps/api と plugin-* は多数のモジュールから import される共通基盤。
+          // vendor chunk に集約することで個別 chunk への重複コピーを避ける。
+          if (id.includes('@tauri-apps/')) return 'vendor-tauri';
+          // それ以外は default chunk へ (lucide-react / zustand 等は小さい)
           return undefined;
         }
       }


### PR DESCRIPTION
## Summary

Issue #481 で計画した、低リスク・小粒で効果のある最適化を 1 PR にバンドルしてスイープ。10 commit (perf 7 / refactor 2 / chore 1)、いずれも単一目的の小コミット。46 ファイル / +465 / -486。

- **Rust**: 成功パスでの heap allocation 削減 (unwrap_or の eager alloc 排除、不要 clone / async / map_or 整理、early-return match を let-else に整理)
- **Canvas**: zustand subscribe を `getState` 経由に切替 + memoize で再 render 削減
- **PTY**: batcher の per-flush alloc 削減と reader chunk 16 KiB 化で syscall / mpsc オーバーヘッド削減
- **UI**: callback 安定化、派生リスト・shell 表示コンポーネント memoize、`TweaksPanel` / `LanguageSection` の module-scope 定数 hoist
- **Build / Lib**: markdown/tauri の vendor chunk 分割 + compressed-size skip、未使用 renderer lib export 削除

## Commits

- `perf(rust): avoid eager allocation in unwrap_or fallbacks`
- `refactor(rust): collapse early-return matches into let-else`
- `perf(rust): drop redundant clones, unused async, simplify map_or`
- `perf(canvas): cut Canvas re-renders via getState callbacks and memoization`
- `perf(pty): reduce per-flush alloc and bump reader chunk to 16 KiB`
- `chore(build): split markdown/tauri vendor chunks and skip compressed-size`
- `refactor(lib): drop unused renderer lib exports`
- `perf(ui): stabilize callbacks and memoize derived lists`
- `perf(ui): memoize presentational shell components`
- `perf(ui): hoist module-scope constants in TweaksPanel/LanguageSection`

## Test plan

- [ ] `npm run typecheck` 通過
- [ ] `npm run build` (Tauri build) 通過
- [ ] 既存 vitest スイート破壊なし
- [ ] `npm run dev` で Canvas / IDE / Terminal の手動 smoke (大量出力時の PTY、Canvas での re-render 体感、設定モーダル / TweaksPanel / LanguageSection の操作応答)

Closes #481