### PR TITLE
feat(filetree): 最近使ったファイルを黄緑/黄色系でハイライト

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -159,6 +159,7 @@ export function App(): JSX.Element {
     setActiveTabId,
     dirtyEditorTabs,
     confirmDiscardEditorTabs,
+    recentFiles,
     openEditorTab,
     updateEditorContent,
     saveEditorTab,
@@ -877,6 +878,7 @@ export function App(): JSX.Element {
         onAddWorkspaceFolder={() => void handleAddWorkspaceFolder()}
         onRemoveWorkspaceFolder={handleRemoveWorkspaceFolder}
         activeFilePath={activeFilePath}
+        recentFiles={recentFiles}
         onOpenFile={(rootPath, relPath) => void openEditorTab(rootPath, relPath)}
         gitStatus={gitStatus}
         gitLoading={gitLoading}

--- a/src/renderer/src/components/FileTreePanel.tsx
+++ b/src/renderer/src/components/FileTreePanel.tsx
@@ -8,6 +8,7 @@ import {
   X
 } from 'lucide-react';
 import type { FileNode } from '../../../types/shared';
+import type { RecentFileEntry } from '../lib/hooks/use-file-tabs';
 import { useT } from '../lib/i18n';
 import { fileIcon, folderIcon } from '../lib/file-icon-color';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
@@ -30,6 +31,8 @@ interface FileTreePanelProps {
    */
   extraRoots: string[];
   activeFilePath: string | null;
+  /** Issue #480: 最近開いたファイルの履歴 (新しい順) */
+  recentFiles?: RecentFileEntry[];
   /** ファイルを開くときにどのルート配下かを明示する */
   onOpenFile: (rootPath: string, relPath: string) => void;
   onAddWorkspaceFolder: () => void;
@@ -45,6 +48,7 @@ export function FileTreePanel({
   primaryRoot,
   extraRoots,
   activeFilePath,
+  recentFiles,
   onOpenFile,
   onAddWorkspaceFolder,
   onRemoveWorkspaceFolder
@@ -127,6 +131,18 @@ export function FileTreePanel({
     // expanded / dirs を意図的に deps から除外 (mount + roots 変動時のみ走る)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [primaryRoot, extraRoots.join(KEY_SEP), loadDir]);
+
+  // Issue #480: recentFiles を rootPath+relPath -> rank (0始まり) のマップに変換。
+  // rank 0 = 直近に開いたファイル, rank 1 = その前, ... (active は UI 側で優先)
+  const recentRankMap = useMemo(() => {
+    const map = new Map<string, number>();
+    if (!recentFiles) return map;
+    for (let i = 0; i < recentFiles.length; i++) {
+      const entry = recentFiles[i];
+      map.set(`${entry.rootPath}${KEY_SEP}${entry.relPath}`, i);
+    }
+    return map;
+  }, [recentFiles]);
 
   const toggleDir = useCallback(
     (rootPath: string, node: FileNode) => {
@@ -228,6 +244,10 @@ export function FileTreePanel({
             ? dirs.get(childKey) ?? null
             : null;
           const isActive = !node.isDir && activeFilePath === node.path;
+          // Issue #480: ファイルの recent ランクを取得 (-1 = 履歴なし)
+          const recentRank = node.isDir
+            ? -1
+            : recentRankMap.get(`${rootPath}${KEY_SEP}${node.path}`) ?? -1;
           return (
             <FileTreeNode
               key={childKey}
@@ -236,6 +256,7 @@ export function FileTreePanel({
               depth={depth}
               isOpen={isOpen}
               isActive={isActive}
+              recentRank={recentRank}
               childState={childState}
               onToggle={toggleDir}
               onOpenFile={onOpenFile}
@@ -335,6 +356,11 @@ interface FileTreeNodeProps {
   depth: number;
   isOpen: boolean;
   isActive: boolean;
+  /**
+   * Issue #480: 最近開いたファイルの順位 (0 = 直近, 1 = その前, ...)。
+   * -1 は履歴に含まれていない。active と重なる場合は UI 側で active を優先する。
+   */
+  recentRank: number;
   /** 子ディレクトリの DirState (再レンダー判定用)。null は未読込 or ファイル */
   childState: DirState | null;
   onToggle: (rootPath: string, node: FileNode) => void;
@@ -354,6 +380,7 @@ function FileTreeNodeImpl({
   depth,
   isOpen,
   isActive,
+  recentRank,
   onToggle,
   onOpenFile,
   onContextMenu,
@@ -421,7 +448,21 @@ function FileTreeNodeImpl({
             />
           </>
         )}
-        <span className="filetree__name">{node.name}</span>
+        <span
+          className={
+            'filetree__name' +
+            // Issue #480: active でない最近ファイルに段階的な色クラスを付与
+            (!isActive && recentRank >= 0
+              ? recentRank === 0
+                ? ' is-recent is-recent-1'
+                : recentRank <= 2
+                  ? ' is-recent is-recent-2'
+                  : recentRank <= 5
+                    ? ' is-recent is-recent-3'
+                    : ' is-recent'
+              : '')
+          }
+        >{node.name}</span>
       </button>
       {node.isDir && isOpen ? renderChildren(rootPath, node.path, depth + 1) : null}
     </>
@@ -444,6 +485,7 @@ const FileTreeNode = memo(FileTreeNodeImpl, (prev, next) => {
     prev.depth === next.depth &&
     prev.isOpen === next.isOpen &&
     prev.isActive === next.isActive &&
+    prev.recentRank === next.recentRank &&
     prev.childState === next.childState &&
     prev.onToggle === next.onToggle &&
     prev.onOpenFile === next.onOpenFile &&

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import type {
   SessionInfo,
   TeamHistoryEntry
 } from '../../../types/shared';
+import type { RecentFileEntry } from '../lib/hooks/use-file-tabs';
 import { ChangesPanel } from './ChangesPanel';
 import { SessionsPanel } from './SessionsPanel';
 import { FileTreePanel } from './FileTreePanel';
@@ -21,6 +22,8 @@ interface SidebarProps {
   onRemoveWorkspaceFolder: (path: string) => void;
   onAddWorkspaceFolder: () => void;
   activeFilePath: string | null;
+  /** Issue #480: 最近開いたファイルの履歴 (新しい順) */
+  recentFiles: RecentFileEntry[];
   onOpenFile: (rootPath: string, relPath: string) => void;
   gitStatus: GitStatus | null;
   gitLoading: boolean;
@@ -53,6 +56,7 @@ export function Sidebar(props: SidebarProps): JSX.Element {
             primaryRoot={props.projectRoot}
             extraRoots={props.workspaceFolders}
             activeFilePath={props.activeFilePath}
+            recentFiles={props.recentFiles}
             onOpenFile={props.onOpenFile}
             onAddWorkspaceFolder={props.onAddWorkspaceFolder}
             onRemoveWorkspaceFolder={props.onRemoveWorkspaceFolder}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -3477,6 +3477,61 @@ body.is-resizing * {
   min-width: 0;
 }
 
+/* Issue #480: 最近開いたファイルの名前色ハイライト (黄緑/黄色系)。
+   active (is-active) は常に最優先: row 自体の色指定が勝つので
+   is-recent は active でないファイルにのみ付与される (TSX 側で制御)。
+   段階: is-recent-1 (直近) → is-recent-2 (2-3番目) → is-recent-3 (4-6番目) → is-recent (それ以降) */
+.filetree__name.is-recent-1 {
+  color: #b5e853;
+  font-weight: 500;
+}
+.filetree__name.is-recent-2 {
+  color: #c8d84a;
+}
+.filetree__name.is-recent-3 {
+  color: #d4c944;
+  opacity: 0.88;
+}
+.filetree__name.is-recent {
+  color: #d4c944;
+  opacity: 0.78;
+}
+/* is-recent-N が付いている場合は is-recent の薄い opacity を上書き */
+.filetree__name.is-recent.is-recent-1,
+.filetree__name.is-recent.is-recent-2 {
+  opacity: 1;
+}
+.filetree__name.is-recent.is-recent-3 {
+  opacity: 0.88;
+}
+
+/* ライトテーマでは黄緑/黄色は背景に溶けやすいため、彩度と明度を調整 */
+[data-theme='claude-light'] .filetree__name.is-recent-1,
+[data-theme='light'] .filetree__name.is-recent-1 {
+  color: #4a8c1a;
+  font-weight: 500;
+}
+[data-theme='claude-light'] .filetree__name.is-recent-2,
+[data-theme='light'] .filetree__name.is-recent-2 {
+  color: #5d8a20;
+}
+[data-theme='claude-light'] .filetree__name.is-recent-3,
+[data-theme='light'] .filetree__name.is-recent-3 {
+  color: #6e8928;
+  opacity: 0.88;
+}
+[data-theme='claude-light'] .filetree__name.is-recent,
+[data-theme='light'] .filetree__name.is-recent {
+  color: #6e8928;
+  opacity: 0.78;
+}
+[data-theme='claude-light'] .filetree__name.is-recent.is-recent-1,
+[data-theme='claude-light'] .filetree__name.is-recent.is-recent-2,
+[data-theme='light'] .filetree__name.is-recent.is-recent-1,
+[data-theme='light'] .filetree__name.is-recent.is-recent-2 {
+  opacity: 1;
+}
+
 .filetree__loading,
 .filetree__empty,
 .filetree__error {

--- a/src/renderer/src/lib/__tests__/recent-files.test.ts
+++ b/src/renderer/src/lib/__tests__/recent-files.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import type { RecentFileEntry } from '../hooks/use-file-tabs';
+import { RECENT_FILES_LIMIT } from '../hooks/use-file-tabs';
+
+/**
+ * Issue #480: 最近開いたファイル履歴のロジックをテスト。
+ * useFileTabs 内の setRecentFiles ロジックを純粋関数として再現し、
+ * 順序・重複排除・上限を検証する。
+ */
+
+/** openEditorTab 時の recentFiles 更新ロジックを再現 */
+function addRecentFile(
+  prev: RecentFileEntry[],
+  rootPath: string,
+  relPath: string
+): RecentFileEntry[] {
+  const filtered = prev.filter(
+    (entry) => !(entry.rootPath === rootPath && entry.relPath === relPath)
+  );
+  return [{ rootPath, relPath }, ...filtered].slice(0, RECENT_FILES_LIMIT);
+}
+
+describe('recentFiles', () => {
+  it('adds a new file to the front of the list', () => {
+    const result = addRecentFile([], '/root', 'src/app.ts');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ rootPath: '/root', relPath: 'src/app.ts' });
+  });
+
+  it('moves an already-existing file to the front', () => {
+    const initial: RecentFileEntry[] = [
+      { rootPath: '/root', relPath: 'a.ts' },
+      { rootPath: '/root', relPath: 'b.ts' },
+      { rootPath: '/root', relPath: 'c.ts' }
+    ];
+    const result = addRecentFile(initial, '/root', 'c.ts');
+    expect(result).toHaveLength(3);
+    expect(result[0].relPath).toBe('c.ts');
+    expect(result[1].relPath).toBe('a.ts');
+    expect(result[2].relPath).toBe('b.ts');
+  });
+
+  it('does not create duplicates', () => {
+    const initial: RecentFileEntry[] = [
+      { rootPath: '/root', relPath: 'a.ts' }
+    ];
+    const result = addRecentFile(initial, '/root', 'a.ts');
+    expect(result).toHaveLength(1);
+    expect(result[0].relPath).toBe('a.ts');
+  });
+
+  it('treats same relPath with different rootPath as separate entries', () => {
+    const initial: RecentFileEntry[] = [
+      { rootPath: '/root1', relPath: 'src/app.ts' }
+    ];
+    const result = addRecentFile(initial, '/root2', 'src/app.ts');
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ rootPath: '/root2', relPath: 'src/app.ts' });
+    expect(result[1]).toEqual({ rootPath: '/root1', relPath: 'src/app.ts' });
+  });
+
+  it('enforces the RECENT_FILES_LIMIT', () => {
+    let list: RecentFileEntry[] = [];
+    // 上限を超える数のファイルを追加
+    for (let i = 0; i < RECENT_FILES_LIMIT + 5; i++) {
+      list = addRecentFile(list, '/root', `file-${i}.ts`);
+    }
+    expect(list).toHaveLength(RECENT_FILES_LIMIT);
+    // 最新のファイルが先頭にある
+    expect(list[0].relPath).toBe(`file-${RECENT_FILES_LIMIT + 4}.ts`);
+    // 最古のファイルは削除されている
+    expect(list.find((e) => e.relPath === 'file-0.ts')).toBeUndefined();
+  });
+
+  it('preserves order of untouched entries', () => {
+    const initial: RecentFileEntry[] = [
+      { rootPath: '/root', relPath: 'a.ts' },
+      { rootPath: '/root', relPath: 'b.ts' },
+      { rootPath: '/root', relPath: 'c.ts' }
+    ];
+    const result = addRecentFile(initial, '/root', 'new.ts');
+    expect(result.map((e) => e.relPath)).toEqual(['new.ts', 'a.ts', 'b.ts', 'c.ts']);
+  });
+
+  it('RECENT_FILES_LIMIT is between 10 and 20', () => {
+    expect(RECENT_FILES_LIMIT).toBeGreaterThanOrEqual(10);
+    expect(RECENT_FILES_LIMIT).toBeLessThanOrEqual(20);
+  });
+});

--- a/src/renderer/src/lib/hooks/use-file-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-file-tabs.ts
@@ -62,6 +62,18 @@ export interface UseFileTabsOptions {
   showToast: ToastFn;
 }
 
+/**
+ * Issue #480: 最近開いたファイルの履歴エントリ。
+ * キーは `rootPath + KEY_SEP + relPath` で一意に識別する。
+ */
+export interface RecentFileEntry {
+  rootPath: string;
+  relPath: string;
+}
+
+/** Issue #480: 履歴上限 */
+export const RECENT_FILES_LIMIT = 15;
+
 export interface UseFileTabsResult {
   // ---- state ----
   editorTabs: EditorTab[];
@@ -76,6 +88,11 @@ export interface UseFileTabsResult {
   dirtyEditorTabs: EditorTab[];
   /** tabIds 省略時は全 dirty を対象。confirm dialog を出して bool を返す。 */
   confirmDiscardEditorTabs: (tabIds?: string[]) => boolean;
+  /**
+   * Issue #480: 最近開いたファイルの履歴 (新しい順)。
+   * active ファイルも含むが、UI 側で active を優先表示する。
+   */
+  recentFiles: RecentFileEntry[];
 
   // ---- handlers ----
   openEditorTab: (rootPath: string, relPath: string) => Promise<void>;
@@ -118,6 +135,8 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
   const [diffTabs, setDiffTabs] = useState<DiffTab[]>([]);
   const [editorTabs, setEditorTabs] = useState<EditorTab[]>([]);
   const [recentlyClosed, setRecentlyClosed] = useState<DiffTab[]>([]);
+  // Issue #480: 最近開いたファイルの履歴 (新しい順、上限 RECENT_FILES_LIMIT)
+  const [recentFiles, setRecentFiles] = useState<RecentFileEntry[]>([]);
 
   const dirtyEditorTabs = useMemo(
     () => editorTabs.filter((tab) => !tab.isBinary && tab.content !== tab.originalContent),
@@ -232,6 +251,13 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
       // Issue #4: 同じ相対パスが別ルートに存在しうるので id に root も混ぜる
       const id = `edit:${effectiveRoot}\u0001${relPath}`;
       setActiveTabId(id);
+      // Issue #480: 最近開いたファイル履歴を更新 (先頭へ移動、上限制限)
+      setRecentFiles((prev) => {
+        const filtered = prev.filter(
+          (entry) => !(entry.rootPath === effectiveRoot && entry.relPath === relPath)
+        );
+        return [{ rootPath: effectiveRoot, relPath }, ...filtered].slice(0, RECENT_FILES_LIMIT);
+      });
       setEditorTabs((prev) => {
         if (prev.some((t) => t.id === id)) return prev;
         return [
@@ -455,6 +481,7 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
     setEditorTabs([]);
     setRecentlyClosed([]);
     setActiveTabId(null);
+    setRecentFiles([]);
   }, []);
 
   return {
@@ -467,6 +494,7 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
     setActiveTabId,
     dirtyEditorTabs,
     confirmDiscardEditorTabs,
+    recentFiles,
     openEditorTab,
     updateEditorContent,
     saveEditorTab,


### PR DESCRIPTION
## Summary
- `use-file-tabs.ts` にセッション内の最近開いたファイル履歴 (`recentFiles`) を追加。`openEditorTab` 成功時にファイルを先頭へ移動し、上限15件で管理
- `App.tsx` → `Sidebar` → `FileTreePanel` → `FileTreeNode` へ `recentFiles` / `recentRank` を伝播し、active でない最近ファイルに段階的な CSS クラス (`is-recent-1` / `is-recent-2` / `is-recent-3` / `is-recent`) を付与
- CSS で `.filetree__name.is-recent-*` に黄緑/黄色系のフォントカラーを設定。ダーク/ミッドナイト/Glass テーマでは明るい黄緑、ライトテーマでは濃い緑系に調整。active 表示は常に最優先

Closes #480

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run test` パス (33ファイル/250テスト)
- [x] `recent-files.test.ts` で履歴の順序・重複排除・上限・マルチルート分離を検証
- [x] `npm run build` 実行確認
- [ ] Tauri 実機で複数ファイルを順に開き、直近ファイルが黄緑系、active ファイルが既存 active 表示になることを確認