### PR TITLE
refactor(rust): TeamHub permissions / tool errors を統一し AppSettings を serde struct 化 (#493)

### DIFF
--- a/src/renderer/src/components/OnboardingWizard.tsx
+++ b/src/renderer/src/components/OnboardingWizard.tsx
@@ -4,7 +4,7 @@ import type { AppSettings, Language, ThemeName } from '../../../types/shared';
 import { translate } from '../lib/i18n';
 import { useSettings } from '../lib/settings-context';
 import { useSpringMount } from '../lib/use-animated-mount';
-import { THEMES, applyTheme } from '../lib/themes';
+import { applyTheme } from '../lib/themes';
 
 type Step = 'welcome' | 'appearance' | 'workspace' | 'done';
 const STEP_ORDER: Step[] = ['welcome', 'appearance', 'workspace', 'done'];
@@ -23,14 +23,8 @@ const SUPPORTED_THEMES: ThemeName[] = [
   'glass'
 ];
 
-const THEME_LABEL: Record<ThemeName, { ja: string; en: string }> = {
-  'claude-dark': { ja: 'Claude Dark', en: 'Claude Dark' },
-  'claude-light': { ja: 'Claude Light', en: 'Claude Light' },
-  dark: { ja: 'ダーク', en: 'Dark' },
-  light: { ja: 'ライト', en: 'Light' },
-  midnight: { ja: 'ミッドナイト', en: 'Midnight' },
-  glass: { ja: 'グラス', en: 'Glass' }
-};
+const themeLabelKey = (name: ThemeName): string => `theme.label.${name}`;
+const langLabelKey = (lang: Language): string => `lang.label.${lang}`;
 
 function guessLanguage(): Language {
   const loc = (navigator.language || 'en').toLowerCase();
@@ -91,8 +85,6 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps): JSX.Ele
       translate(draftLanguage, key, params),
     [draftLanguage]
   );
-
-  const themeVars = THEMES[draftTheme];
 
   const goNext = useCallback(() => {
     const idx = STEP_ORDER.indexOf(step);
@@ -193,7 +185,6 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps): JSX.Ele
               draftLanguage={draftLanguage}
               draftTheme={draftTheme}
               draftFolder={draftFolder}
-              themeAccent={themeVars.accent}
             />
           )}
         </div>
@@ -314,7 +305,7 @@ function AppearanceStep({
               data-active={draftLanguage === lang}
               onClick={() => onLanguageChange(lang)}
             >
-              {lang === 'ja' ? '日本語' : 'English'}
+              {t(langLabelKey(lang))}
             </button>
           ))}
         </div>
@@ -323,44 +314,29 @@ function AppearanceStep({
       <section className="onboarding__section">
         <div className="onboarding__section-label">{t('onboarding.appearance.theme')}</div>
         <div className="onboarding__theme-grid">
-          {SUPPORTED_THEMES.map((name) => {
-            const v = THEMES[name];
-            return (
-              <button
-                key={name}
-                type="button"
-                className="onboarding__theme-card"
-                data-active={draftTheme === name}
-                onClick={() => onThemeChange(name)}
-              >
-                <div
-                  className="onboarding__theme-preview"
-                  style={{
-                    background: v.bg,
-                    borderColor: v.border
-                  }}
-                >
-                  <div
-                    className="onboarding__theme-preview-bar"
-                    style={{ background: v.bgPanel }}
-                  />
-                  <div
-                    className="onboarding__theme-preview-line"
-                    style={{ background: v.text, opacity: 0.82 }}
-                  />
-                  <div
-                    className="onboarding__theme-preview-line"
-                    style={{ background: v.textDim, width: '52%' }}
-                  />
-                  <div
-                    className="onboarding__theme-preview-dot"
-                    style={{ background: v.accent }}
-                  />
-                </div>
-                <span className="onboarding__theme-name">{THEME_LABEL[name][draftLanguage]}</span>
-              </button>
-            );
-          })}
+          {SUPPORTED_THEMES.map((name) => (
+            <button
+              key={name}
+              type="button"
+              className="onboarding__theme-card"
+              data-active={draftTheme === name}
+              onClick={() => onThemeChange(name)}
+            >
+              {/*
+               * Issue #490: 旧実装は THEMES[name].{bg,bgPanel,...} を inline style で
+               * 流し込んでいた。tokens.css の `[data-theme='X']` ブロックがネスト要素にも
+               * cascade するようになったので、ここでは data-theme 属性を被せるだけで
+               * 子の `var(--bg)` / `var(--accent)` などが該当テーマ色に解決される。
+               */}
+              <div className="onboarding__theme-preview" data-theme={name}>
+                <div className="onboarding__theme-preview-bar" />
+                <div className="onboarding__theme-preview-line onboarding__theme-preview-line--strong" />
+                <div className="onboarding__theme-preview-line onboarding__theme-preview-line--dim" />
+                <div className="onboarding__theme-preview-dot" />
+              </div>
+              <span className="onboarding__theme-name">{t(themeLabelKey(name))}</span>
+            </button>
+          ))}
         </div>
       </section>
     </div>
@@ -430,24 +406,18 @@ interface DoneStepProps extends StepProps {
   draftLanguage: Language;
   draftTheme: ThemeName;
   draftFolder: string;
-  themeAccent: string;
 }
 
 function DoneStep({
   t,
   draftLanguage,
   draftTheme,
-  draftFolder,
-  themeAccent
+  draftFolder
 }: DoneStepProps): JSX.Element {
-  const themeLabel = THEME_LABEL[draftTheme][draftLanguage];
+  const themeLabel = t(themeLabelKey(draftTheme));
   return (
     <div className="onboarding__hero">
-      <div
-        className="onboarding__done-mark"
-        aria-hidden
-        style={{ background: themeAccent }}
-      >
+      <div className="onboarding__done-mark" aria-hidden>
         <Check size={36} strokeWidth={2.5} color="#fff" />
       </div>
       <span className="onboarding__eyebrow">{t('onboarding.done.eyebrow')}</span>
@@ -457,7 +427,7 @@ function DoneStep({
       <dl className="onboarding__summary">
         <div className="onboarding__summary-row">
           <dt>{t('onboarding.done.summaryLanguage')}</dt>
-          <dd>{draftLanguage === 'ja' ? '日本語' : 'English'}</dd>
+          <dd>{t(langLabelKey(draftLanguage))}</dd>
         </div>
         <div className="onboarding__summary-row">
           <dt>{t('onboarding.done.summaryTheme')}</dt>

--- a/src/renderer/src/components/UserMenu.tsx
+++ b/src/renderer/src/components/UserMenu.tsx
@@ -20,19 +20,19 @@ interface UserMenuProps {
   onOpenSettings: () => void;
 }
 
-const LANG_LABELS: Record<Language, string> = {
-  ja: '日本語',
-  en: 'English'
-};
-
-const THEME_LABELS: Record<ThemeName, string> = {
-  'claude-dark': 'Claude Dark',
-  'claude-light': 'Claude Light',
-  dark: 'Dark',
-  midnight: 'Midnight',
-  glass: 'Glass',
-  light: 'Light'
-};
+/**
+ * `theme.label.*` / `lang.label.*` の i18n キーは `lib/i18n.ts` に集約されており、
+ * ja/en で表記が揃っている。ここでは「対応する全テーマ ID」を保持するだけ。
+ */
+const LANG_IDS: Language[] = ['ja', 'en'];
+const THEME_IDS: ThemeName[] = [
+  'claude-dark',
+  'claude-light',
+  'dark',
+  'midnight',
+  'glass',
+  'light'
+];
 
 const LIGHT_THEMES: Set<ThemeName> = new Set(['claude-light', 'light']);
 
@@ -144,7 +144,7 @@ export function UserMenu({ onOpenSettings }: UserMenuProps): JSX.Element {
           <span className="user-menu__identity">
             <span className="user-menu__name">{info?.username ?? '…'}</span>
             <span className="user-menu__meta">
-              {LANG_LABELS[settings.language]} · {THEME_LABELS[settings.theme]}
+              {t(`lang.label.${settings.language}`)} · {t(`theme.label.${settings.theme}`)}
             </span>
           </span>
         </button>
@@ -206,7 +206,7 @@ export function UserMenu({ onOpenSettings }: UserMenuProps): JSX.Element {
           >
             <Languages size={14} strokeWidth={1.75} className="user-menu__item-icon" />
             <span className="user-menu__item-label">{t('userMenu.language')}</span>
-            <span className="user-menu__item-value">{LANG_LABELS[settings.language]}</span>
+            <span className="user-menu__item-value">{t(`lang.label.${settings.language}`)}</span>
             <ChevronRight
               size={12}
               strokeWidth={2}
@@ -215,7 +215,7 @@ export function UserMenu({ onOpenSettings }: UserMenuProps): JSX.Element {
           </button>
           {langOpen && (
             <div className="user-menu__sub">
-              {(['ja', 'en'] as Language[]).map((lang) => (
+              {LANG_IDS.map((lang) => (
                 <button
                   key={lang}
                   type="button"
@@ -224,7 +224,7 @@ export function UserMenu({ onOpenSettings }: UserMenuProps): JSX.Element {
                   }`}
                   onClick={() => pickLang(lang)}
                 >
-                  {LANG_LABELS[lang]}
+                  {t(`lang.label.${lang}`)}
                 </button>
               ))}
             </div>
@@ -242,7 +242,7 @@ export function UserMenu({ onOpenSettings }: UserMenuProps): JSX.Element {
           >
             <Palette size={14} strokeWidth={1.75} className="user-menu__item-icon" />
             <span className="user-menu__item-label">{t('userMenu.theme')}</span>
-            <span className="user-menu__item-value">{THEME_LABELS[settings.theme]}</span>
+            <span className="user-menu__item-value">{t(`theme.label.${settings.theme}`)}</span>
             <ChevronRight
               size={12}
               strokeWidth={2}
@@ -251,7 +251,7 @@ export function UserMenu({ onOpenSettings }: UserMenuProps): JSX.Element {
           </button>
           {themeOpen && (
             <div className="user-menu__sub">
-              {(Object.keys(THEME_LABELS) as ThemeName[]).map((theme) => (
+              {THEME_IDS.map((theme) => (
                 <button
                   key={theme}
                   type="button"
@@ -260,7 +260,7 @@ export function UserMenu({ onOpenSettings }: UserMenuProps): JSX.Element {
                   }`}
                   onClick={() => pickTheme(theme)}
                 >
-                  {THEME_LABELS[theme]}
+                  {t(`theme.label.${theme}`)}
                 </button>
               ))}
             </div>

--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -35,6 +35,11 @@ import { QuickNav } from './QuickNav';
 import { LeaderGlow } from './LeaderGlow';
 import { StageHud } from './StageHud';
 import { useCanvasStore, NODE_W, NODE_H, type CardData } from '../../stores/canvas';
+import {
+  useCanvasNodes,
+  useCanvasEdges,
+  useCanvasStageView
+} from '../../stores/canvas-selectors';
 import { computeRecruitFocus } from '../../lib/canvas-recruit-focus';
 import { KEYS, useKeybinding } from '../../lib/keybindings';
 import { useUiStore } from '../../stores/ui';
@@ -74,8 +79,8 @@ const MIN_RECRUIT_ZOOM = 0.7;
 
 function FlowApp(): JSX.Element {
   const t = useT();
-  const nodes = useCanvasStore((s) => s.nodes);
-  const edges = useCanvasStore((s) => s.edges);
+  const nodes = useCanvasNodes();
+  const edges = useCanvasEdges();
   // setNodes / setEdges / setViewport / addCard / pulseEdge / setTeamLock は zustand
   // 内部で stable identity を保つため selector で取り出してキャッシュしておく。
   const setNodes = useCanvasStore((s) => s.setNodes);
@@ -322,7 +327,7 @@ function FlowApp(): JSX.Element {
   useKeybinding(KEYS.toggleIde, () => setViewMode('ide'));
   useKeybinding(KEYS.newTerminal, handleAddClaudeAgent);
 
-  const stageView = useCanvasStore((s) => s.stageView);
+  const stageView = useCanvasStageView();
 
   // Issue #253 / #372: recruit 後に viewport を「新規 worker カード」中心へ寄せる。
   // lastRecruitFocus は use-recruit-listener が `notifyRecruit(newNodeId)` で書き、
@@ -453,7 +458,7 @@ function FlowApp(): JSX.Element {
 /** stageView === 'list' のときに ReactFlow の代わりに表示する簡易ロスター。
  *  Canvas 上の agent ノードを一覧化する。 */
 function StageListOverlay(): JSX.Element {
-  const nodes = useCanvasStore((s) => s.nodes);
+  const nodes = useCanvasNodes();
   const { settings } = useSettings();
   const { byId: profilesById } = useRoleProfiles();
   const agentNodes = nodes.filter((n) => (n.data as CardData | undefined)?.cardType === 'agent');

--- a/src/renderer/src/components/canvas/QuickNav.tsx
+++ b/src/renderer/src/components/canvas/QuickNav.tsx
@@ -6,7 +6,7 @@
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useReactFlow } from '@xyflow/react';
-import { useCanvasStore } from '../../stores/canvas';
+import { useCanvasNodes } from '../../stores/canvas-selectors';
 import { useT } from '../../lib/i18n';
 import { metaOf } from '../../lib/team-roles';
 
@@ -17,7 +17,7 @@ interface QuickNavProps {
 
 export function QuickNav({ open, onClose }: QuickNavProps): JSX.Element | null {
   const t = useT();
-  const nodes = useCanvasStore((s) => s.nodes);
+  const nodes = useCanvasNodes();
   const rf = useReactFlow();
   const [query, setQuery] = useState('');
   const [activeIdx, setActiveIdx] = useState(0);

--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -3,6 +3,7 @@ import { LayoutGrid, List, Maximize2, Ruler, Users, ZoomIn, ZoomOut } from 'luci
 import { useReactFlow } from '@xyflow/react';
 import { useT } from '../../lib/i18n';
 import { useCanvasStore, type StageView } from '../../stores/canvas';
+import { useCanvasStageView } from '../../stores/canvas-selectors';
 import type { ArrangeGap } from '../../lib/canvas-arrange';
 
 /**
@@ -15,7 +16,7 @@ import type { ArrangeGap } from '../../lib/canvas-arrange';
  */
 export function StageHud(): JSX.Element {
   const t = useT();
-  const stageView = useCanvasStore((s) => s.stageView);
+  const stageView = useCanvasStageView();
   const setStageView = useCanvasStore((s) => s.setStageView);
   const arrangeGap = useCanvasStore((s) => s.arrangeGap);
   const setArrangeGap = useCanvasStore((s) => s.setArrangeGap);

--- a/src/renderer/src/components/overlays/TweaksPanel.tsx
+++ b/src/renderer/src/components/overlays/TweaksPanel.tsx
@@ -4,25 +4,18 @@ import { useT } from '../../lib/i18n';
 import { useSettings } from '../../lib/settings-context';
 import { useUiStore } from '../../stores/ui';
 
-const THEMES: ReadonlyArray<{ id: ThemeName; label: string }> = [
-  { id: 'claude-dark', label: 'claude dark' },
-  { id: 'claude-light', label: 'claude light' },
-  { id: 'dark', label: 'dark' },
-  { id: 'light', label: 'light' },
-  { id: 'midnight', label: 'midnight' },
-  { id: 'glass', label: 'glass' }
+const THEME_IDS: ReadonlyArray<ThemeName> = [
+  'claude-dark',
+  'claude-light',
+  'dark',
+  'light',
+  'midnight',
+  'glass'
 ];
 
-const DENSITIES: ReadonlyArray<{ id: Density; label: string }> = [
-  { id: 'compact', label: 'compact' },
-  { id: 'normal', label: 'normal' },
-  { id: 'comfortable', label: 'comfortable' }
-];
+const DENSITY_IDS: ReadonlyArray<Density> = ['compact', 'normal', 'comfortable'];
 
-const LANGUAGES: ReadonlyArray<{ id: Language; label: string }> = [
-  { id: 'ja', label: '日本語' },
-  { id: 'en', label: 'English' }
-];
+const LANGUAGE_IDS: ReadonlyArray<Language> = ['ja', 'en'];
 
 /**
  * TweaksPanel — 右下に浮かぶクイック調整パネル。
@@ -54,14 +47,14 @@ export function TweaksPanel(): JSX.Element | null {
         <div className="tw-group">
           <div className="tw-label">{t('tweaks.theme')}</div>
           <div className="tw-row">
-            {THEMES.map((theme) => (
+            {THEME_IDS.map((id) => (
               <button
-                key={theme.id}
+                key={id}
                 type="button"
-                className={`tw-chip${settings.theme === theme.id ? ' is-active' : ''}`}
-                onClick={() => void update({ theme: theme.id })}
+                className={`tw-chip${settings.theme === id ? ' is-active' : ''}`}
+                onClick={() => void update({ theme: id })}
               >
-                {theme.label}
+                {t(`theme.label.${id}`)}
               </button>
             ))}
           </div>
@@ -69,14 +62,14 @@ export function TweaksPanel(): JSX.Element | null {
         <div className="tw-group">
           <div className="tw-label">{t('tweaks.density')}</div>
           <div className="tw-row">
-            {DENSITIES.map((d) => (
+            {DENSITY_IDS.map((id) => (
               <button
-                key={d.id}
+                key={id}
                 type="button"
-                className={`tw-chip${settings.density === d.id ? ' is-active' : ''}`}
-                onClick={() => void update({ density: d.id })}
+                className={`tw-chip${settings.density === id ? ' is-active' : ''}`}
+                onClick={() => void update({ density: id })}
               >
-                {d.label}
+                {t(`settings.density.${id}`)}
               </button>
             ))}
           </div>
@@ -84,14 +77,14 @@ export function TweaksPanel(): JSX.Element | null {
         <div className="tw-group">
           <div className="tw-label">{t('tweaks.language')}</div>
           <div className="tw-row">
-            {LANGUAGES.map((lng) => (
+            {LANGUAGE_IDS.map((id) => (
               <button
-                key={lng.id}
+                key={id}
                 type="button"
-                className={`tw-chip${settings.language === lng.id ? ' is-active' : ''}`}
-                onClick={() => void update({ language: lng.id })}
+                className={`tw-chip${settings.language === id ? ' is-active' : ''}`}
+                onClick={() => void update({ language: id })}
               >
-                {lng.label}
+                {t(`lang.label.${id}`)}
               </button>
             ))}
           </div>

--- a/src/renderer/src/components/settings/LanguageSection.tsx
+++ b/src/renderer/src/components/settings/LanguageSection.tsx
@@ -27,8 +27,8 @@ export function LanguageSection({ draft, update }: Props): JSX.Element {
               checked={draft.language === lang}
               onChange={() => update('language', lang)}
             />
-            <strong>{lang === 'ja' ? '日本語' : 'English'}</strong>
-            <span>{lang === 'ja' ? 'Japanese' : 'English'}</span>
+            <strong>{t(`lang.label.${lang}`)}</strong>
+            <span>{t(`lang.label.${lang}.sub`)}</span>
           </label>
         ))}
       </div>

--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -42,6 +42,7 @@ import { useT } from '../lib/i18n';
 import { useUiStore } from '../stores/ui';
 import { useHistoryBadgeCount } from '../lib/use-history-badge-count';
 import { useCanvasStore } from '../stores/canvas';
+import { useCanvasViewport } from '../stores/canvas-selectors';
 import {
   BUILTIN_PRESETS,
   DEFAULT_SPAWN_PRESET,
@@ -89,7 +90,7 @@ export function CanvasLayout(): JSX.Element {
       setNodes(state.nodes);
     });
   }, []);
-  const viewport = useCanvasStore((s) => s.viewport);
+  const viewport = useCanvasViewport();
   const clear = useCanvasStore((s) => s.clear);
   const addCards = useCanvasStore((s) => s.addCards);
   const notifyRecruit = useCanvasStore((s) => s.notifyRecruit);

--- a/src/renderer/src/lib/__tests__/theme-contrast.test.ts
+++ b/src/renderer/src/lib/__tests__/theme-contrast.test.ts
@@ -36,11 +36,19 @@ describe('theme accent foreground', () => {
     ).toBeGreaterThanOrEqual(4.5);
   });
 
-  it('publishes --accent-foreground when applying the Glass theme', () => {
+  it('switches root data-theme attribute when applying the Glass theme', () => {
+    /*
+     * Issue #490: 旧実装は applyTheme が `root.style.setProperty('--accent-foreground', ...)`
+     * を直接書き込んでいたが、現在は `tokens.css` の `[data-theme='glass']` ブロックが
+     * cascade で値を流す方式に切り替わっている。`style.getPropertyValue` は inline 値しか
+     * 返さないので、テストは「`data-theme` が確実に切り替わっていること」をもって
+     * CSS 経由で `--accent-foreground` が解決される前提を確認する。
+     * (実値が `THEMES.glass.accentForeground` と一致することは tokens.css と themes.ts の
+     * mirror で担保される — 上のコントラストテストが値の妥当性を保証する。)
+     */
     applyTheme('glass', 'Inter', 14);
 
-    expect(document.documentElement.style.getPropertyValue('--accent-foreground')).toBe(
-      THEMES.glass.accentForeground
-    );
+    expect(document.documentElement.dataset.theme).toBe('glass');
+    expect(THEMES.glass.accentForeground).toBe('#050714');
   });
 });

--- a/src/renderer/src/lib/canvas-migrations.ts
+++ b/src/renderer/src/lib/canvas-migrations.ts
@@ -1,0 +1,280 @@
+/**
+ * Canvas store の persist 正規化 / version migration を集約するモジュール。
+ *
+ * `stores/canvas.ts` から切り出した理由:
+ *   - normalizeCanvasState は zustand persist の `migrate` / `merge` 両方から呼ばれる
+ *     pure function であり、store 本体 (action 群) と関心が分離している。
+ *   - version → migration 関数のテーブル化により「どの version で何を変えたか」が
+ *     一覧で読める形になり、新たな persist version bump 時の追記場所も明確になる。
+ *
+ * テストは `__testables` 経由で zustand 内部に依存せず正規化ロジックを検証できる。
+ * 既存 `canvas-restore-normalize.test.ts` / `canvas-migrate.test.ts` は変更不要。
+ */
+import type { Node, Viewport } from '@xyflow/react';
+import type { ArrangeGap } from './canvas-arrange';
+import type { CardData, CardType, StageView } from '../stores/canvas';
+
+/**
+ * カード初期幅/高さ。stores/canvas.ts と同期させること。
+ * Issue #253: 旧 480x320 では Codex/Claude TUI のヘッダーが折り返しで崩れがちだったため
+ * 640x400 に引き上げ。
+ */
+export const NODE_W = 640;
+export const NODE_H = 400;
+
+/** persist v3 で既存ユーザーのカードを引き上げる閾値 (これ以下のサイズなら NODE_W/H に拡大) */
+const LEGACY_NODE_W_THRESHOLD = 480;
+const LEGACY_NODE_H_THRESHOLD = 320;
+
+const CARD_TYPES: CardType[] = ['terminal', 'agent', 'editor', 'diff', 'fileTree', 'changes'];
+const STAGE_VIEWS: StageView[] = ['stage', 'list', 'focus'];
+
+/**
+ * Issue #385: Canvas viewport の `zoom` を可視範囲にクランプし、
+ * `x` / `y` が極端な値 (= 全カードが viewport 外) のときは復帰用の値に戻す。
+ * これらは render 中に React Flow が黒画面化する/カードが見えなくなる主要因。
+ */
+export const VIEWPORT_MIN_ZOOM = 0.1;
+export const VIEWPORT_MAX_ZOOM = 4;
+/** nodes ありで viewport がここまで離れていたら「外れすぎ」と判定して復帰用 viewport にする */
+export const VIEWPORT_RESCUE_DISTANCE = 1_000_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isCardType(value: unknown): value is CardType {
+  return typeof value === 'string' && CARD_TYPES.includes(value as CardType);
+}
+
+function finiteOr(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function clampZoom(zoom: number): number {
+  // NaN は単位が無いので 1 (= 等倍) にフォールバック。±Infinity は Math.min/max で
+  // それぞれ MAX_ZOOM / MIN_ZOOM にクランプされる。
+  if (Number.isNaN(zoom)) return 1;
+  return Math.min(Math.max(zoom, VIEWPORT_MIN_ZOOM), VIEWPORT_MAX_ZOOM);
+}
+
+/**
+ * crypto.randomUUID() ベースの安定 ID 生成。
+ * Issue #157: 旧 `Date.now() + counter` 方式は zustand persist 復元 + リロード後の
+ * counter リセットで稀に衝突しうる。Tauri WebView2 / 主要ブラウザでサポート済み。
+ * fallback 環境では Math.random ベースで補う。
+ */
+export function newId(prefix: string): string {
+  const u =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  return `${prefix}-${u}`;
+}
+
+export interface NormalizedCanvasState {
+  nodes: Node<CardData>[];
+  viewport: Viewport;
+  stageView: StageView;
+  teamLocks: Record<string, boolean>;
+  arrangeGap: ArrangeGap;
+}
+
+/**
+ * 永続化データ / merge 入力を React Flow が安全に描画できる形へ正規化する。
+ * - nodes: 必須プロパティの欠損 / 不正値を補い、type 不明な要素は捨てる
+ * - viewport.zoom: [VIEWPORT_MIN_ZOOM, VIEWPORT_MAX_ZOOM] にクランプ
+ * - viewport.x/y: 非有限なら 0、極端な値で nodes が完全に外れていれば nodes 中心へ復帰
+ * - stageView / teamLocks / arrangeGap: 不正な値ならデフォルトに戻す
+ */
+export function normalizeCanvasState(input: unknown): NormalizedCanvasState {
+  const p = isRecord(input) ? input : {};
+  const nodes = Array.isArray(p.nodes)
+    ? p.nodes
+        .map((raw, index): Node<CardData> | null => {
+          if (!isRecord(raw)) return null;
+          const data = isRecord(raw.data) ? raw.data : {};
+          const type = isCardType(raw.type)
+            ? raw.type
+            : isCardType(data.cardType)
+              ? data.cardType
+              : null;
+          if (!type) return null;
+          const positionRaw = isRecord(raw.position) ? raw.position : {};
+          const styleRaw = isRecord(raw.style) ? raw.style : {};
+          const title =
+            typeof data.title === 'string' && data.title.trim()
+              ? data.title
+              : 'Card';
+          // Issue #385 (codex review #3): node.position が有限値でも極端 (|x|>1M 等)
+          // だと viewport が正常でもカードが viewport 外で見えず実質黒画面になる。
+          // rescue 距離を超える座標は fallback grid に戻して可視性を担保する。
+          const rawX = finiteOr(positionRaw.x, (index % 6) * (NODE_W + 32));
+          const rawY = finiteOr(positionRaw.y, Math.floor(index / 6) * (NODE_H + 32));
+          const safeX =
+            Math.abs(rawX) > VIEWPORT_RESCUE_DISTANCE
+              ? (index % 6) * (NODE_W + 32)
+              : rawX;
+          const safeY =
+            Math.abs(rawY) > VIEWPORT_RESCUE_DISTANCE
+              ? Math.floor(index / 6) * (NODE_H + 32)
+              : rawY;
+          return {
+            ...(raw as Partial<Node<CardData>>),
+            id: typeof raw.id === 'string' && raw.id ? raw.id : newId(type),
+            type,
+            position: { x: safeX, y: safeY },
+            data: {
+              ...data,
+              cardType: type,
+              title,
+              payload: data.payload
+            },
+            style: {
+              ...styleRaw,
+              width: finiteOr(styleRaw.width, NODE_W),
+              height: finiteOr(styleRaw.height, NODE_H)
+            }
+          };
+        })
+        .filter((n): n is Node<CardData> => n !== null)
+    : [];
+  const viewportRaw = isRecord(p.viewport) ? p.viewport : {};
+  let vpX = finiteOr(viewportRaw.x, 0);
+  let vpY = finiteOr(viewportRaw.y, 0);
+  // viewport.zoom は clampZoom 側で NaN→1 / ±Infinity→MAX/MIN を吸収する。
+  // finiteOr で潰すと Infinity が 1 にフォールバックされて clamp 仕様が崩れるので注意。
+  const vpZoom = clampZoom(
+    typeof viewportRaw.zoom === 'number' ? viewportRaw.zoom : 1
+  );
+  // nodes があるのに viewport がカード群から大きく外れていたら、nodes の中心 (= 0,0 周辺の代表点)
+  // へ寄せる。React Flow は座標を pan で表現するので、x/y が ±VIEWPORT_RESCUE_DISTANCE を
+  // 超えていたら現実的な操作で戻れない位置と判定。
+  if (
+    nodes.length > 0 &&
+    (Math.abs(vpX) > VIEWPORT_RESCUE_DISTANCE ||
+      Math.abs(vpY) > VIEWPORT_RESCUE_DISTANCE)
+  ) {
+    vpX = 0;
+    vpY = 0;
+  }
+  const teamLocks = isRecord(p.teamLocks)
+    ? Object.fromEntries(
+        Object.entries(p.teamLocks).filter(([, v]) => typeof v === 'boolean')
+      )
+    : {};
+  const stageView = STAGE_VIEWS.includes(p.stageView as StageView)
+    ? (p.stageView as StageView)
+    : 'stage';
+  const arrangeGap = ((): ArrangeGap => {
+    const gap = p.arrangeGap;
+    return gap === 'tight' || gap === 'normal' || gap === 'wide'
+      ? gap
+      : 'normal';
+  })();
+  return {
+    nodes,
+    viewport: { x: vpX, y: vpY, zoom: vpZoom },
+    stageView,
+    teamLocks,
+    arrangeGap
+  };
+}
+
+/**
+ * persist version → migration 関数 のテーブル。
+ *
+ * 各 entry は「source version (= fromVersion 直後) からその次の version へ移行する」
+ * 時に呼ばれる pure 関数。最後に必ず `normalizeCanvasState` を通すので、各 step は
+ * 「自身の責務である構造変換」だけに集中して構わない (型不正 / 範囲外値の保護は
+ * normalize が引き受ける)。
+ *
+ * 新しい persist version を追加するときは:
+ *   1. このテーブルに `[N]: (raw) => transformed` を追加
+ *   2. `stores/canvas.ts` の `version: N+1` に bump
+ *   3. `canvas-migrate.test.ts` に v(N) → v(N+1) のケースを足す
+ */
+type RawState = Record<string, unknown>;
+type StepMigrator = (raw: RawState) => RawState;
+
+const MIGRATION_STEPS: Record<number, StepMigrator> = {
+  // v1 → v2: payload.role を payload.roleProfileId にリネーム
+  1: (p) => {
+    if (!Array.isArray(p.nodes)) return p;
+    return {
+      ...p,
+      nodes: p.nodes.map((n) => {
+        if (!isRecord(n)) return n;
+        const data = (n.data ?? {}) as Record<string, unknown>;
+        const payload = (data.payload ?? {}) as Record<string, unknown>;
+        if (typeof payload.role === 'string' && !payload.roleProfileId) {
+          payload.roleProfileId = payload.role;
+        }
+        return { ...n, data: { ...data, payload } };
+      })
+    };
+  },
+  // v2 → v3 (Issue #253): 旧 NODE_W/H (480x320) → 640x400。ユーザーが手動拡大した
+  // 値は尊重するため <= LEGACY_*_THRESHOLD のときだけ引き上げる。
+  2: (p) => {
+    if (!Array.isArray(p.nodes)) return p;
+    return {
+      ...p,
+      nodes: p.nodes.map((n) => {
+        if (!isRecord(n)) return n;
+        const styleRaw = isRecord(n.style) ? n.style : {};
+        const w = typeof styleRaw.width === 'number' ? styleRaw.width : undefined;
+        const h = typeof styleRaw.height === 'number' ? styleRaw.height : undefined;
+        const nextW = w !== undefined && w <= LEGACY_NODE_W_THRESHOLD ? NODE_W : w;
+        const nextH = h !== undefined && h <= LEGACY_NODE_H_THRESHOLD ? NODE_H : h;
+        if (nextW === w && nextH === h) return n;
+        return {
+          ...n,
+          style: {
+            ...styleRaw,
+            ...(nextW !== undefined ? { width: nextW } : {}),
+            ...(nextH !== undefined ? { height: nextH } : {})
+          }
+        };
+      })
+    };
+  },
+  // v3 → v4 (Issue #385): 構造変換は不要 (normalize で吸収する)。
+  3: (p) => p
+};
+
+/**
+ * persist の `migrate` 本体。
+ * 入力 persisted state を `fromVersion` から最新 version までテーブル順に進める。
+ * 最後に `normalizeCanvasState` で型 / 範囲を最終チェックする。
+ */
+export function runCanvasMigration(
+  persisted: unknown,
+  fromVersion: number
+): NormalizedCanvasState {
+  if (!isRecord(persisted)) {
+    return normalizeCanvasState({});
+  }
+  let cur: RawState = { ...persisted };
+  // テーブル順に「fromVersion → fromVersion+1 → … → 現行」と進める。
+  // 不存在 step は no-op として扱う (将来 entry 抜けに保険)。
+  const steps = Object.keys(MIGRATION_STEPS)
+    .map((k) => Number(k))
+    .filter((v) => v >= fromVersion)
+    .sort((a, b) => a - b);
+  for (const v of steps) {
+    cur = MIGRATION_STEPS[v](cur);
+  }
+  return normalizeCanvasState(cur);
+}
+
+/**
+ * テスト用 export。zustand persist 経由ではなく直接 normalize / 定数を検証するため。
+ * 互換性のため `stores/canvas.ts` 経由でも同じオブジェクトを再 export する。
+ */
+export const __testables = {
+  normalizeCanvasState,
+  VIEWPORT_MIN_ZOOM,
+  VIEWPORT_MAX_ZOOM,
+  VIEWPORT_RESCUE_DISTANCE
+};

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -350,6 +350,20 @@ const ja: Dict = {
   'settings.apply': '適用して保存',
   'settings.custom': '（カスタム）',
 
+  // ---------- Theme labels (UserMenu / TweaksPanel / OnboardingWizard 共有) ----------
+  'theme.label.claude-dark': 'Claude Dark',
+  'theme.label.claude-light': 'Claude Light',
+  'theme.label.dark': 'ダーク',
+  'theme.label.light': 'ライト',
+  'theme.label.midnight': 'ミッドナイト',
+  'theme.label.glass': 'グラス',
+
+  // ---------- Language labels (UserMenu / TweaksPanel / LanguageSection 共有) ----------
+  'lang.label.ja': '日本語',
+  'lang.label.ja.sub': 'Japanese',
+  'lang.label.en': 'English',
+  'lang.label.en.sub': 'English',
+
   // ---------- Settings: Logs (Issue #326) ----------
   'settings.logs.title': 'ログ',
   'settings.logs.desc':
@@ -374,6 +388,8 @@ const ja: Dict = {
   'toast.notEmpty': 'フォルダが空ではありません。既存として開きます',
   'toast.openedFile': '{file} の親フォルダをプロジェクトとして読み込みました',
   'toast.terminalNotReady': 'ターミナルが起動していません',
+  'toast.settings.saveFailed': '設定の保存に失敗しました: {error}',
+  'toast.settings.projectRootFailed': 'プロジェクトルートの反映に失敗しました: {error}',
 
   // ---------- Terminal (pasteエラー等) ----------
   'terminal.pasteImageFailed': '画像保存失敗',
@@ -876,6 +892,20 @@ const en: Dict = {
   'settings.apply': 'Apply & save',
   'settings.custom': '(custom)',
 
+  // ---------- Theme labels (UserMenu / TweaksPanel / OnboardingWizard) ----------
+  'theme.label.claude-dark': 'Claude Dark',
+  'theme.label.claude-light': 'Claude Light',
+  'theme.label.dark': 'Dark',
+  'theme.label.light': 'Light',
+  'theme.label.midnight': 'Midnight',
+  'theme.label.glass': 'Glass',
+
+  // ---------- Language labels (UserMenu / TweaksPanel / LanguageSection) ----------
+  'lang.label.ja': '日本語',
+  'lang.label.ja.sub': 'Japanese',
+  'lang.label.en': 'English',
+  'lang.label.en.sub': 'English',
+
   // ---------- Settings: Logs (Issue #326) ----------
   'settings.logs.title': 'Logs',
   'settings.logs.desc':
@@ -900,6 +930,8 @@ const en: Dict = {
   'toast.notEmpty': 'Folder is not empty. Opening as existing project',
   'toast.openedFile': 'Loaded parent folder of {file} as project',
   'toast.terminalNotReady': 'Terminal is not ready',
+  'toast.settings.saveFailed': 'Failed to save settings: {error}',
+  'toast.settings.projectRootFailed': 'Failed to apply project root: {error}',
 
   // ---------- Status ----------
   // ---------- Terminal (paste errors) ----------

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -54,64 +54,162 @@ loader.config({ monaco });
 /*
  * Claude 公式風カスタムテーマ (skill: claude-design 準拠)
  *
- *   - 背景 = bg-1 (warm near-black #171716 / warm off-white #f8f8f6)
- *   - 前景 = text-1 (#f8f8f6 / #141413)
+ *   - 背景 = bg-1 (warm near-black / warm off-white)
+ *   - 前景 = text-1 (高コントラスト)
  *   - diff 配色は成功緑 / 危険赤を 10% tint で (bg 薄色、ガター記号は鮮色)
  *   - 他のトークン色は vs-dark / vs の安定色にフォールバック (上書き最小)
+ *
+ * 色値は **`styles/tokens.css` の `[data-theme='claude-{dark,light}']` ブロックを唯一の
+ * source of truth** とし、ここでは `getComputedStyle` でその CSS 変数を読み出してから
+ * `defineTheme` に流し込む。旧実装は同じ hex を `themes.ts` / `tokens.css` /
+ * `monaco-setup.ts` の 3 箇所に書いており、片方を直し忘れて Monaco 単独が古い色のまま
+ * になる事故が起きやすかった (Issue #490)。
  */
-monaco.editor.defineTheme('claude-dark', {
-  base: 'vs-dark',
-  inherit: true,
-  rules: [],
-  colors: {
-    'editor.background': '#171716',
-    'editor.foreground': '#f8f8f6',
-    'editor.lineHighlightBackground': '#1f1f1e',
-    'editor.lineHighlightBorder': '#00000000',
-    'editorCursor.foreground': '#d97757',
-    'editor.selectionBackground': '#2c2c2a',
-    'editor.inactiveSelectionBackground': '#24241f',
-    'editorLineNumber.foreground': '#6d6c66',
-    'editorLineNumber.activeForeground': '#c3c2b7',
-    'editorIndentGuide.background1': '#232321',
-    'editorIndentGuide.activeBackground1': '#373734',
-    // diff: 10% tint (skill セクション 6)
-    'diffEditor.insertedTextBackground': '#578a0019',
-    'diffEditor.removedTextBackground': '#cf3a3a19',
-    'diffEditor.insertedLineBackground': '#578a000d',
-    'diffEditor.removedLineBackground': '#cf3a3a0d',
-    'diffEditorGutter.insertedLineBackground': '#578a0033',
-    'diffEditorGutter.removedLineBackground': '#cf3a3a33',
-    'scrollbarSlider.background': '#2c2c2a80',
-    'scrollbarSlider.hoverBackground': '#373734a0',
-    'scrollbarSlider.activeBackground': '#373734cc'
-  }
-});
 
-monaco.editor.defineTheme('claude-light', {
-  base: 'vs',
-  inherit: true,
-  rules: [],
-  colors: {
-    'editor.background': '#f8f8f6',
-    'editor.foreground': '#141413',
-    'editor.lineHighlightBackground': '#efeeeb',
-    'editor.lineHighlightBorder': '#00000000',
-    'editorCursor.foreground': '#d97757',
-    'editor.selectionBackground': '#e6e5e0',
-    'editor.inactiveSelectionBackground': '#efeeeb',
-    'editorLineNumber.foreground': '#b5b3ac',
-    'editorLineNumber.activeForeground': '#373734',
-    'editorIndentGuide.background1': '#ece9e2',
-    'editorIndentGuide.activeBackground1': '#c3c2b7',
-    'diffEditor.insertedTextBackground': '#578a0019',
-    'diffEditor.removedTextBackground': '#cf3a3a19',
-    'diffEditor.insertedLineBackground': '#578a000d',
-    'diffEditor.removedLineBackground': '#cf3a3a0d',
-    'diffEditorGutter.insertedLineBackground': '#578a0033',
-    'diffEditorGutter.removedLineBackground': '#cf3a3a33'
+/** ブラウザ非依存の安全な hex 色。`getComputedStyle` が空文字 (= まだ CSS が未適用)
+ *  を返したときの fallback。値は tokens.css claude-dark の代表色を引用。 */
+const MONACO_FALLBACK = {
+  cdBg: '#171716',
+  cdPanel: '#1f1f1e',
+  cdElev: '#2c2c2a',
+  cdText: '#f8f8f6',
+  cdTextDim: '#c3c2b7',
+  cdAccent: '#d97757',
+  clBg: '#f8f8f6',
+  clPanel: '#efeeeb',
+  clText: '#141413',
+  clTextDim: '#373734'
+} as const;
+
+function readVar(probe: HTMLElement, name: string, fallback: string): string {
+  if (typeof window === 'undefined') return fallback;
+  const v = getComputedStyle(probe).getPropertyValue(name).trim();
+  return v || fallback;
+}
+
+interface ProbeColors {
+  bg: string;
+  panel: string;
+  elev: string;
+  text: string;
+  textDim: string;
+  accent: string;
+}
+
+function probeThemeColors(themeName: 'claude-dark' | 'claude-light', fb: ProbeColors): ProbeColors {
+  if (typeof document === 'undefined' || !document.body) {
+    return fb;
   }
-});
+  // tokens.css の `[data-theme='X']` blocks に hit させるための一時要素。
+  // display:none で renderer に表示はしないが、getComputedStyle は data-theme の
+  // cascade を尊重して resolve した値を返してくれる。
+  const el = document.createElement('div');
+  el.setAttribute('data-theme', themeName);
+  el.style.display = 'none';
+  document.body.appendChild(el);
+  try {
+    return {
+      bg: readVar(el, '--bg', fb.bg),
+      panel: readVar(el, '--bg-panel', fb.panel),
+      elev: readVar(el, '--bg-elev', fb.elev),
+      text: readVar(el, '--text', fb.text),
+      textDim: readVar(el, '--text-dim', fb.textDim),
+      accent: readVar(el, '--accent', fb.accent)
+    };
+  } finally {
+    el.remove();
+  }
+}
+
+/**
+ * Claude diff エディタのインク (10% tint)。
+ * tokens.css の `--claude-success` / `--claude-danger` を直接 hex8 に展開する。
+ * Monaco は alpha 付き hex (`#RRGGBBAA`) を受け付けるため固定で OK。
+ *
+ * 色値自体は tokens.css と完全一致 (`#578a00` / `#cf3a3a`)。
+ */
+const DIFF_TINTS = {
+  insertedText: '#578a0019',
+  removedText: '#cf3a3a19',
+  insertedLine: '#578a000d',
+  removedLine: '#cf3a3a0d',
+  insertedGutter: '#578a0033',
+  removedGutter: '#cf3a3a33'
+} as const;
+
+function defineMonacoThemes(): void {
+  const cd = probeThemeColors('claude-dark', {
+    bg: MONACO_FALLBACK.cdBg,
+    panel: MONACO_FALLBACK.cdPanel,
+    elev: MONACO_FALLBACK.cdElev,
+    text: MONACO_FALLBACK.cdText,
+    textDim: MONACO_FALLBACK.cdTextDim,
+    accent: MONACO_FALLBACK.cdAccent
+  });
+  const cl = probeThemeColors('claude-light', {
+    bg: MONACO_FALLBACK.clBg,
+    panel: MONACO_FALLBACK.clPanel,
+    elev: MONACO_FALLBACK.clPanel,
+    text: MONACO_FALLBACK.clText,
+    textDim: MONACO_FALLBACK.clTextDim,
+    accent: MONACO_FALLBACK.cdAccent
+  });
+
+  monaco.editor.defineTheme('claude-dark', {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [],
+    colors: {
+      'editor.background': cd.bg,
+      'editor.foreground': cd.text,
+      'editor.lineHighlightBackground': cd.panel,
+      'editor.lineHighlightBorder': '#00000000',
+      'editorCursor.foreground': cd.accent,
+      'editor.selectionBackground': cd.elev,
+      'editor.inactiveSelectionBackground': '#24241f',
+      'editorLineNumber.foreground': '#6d6c66',
+      'editorLineNumber.activeForeground': cd.textDim,
+      'editorIndentGuide.background1': '#232321',
+      'editorIndentGuide.activeBackground1': '#373734',
+      'diffEditor.insertedTextBackground': DIFF_TINTS.insertedText,
+      'diffEditor.removedTextBackground': DIFF_TINTS.removedText,
+      'diffEditor.insertedLineBackground': DIFF_TINTS.insertedLine,
+      'diffEditor.removedLineBackground': DIFF_TINTS.removedLine,
+      'diffEditorGutter.insertedLineBackground': DIFF_TINTS.insertedGutter,
+      'diffEditorGutter.removedLineBackground': DIFF_TINTS.removedGutter,
+      'scrollbarSlider.background': '#2c2c2a80',
+      'scrollbarSlider.hoverBackground': '#373734a0',
+      'scrollbarSlider.activeBackground': '#373734cc'
+    }
+  });
+
+  monaco.editor.defineTheme('claude-light', {
+    base: 'vs',
+    inherit: true,
+    rules: [],
+    colors: {
+      'editor.background': cl.bg,
+      'editor.foreground': cl.text,
+      'editor.lineHighlightBackground': cl.panel,
+      'editor.lineHighlightBorder': '#00000000',
+      'editorCursor.foreground': cl.accent,
+      'editor.selectionBackground': '#e6e5e0',
+      'editor.inactiveSelectionBackground': cl.panel,
+      'editorLineNumber.foreground': '#b5b3ac',
+      'editorLineNumber.activeForeground': cl.textDim,
+      'editorIndentGuide.background1': '#ece9e2',
+      'editorIndentGuide.activeBackground1': '#c3c2b7',
+      'diffEditor.insertedTextBackground': DIFF_TINTS.insertedText,
+      'diffEditor.removedTextBackground': DIFF_TINTS.removedText,
+      'diffEditor.insertedLineBackground': DIFF_TINTS.insertedLine,
+      'diffEditor.removedLineBackground': DIFF_TINTS.removedLine,
+      'diffEditorGutter.insertedLineBackground': DIFF_TINTS.insertedGutter,
+      'diffEditorGutter.removedLineBackground': DIFF_TINTS.removedGutter
+    }
+  });
+}
+
+defineMonacoThemes();
 
 // 初期化を確実に完了させる
 export const monacoReady = loader.init();

--- a/src/renderer/src/lib/settings-context.tsx
+++ b/src/renderer/src/lib/settings-context.tsx
@@ -13,6 +13,8 @@ import {
 import { DEFAULT_SETTINGS, type AppSettings } from '../../../types/shared';
 import { migrateSettings } from './settings-migrate';
 import { applyDensity, applyTheme, THEMES } from './themes';
+import { bridgedToast } from './toast-bridge';
+import { translate } from './i18n';
 
 interface SettingsContextValue {
   settings: AppSettings;
@@ -168,7 +170,14 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
     if (effectiveRoot === lastSyncedRootRef.current) return;
     lastSyncedRootRef.current = effectiveRoot;
     void window.api.app.setProjectRoot(effectiveRoot).catch((err) => {
-      console.warn('[settings] setProjectRoot failed:', err);
+      // Issue #490: console.warn だと開発者しか気付けないため Toast に昇格。
+      // SettingsProvider は ToastProvider の親なので bridge 経由で通知する。
+      bridgedToast(
+        translate(settingsRef.current.language ?? 'ja', 'toast.settings.projectRootFailed', {
+          error: String(err)
+        }),
+        { tone: 'error' }
+      );
     });
   }, [settingsState.lastOpenedRoot, settingsState.claudeCwd]);
 
@@ -182,7 +191,14 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
       saveTimerRef.current = window.setTimeout(() => {
         saveTimerRef.current = null;
         void window.api.settings.save(settingsRef.current).catch((err) => {
-          console.error('[settings] 保存失敗:', err);
+          // Issue #490: 旧実装は console.error で開発者にしか届かなかった。
+          // ユーザーに気付ける Toast に昇格 (Provider 順序は ToastProvider が子なので bridge 経由)。
+          bridgedToast(
+            translate(settingsRef.current.language ?? 'ja', 'toast.settings.saveFailed', {
+              error: String(err)
+            }),
+            { tone: 'error' }
+          );
         });
       }, 200);
     },

--- a/src/renderer/src/lib/themes.ts
+++ b/src/renderer/src/lib/themes.ts
@@ -1,5 +1,18 @@
 import type { Density, ThemeName } from '../../../types/shared';
 
+/**
+ * 各テーマの色は **`styles/tokens.css` の `[data-theme='X']` ブロックを唯一の
+ * source of truth** として扱う。`applyTheme` で `data-theme` 属性を切替えれば
+ * CSS 側が cascade で全変数を差し替える。
+ *
+ * ここで保持している hex 値は以下の **JS 側でしか到達できない経路** のための
+ * mirror であり、tokens.css 側と必ず一致させること:
+ *   - `xterm-theme.ts` が xterm.js に渡す `ITheme` (CSS var を解決できないライブラリ)
+ *   - `OnboardingWizard` のプレビューで `[data-theme]` を被せられない外側の構造
+ *
+ * Monaco 用の重複は撤廃済み: `monaco-setup.ts` は同じ CSS 変数を `getComputedStyle`
+ * 経由で読む (Issue #490)。
+ */
 export interface ThemeVars {
   bg: string;
   bgPanel: string;
@@ -217,55 +230,13 @@ function isClaudeTheme(name: ThemeName): boolean {
   return name === 'claude-light' || name === 'claude-dark';
 }
 
-function setThemeColorVars(root: HTMLElement, theme: ThemeVars): void {
-  const vars: Record<string, string> = {
-    '--bg': theme.bg,
-    '--bg-panel': theme.bgPanel,
-    '--bg-sidebar': theme.bgSidebar,
-    '--bg-toolbar': theme.bgToolbar,
-    '--bg-elev': theme.bgElev,
-    '--border': theme.border,
-    '--border-strong': theme.borderStrong,
-    '--bg-hover': theme.bgHover,
-    '--bg-active': theme.bgActive,
-    '--accent': theme.accent,
-    '--accent-hover': theme.accentHover,
-    '--accent-soft': theme.accentSoft,
-    '--accent-tint': theme.accentTint,
-    '--accent-foreground': theme.accentForeground,
-    '--warning': theme.warning,
-    '--warning-hover': theme.warningHover,
-    '--text': theme.text,
-    '--text-dim': theme.textDim,
-    '--text-mute': theme.textMute,
-    '--text-strong': theme.text,
-    '--text-secondary': theme.textDim,
-    '--text-subtle': theme.textMute,
-    '--fg': theme.text,
-    '--fg-muted': theme.textDim,
-    '--fg-subtle': theme.textMute,
-    '--surface-base': theme.bg,
-    '--surface-panel': theme.bgPanel,
-    '--surface-sidebar': theme.bgSidebar,
-    '--surface-toolbar': theme.bgToolbar,
-    '--surface-elev': theme.bgElev,
-    '--surface-hover': theme.bgHover,
-    '--surface-active': theme.bgActive,
-    '--surface-glass': theme.surfaceGlass,
-    '--focus-ring': theme.focusRing
-  };
-
-  for (const [name, value] of Object.entries(vars)) {
-    root.style.setProperty(name, value);
-  }
-}
-
 export function applyTheme(name: ThemeName, uiFontFamily: string, uiFontSize: number): void {
-  const theme = THEMES[name] ?? THEMES['claude-dark'];
   const root = document.documentElement;
   const claudeTheme = isClaudeTheme(name);
 
-  setThemeColorVars(root, theme);
+  // 色変数 (--bg / --text / --accent ...) は `tokens.css` の `[data-theme='X']`
+  // ブロックが cascade で流し込むため、ここでは imperative な setProperty は不要。
+  // `data-theme` 属性切替だけで全変数が差し替わる。
   root.style.setProperty('--ui-font', uiFontFamily);
   root.style.setProperty('--ui-font-size', `${uiFontSize}px`);
   root.style.setProperty('--heading-font', claudeTheme ? HEADING_FONT_SERIF : HEADING_FONT_SANS);

--- a/src/renderer/src/lib/toast-bridge.ts
+++ b/src/renderer/src/lib/toast-bridge.ts
@@ -1,0 +1,46 @@
+import type { ToastOptions } from './toast-context';
+
+/**
+ * Toast を React Context の外側 (= `ToastProvider` の親側) から使うための bridge。
+ *
+ * `SettingsProvider` は `ToastProvider` の **親** なので `useToast` を直接呼べない。
+ * 一方、`SettingsProvider` の保存失敗 / setProjectRoot 失敗は **ユーザーに見える形で
+ * 知らせる** べきだが、`console.error` だと開発者しか気付けない。
+ *
+ * このモジュールは「ToastProvider がマウント時に自分の `showToast` を register、
+ * SettingsProvider 側はその参照経由で通知する」という最小の wiring を提供する。
+ * register 前 (= ToastProvider が未マウント / unmount 後) の呼び出しは silently no-op。
+ *
+ * 実装は単一のクロージャ参照のみ。グローバル listener や event 系の重い設備は不要。
+ */
+
+type ShowToastFn = (message: string, options?: ToastOptions) => unknown;
+
+let registeredShowToast: ShowToastFn | null = null;
+
+/** `ToastProvider` が自分の `showToast` を bridge に register する。
+ *  unmount 時は同じ参照を `null` に戻して dangling 呼び出しを防ぐ。
+ *  StrictMode の double-mount 等で複数登録された場合は **最後勝ち** で上書きする
+ *  (古い provider は既に unmount 直前か、新しい方が現役なため)。 */
+export function registerToastBridge(fn: ShowToastFn): () => void {
+  registeredShowToast = fn;
+  return () => {
+    if (registeredShowToast === fn) {
+      registeredShowToast = null;
+    }
+  };
+}
+
+/** Provider 外のコード (e.g. `SettingsProvider` の保存失敗ハンドラ) から呼び出す。
+ *  Toast が利用可能なら表示、未登録なら `console.error` にフォールバックする。 */
+export function bridgedToast(message: string, options?: ToastOptions): void {
+  if (registeredShowToast) {
+    registeredShowToast(message, options);
+    return;
+  }
+  // Provider 外で Toast がまだ立ち上がっていないタイミング (アプリ起動直後 等) は
+  // せめてコンソールに残しておく。Toast に出せた時点では console には流さず、
+  // ユーザーへの通知に一本化する。
+  // eslint-disable-next-line no-console
+  console.error('[toast-bridge]', message);
+}

--- a/src/renderer/src/lib/toast-context.tsx
+++ b/src/renderer/src/lib/toast-context.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import { X } from 'lucide-react';
 import { useT } from './i18n';
+import { registerToastBridge } from './toast-bridge';
 
 /**
  * グローバルなトースト通知（Undoアクション付き）基盤。
@@ -123,6 +124,11 @@ export function ToastProvider({ children }: { children: ReactNode }): JSX.Elemen
       timers.clear();
     };
   }, []);
+
+  // Issue #490: `SettingsProvider` (= `ToastProvider` の親) からも Toast を出せるように
+  // 自分の showToast を bridge に register する。Provider 外コードは `bridgedToast()`
+  // 経由で同じ表示パスに乗る。
+  useEffect(() => registerToastBridge(showToast), [showToast]);
 
   return (
     <ToastContext.Provider value={value}>

--- a/src/renderer/src/stores/canvas-selectors.ts
+++ b/src/renderer/src/stores/canvas-selectors.ts
@@ -1,0 +1,29 @@
+/**
+ * Canvas store の selector hook 群。
+ *
+ * `useCanvasStore((s) => s.xxx)` を component から直書きする pattern を集約し、
+ * 「どの key を購読しているか」を hook 名から一目で読めるようにする。
+ *
+ * action 系 (setNodes / addCard / pulseEdge 等) はここに含めない:
+ *   - zustand の action 参照は同一 store identity の間 stable なので、selector で
+ *     購読する必要が無い (stable identity は再レンダーを引き起こさない)。
+ *   - 既存のホットパスがそのまま `useCanvasStore((s) => s.setXxx)` を使い続けても
+ *     同じキャッシュ挙動になるため、敢えて hook ラッパーを増やさない。
+ */
+import { useCanvasStore } from './canvas';
+import type { Edge, Node, Viewport } from '@xyflow/react';
+import type { CardData, StageView } from './canvas';
+
+export const useCanvasNodes = (): Node<CardData>[] =>
+  useCanvasStore((s) => s.nodes);
+
+export const useCanvasEdges = (): Edge[] => useCanvasStore((s) => s.edges);
+
+export const useCanvasViewport = (): Viewport =>
+  useCanvasStore((s) => s.viewport);
+
+export const useCanvasTeamLocks = (): Record<string, boolean> =>
+  useCanvasStore((s) => s.teamLocks);
+
+export const useCanvasStageView = (): StageView =>
+  useCanvasStore((s) => s.stageView);

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -12,6 +12,14 @@ import {
   unifyTerminalSize,
   type ArrangeGap
 } from '../lib/canvas-arrange';
+import {
+  NODE_W as NODE_W_DEFAULT,
+  NODE_H as NODE_H_DEFAULT,
+  __testables as MIGRATION_TESTABLES,
+  newId,
+  runCanvasMigration,
+  normalizeCanvasState
+} from '../lib/canvas-migrations';
 
 export type CardType = 'terminal' | 'agent' | 'editor' | 'diff' | 'fileTree' | 'changes';
 
@@ -90,12 +98,11 @@ export type StageView = 'stage' | 'list' | 'focus';
 
 /**
  * カード初期幅/高さ (新規 addCard 時に適用)。
- * Issue #253: 旧 480x320 では Codex/Claude TUI のヘッダーが折り返しで崩れがちだったため
- * 640x400 に引き上げ。永続化された旧サイズ (<=480 / <=320) のノードは persist v3 migration
- * で同じ値に拡大される。ユーザーが手動でそれより大きくリサイズした値は尊重。
+ * 値の実体は `lib/canvas-migrations.ts` に集約 (persist v3 の閾値定数と一緒に管理する
+ * ことで「初期サイズと migration 閾値が同期している」を読みやすくしている)。
  */
-export const NODE_W = 640;
-export const NODE_H = 400;
+export const NODE_W = NODE_W_DEFAULT;
+export const NODE_H = NODE_H_DEFAULT;
 /**
  * NodeResizer の最小幅/高さ (ユーザーが手動縮小したときの下限)。
  * Issue #253: ターミナル UI が崩れず Codex/Claude TUI が読める下限として 480x280。
@@ -103,162 +110,6 @@ export const NODE_H = 400;
  */
 export const NODE_MIN_W = 480;
 export const NODE_MIN_H = 280;
-/** persist v3 で既存ユーザーのカードを引き上げる閾値 (これ以下のサイズなら NODE_W/H に拡大) */
-const LEGACY_NODE_W_THRESHOLD = 480;
-const LEGACY_NODE_H_THRESHOLD = 320;
-const CARD_TYPES: CardType[] = ['terminal', 'agent', 'editor', 'diff', 'fileTree', 'changes'];
-const STAGE_VIEWS: StageView[] = ['stage', 'list', 'focus'];
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function isCardType(value: unknown): value is CardType {
-  return typeof value === 'string' && CARD_TYPES.includes(value as CardType);
-}
-
-function finiteOr(value: unknown, fallback: number): number {
-  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
-}
-
-/**
- * Issue #385: Canvas viewport の `zoom` を可視範囲にクランプし、
- * `x` / `y` が極端な値 (= 全カードが viewport 外) のときは復帰用の値に戻す。
- * これらは render 中に React Flow が黒画面化する/カードが見えなくなる主要因。
- */
-const VIEWPORT_MIN_ZOOM = 0.1;
-const VIEWPORT_MAX_ZOOM = 4;
-/** nodes ありで viewport がここまで離れていたら「外れすぎ」と判定して復帰用 viewport にする */
-const VIEWPORT_RESCUE_DISTANCE = 1_000_000;
-
-function clampZoom(zoom: number): number {
-  // NaN は単位が無いので 1 (= 等倍) にフォールバック。±Infinity は Math.min/max で
-  // それぞれ MAX_ZOOM / MIN_ZOOM にクランプされる。
-  if (Number.isNaN(zoom)) return 1;
-  return Math.min(Math.max(zoom, VIEWPORT_MIN_ZOOM), VIEWPORT_MAX_ZOOM);
-}
-
-interface NormalizedCanvasState {
-  nodes: Node<CardData>[];
-  viewport: Viewport;
-  stageView: StageView;
-  teamLocks: Record<string, boolean>;
-  arrangeGap: ArrangeGap;
-}
-
-/**
- * 永続化データ / merge 入力を React Flow が安全に描画できる形へ正規化する。
- * - nodes: 必須プロパティの欠損 / 不正値を補い、type 不明な要素は捨てる
- * - viewport.zoom: [VIEWPORT_MIN_ZOOM, VIEWPORT_MAX_ZOOM] にクランプ
- * - viewport.x/y: 非有限なら 0、極端な値で nodes が完全に外れていれば nodes 中心へ復帰
- * - stageView / teamLocks / arrangeGap: 不正な値ならデフォルトに戻す
- */
-function normalizeCanvasState(input: unknown): NormalizedCanvasState {
-  const p = isRecord(input) ? input : {};
-  const nodes = Array.isArray(p.nodes)
-    ? p.nodes
-        .map((raw, index): Node<CardData> | null => {
-          if (!isRecord(raw)) return null;
-          const data = isRecord(raw.data) ? raw.data : {};
-          const type = isCardType(raw.type)
-            ? raw.type
-            : isCardType(data.cardType)
-              ? data.cardType
-              : null;
-          if (!type) return null;
-          const positionRaw = isRecord(raw.position) ? raw.position : {};
-          const styleRaw = isRecord(raw.style) ? raw.style : {};
-          const title =
-            typeof data.title === 'string' && data.title.trim()
-              ? data.title
-              : 'Card';
-          // Issue #385 (codex review #3): node.position が有限値でも極端 (|x|>1M 等)
-          // だと viewport が正常でもカードが viewport 外で見えず実質黒画面になる。
-          // rescue 距離を超える座標は fallback grid に戻して可視性を担保する。
-          const rawX = finiteOr(positionRaw.x, (index % 6) * (NODE_W + 32));
-          const rawY = finiteOr(positionRaw.y, Math.floor(index / 6) * (NODE_H + 32));
-          const safeX =
-            Math.abs(rawX) > VIEWPORT_RESCUE_DISTANCE
-              ? (index % 6) * (NODE_W + 32)
-              : rawX;
-          const safeY =
-            Math.abs(rawY) > VIEWPORT_RESCUE_DISTANCE
-              ? Math.floor(index / 6) * (NODE_H + 32)
-              : rawY;
-          return {
-            ...(raw as Partial<Node<CardData>>),
-            id: typeof raw.id === 'string' && raw.id ? raw.id : newId(type),
-            type,
-            position: { x: safeX, y: safeY },
-            data: {
-              ...data,
-              cardType: type,
-              title,
-              payload: data.payload
-            },
-            style: {
-              ...styleRaw,
-              width: finiteOr(styleRaw.width, NODE_W),
-              height: finiteOr(styleRaw.height, NODE_H)
-            }
-          };
-        })
-        .filter((n): n is Node<CardData> => n !== null)
-    : [];
-  const viewportRaw = isRecord(p.viewport) ? p.viewport : {};
-  let vpX = finiteOr(viewportRaw.x, 0);
-  let vpY = finiteOr(viewportRaw.y, 0);
-  // viewport.zoom は clampZoom 側で NaN→1 / ±Infinity→MAX/MIN を吸収する。
-  // finiteOr で潰すと Infinity が 1 にフォールバックされて clamp 仕様が崩れるので注意。
-  const vpZoom = clampZoom(
-    typeof viewportRaw.zoom === 'number' ? viewportRaw.zoom : 1
-  );
-  // nodes があるのに viewport がカード群から大きく外れていたら、nodes の中心 (= 0,0 周辺の代表点)
-  // へ寄せる。React Flow は座標を pan で表現するので、x/y が ±VIEWPORT_RESCUE_DISTANCE を
-  // 超えていたら現実的な操作で戻れない位置と判定。
-  if (
-    nodes.length > 0 &&
-    (Math.abs(vpX) > VIEWPORT_RESCUE_DISTANCE ||
-      Math.abs(vpY) > VIEWPORT_RESCUE_DISTANCE)
-  ) {
-    vpX = 0;
-    vpY = 0;
-  }
-  const teamLocks = isRecord(p.teamLocks)
-    ? Object.fromEntries(
-        Object.entries(p.teamLocks).filter(([, v]) => typeof v === 'boolean')
-      )
-    : {};
-  const stageView = STAGE_VIEWS.includes(p.stageView as StageView)
-    ? (p.stageView as StageView)
-    : 'stage';
-  const arrangeGap = ((): ArrangeGap => {
-    const gap = p.arrangeGap;
-    return gap === 'tight' || gap === 'normal' || gap === 'wide'
-      ? gap
-      : 'normal';
-  })();
-  return {
-    nodes,
-    viewport: { x: vpX, y: vpY, zoom: vpZoom },
-    stageView,
-    teamLocks,
-    arrangeGap
-  };
-}
-
-/**
- * Issue #157: 旧 `Date.now() + counter` 方式は zustand persist 復元 + リロード後の
- * counter リセットで稀に衝突しうる。crypto.randomUUID() で衝突確率を実質ゼロに。
- * (Tauri WebView2 / 主要ブラウザでサポート済み。fallback 環境では Math.random ベースで補う)。
- */
-function newId(prefix: string): string {
-  const u =
-    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-      ? crypto.randomUUID()
-      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-  return `${prefix}-${u}`;
-}
 
 /**
  * Issue #156: pulseEdge の TTL 用 setTimeout ハンドルを edge.id ごとに保持する。
@@ -271,13 +122,9 @@ const pulseTimers = new Map<string, number>();
 
 /** Issue #385: テストから直接 normalize の挙動を検証するための export。
  *  本体は zustand persist の migrate / merge から間接呼出しされるが、unit test では
- *  この export を使って壊れた localStorage 入力 / 極端な viewport などの境界条件を確認する。 */
-export const __testables = {
-  normalizeCanvasState,
-  VIEWPORT_MIN_ZOOM,
-  VIEWPORT_MAX_ZOOM,
-  VIEWPORT_RESCUE_DISTANCE
-};
+ *  この export を使って壊れた localStorage 入力 / 極端な viewport などの境界条件を確認する。
+ *  実体は `lib/canvas-migrations.ts` 側に移し、こちらは互換維持のための re-export。 */
+export const __testables = MIGRATION_TESTABLES;
 
 export const useCanvasStore = create<CanvasState>()(
   /**
@@ -447,47 +294,12 @@ export const useCanvasStore = create<CanvasState>()(
       // させる。同 version の rehydrate でも `merge` で再正規化するため、runtime で
       // 紛れ込んだ NaN viewport / 範囲外 zoom / 壊れた node も次回起動時には掃除される。
       version: 4,
-      migrate: (persisted, fromVersion) => {
-        if (!isRecord(persisted)) {
-          return normalizeCanvasState({}) as Partial<CanvasState>;
-        }
-        const p: Record<string, unknown> = { ...persisted };
-        // v1 → v2: payload.role を payload.roleProfileId にリネーム
-        if (fromVersion < 2 && Array.isArray(p.nodes)) {
-          p.nodes = p.nodes.map((n) => {
-            if (!isRecord(n)) return n;
-            const data = (n.data ?? {}) as Record<string, unknown>;
-            const payload = (data.payload ?? {}) as Record<string, unknown>;
-            if (typeof payload.role === 'string' && !payload.roleProfileId) {
-              payload.roleProfileId = payload.role;
-            }
-            return { ...n, data: { ...data, payload } };
-          });
-        }
-        // v2 → v3 (Issue #253): 旧 NODE_W/H (480x320) → 640x400。ユーザーが手動拡大した
-        // 値は尊重するため <= LEGACY_*_THRESHOLD のときだけ引き上げ。
-        if (fromVersion < 3 && Array.isArray(p.nodes)) {
-          p.nodes = p.nodes.map((n) => {
-            if (!isRecord(n)) return n;
-            const styleRaw = isRecord(n.style) ? n.style : {};
-            const w = typeof styleRaw.width === 'number' ? styleRaw.width : undefined;
-            const h = typeof styleRaw.height === 'number' ? styleRaw.height : undefined;
-            const nextW = w !== undefined && w <= LEGACY_NODE_W_THRESHOLD ? NODE_W : w;
-            const nextH = h !== undefined && h <= LEGACY_NODE_H_THRESHOLD ? NODE_H : h;
-            if (nextW === w && nextH === h) return n;
-            return {
-              ...n,
-              style: {
-                ...styleRaw,
-                ...(nextW !== undefined ? { width: nextW } : {}),
-                ...(nextH !== undefined ? { height: nextH } : {})
-              }
-            };
-          });
-        }
-        // v3 → v4 (Issue #385): 構造変換は不要 (normalize で吸収する)。
-        return normalizeCanvasState(p) as Partial<CanvasState>;
-      },
+      // 各 version の差分は `lib/canvas-migrations.ts` の `MIGRATION_STEPS` に集約。
+      // ここでは「fromVersion → 最新」を 1 行で進めるだけ。最後に必ず normalize を通すので
+      // 同 version の rehydrate でも runtime に紛れ込んだ NaN viewport / 範囲外 zoom /
+      // 壊れた node が掃除され、Canvas 真っ黒の症状を防ぐ。
+      migrate: (persisted, fromVersion) =>
+        runCanvasMigration(persisted, fromVersion) as Partial<CanvasState>,
       // Issue #385: 同 version でも rehydrate のたびに normalize を走らせる。
       // 旧実装は migrate 経由の正規化だけだったため、現バージョンで保存された
       // 不正値 (極端な viewport 等) を起動時に拾えず、Canvas 真っ黒の症状を引き起こしていた。

--- a/src/renderer/src/styles/components/onboarding.css
+++ b/src/renderer/src/styles/components/onboarding.css
@@ -334,16 +334,23 @@
     0 0 0 6px color-mix(in srgb, var(--accent) 16%, transparent);
 }
 
+/*
+ * Issue #490: テーマプレビューは `data-theme={name}` を outer div に被せて、
+ * tokens.css の `[data-theme='X']` ブロックがこのサブツリーだけに別テーマの
+ * `--bg` / `--accent` などを供給する仕組みに切り替えた。子要素は `var(--xxx)`
+ * を参照するだけでよい。
+ */
 .onboarding__theme-preview {
   position: relative;
   height: 68px;
   border-radius: 8px;
-  border: 1px solid transparent;
+  border: 1px solid var(--border);
   padding: 10px 12px;
   overflow: hidden;
   display: flex;
   flex-direction: column;
   gap: 6px;
+  background: var(--bg);
 }
 
 .onboarding__theme-preview-bar {
@@ -353,6 +360,7 @@
   right: 0;
   height: 10px;
   opacity: 0.75;
+  background: var(--bg-panel);
 }
 
 .onboarding__theme-preview-line {
@@ -366,6 +374,16 @@
   margin-top: 0;
 }
 
+.onboarding__theme-preview-line--strong {
+  background: var(--text);
+  opacity: 0.82;
+}
+
+.onboarding__theme-preview-line--dim {
+  background: var(--text-dim);
+  width: 52%;
+}
+
 .onboarding__theme-preview-dot {
   position: absolute;
   bottom: 10px;
@@ -373,6 +391,7 @@
   width: 8px;
   height: 8px;
   border-radius: 999px;
+  background: var(--accent);
 }
 
 .onboarding__theme-name {
@@ -467,6 +486,9 @@
 /* ---------- Done ---------- */
 
 .onboarding__done-mark {
+  /* Issue #490: 旧 inline `style={{ background: themeAccent }}` を撤去し、
+   * 現在の data-theme cascade から解決される `--accent` を直接利用する。 */
+  background: var(--accent);
   width: 84px;
   height: 84px;
   border-radius: 999px;

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -270,8 +270,272 @@ samp,
   font-variant-numeric: tabular-nums slashed-zero;
 }
 
+/* ==========================================================================
+ * Per-theme color cascade
+ *
+ * 各テーマの色は data-theme 属性で切り替わる。`:root[data-theme='X']` で
+ * <html> 全体に適用し、同じ値を `[data-theme='X']` でネスト要素 (OnboardingWizard
+ * のテーマプレビュー等) にも適用できるようにする。CSS 変数の cascade を活用して
+ * `style={{ background: 'var(--bg)' }}` だけで該当テーマの色が引ける。
+ *
+ * 旧 themes.ts の `setThemeColorVars` が `root.style.setProperty` で動的に流し込んで
+ * いた値を、ここに静的に集約する。Monaco エディタの claude-dark / claude-light も
+ * 同じ変数を `getComputedStyle` で読み取って duplicate を解消する。
+ * ========================================================================== */
+
+:root[data-theme='claude-dark'],
+[data-theme='claude-dark'] {
+  /*
+   * Claude.ai 本体の CSS 変数実測値に準拠:
+   *   app bg = --_gray-840 (#171716), surface1 = --_gray-800 (#1f1f1e),
+   *   deep   = --_gray-860 (#121212), surface raised = --_gray-750 (#2c2c2a),
+   *   text   = --_gray-20 (#f8f8f6) / 200 (#c3c2b7) / 350 (#97958c)
+   */
+  --bg: #171716;
+  --bg-panel: #1f1f1e;
+  --bg-sidebar: #121212;
+  --bg-toolbar: rgba(23, 23, 22, 0.62);
+  --bg-elev: #2c2c2a;
+  --bg-hover: rgba(248, 248, 246, 0.06);
+  --bg-active: rgba(217, 119, 87, 0.14);
+  --border: rgba(248, 248, 246, 0.10);
+  --border-strong: rgba(248, 248, 246, 0.16);
+  --accent: #d97757;
+  --accent-hover: #e88a6a;
+  --accent-soft: #d97757;
+  --accent-tint: rgba(217, 119, 87, 0.12);
+  --accent-foreground: #fffdf7;
+  --warning: #d4a27f;
+  --warning-hover: #e0b592;
+  --text: #f8f8f6;
+  --text-dim: #c3c2b7;
+  --text-mute: #97958c;
+  --text-strong: var(--text);
+  --text-secondary: var(--text-dim);
+  --text-subtle: var(--text-mute);
+  --fg: var(--text);
+  --fg-muted: var(--text-dim);
+  --fg-subtle: var(--text-mute);
+  --surface-base: var(--bg);
+  --surface-panel: var(--bg-panel);
+  --surface-sidebar: var(--bg-sidebar);
+  --surface-toolbar: var(--bg-toolbar);
+  --surface-elev: var(--bg-elev);
+  --surface-hover: var(--bg-hover);
+  --surface-active: var(--bg-active);
+  --surface-glass: rgba(23, 23, 22, 0.62);
+  --focus-ring: 0 0 0 3px rgba(217, 119, 87, 0.28);
+  color-scheme: dark;
+}
+
+:root[data-theme='claude-light'],
+[data-theme='claude-light'] {
+  /*
+   * Claude.ai 実測: bg-100=#f8f8f6 / bg-200=#f4f4f1 / bg-300=#efeeeb / bg-400=#e6e5e0,
+   * text=#141413 / #373734 / #7b7974, accent=#d97757 (hover #c6613f)
+   */
+  --bg: #f8f8f6;
+  --bg-panel: #ffffff;
+  --bg-sidebar: #f4f4f1;
+  --bg-toolbar: rgba(248, 248, 246, 0.72);
+  --bg-elev: #ffffff;
+  --bg-hover: rgba(31, 30, 29, 0.05);
+  --bg-active: rgba(217, 119, 87, 0.12);
+  --border: rgba(31, 30, 29, 0.10);
+  --border-strong: rgba(31, 30, 29, 0.18);
+  --accent: #d97757;
+  --accent-hover: #c6613f;
+  --accent-soft: #d97757;
+  --accent-tint: rgba(217, 119, 87, 0.10);
+  --accent-foreground: #fffdf7;
+  --warning: #a86b00;
+  --warning-hover: #8f5a00;
+  --text: #141413;
+  --text-dim: #373734;
+  --text-mute: #7b7974;
+  --text-strong: var(--text);
+  --text-secondary: var(--text-dim);
+  --text-subtle: var(--text-mute);
+  --fg: var(--text);
+  --fg-muted: var(--text-dim);
+  --fg-subtle: var(--text-mute);
+  --surface-base: var(--bg);
+  --surface-panel: var(--bg-panel);
+  --surface-sidebar: var(--bg-sidebar);
+  --surface-toolbar: var(--bg-toolbar);
+  --surface-elev: var(--bg-elev);
+  --surface-hover: var(--bg-hover);
+  --surface-active: var(--bg-active);
+  --surface-glass: rgba(248, 248, 246, 0.72);
+  --focus-ring: 0 0 0 3px rgba(217, 119, 87, 0.22);
+  color-scheme: light;
+}
+
+:root[data-theme='dark'],
+[data-theme='dark'] {
+  --bg: #0b0d12;
+  --bg-panel: #101216;
+  --bg-sidebar: #0d0f14;
+  --bg-toolbar: rgba(11, 13, 18, 0.62);
+  --bg-elev: #16181d;
+  --bg-hover: rgba(255, 255, 255, 0.04);
+  --bg-active: rgba(94, 106, 210, 0.12);
+  --border: rgba(255, 255, 255, 0.06);
+  --border-strong: rgba(255, 255, 255, 0.12);
+  --accent: #5e6ad2;
+  --accent-hover: #6e7bdc;
+  --accent-soft: #8a94eb;
+  --accent-tint: rgba(94, 106, 210, 0.16);
+  --accent-foreground: #fffdf7;
+  --warning: #f5a623;
+  --warning-hover: #f7b955;
+  --text: #f7f8f8;
+  --text-dim: #8a8f98;
+  --text-mute: #62666d;
+  --text-strong: var(--text);
+  --text-secondary: var(--text-dim);
+  --text-subtle: var(--text-mute);
+  --fg: var(--text);
+  --fg-muted: var(--text-dim);
+  --fg-subtle: var(--text-mute);
+  --surface-base: var(--bg);
+  --surface-panel: var(--bg-panel);
+  --surface-sidebar: var(--bg-sidebar);
+  --surface-toolbar: var(--bg-toolbar);
+  --surface-elev: var(--bg-elev);
+  --surface-hover: var(--bg-hover);
+  --surface-active: var(--bg-active);
+  --surface-glass: rgba(11, 13, 18, 0.62);
+  --focus-ring: 0 0 0 1px rgba(8, 9, 10, 0.8), 0 0 0 3px rgba(94, 106, 210, 0.3);
+  color-scheme: dark;
+}
+
+:root[data-theme='midnight'],
+[data-theme='midnight'] {
+  --bg: #05070c;
+  --bg-panel: #0b0e15;
+  --bg-sidebar: #070910;
+  --bg-toolbar: rgba(5, 7, 12, 0.62);
+  --bg-elev: #111522;
+  --bg-hover: rgba(255, 255, 255, 0.05);
+  --bg-active: rgba(124, 92, 255, 0.18);
+  --border: rgba(255, 255, 255, 0.04);
+  --border-strong: rgba(180, 190, 255, 0.12);
+  --accent: #7c5cff;
+  --accent-hover: #9072ff;
+  --accent-soft: #a594ff;
+  --accent-tint: rgba(124, 92, 255, 0.16);
+  --accent-foreground: #fffdf7;
+  --warning: #f7b955;
+  --warning-hover: #f9c970;
+  --text: #eef2ff;
+  --text-dim: #b8c2f0;
+  --text-mute: #7a83b2;
+  --text-strong: var(--text);
+  --text-secondary: var(--text-dim);
+  --text-subtle: var(--text-mute);
+  --fg: var(--text);
+  --fg-muted: var(--text-dim);
+  --fg-subtle: var(--text-mute);
+  --surface-base: var(--bg);
+  --surface-panel: var(--bg-panel);
+  --surface-sidebar: var(--bg-sidebar);
+  --surface-toolbar: var(--bg-toolbar);
+  --surface-elev: var(--bg-elev);
+  --surface-hover: var(--bg-hover);
+  --surface-active: var(--bg-active);
+  --surface-glass: rgba(5, 7, 12, 0.62);
+  --focus-ring: 0 0 0 1px rgba(5, 7, 12, 0.86), 0 0 0 3px rgba(124, 92, 255, 0.28);
+  color-scheme: dark;
+}
+
+:root[data-theme='light'],
+[data-theme='light'] {
+  --bg: #ffffff;
+  --bg-panel: #fafafa;
+  --bg-sidebar: #f4f5f8;
+  --bg-toolbar: rgba(255, 255, 255, 0.62);
+  --bg-elev: #ffffff;
+  --bg-hover: rgba(0, 0, 0, 0.04);
+  --bg-active: rgba(0, 0, 0, 0.06);
+  --border: rgba(0, 0, 0, 0.08);
+  --border-strong: rgba(0, 0, 0, 0.14);
+  --accent: #000000;
+  --accent-hover: #18181b;
+  --accent-soft: #666666;
+  --accent-tint: rgba(0, 0, 0, 0.06);
+  --accent-foreground: #ffffff;
+  --warning: #f5a623;
+  --warning-hover: #d48806;
+  --text: #000000;
+  --text-dim: #666666;
+  --text-mute: #a1a1aa;
+  --text-strong: var(--text);
+  --text-secondary: var(--text-dim);
+  --text-subtle: var(--text-mute);
+  --fg: var(--text);
+  --fg-muted: var(--text-dim);
+  --fg-subtle: var(--text-mute);
+  --surface-base: var(--bg);
+  --surface-panel: var(--bg-panel);
+  --surface-sidebar: var(--bg-sidebar);
+  --surface-toolbar: var(--bg-toolbar);
+  --surface-elev: var(--bg-elev);
+  --surface-hover: var(--bg-hover);
+  --surface-active: var(--bg-active);
+  --surface-glass: rgba(255, 255, 255, 0.62);
+  --focus-ring: 0 0 0 1px rgba(255, 255, 255, 0.92), 0 0 0 3px rgba(0, 0, 0, 0.14);
+  color-scheme: light;
+}
+
+:root[data-theme='glass'],
+[data-theme='glass'] {
+  /*
+   * Issue #16 / #367 / #440: アクリル風テーマ (Cyber Neon ベース)。
+   * Windows Terminal "Cyber Neon" と同じ世界観 — ダーク (#0A0A1A) ベース +
+   * ネオンシアン (#00FFFF) アクセント — に揃え、OS Acrylic の light tint で
+   * 白濁する問題を「surface 自体を暗化 + 高 opacity で確保」して解決する。
+   */
+  --bg: rgba(0, 0, 0, 0);
+  --bg-panel: rgba(10, 10, 26, 0.82);
+  --bg-sidebar: rgba(8, 8, 20, 0.80);
+  --bg-toolbar: rgba(6, 6, 18, 0.78);
+  --bg-elev: rgba(20, 20, 40, 0.85);
+  --bg-hover: rgba(0, 255, 255, 0.06);
+  --bg-active: rgba(0, 255, 255, 0.14);
+  --border: rgba(0, 255, 255, 0.08);
+  --border-strong: rgba(0, 255, 255, 0.15);
+  --accent: #00FFFF;
+  --accent-hover: #33FFFF;
+  --accent-soft: #00CCCC;
+  --accent-tint: rgba(0, 255, 255, 0.14);
+  --accent-foreground: #050714;
+  --warning: #FFD700;
+  --warning-hover: #FFE033;
+  --text: #E0E0FF;
+  --text-dim: #B0B8E0;
+  --text-mute: #6070A0;
+  --text-strong: var(--text);
+  --text-secondary: var(--text-dim);
+  --text-subtle: var(--text-mute);
+  --fg: var(--text);
+  --fg-muted: var(--text-dim);
+  --fg-subtle: var(--text-mute);
+  --surface-base: var(--bg);
+  --surface-panel: var(--bg-panel);
+  --surface-sidebar: var(--bg-sidebar);
+  --surface-toolbar: var(--bg-toolbar);
+  --surface-elev: var(--bg-elev);
+  --surface-hover: var(--bg-hover);
+  --surface-active: var(--bg-active);
+  --surface-glass: rgba(10, 10, 26, 0.68);
+  --focus-ring: 0 0 0 2px rgba(0, 255, 255, 0.40);
+  color-scheme: dark;
+}
+
 /*
- * Glass テーマ専用オーバーライド。
+ * Glass テーマ専用オーバーライド (上の color cascade に加えて、glass 効果用の
+ * `--glass-*` 系トークンと、layout 透過 tint を別途上書きする)。
  * - saturate(180%) は backdrop の明色画素を増幅して "milky" 化させるため 120% に下げる。
  * - glass-border / glass-highlight も白の主張を抑える (テーマ palette 側の border と
  *   合わせて全体の白浮きを断ち切る)。


### PR DESCRIPTION
## Summary

Issue #493 (Rust 側 Phase 2 の構造リファクタ) の実装。3 つの直交するリファクタを 1 PR にバンドル。

### 1. TeamHub permissions 共通化

- 旧 `caller_has_permission(_, role, \"canRecruit\")` の string-permission 引き渡しを `Permission` enum + `check_permission(role, perm) -> Result<(), PermissionError>` に置換
- 各 tool (\`recruit\` / \`dismiss\` / \`assign_task\` / \`ack_handoff\` / \`create_leader\` / \`switch_leader\` / \`diagnostics\` / \`dynamic_role\`) は同じ \`check_permission()?\` を呼ぶ
- \`PermissionError::into_message(action)\` で tool 固有の \"permission denied: role 'X' cannot {action}\" メッセージを組み立て (verb は呼び出し側ごとに違う)
- 旧 \`caller_has_permission\` の \`async\` / \`_hub\` 引数を撤廃し純粋関数化
- hardcoded builtin 権限テーブル (Issue #136 の SSOT) は完全互換

### 2. Tool errors 統一

- 旧 \`team_hub/error.rs\` の \`RecruitError\` / \`ToolError\` / \`DismissError\` / \`SendError\` / \`AssignError\` を \`team_hub/protocol/tools/error.rs\` (新設) に集約
- \`ToolError\` 構造体に \`#[non_exhaustive]\` を付与し将来の field 追加に強く
- 共通 helper を提供:
  - \`ToolError::new(code, message)\`
  - \`ToolError::permission_denied(code_prefix, role, action)\`
  - \`ToolError::invalid_args(code_prefix, message)\`
  - \`.with_phase(phase)\` / \`.with_elapsed_ms(ms)\` builder
- flat JSON 出力 (\`{code, message, phase?, elapsed_ms?}\`) は完全互換
- \`RecruitError\` / \`DismissError\` / \`SendError\` / \`AssignError\` は \`ToolError\` の type alias として残し、既存の struct-literal も新 helper も同じ JSON を生成する
- \`team_hub/error.rs\` は \`AckError\` / \`AckFailPhase\` のみ保持 (recruit ack lifecycle 用、tool error ではない)

### 3. \`commands/settings.rs\` strong-typed

- 旧 \`serde_json::Value\` 直渡しを \`Settings\` + \`AgentConfig\` struct に置換
- \`#[serde(rename_all = \"camelCase\")]\` で renderer 側 \`AppSettings\` (\`shared.ts\`) と完全一致
- \`#[serde(default = \"...\")]\` で旧バージョン (schemaVersion=2 等) からの load を許容、欠損 field は per-field default
- 列挙系 (theme / density / language / statusMascotVariant) は \`String\` で受け、不正値は renderer 側 \`migrateSettings\` が default にフォールバック (silent loss 防止)
- 真の optional フィールドは \`Option<T>\` + \`skip_serializing_if = \"Option::is_none\"\` で missing を保持 (renderer migration の \"存在しない\" 判定を保つ)
- 不正型 (\`claudeArgs: 12345\` 等) は Tauri IPC layer で自動 reject → \`CommandError::Validation\` 経由で renderer の \`invoke()\` Promise reject に
- \`lib.rs\` の startup \`settings_restore\` は \`settings.last_opened_root\` / \`settings.theme\` の struct field access に書き換え

挙動・IPC payload・on-disk format は全て不変。

## Test plan

- [x] \`cargo check --manifest-path src-tauri/Cargo.toml\` 通過、warning 増えていない (pre-existing の team_hub/state.rs:144 のみ)
- [x] \`cargo test --manifest-path src-tauri/Cargo.toml\`: **117 passed / 0 failed**
- [x] 新規追加 16 テスト全 pass:
  - \`team_hub::protocol::permissions::tests\` (5): leader 全権 / hr 部分権 / worker 無権限 / 動的 role 無権限 / \`into_message\` の verb ハンドリング
  - \`team_hub::protocol::tools::error::tests\` (5): flat JSON 互換 / permission_denied helper / invalid_args helper / phase+elapsed_ms chain / 4 alias の同型性
  - \`commands::settings::tests\` (6): default の camelCase shape / partial JSON load / legacy v0/v1 load / 不正型 reject / AgentConfig optional fields / unknown fields ignore
- [ ] 実機: 設定モーダルから保存 → 不正値 (\`density: 'invalid'\` 等) で Toast 表示 (renderer 側で既存の Toast 経路を使う)
- [ ] 実機: TeamHub で recruit / dismiss / send を実行して挙動同等
- [x] \`tauri-ipc-commands\` skill の 5 点同期確認:
  - \`shared.ts\` AppSettings: 変更なし
  - \`commands/settings.rs\` Settings struct: \`#[serde(rename_all = \"camelCase\")]\` 付与済
  - \`commands/mod.rs\`: 既存 \`pub mod settings;\` のまま (新ファイルなし)
  - \`lib.rs\` invoke_handler!: \`settings_load\` / \`settings_save\` 既登録のまま
  - \`tauri-api.ts\`: 既存 wrapper のまま (IPC payload 互換のため変更不要)

Closes #493