### PR TITLE
fix(filetree): 初回フォルダ展開でloadDirが実行されないバグを修正

### DIFF
--- a/src/renderer/src/lib/__tests__/filetree-state-context.test.tsx
+++ b/src/renderer/src/lib/__tests__/filetree-state-context.test.tsx
@@ -207,6 +207,74 @@ describe('FileTreeStateProvider — concurrency queue', () => {
   });
 });
 
+// ---- Issue #478: 初回 toggleDir で loadDir が呼ばれる -----------------------
+
+describe('FileTreeStateProvider — toggleDir triggers loadDir on first expand (Issue #478)', () => {
+  it('初回 toggleDir() で files.list が1回呼ばれる', async () => {
+    const filesApi: MockFilesApi = {
+      list: vi.fn(async () => ({
+        ok: true,
+        entries: [{ name: 'child.ts', isDir: false, path: 'src/child.ts' }]
+      }))
+    };
+    installWindowApi(filesApi, () => Promise.resolve({ schemaVersion: 6 }));
+
+    const { result } = renderHook(() => useFileTreeState(), { wrapper });
+
+    // 初回 toggleDir: 未展開のディレクトリを開く → loadDir が即発火すること
+    await act(async () => {
+      result.current.toggleDir('/root', 'src');
+    });
+
+    // queue drain + state 反映を待つ
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // files.list が1回呼ばれている (Issue #478 回帰: 0回ではないこと)
+    expect(filesApi.list).toHaveBeenCalledTimes(1);
+    expect(filesApi.list).toHaveBeenCalledWith('/root', 'src');
+  });
+
+  it('既にロード済みのディレクトリを再展開しても追加の files.list は発火しない', async () => {
+    const filesApi: MockFilesApi = {
+      list: vi.fn(async () => ({
+        ok: true,
+        entries: []
+      }))
+    };
+    installWindowApi(filesApi, () => Promise.resolve({ schemaVersion: 6 }));
+
+    const { result } = renderHook(() => useFileTreeState(), { wrapper });
+
+    // 初回展開
+    await act(async () => {
+      result.current.toggleDir('/root', 'src');
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(filesApi.list).toHaveBeenCalledTimes(1);
+
+    // 折り畳み
+    await act(async () => {
+      result.current.toggleDir('/root', 'src');
+    });
+
+    // 再展開: dirs キャッシュにあるので loadDir は呼ばれない
+    await act(async () => {
+      result.current.toggleDir('/root', 'src');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // files.list は初回の1回のみ
+    expect(filesApi.list).toHaveBeenCalledTimes(1);
+  });
+});
+
 // ---- lazy prune --------------------------------------------------------
 
 describe('FileTreeStateProvider — lazy prune on load failure', () => {

--- a/src/renderer/src/lib/filetree-state-context.tsx
+++ b/src/renderer/src/lib/filetree-state-context.tsx
@@ -349,27 +349,34 @@ export function FileTreeStateProvider({ children }: { children: ReactNode }): JS
     [drainQueue, pruneOnLoadFailure]
   );
 
-  // 自己レビュー N1 / W1 / A3: setState updater 内で wasOpen を判定して loadDir 必要性を
-  // 確定する (closure stale を排除)。dirs.has は呼び出し時 closure でも実害なし
-  // (load の重複は pendingPromisesRef で抑止される)。
+  // Issue #478: expandedRef を toggleDir より前に配置し、クリック時点の最新 expanded を
+  // 同期的に参照できるようにする。refreshAll でも同じ ref を使う。
+  const expandedRef = useRef(expanded);
+  expandedRef.current = expanded;
+
+  // dirs の最新値を同期的に参照する ref (load の重複は pendingPromisesRef で抑止)。
   const dirsRef = useRef(dirs);
   dirsRef.current = dirs;
 
   const toggleDir = useCallback(
     (rootPath: string, relPath: string) => {
       const key = dirKey(rootPath, relPath);
-      let nowOpened = false;
+      // Issue #478: setExpanded updater の実行タイミングに依存せず、ref で同期的に判定。
+      const wasOpen = expandedRef.current.has(key);
+
       setExpanded((prev) => {
         const next = new Set(prev);
         if (next.has(key)) {
           next.delete(key);
         } else {
           next.add(key);
-          nowOpened = true;
         }
         return next;
       });
-      if (nowOpened && !dirsRef.current.has(key)) {
+
+      // 閉じていた → 開く、かつ dirs キャッシュにまだ無い場合だけ loadDir を発火。
+      // pendingPromisesRef による重複ロード抑止、MAX_CONCURRENT_LOADS、load 失敗時 prune は維持。
+      if (!wasOpen && !dirsRef.current.has(key)) {
         void loadDir(rootPath, relPath);
       }
     },
@@ -385,11 +392,7 @@ export function FileTreeStateProvider({ children }: { children: ReactNode }): JS
     });
   }, []);
 
-  // 自己レビュー: refreshAll 内で expanded を closure 経由で見ると stale なので、
-  // ref 経由で最新値を読む。
-  const expandedRef = useRef(expanded);
-  expandedRef.current = expanded;
-
+  // refreshAll は上で定義済みの expandedRef を参照する。
   const refreshAll = useCallback(
     (roots: string[]) => {
       for (const root of roots) {


### PR DESCRIPTION
## Summary
- `toggleDir()` でReactの `setExpanded()` updater内の変数(`nowOpened`)に依存していた `loadDir()` 呼び出し判定を、`expandedRef` による同期参照に修正
- 初回クリック時にも即座に `loadDir()` が実行され、子要素が表示されるように
- 既存の `pendingPromisesRef` による重複ロード抑止、`MAX_CONCURRENT_LOADS`、load 失敗時 prune の挙動は維持

## 変更内容
1. `expandedRef` を `toggleDir()` より前に配置し、クリック時点の最新 `expanded` を同期的に参照
2. `toggleDir()` で `wasOpen = expandedRef.current.has(key)` を先に計算、`setExpanded()` は純粋にSetをトグルするだけに
3. `!wasOpen && !dirsRef.current.has(key)` の場合だけ `loadDir()` を呼ぶ
4. 重複していた `expandedRef` 定義を統合（`refreshAll` と共有）
5. 回帰テスト追加: 初回 `toggleDir()` で `files.list` が1回呼ばれることを検証

## Test plan
- [x] `npm run typecheck` PASS
- [x] `npm run test` PASS（207テスト全PASS、新規回帰テスト2件含む）
- [x] `npm run build` PASS
- [ ] Tauri実機で未ロードフォルダを1回クリック → 初回で子要素表示

Closes #478