### PR TITLE
feat(filetree): フォルダ名ベースのVSCode風アイコン表示を追加

### DIFF
--- a/src/renderer/src/components/FileTreePanel.tsx
+++ b/src/renderer/src/components/FileTreePanel.tsx
@@ -3,15 +3,13 @@ import {
   ChevronDown,
   ChevronRight,
   File as DefaultFileIcon,
-  Folder,
-  FolderOpen,
   FolderPlus,
   RefreshCw,
   X
 } from 'lucide-react';
 import type { FileNode } from '../../../types/shared';
 import { useT } from '../lib/i18n';
-import { fileIcon } from '../lib/file-icon-color';
+import { fileIcon, folderIcon } from '../lib/file-icon-color';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 import { useToast } from '../lib/toast-context';
 import { api } from '../lib/tauri-api';
@@ -364,6 +362,7 @@ function FileTreeNodeImpl({
   const fileIconDef = node.isDir ? undefined : fileIcon(node.name);
   const FileTypeIcon = fileIconDef?.Icon ?? DefaultFileIcon;
   const fileTypeColor = fileIconDef?.color;
+  const folderDef = node.isDir ? folderIcon(node.name, isOpen) : undefined;
 
   const handleClick = (): void => {
     if (node.isDir) onToggle(rootPath, node);
@@ -393,30 +392,22 @@ function FileTreeNodeImpl({
         onClick={handleClick}
         onContextMenu={(e) => onContextMenu(e, rootPath, node)}
       >
-        {node.isDir ? (
+        {node.isDir && folderDef ? (
           <>
             <ChevronRight
               size={13}
               strokeWidth={2.25}
               className={`filetree__chevron${isOpen ? ' is-open' : ''}`}
             />
-            {isOpen ? (
-              <FolderOpen
-                size={14}
-                strokeWidth={2}
-                fill="currentColor"
-                fillOpacity={0.22}
-                className="filetree__icon filetree__icon--open"
-              />
-            ) : (
-              <Folder
-                size={14}
-                strokeWidth={2}
-                fill="currentColor"
-                fillOpacity={0.18}
-                className="filetree__icon"
-              />
-            )}
+            <folderDef.Icon
+              size={14}
+              strokeWidth={2}
+              fill="currentColor"
+              fillOpacity={isOpen ? 0.22 : 0.18}
+              className={`filetree__icon${isOpen ? ' filetree__icon--open' : ''}${folderDef.color ? ' filetree__icon--colored' : ''}`}
+              style={folderDef.color ? { color: folderDef.color } : undefined}
+              aria-hidden
+            />
           </>
         ) : (
           <>

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -3439,8 +3439,18 @@ body.is-resizing * {
 }
 
 /* 開フォルダはテラコッタで点灯。fill もテラコッタ opacity 0.22 で乗る */
-.filetree__icon--open {
+.filetree__icon--open:not(.filetree__icon--colored) {
   color: var(--accent);
+  opacity: 1;
+}
+
+/* フォルダ名ベースの識別色が付いている場合。inline style で color を指定し、
+   開閉どちらでも同じ色を維持して VSCode 風の統一感を出す。 */
+.filetree__icon--colored {
+  opacity: 0.88;
+  transition: opacity 120ms var(--ease-out-soft);
+}
+.filetree__icon--colored.filetree__icon--open {
   opacity: 1;
 }
 

--- a/src/renderer/src/lib/__tests__/file-icon-color.test.ts
+++ b/src/renderer/src/lib/__tests__/file-icon-color.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import { fileIcon, fileIconColor, folderIcon } from '../file-icon-color';
+
+// ---------- fileIcon ----------
+
+describe('fileIcon', () => {
+  it('returns correct icon for .ts files', () => {
+    const def = fileIcon('app.ts');
+    expect(def).toBeDefined();
+    expect(def!.color).toBe('#3178c6');
+  });
+
+  it('returns correct icon for .tsx files', () => {
+    const def = fileIcon('Component.tsx');
+    expect(def).toBeDefined();
+    expect(def!.color).toBe('#3178c6');
+  });
+
+  it('returns correct icon for .js files', () => {
+    const def = fileIcon('index.js');
+    expect(def).toBeDefined();
+    expect(def!.color).toBe('#f7df1e');
+  });
+
+  it('handles .d.ts double extension', () => {
+    const def = fileIcon('global.d.ts');
+    expect(def).toBeDefined();
+    expect(def!.color).toBe('#60a5fa');
+  });
+
+  it('matches special file names (case-insensitive)', () => {
+    const pkg = fileIcon('package.json');
+    expect(pkg).toBeDefined();
+    expect(pkg!.color).toBe('#dc2626');
+
+    const readme = fileIcon('README.md');
+    expect(readme).toBeDefined();
+    expect(readme!.color).toBe('#e0e0d6');
+  });
+
+  it('returns undefined for unknown extension', () => {
+    expect(fileIcon('unknown.xyz')).toBeUndefined();
+  });
+
+  it('returns undefined for extensionless unknown file', () => {
+    expect(fileIcon('UNKNOWN_FILE')).toBeUndefined();
+  });
+
+  it('handles css files', () => {
+    const def = fileIcon('styles.css');
+    expect(def).toBeDefined();
+    expect(def!.color).toBe('#ec4899');
+  });
+
+  it('handles markdown files', () => {
+    const def = fileIcon('notes.md');
+    expect(def).toBeDefined();
+    expect(def!.color).toBe('#60a5fa');
+  });
+
+  it('handles rust files', () => {
+    const def = fileIcon('main.rs');
+    expect(def).toBeDefined();
+    expect(def!.color).toBe('#ce422b');
+  });
+
+  it('handles CLAUDE.md special file', () => {
+    const def = fileIcon('CLAUDE.md');
+    expect(def).toBeDefined();
+    expect(def!.color).toBe('#d97757');
+  });
+});
+
+// ---------- fileIconColor ----------
+
+describe('fileIconColor', () => {
+  it('returns color string for known extension', () => {
+    expect(fileIconColor('app.ts')).toBe('#3178c6');
+  });
+
+  it('returns undefined for unknown', () => {
+    expect(fileIconColor('foo.qqq')).toBeUndefined();
+  });
+});
+
+// ---------- folderIcon ----------
+
+describe('folderIcon', () => {
+  it('returns specific icon for "src" folder', () => {
+    const closed = folderIcon('src', false);
+    expect(closed.color).toBe('#60a5fa');
+    expect(closed.Icon).toBeDefined();
+
+    const open = folderIcon('src', true);
+    expect(open.color).toBe('#60a5fa');
+    expect(open.Icon).toBeDefined();
+  });
+
+  it('returns specific icon for "components" folder', () => {
+    const def = folderIcon('components', false);
+    expect(def.color).toBe('#f472b6');
+  });
+
+  it('returns specific icon for "lib" folder', () => {
+    const def = folderIcon('lib', false);
+    expect(def.color).toBe('#a78bfa');
+  });
+
+  it('returns specific icon for "hooks" folder', () => {
+    const def = folderIcon('hooks', false);
+    expect(def.color).toBe('#fbbf24');
+  });
+
+  it('returns specific icon for "styles" folder', () => {
+    const def = folderIcon('styles', false);
+    expect(def.color).toBe('#ec4899');
+  });
+
+  it('returns specific icon for "tests" and "__tests__"', () => {
+    expect(folderIcon('tests', false).color).toBe('#22c55e');
+    expect(folderIcon('__tests__', false).color).toBe('#22c55e');
+    expect(folderIcon('test', false).color).toBe('#22c55e');
+  });
+
+  it('returns specific icon for "docs" folder', () => {
+    const def = folderIcon('docs', false);
+    expect(def.color).toBe('#60a5fa');
+  });
+
+  it('returns specific icon for ".github" folder', () => {
+    const def = folderIcon('.github', false);
+    expect(def.color).toBe('#f87171');
+  });
+
+  it('returns specific icon for "build" and "dist"', () => {
+    expect(folderIcon('build', false).color).toBe('#f59e0b');
+    expect(folderIcon('dist', false).color).toBe('#f59e0b');
+  });
+
+  it('returns specific icon for "node_modules"', () => {
+    const def = folderIcon('node_modules', false);
+    expect(def.color).toBe('#64748b');
+  });
+
+  it('returns specific icon for "src-tauri"', () => {
+    const def = folderIcon('src-tauri', false);
+    expect(def.color).toBe('#facc15');
+  });
+
+  it('returns specific icon for "tasks"', () => {
+    const def = folderIcon('tasks', false);
+    expect(def.color).toBe('#f97316');
+  });
+
+  it('returns specific icon for "skills"', () => {
+    const def = folderIcon('skills', false);
+    expect(def.color).toBe('#d97757');
+  });
+
+  it('is case-insensitive', () => {
+    expect(folderIcon('SRC', false).color).toBe('#60a5fa');
+    expect(folderIcon('Components', false).color).toBe('#f472b6');
+    expect(folderIcon('.GitHub', false).color).toBe('#f87171');
+  });
+
+  it('returns default (empty color) for unknown folder names', () => {
+    const def = folderIcon('my-custom-folder', false);
+    expect(def.color).toBe('');
+    expect(def.Icon).toBeDefined();
+  });
+
+  it('returns different icons for open vs closed default folders', () => {
+    const closed = folderIcon('unknown-folder', false);
+    const open = folderIcon('unknown-folder', true);
+    // Default folder uses Folder (closed) and FolderOpen (open)
+    expect(closed.Icon).not.toBe(open.Icon);
+  });
+
+  it('handles "public" and "static" folders', () => {
+    expect(folderIcon('public', false).color).toBe('#06b6d4');
+    expect(folderIcon('static', false).color).toBe('#06b6d4');
+  });
+
+  it('handles "api" and "routes" folders', () => {
+    expect(folderIcon('api', false).color).toBe('#10b981');
+    expect(folderIcon('routes', false).color).toBe('#10b981');
+  });
+
+  it('handles "config" folder', () => {
+    expect(folderIcon('config', false).color).toBe('#94a3b8');
+  });
+
+  it('handles "scripts" and "bin" folders', () => {
+    expect(folderIcon('scripts', false).color).toBe('#22c55e');
+    expect(folderIcon('bin', false).color).toBe('#22c55e');
+  });
+
+  it('handles "types" folder', () => {
+    expect(folderIcon('types', false).color).toBe('#3178c6');
+  });
+
+  it('handles "stores" folder', () => {
+    expect(folderIcon('stores', false).color).toBe('#facc15');
+  });
+
+  it('handles "renderer" folder', () => {
+    expect(folderIcon('renderer', false).color).toBe('#60a5fa');
+  });
+});

--- a/src/renderer/src/lib/file-icon-color.ts
+++ b/src/renderer/src/lib/file-icon-color.ts
@@ -26,6 +26,15 @@ import {
   FileText,
   FileVideo,
   FileType2,
+  Folder,
+  FolderArchive,
+  FolderCode,
+  FolderCog,
+  FolderGit2,
+  FolderHeart,
+  FolderKey,
+  FolderOpen,
+  FolderOutput,
   Gem,
   GitBranch,
   Globe,
@@ -43,6 +52,7 @@ import {
   Snowflake,
   Sparkles,
   Terminal,
+  TestTube2,
   Type as TypeIcon,
   Video,
   Wrench,
@@ -259,4 +269,147 @@ export function fileIcon(name: string): FileIconDef | undefined {
 /** 旧 API: 色だけ返す。他箇所 (Canvas 等) が参照している可能性があるので残す。 */
 export function fileIconColor(name: string): string | undefined {
   return fileIcon(name)?.color;
+}
+
+// ========== フォルダアイコン (VSCode Material Icon Theme 風) ==========
+
+export interface FolderIconDef {
+  /** 閉じ状態のアイコン */
+  Icon: LucideIcon;
+  /** 開き状態のアイコン (未指定時は Icon をそのまま使う) */
+  IconOpen?: LucideIcon;
+  /** フォルダの識別色 (開閉どちらでも同じ色を使い、VSCode 風に統一感を出す) */
+  color: string;
+}
+
+/**
+ * フォルダ名 → アイコン + 色マッピング。
+ * キーは小文字正規化済み。VSCode の material-icon-theme を参考に、
+ * lucide-react の中から最も意味の近いアイコンを割り当てている。
+ */
+const FOLDER: Record<string, FolderIconDef> = {
+  // ソースコード系
+  src:        { Icon: FolderCode,    IconOpen: FolderCode,    color: '#60a5fa' },
+  source:     { Icon: FolderCode,    IconOpen: FolderCode,    color: '#60a5fa' },
+  app:        { Icon: FolderCode,    IconOpen: FolderCode,    color: '#818cf8' },
+  pages:      { Icon: FolderCode,    IconOpen: FolderCode,    color: '#818cf8' },
+
+  // コンポーネント / UI
+  components: { Icon: Layers,        IconOpen: Layers,        color: '#f472b6' },
+  component:  { Icon: Layers,        IconOpen: Layers,        color: '#f472b6' },
+  layouts:    { Icon: Layers,        IconOpen: Layers,        color: '#c084fc' },
+  views:      { Icon: Layers,        IconOpen: Layers,        color: '#c084fc' },
+
+  // ライブラリ / ユーティリティ
+  lib:        { Icon: FolderCode,    IconOpen: FolderCode,    color: '#a78bfa' },
+  libs:       { Icon: FolderCode,    IconOpen: FolderCode,    color: '#a78bfa' },
+  utils:      { Icon: FolderCog,     IconOpen: FolderCog,     color: '#94a3b8' },
+  helpers:    { Icon: FolderCog,     IconOpen: FolderCog,     color: '#94a3b8' },
+
+  // React Hooks
+  hooks:      { Icon: Zap,           IconOpen: Zap,           color: '#fbbf24' },
+  composables: { Icon: Zap,          IconOpen: Zap,           color: '#fbbf24' },
+
+  // スタイル
+  styles:     { Icon: Paintbrush,    IconOpen: Paintbrush,    color: '#ec4899' },
+  css:        { Icon: Paintbrush,    IconOpen: Paintbrush,    color: '#ec4899' },
+  scss:       { Icon: Paintbrush,    IconOpen: Paintbrush,    color: '#ec4899' },
+
+  // テスト
+  tests:      { Icon: TestTube2,     IconOpen: TestTube2,     color: '#22c55e' },
+  test:       { Icon: TestTube2,     IconOpen: TestTube2,     color: '#22c55e' },
+  __tests__:  { Icon: TestTube2,     IconOpen: TestTube2,     color: '#22c55e' },
+  __test__:   { Icon: TestTube2,     IconOpen: TestTube2,     color: '#22c55e' },
+  spec:       { Icon: TestTube2,     IconOpen: TestTube2,     color: '#22c55e' },
+  specs:      { Icon: TestTube2,     IconOpen: TestTube2,     color: '#22c55e' },
+  e2e:        { Icon: TestTube2,     IconOpen: TestTube2,     color: '#16a34a' },
+  cypress:    { Icon: TestTube2,     IconOpen: TestTube2,     color: '#16a34a' },
+
+  // ドキュメント
+  docs:       { Icon: BookOpen,      IconOpen: BookOpen,      color: '#60a5fa' },
+  doc:        { Icon: BookOpen,      IconOpen: BookOpen,      color: '#60a5fa' },
+  documentation: { Icon: BookOpen,   IconOpen: BookOpen,      color: '#60a5fa' },
+
+  // Git / CI / CD
+  '.github':  { Icon: FolderGit2,    IconOpen: FolderGit2,    color: '#f87171' },
+  '.git':     { Icon: FolderGit2,    IconOpen: FolderGit2,    color: '#f87171' },
+  '.gitlab':  { Icon: FolderGit2,    IconOpen: FolderGit2,    color: '#fb923c' },
+  '.circleci': { Icon: FolderCog,    IconOpen: FolderCog,     color: '#64748b' },
+  '.vscode':  { Icon: FolderCog,     IconOpen: FolderCog,     color: '#0ea5e9' },
+
+  // ビルド出力
+  build:      { Icon: FolderOutput,  IconOpen: FolderOutput,  color: '#f59e0b' },
+  dist:       { Icon: FolderOutput,  IconOpen: FolderOutput,  color: '#f59e0b' },
+  out:        { Icon: FolderOutput,  IconOpen: FolderOutput,  color: '#f59e0b' },
+  output:     { Icon: FolderOutput,  IconOpen: FolderOutput,  color: '#f59e0b' },
+
+  // パッケージ / 依存
+  node_modules: { Icon: FolderArchive, IconOpen: FolderArchive, color: '#64748b' },
+  vendor:     { Icon: FolderArchive, IconOpen: FolderArchive, color: '#64748b' },
+  packages:   { Icon: Package,       IconOpen: Package,       color: '#dc2626' },
+
+  // 設定 / 環境
+  config:     { Icon: FolderCog,     IconOpen: FolderCog,     color: '#94a3b8' },
+  configs:    { Icon: FolderCog,     IconOpen: FolderCog,     color: '#94a3b8' },
+  '.config':  { Icon: FolderCog,     IconOpen: FolderCog,     color: '#94a3b8' },
+
+  // 静的アセット
+  assets:     { Icon: FolderHeart,   IconOpen: FolderHeart,   color: '#a78bfa' },
+  images:     { Icon: FolderHeart,   IconOpen: FolderHeart,   color: '#a78bfa' },
+  img:        { Icon: FolderHeart,   IconOpen: FolderHeart,   color: '#a78bfa' },
+  icons:      { Icon: FolderHeart,   IconOpen: FolderHeart,   color: '#a78bfa' },
+  fonts:      { Icon: FolderHeart,   IconOpen: FolderHeart,   color: '#f59e0b' },
+  media:      { Icon: FolderHeart,   IconOpen: FolderHeart,   color: '#ec4899' },
+  public:     { Icon: Globe,         IconOpen: Globe,         color: '#06b6d4' },
+  static:     { Icon: Globe,         IconOpen: Globe,         color: '#06b6d4' },
+
+  // タスク / スキル (vibe-editor 固有)
+  'src-tauri': { Icon: FolderCog,    IconOpen: FolderCog,     color: '#facc15' },
+  tasks:      { Icon: FolderKey,     IconOpen: FolderKey,     color: '#f97316' },
+  skills:     { Icon: Sparkles,      IconOpen: Sparkles,      color: '#d97757' },
+
+  // セキュリティ
+  '.ssh':     { Icon: FolderKey,     IconOpen: FolderKey,     color: '#16a34a' },
+  '.certs':   { Icon: Shield,        IconOpen: Shield,        color: '#16a34a' },
+
+  // その他
+  scripts:    { Icon: Terminal,      IconOpen: Terminal,      color: '#22c55e' },
+  bin:        { Icon: Terminal,      IconOpen: Terminal,      color: '#22c55e' },
+  types:      { Icon: FileCode2,     IconOpen: FileCode2,     color: '#3178c6' },
+  typings:    { Icon: FileCode2,     IconOpen: FileCode2,     color: '#3178c6' },
+  stores:     { Icon: Layers,        IconOpen: Layers,        color: '#facc15' },
+  store:      { Icon: Layers,        IconOpen: Layers,        color: '#facc15' },
+  api:        { Icon: Globe,         IconOpen: Globe,         color: '#10b981' },
+  routes:     { Icon: Globe,         IconOpen: Globe,         color: '#10b981' },
+  middleware: { Icon: FolderCog,     IconOpen: FolderCog,     color: '#6366f1' },
+  plugins:    { Icon: Zap,           IconOpen: Zap,           color: '#a855f7' },
+  i18n:       { Icon: Globe,         IconOpen: Globe,         color: '#06b6d4' },
+  locales:    { Icon: Globe,         IconOpen: Globe,         color: '#06b6d4' },
+  locale:     { Icon: Globe,         IconOpen: Globe,         color: '#06b6d4' },
+  overlays:   { Icon: Layers,        IconOpen: Layers,        color: '#818cf8' },
+  canvas:     { Icon: Layers,        IconOpen: Layers,        color: '#f59e0b' },
+  shell:      { Icon: Terminal,      IconOpen: Terminal,      color: '#22c55e' },
+  settings:   { Icon: FolderCog,     IconOpen: FolderCog,     color: '#94a3b8' },
+  renderer:   { Icon: FolderCode,    IconOpen: FolderCode,    color: '#60a5fa' }
+};
+
+/** デフォルトのフォルダ定義 (マッピングに一致しなかった場合) */
+const DEFAULT_FOLDER: FolderIconDef = {
+  Icon: Folder,
+  IconOpen: FolderOpen,
+  color: '' // 色なし = 既存テーマの currentColor で描画
+};
+
+/**
+ * フォルダ名と開閉状態からアイコン + 色を返す。
+ * 未知のフォルダ名にはデフォルト (汎用 Folder / FolderOpen) をフォールバック。
+ */
+export function folderIcon(
+  name: string,
+  isOpen: boolean
+): { Icon: LucideIcon; color: string } {
+  const lower = name.toLowerCase();
+  const def = FOLDER[lower] ?? DEFAULT_FOLDER;
+  const Icon = isOpen ? (def.IconOpen ?? def.Icon) : def.Icon;
+  return { Icon, color: def.color };
 }


### PR DESCRIPTION
## Summary
- `file-icon-color.ts` に `folderIcon(name, isOpen)` 関数を追加。フォルダ名から lucide-react アイコン + 識別色を返す
- VSCode Material Icon Theme を参考に、src / components / lib / hooks / tests / docs / .github / build / dist / node_modules / src-tauri / tasks / skills 等 50+ のフォルダ名マッピングを定義
- `FileTreePanel.tsx` のフォルダ描画を `folderIcon()` に差し替え、開閉状態で色を維持しつつ VSCode 風の視認性を実現
- CSS は `.filetree__icon--colored` クラスで色と opacity のみ調整（既存のサイズ・余白は維持）
- `file-icon-color.test.ts` に 36 テスト（fileIcon / fileIconColor / folderIcon の代表的なケース）を追加

## Test plan
- [x] `npm run typecheck` PASS
- [x] `npm run test` 全 243 テスト PASS（32 ファイル）
- [x] `npm run build` PASS（vibe-editor.exe + NSIS installer 生成確認）
- [x] `folderIcon()` の単体テスト 20+ ケース PASS（代表的なフォルダ名・大文字小文字・未知フォルダのフォールバック）

Closes #479