### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.4.12",
+  "version": "1.5.0",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5212,7 +5212,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.4.12"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.4.12"
+version = "1.5.0"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.4.12",
+  "version": "1.5.0",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## v1.5.0 Release

### New Features
- **feat(filetree):** フォルダ名ベースの VSCode 風アイコン表示を追加 (#484, Closes #479)
  - `folderIcon()` 関数で 50+ のフォルダ名マッピング（src, components, lib, .github 等）
  - lucide-react アイコン + テーマ対応カラー
- **feat(filetree):** 最近使ったファイルを黄緑/黄色系でハイライト (#485, Closes #480)
  - セッション内最近ファイル履歴（上限15件）
  - 3段階の色分け（is-recent-1/2/3）、ダーク/ライト両テーマ対応
  - active ファイルは常に既存スタイル優先

### Bug Fixes
- **fix(filetree):** 初回フォルダ展開で loadDir が実行されないバグを修正 (#483, Closes #478)
  - React 18 automatic batching による stale closure を `expandedRef` 同期参照で解消

### Performance
- **perf:** Rust / Canvas / PTY / UI の小規模最適化スイープ (#482)

### Quality
- typecheck PASS
- 全 250 テスト PASS
- build PASS（vite + cargo tauri）