### PR TITLE
fix(terminal): IDE scrollbar 操作不可を修正 + Canvas ターミナル初期サイズを拡大 (#496 #497)

### DIFF
--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1693,6 +1693,20 @@ body.is-resizing * {
   background: var(--fg) !important;
 }
 
+/* Issue #496: IDE モードのターミナルでも xterm v6 の custom scrollbar を「常時表示」にする。
+   xterm の SmoothScrollableElement は `vertical: ScrollbarVisibility.Auto` で生成され、
+   JS が `.visible` / `.invisible` クラスを切替えて opacity / pointer-events を絞るため、
+   hover で消えて掴めない症状が発生する (Canvas 側は Issue #272 v4 で同等対策済み)。
+   `.terminal-pane .terminal-view` スコープに限定して IDE のターミナル本体だけ常時表示にし、
+   Canvas (`.react-flow__node` 配下) の既存ルールには触れない。transition も無効化して
+   即時表示にし、フェードによるチラつきを避ける。 */
+.terminal-pane .terminal-view .xterm-scrollable-element > .scrollbar.vertical {
+  opacity: 1 !important;
+  visibility: visible !important;
+  pointer-events: auto !important;
+  transition: none !important;
+}
+
 /* Glass テーマ時は xterm を透過させて親の backdrop-filter を活かす (Issue #89)。
    `.xterm-viewport` の透過は Issue #365 の修正で全テーマ共通になったため、ここでは
    `.terminal-view` の solid 背景のみを打ち消す。 */

--- a/src/renderer/src/lib/canvas-migrations.ts
+++ b/src/renderer/src/lib/canvas-migrations.ts
@@ -18,13 +18,22 @@ import type { CardData, CardType, StageView } from '../stores/canvas';
  * カード初期幅/高さ。stores/canvas.ts と同期させること。
  * Issue #253: 旧 480x320 では Codex/Claude TUI のヘッダーが折り返しで崩れがちだったため
  * 640x400 に引き上げ。
+ * Issue #497: 640x400 でも Canvas で初回 Codex を開いた直後の TUI が窮屈だったため、
+ * 760x460 に再引き上げ。手動拡大値 (>640 / >400) は v5 migration で維持する。
  */
-export const NODE_W = 640;
-export const NODE_H = 400;
+export const NODE_W = 760;
+export const NODE_H = 460;
 
-/** persist v3 で既存ユーザーのカードを引き上げる閾値 (これ以下のサイズなら NODE_W/H に拡大) */
-const LEGACY_NODE_W_THRESHOLD = 480;
-const LEGACY_NODE_H_THRESHOLD = 320;
+/** persist v3 で既存ユーザーのカードを引き上げる閾値 (これ以下のサイズなら 640x400 に拡大) */
+const LEGACY_NODE_W_THRESHOLD_V3 = 480;
+const LEGACY_NODE_H_THRESHOLD_V3 = 320;
+/** v3 当時の既定サイズ (v3 migration の引き上げターゲット, v5 では旧既定値の閾値) */
+const LEGACY_NODE_W_V3 = 640;
+const LEGACY_NODE_H_V3 = 400;
+/** persist v5 で既存ユーザーのカードを引き上げる閾値 (これ以下のサイズなら NODE_W/H に拡大)
+ *  Issue #497: 旧既定 640x400 のみ新既定 760x460 へ移行し、>640 / >400 の手動拡大値は維持する。 */
+const LEGACY_NODE_W_THRESHOLD_V5 = LEGACY_NODE_W_V3;
+const LEGACY_NODE_H_THRESHOLD_V5 = LEGACY_NODE_H_V3;
 
 const CARD_TYPES: CardType[] = ['terminal', 'agent', 'editor', 'diff', 'fileTree', 'changes'];
 const STAGE_VIEWS: StageView[] = ['stage', 'list', 'focus'];
@@ -215,7 +224,9 @@ const MIGRATION_STEPS: Record<number, StepMigrator> = {
     };
   },
   // v2 → v3 (Issue #253): 旧 NODE_W/H (480x320) → 640x400。ユーザーが手動拡大した
-  // 値は尊重するため <= LEGACY_*_THRESHOLD のときだけ引き上げる。
+  // 値は尊重するため <= LEGACY_*_THRESHOLD_V3 のときだけ引き上げる。
+  // ※ v3 当時の引き上げ先は 640x400 で、現行 NODE_W/H ではない。v5 migration が
+  // 続けて同じ ladder で 760x460 まで持ち上げるため、ここでは v3 の既定値で止める。
   2: (p) => {
     if (!Array.isArray(p.nodes)) return p;
     return {
@@ -225,8 +236,10 @@ const MIGRATION_STEPS: Record<number, StepMigrator> = {
         const styleRaw = isRecord(n.style) ? n.style : {};
         const w = typeof styleRaw.width === 'number' ? styleRaw.width : undefined;
         const h = typeof styleRaw.height === 'number' ? styleRaw.height : undefined;
-        const nextW = w !== undefined && w <= LEGACY_NODE_W_THRESHOLD ? NODE_W : w;
-        const nextH = h !== undefined && h <= LEGACY_NODE_H_THRESHOLD ? NODE_H : h;
+        const nextW =
+          w !== undefined && w <= LEGACY_NODE_W_THRESHOLD_V3 ? LEGACY_NODE_W_V3 : w;
+        const nextH =
+          h !== undefined && h <= LEGACY_NODE_H_THRESHOLD_V3 ? LEGACY_NODE_H_V3 : h;
         if (nextW === w && nextH === h) return n;
         return {
           ...n,
@@ -240,7 +253,36 @@ const MIGRATION_STEPS: Record<number, StepMigrator> = {
     };
   },
   // v3 → v4 (Issue #385): 構造変換は不要 (normalize で吸収する)。
-  3: (p) => p
+  3: (p) => p,
+  // v4 → v5 (Issue #497): 旧 NODE_W/H (640x400) → 760x460。ユーザーが手動拡大した
+  // 値 (>640 / >400) は尊重するため <= LEGACY_*_THRESHOLD_V5 のときだけ引き上げる。
+  // 軸ごとに独立判定するので「width だけ手動拡大、height は既定」のような中間サイズも
+  // 既定軸だけ拡大される。
+  4: (p) => {
+    if (!Array.isArray(p.nodes)) return p;
+    return {
+      ...p,
+      nodes: p.nodes.map((n) => {
+        if (!isRecord(n)) return n;
+        const styleRaw = isRecord(n.style) ? n.style : {};
+        const w = typeof styleRaw.width === 'number' ? styleRaw.width : undefined;
+        const h = typeof styleRaw.height === 'number' ? styleRaw.height : undefined;
+        const nextW =
+          w !== undefined && w <= LEGACY_NODE_W_THRESHOLD_V5 ? NODE_W : w;
+        const nextH =
+          h !== undefined && h <= LEGACY_NODE_H_THRESHOLD_V5 ? NODE_H : h;
+        if (nextW === w && nextH === h) return n;
+        return {
+          ...n,
+          style: {
+            ...styleRaw,
+            ...(nextW !== undefined ? { width: nextW } : {}),
+            ...(nextH !== undefined ? { height: nextH } : {})
+          }
+        };
+      })
+    };
+  }
 };
 
 /**

--- a/src/renderer/src/stores/__tests__/canvas-migrate.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-migrate.test.ts
@@ -1,23 +1,23 @@
 /**
- * Canvas store の persist migration (v2 → v3) を、persist middleware を介さずに
+ * Canvas store の persist migration を、persist middleware を介さずに
  * 状態オブジェクト直書きで再現してテストする。
  *
- * Issue #253: 旧 NODE_W/H (480x320) で永続化された小さいカードを NODE_W/H (640x400) に
- * 拡大する。ユーザー手動拡大値 (>480 / >320) は尊重する。
+ * Issue #253 (v2 → v3): 旧 NODE_W/H (480x320) で永続化された小さいカードを 640x400 に拡大する。
+ *   ユーザー手動拡大値 (>480 / >320) は尊重する。
+ * Issue #497 (v4 → v5): 640x400 (= 旧 v3 既定) のカードを新既定 760x460 に拡大する。
+ *   ユーザー手動拡大値 (>640 / >400) は尊重する。
+ *
+ * 古い fromVersion からの呼び出しは ladder で v2→v3→…→v5 と段階的に進むため、
+ * v1 / v2 入力のテストは「最終的に 760x460 になる」ことを期待する。
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 
-// Issue #253 review (W#3): migrate を pure function として取得する。
-// store state には依存しない。Vitest の動的 import は通常モジュールキャッシュを使う
-// (vi.resetModules() なしでは 2 回目以降同一インスタンスが返る) ので、本関数は
-// 「migrate 関数を引っ張り出すための薄いラッパー」として機能している。
-// テストは `useCanvasStore.persist.getOptions().migrate!` を pure function として呼ぶだけで、
-// store 内部の hydrated state には触れないため、キャッシュされていても動作に影響しない。
+// migrate を pure function として取得する。store state には依存しない。
 async function loadStore() {
   return await import('../canvas');
 }
 
-describe('canvas persist migrate (Issue #253 v3)', () => {
+describe('canvas persist migrate (Issue #253 / #497)', () => {
   beforeEach(() => {
     // jsdom localStorage を毎テストでクリアして persist 由来の干渉を防ぐ
     if (typeof localStorage !== 'undefined') {
@@ -25,7 +25,7 @@ describe('canvas persist migrate (Issue #253 v3)', () => {
     }
   });
 
-  it('v2 → v3: width<=480 / height<=320 のノードは 640/400 に拡大される', async () => {
+  it('v2 → v5: width<=480 / height<=320 のノードは 760/460 に拡大される', async () => {
     const { useCanvasStore } = await loadStore();
     const persistApi = useCanvasStore.persist;
     const migrate = persistApi.getOptions().migrate!;
@@ -45,11 +45,11 @@ describe('canvas persist migrate (Issue #253 v3)', () => {
       teamLocks: {}
     };
     const result = migrate(v2State, 2) as { nodes: { style: { width: number; height: number } }[] };
-    expect(result.nodes[0].style.width).toBe(640);
-    expect(result.nodes[0].style.height).toBe(400);
+    expect(result.nodes[0].style.width).toBe(760);
+    expect(result.nodes[0].style.height).toBe(460);
   });
 
-  it('v2 → v3: width>480 のノードはユーザー手動拡大値として尊重される', async () => {
+  it('v2 → v5: width>640 のノードはユーザー手動拡大値として尊重される', async () => {
     const { useCanvasStore } = await loadStore();
     const migrate = useCanvasStore.persist.getOptions().migrate!;
 
@@ -72,10 +72,12 @@ describe('canvas persist migrate (Issue #253 v3)', () => {
     expect(result.nodes[0].style.height).toBe(600);
   });
 
-  it('v2 → v3: 中間サイズ (width=600, height=320) は片方だけ引き上げ', async () => {
+  it('v2 → v5: 中間サイズ (width=600, height=320) は ladder で両軸 760/460 に拡大される', async () => {
     const { useCanvasStore } = await loadStore();
     const migrate = useCanvasStore.persist.getOptions().migrate!;
 
+    // width=600 は v2→v3 では尊重 (>480) だが v4→v5 では <=640 で 760 に拡大される。
+    // height=320 は v2→v3 で 400 になり、v4→v5 で <=400 のため 460 に拡大される。
     const v2State = {
       nodes: [
         {
@@ -91,11 +93,11 @@ describe('canvas persist migrate (Issue #253 v3)', () => {
       teamLocks: {}
     };
     const result = migrate(v2State, 2) as { nodes: { style: { width: number; height: number } }[] };
-    expect(result.nodes[0].style.width).toBe(600); // ユーザー拡大値で尊重
-    expect(result.nodes[0].style.height).toBe(400); // 旧デフォルト相当 → 拡大
+    expect(result.nodes[0].style.width).toBe(760);
+    expect(result.nodes[0].style.height).toBe(460);
   });
 
-  it('v1 → v3: payload.role リネーム + size 拡大の両方が適用される', async () => {
+  it('v1 → v5: payload.role リネーム + size 拡大の両方が適用される', async () => {
     const { useCanvasStore } = await loadStore();
     const migrate = useCanvasStore.persist.getOptions().migrate!;
 
@@ -124,12 +126,12 @@ describe('canvas persist migrate (Issue #253 v3)', () => {
       }[];
     };
     const result = migrate(v1State, 1) as Migrated;
-    expect(result.nodes[0].style.width).toBe(640);
-    expect(result.nodes[0].style.height).toBe(400);
+    expect(result.nodes[0].style.width).toBe(760);
+    expect(result.nodes[0].style.height).toBe(460);
     expect(result.nodes[0].data.payload.roleProfileId).toBe('leader');
   });
 
-  it('v2 → v3: 壊れた nodes (style 欠損) は最終正規化で width=640 / height=400 のデフォルトが入る', async () => {
+  it('v2 → v5: 壊れた nodes (style 欠損) は最終正規化で width=760 / height=460 のデフォルトが入る', async () => {
     const { useCanvasStore } = await loadStore();
     const migrate = useCanvasStore.persist.getOptions().migrate!;
 
@@ -148,11 +150,11 @@ describe('canvas persist migrate (Issue #253 v3)', () => {
       teamLocks: {}
     };
     const result = migrate(v2State, 2) as { nodes: { style: { width: number; height: number } }[] };
-    expect(result.nodes[0].style.width).toBe(640);
-    expect(result.nodes[0].style.height).toBe(400);
+    expect(result.nodes[0].style.width).toBe(760);
+    expect(result.nodes[0].style.height).toBe(460);
   });
 
-  it('v2 → v3: nodes 配列が空でもクラッシュしない', async () => {
+  it('v2 → v5: nodes 配列が空でもクラッシュしない', async () => {
     const { useCanvasStore } = await loadStore();
     const migrate = useCanvasStore.persist.getOptions().migrate!;
 
@@ -165,5 +167,75 @@ describe('canvas persist migrate (Issue #253 v3)', () => {
     const result = migrate(v2State, 2) as { nodes: unknown[] };
     expect(Array.isArray(result.nodes)).toBe(true);
     expect(result.nodes).toHaveLength(0);
+  });
+
+  // Issue #497 v4 → v5: 単独 step の挙動を直接検証する (v3→v4 が no-op なのでこの組合せが本質)。
+  it('v4 → v5: width<=640 / height<=400 のノードは 760/460 に拡大される', async () => {
+    const { useCanvasStore } = await loadStore();
+    const migrate = useCanvasStore.persist.getOptions().migrate!;
+
+    const v4State = {
+      nodes: [
+        {
+          id: 't-5',
+          type: 'terminal',
+          position: { x: 0, y: 0 },
+          data: { cardType: 'terminal', title: 'Old default' },
+          style: { width: 640, height: 400 }
+        }
+      ],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      stageView: 'stage',
+      teamLocks: {}
+    };
+    const result = migrate(v4State, 4) as { nodes: { style: { width: number; height: number } }[] };
+    expect(result.nodes[0].style.width).toBe(760);
+    expect(result.nodes[0].style.height).toBe(460);
+  });
+
+  it('v4 → v5: 手動拡大値 (>640 / >400) は維持される', async () => {
+    const { useCanvasStore } = await loadStore();
+    const migrate = useCanvasStore.persist.getOptions().migrate!;
+
+    const v4State = {
+      nodes: [
+        {
+          id: 't-6',
+          type: 'terminal',
+          position: { x: 0, y: 0 },
+          data: { cardType: 'terminal', title: 'Manual big' },
+          style: { width: 900, height: 700 }
+        }
+      ],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      stageView: 'stage',
+      teamLocks: {}
+    };
+    const result = migrate(v4State, 4) as { nodes: { style: { width: number; height: number } }[] };
+    expect(result.nodes[0].style.width).toBe(900);
+    expect(result.nodes[0].style.height).toBe(700);
+  });
+
+  it('v4 → v5: 中間サイズは軸ごとに独立判定される (width=800 維持 / height=400 拡大)', async () => {
+    const { useCanvasStore } = await loadStore();
+    const migrate = useCanvasStore.persist.getOptions().migrate!;
+
+    const v4State = {
+      nodes: [
+        {
+          id: 't-7',
+          type: 'terminal',
+          position: { x: 0, y: 0 },
+          data: { cardType: 'terminal', title: 'Wide manual' },
+          style: { width: 800, height: 400 }
+        }
+      ],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      stageView: 'stage',
+      teamLocks: {}
+    };
+    const result = migrate(v4State, 4) as { nodes: { style: { width: number; height: number } }[] };
+    expect(result.nodes[0].style.width).toBe(800); // ユーザー拡大値で尊重
+    expect(result.nodes[0].style.height).toBe(460); // 旧既定相当 → 拡大
   });
 });

--- a/src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts
@@ -88,8 +88,9 @@ describe('normalizeCanvasState (Issue #385)', () => {
     const n = out.nodes[0]!;
     expect(Number.isFinite(n.position.x)).toBe(true);
     expect(Number.isFinite(n.position.y)).toBe(true);
-    expect((n.style as { width: number }).width).toBe(640);
-    expect((n.style as { height: number }).height).toBe(400);
+    // Issue #497: 既定サイズは 760x460 (旧 640x400 から再引き上げ)
+    expect((n.style as { width: number }).width).toBe(760);
+    expect((n.style as { height: number }).height).toBe(460);
     expect(n.data.title).toBe('Card'); // 空タイトル → 'Card'
   });
 

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -290,10 +290,12 @@ export const useCanvasStore = create<CanvasState>()(
     }),
     {
       name: 'vibe-editor:canvas',
-      // Issue #385: v4 へ bump し、persisted state は必ず normalizeCanvasState を経由
-      // させる。同 version の rehydrate でも `merge` で再正規化するため、runtime で
-      // 紛れ込んだ NaN viewport / 範囲外 zoom / 壊れた node も次回起動時には掃除される。
-      version: 4,
+      // Issue #385: v4 で persisted state は必ず normalizeCanvasState を経由させる。
+      // 同 version の rehydrate でも `merge` で再正規化するため、runtime で紛れ込んだ
+      // NaN viewport / 範囲外 zoom / 壊れた node も次回起動時には掃除される。
+      // Issue #497: v5 で旧既定 640x400 のカードを新既定 760x460 へ移行する
+      // (>640 / >400 の手動拡大値は尊重)。詳細は `lib/canvas-migrations.ts` の v4 step。
+      version: 5,
       // 各 version の差分は `lib/canvas-migrations.ts` の `MIGRATION_STEPS` に集約。
       // ここでは「fromVersion → 最新」を 1 行で進めるだけ。最後に必ず normalize を通すので
       // 同 version の rehydrate でも runtime に紛れ込んだ NaN viewport / 範囲外 zoom /

--- a/src/renderer/src/styles/__tests__/terminal-css-contract.test.ts
+++ b/src/renderer/src/styles/__tests__/terminal-css-contract.test.ts
@@ -1,0 +1,53 @@
+/// <reference types="node" />
+
+/**
+ * Terminal CSS contract test (Issue #496).
+ *
+ * IDE モード (`.terminal-pane .terminal-view ...`) のターミナル scrollbar が
+ * hover で消えて掴めない症状の再発を防ぐためのレグレッションガード。
+ * xterm v6 SmoothScrollableElement は autohide が JS 側で切替わるため、CSS で
+ * `.scrollbar.vertical` を常時表示・操作可能に固定する必要がある。
+ *
+ * Canvas 側 (`.react-flow__node` 配下) は `canvas.css` に同等ルールが存在し、
+ * そちらは触らないことも合わせて明示する。
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const stylesDir = dirname(testDir);
+const rendererSrcDir = dirname(stylesDir);
+const componentsDir = join(stylesDir, 'components');
+
+function readIndexCss(): string {
+  return readFileSync(join(rendererSrcDir, 'index.css'), 'utf8');
+}
+
+function readComponentCss(fileName: string): string {
+  return readFileSync(join(componentsDir, fileName), 'utf8');
+}
+
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+describe('Terminal CSS contract (Issue #496)', () => {
+  it('keeps the IDE-mode xterm vertical scrollbar always visible and interactive', () => {
+    const css = stripCssComments(readIndexCss());
+
+    expect(css).toMatch(
+      /\.terminal-pane\s+\.terminal-view\s+\.xterm-scrollable-element\s*>\s*\.scrollbar\.vertical\s*\{[\s\S]*opacity:\s*1\s*!important[\s\S]*visibility:\s*visible\s*!important[\s\S]*pointer-events:\s*auto\s*!important[\s\S]*transition:\s*none\s*!important[\s\S]*\}/
+    );
+  });
+
+  it('keeps the Canvas-mode xterm vertical scrollbar always visible (Issue #272 v4 unchanged)', () => {
+    const css = stripCssComments(readComponentCss('canvas.css'));
+
+    expect(css).toMatch(
+      /\.react-flow__node\s+\.terminal-view\s+\.xterm-scrollable-element\s*>\s*\.scrollbar\.vertical\s*\{[\s\S]*opacity:\s*1\s*!important[\s\S]*visibility:\s*visible\s*!important[\s\S]*pointer-events:\s*auto\s*!important[\s\S]*transition:\s*none\s*!important[\s\S]*\}/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

直交する 2 件の小規模 UI バグ / 改善を 1 PR にバンドル (1 commit / issue)。

### 1. `fix(terminal)`: IDE モードの xterm scrollbar が hover で消えて掴めないバグを修正 (#496)

xterm v6 の `SmoothScrollableElement` は `vertical: ScrollbarVisibility.Auto` で生成され、内部 JS が `.visible` / `.invisible` クラスを切替えて opacity / pointer-events を制御するため、ポインタを scrollbar に重ねた瞬間に消えて掴めない症状が発生していた。Canvas モードは Issue #272 v4 で `.react-flow__node .terminal-view` スコープに常時表示ルールがあるが、IDE モード (`.terminal-pane .terminal-view`) には同等のガードが無かった。

`.terminal-pane .terminal-view .xterm-scrollable-element > .scrollbar.vertical` を `opacity:1 / visibility:visible / pointer-events:auto / transition:none !important` に固定するルールを `index.css` に追加。Canvas 既存ルールには触らない。`src/renderer/src/styles/__tests__/terminal-css-contract.test.ts` を新規追加し、IDE / Canvas 両スコープのレグレッションをガード。

### 2. `feat(canvas)`: ターミナルカードの初期サイズを 760x460 に拡大 (#497)

Canvas モードで Codex / Claude TUI を新規カードとして開いた直後、旧既定 640x400 のカードでは TUI が窮屈で手動リサイズ前提だった。`NODE_W` / `NODE_H` (SSOT: `lib/canvas-migrations.ts`) を `760x460` に bump。

- persist version を 4 → 5 に上げ、v4 → v5 migration を追加。
- 旧既定 640x400 相当のカード (`width<=640` / `height<=400`) は自動拡大、軸ごとに独立判定。
- 手動拡大値 (`>640` / `>400`) は維持。
- `canvas-arrange` / `canvas-placement` / `workspace-presets` は `NODE_W/H` 定数経由なのでテスト含めて自動追従。
- `canvas-migrate.test.ts` を v2→v5 / v4→v5 ladder ベースに更新し、v4→v5 単独 step の専用ケース (旧既定値拡大 / 手動値維持 / 軸独立判定) を追加。

Closes #496
Closes #497

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run test` 通過 (255 / 255)
- [x] `npm run build:vite` 通過
- [x] `git diff --check` クリーン
- [x] `terminal-css-contract.test.ts` (new) で IDE / Canvas 両スコープの常時表示ルールをガード
- [x] `canvas-migrate.test.ts` で v1/v2/v4 → v5 ladder と v4→v5 単独 step を確認
- [ ] Tauri 実機 (`npm run dev`) で IDE ターミナル scrollbar の hover / drag 操作を確認
- [ ] Tauri 実機で Canvas → Add → Codex の初期表示が 760x460 で崩れないことを確認