### PR TITLE
refactor(rust): TeamHub permissions / tool errors を統一し AppSettings を serde struct 化 (#493)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -3,11 +3,22 @@
 // userData/settings.json に AppSettings を保存。
 // 既存 Electron では app.getPath('userData') を使っていたが、
 // Tauri では `~/.vibe-editor/settings.json` に統一する (シンプル化)。
-// Electron からの移行時は旧 settings.json を一度 import する処理が必要 (Phase 1 後半 TODO)。
+//
+// Issue #493 (Phase 2): 旧 `serde_json::Value` 直渡しを `Settings` strong-typed struct に
+// 置換した。`#[serde(rename_all = "camelCase")]` で renderer 側の AppSettings と完全一致、
+// `#[serde(default)]` で旧バージョン (schemaVersion=2 等) からの load を許容する。
+// 不正な型 (`claudeArgs` が string でない等) は Tauri IPC layer で自動 reject され、renderer 側
+// `invoke()` の Promise が reject される (renderer 側 SettingsContext で Toast 表示済み)。
+//
+// 列挙値 (`theme` / `density` / `language` / `statusMascotVariant`) は `String` で受ける。
+// 既存値が新バージョンの ThemeName 等にマッチしないケースを silent に消さないため。
+// 不正値は renderer 側 `migrateSettings` が default にフォールバックする。
 
 use crate::commands::atomic_write::atomic_write;
+use crate::commands::error::{CommandError, CommandResult};
 use once_cell::sync::Lazy;
-use serde_json::Value;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use tokio::fs;
 use tokio::sync::Mutex;
 
@@ -15,19 +26,216 @@ use tokio::sync::Mutex;
 /// どちらかが temp rename 競合して 1 つが失敗しうるが、この Mutex で書き込みを 1 つずつに。
 static SAVE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
+/// `~/.vibe-editor/settings.json` の serde 表現。renderer 側 `src/types/shared.ts` の
+/// `AppSettings` と完全一致 (camelCase ですべての field が同名・同型)。
+///
+/// 設計指針:
+/// - 必須フィールドにも `#[serde(default = "...")]` を付けて、旧バージョンの settings.json から
+///   load しても missing field でエラーにならないようにする。
+/// - 列挙系 (theme/density/language/statusMascotVariant) は `String` で受け、enum 化はしない。
+///   既存ユーザーの値が新 ThemeName ユニオンにマッチしないとき、silent に default に戻すと
+///   ユーザー設定が消失する事故が起きるため、value 検証は renderer 側 `migrateSettings` に任せる。
+/// - 真に optional (renderer 側 `?` 付き) なフィールドは `Option<T>` で、`None` のときは
+///   `skip_serializing_if` で JSON 出力から省略 (renderer migration が "存在しない" 判定で
+///   default 投入してくれる)。
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Settings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<u32>,
+    #[serde(default = "default_language")]
+    pub language: String,
+    #[serde(default = "default_theme")]
+    pub theme: String,
+    #[serde(default = "default_ui_font_family")]
+    pub ui_font_family: String,
+    #[serde(default = "default_ui_font_size")]
+    pub ui_font_size: f64,
+    #[serde(default = "default_editor_font_family")]
+    pub editor_font_family: String,
+    #[serde(default = "default_editor_font_size")]
+    pub editor_font_size: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_font_family: Option<String>,
+    #[serde(default = "default_terminal_font_size")]
+    pub terminal_font_size: f64,
+    #[serde(default = "default_density")]
+    pub density: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_mascot_variant: Option<String>,
+
+    // ---------- Claude Code 起動オプション ----------
+    #[serde(default = "default_claude_command")]
+    pub claude_command: String,
+    #[serde(default)]
+    pub claude_args: String,
+    #[serde(default)]
+    pub claude_cwd: String,
+    #[serde(default)]
+    pub last_opened_root: String,
+    #[serde(default)]
+    pub recent_projects: Vec<String>,
+    #[serde(default)]
+    pub workspace_folders: Vec<String>,
+    #[serde(default = "default_claude_code_panel_width")]
+    pub claude_code_panel_width: f64,
+    #[serde(default = "default_sidebar_width")]
+    pub sidebar_width: f64,
+
+    // ---------- Codex ----------
+    #[serde(default = "default_codex_command")]
+    pub codex_command: String,
+    #[serde(default)]
+    pub codex_args: String,
+
+    #[serde(default)]
+    pub notepad: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub has_completed_onboarding: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_agents: Option<Vec<AgentConfig>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_auto_setup: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub webview_zoom: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_tree_expanded: Option<HashMap<String, Vec<String>>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_tree_collapsed_roots: Option<Vec<String>>,
+}
+
+/// shared.ts `AgentConfig` を mirror。`cwd` / `color` は optional。
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentConfig {
+    pub id: String,
+    pub name: String,
+    pub command: String,
+    pub args: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+}
+
+// `Settings::default()` は renderer の `DEFAULT_SETTINGS` と一致させる。
+// initial install で settings.json が無いとき / parse 失敗時に返す値。
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            schema_version: Some(APP_SETTINGS_SCHEMA_VERSION),
+            language: default_language(),
+            theme: default_theme(),
+            ui_font_family: default_ui_font_family(),
+            ui_font_size: default_ui_font_size(),
+            editor_font_family: default_editor_font_family(),
+            editor_font_size: default_editor_font_size(),
+            terminal_font_family: Some(default_terminal_font_family()),
+            terminal_font_size: default_terminal_font_size(),
+            density: default_density(),
+            status_mascot_variant: Some("vibe".to_string()),
+            claude_command: default_claude_command(),
+            claude_args: String::new(),
+            claude_cwd: String::new(),
+            last_opened_root: String::new(),
+            recent_projects: Vec::new(),
+            workspace_folders: Vec::new(),
+            claude_code_panel_width: default_claude_code_panel_width(),
+            sidebar_width: default_sidebar_width(),
+            codex_command: default_codex_command(),
+            codex_args: String::new(),
+            notepad: String::new(),
+            has_completed_onboarding: Some(false),
+            custom_agents: Some(Vec::new()),
+            mcp_auto_setup: Some(true),
+            webview_zoom: None,
+            file_tree_expanded: Some(HashMap::new()),
+            file_tree_collapsed_roots: Some(Vec::new()),
+        }
+    }
+}
+
+// ---- per-field defaults (`#[serde(default = "...")]` から参照) ----
+//
+// renderer 側 `DEFAULT_SETTINGS` と完全一致させる。新フィールド追加時は両方を同時に更新する。
+
+/// Issue #75 / #449: 現在のスキーマ版数。`shared.ts APP_SETTINGS_SCHEMA_VERSION` と同期。
+pub const APP_SETTINGS_SCHEMA_VERSION: u32 = 10;
+
+fn default_language() -> String {
+    "ja".to_string()
+}
+
+fn default_theme() -> String {
+    "claude-dark".to_string()
+}
+
+fn default_ui_font_family() -> String {
+    "'Inter Variable', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', \
+     'Hiragino Sans', 'Yu Gothic UI', sans-serif"
+        .to_string()
+}
+
+fn default_ui_font_size() -> f64 {
+    14.0
+}
+
+fn default_editor_font_family() -> String {
+    "'JetBrains Mono Variable', 'Geist Mono Variable', 'Cascadia Code', 'Consolas', monospace"
+        .to_string()
+}
+
+fn default_editor_font_size() -> f64 {
+    13.0
+}
+
+fn default_terminal_font_family() -> String {
+    "'JetBrainsMono Nerd Font Mono', 'JetBrains Mono Variable', 'Cascadia Mono', \
+     'Cascadia Code', Consolas, 'Lucida Console', 'Segoe UI Symbol', monospace"
+        .to_string()
+}
+
+fn default_terminal_font_size() -> f64 {
+    13.0
+}
+
+fn default_density() -> String {
+    "normal".to_string()
+}
+
+fn default_claude_command() -> String {
+    "claude".to_string()
+}
+
+fn default_codex_command() -> String {
+    "codex".to_string()
+}
+
+fn default_claude_code_panel_width() -> f64 {
+    460.0
+}
+
+fn default_sidebar_width() -> f64 {
+    272.0
+}
+
 #[tauri::command]
-pub async fn settings_load() -> Value {
+pub async fn settings_load() -> Settings {
     tracing::info!("[IPC] settings_load called");
     let path = crate::util::config_paths::settings_path();
     let Ok(bytes) = fs::read(&path).await else {
-        return Value::Null;
+        // Issue #29: 初回起動 / 読み取り不能時は default を返す。renderer 側 `migrateSettings`
+        // は schemaVersion=10 (current) で呼ばれることになるので migration は no-op、
+        // shallow merge で DEFAULT_SETTINGS と一致した値が settingsRef に乗る。
+        return Settings::default();
     };
-    match serde_json::from_slice::<Value>(&bytes) {
+    match serde_json::from_slice::<Settings>(&bytes) {
         Ok(v) => v,
         Err(e) => {
             // Issue #170: 旧実装は parse 失敗時に黙って Null を返し、次の save で
             // ユーザー設定が完全消失する事故が起きていた。.bak に元ファイルを退避してから
-            // Null を返すことで、ユーザーが手動で復元できるようにする。
+            // default を返すことで、ユーザーが手動で復元できるようにする。
+            // Issue #493: strong-typing 後も `.bak` 退避は同じ流儀で維持する。
             tracing::error!(
                 "[settings] parse failed ({}), backing up to settings.json.bak",
                 e
@@ -35,18 +243,122 @@ pub async fn settings_load() -> Value {
             let bak = path.with_extension("json.bak");
             // best-effort: バックアップが取れなくても続行
             let _ = atomic_write(&bak, &bytes).await;
-            Value::Null
+            Settings::default()
         }
     }
 }
 
 #[tauri::command]
-pub async fn settings_save(settings: Value) -> crate::commands::error::CommandResult<()> {
+pub async fn settings_save(settings: Settings) -> CommandResult<()> {
     let _g = SAVE_LOCK.lock().await;
     let path = crate::util::config_paths::settings_path();
-    let json = serde_json::to_vec_pretty(&settings).map_err(|e| e.to_string())?;
+    let json = serde_json::to_vec_pretty(&settings)?;
     // Issue #37: 書き込み中の crash で settings.json が半端 JSON にならないよう atomic
-    Ok(atomic_write(&path, &json)
+    atomic_write(&path, &json)
         .await
-        .map_err(|e| e.to_string())?)
+        .map_err(|e| CommandError::Internal(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// `Settings::default()` が renderer の `DEFAULT_SETTINGS` と camelCase で同名同値であること。
+    #[test]
+    fn default_settings_serializes_to_expected_camelcase_shape() {
+        let s = Settings::default();
+        let v = serde_json::to_value(&s).unwrap();
+        assert_eq!(v["schemaVersion"], json!(APP_SETTINGS_SCHEMA_VERSION));
+        assert_eq!(v["language"], json!("ja"));
+        assert_eq!(v["theme"], json!("claude-dark"));
+        assert_eq!(v["density"], json!("normal"));
+        assert_eq!(v["uiFontSize"], json!(14.0));
+        assert_eq!(v["editorFontSize"], json!(13.0));
+        assert_eq!(v["terminalFontSize"], json!(13.0));
+        assert_eq!(v["claudeCommand"], json!("claude"));
+        assert_eq!(v["codexCommand"], json!("codex"));
+        assert_eq!(v["claudeCodePanelWidth"], json!(460.0));
+        assert_eq!(v["sidebarWidth"], json!(272.0));
+        assert_eq!(v["mcpAutoSetup"], json!(true));
+        assert_eq!(v["hasCompletedOnboarding"], json!(false));
+        // webviewZoom は None なので skip_serializing
+        assert!(v.get("webviewZoom").is_none());
+    }
+
+    /// Issue #170 互換: 部分的な JSON でも `serde(default)` で field 単位 fallback が効く。
+    #[test]
+    fn partial_json_loads_with_defaults() {
+        let raw = json!({
+            "schemaVersion": 5,
+            "theme": "dark",
+            // 他は意図的に欠損
+        });
+        let s: Settings = serde_json::from_value(raw).unwrap();
+        assert_eq!(s.schema_version, Some(5));
+        assert_eq!(s.theme, "dark");
+        // missing fields は default に
+        assert_eq!(s.language, "ja");
+        assert_eq!(s.ui_font_size, 14.0);
+        assert_eq!(s.claude_command, "claude");
+    }
+
+    /// Issue #493: 旧バージョン (schemaVersion=0 / 1) からの load も deserialize 失敗しないこと。
+    /// renderer 側 `migrateSettings` が古い値を新スキーマに昇格させる。
+    #[test]
+    fn legacy_v0_v1_settings_load_without_error() {
+        let v0 = json!({
+            "language": "en",
+            "theme": "light",
+            // schemaVersion 無し (= 旧 v0)
+            "claudeCwd": "/home/user/proj",
+            "recentProjects": ["/a", "/b"],
+        });
+        let s: Settings = serde_json::from_value(v0).unwrap();
+        assert_eq!(s.schema_version, None);
+        assert_eq!(s.language, "en");
+        assert_eq!(s.claude_cwd, "/home/user/proj");
+        assert_eq!(s.recent_projects, vec!["/a".to_string(), "/b".to_string()]);
+    }
+
+    /// 不正な型 (`claudeArgs` が number) は deserialize で reject される。
+    /// Tauri IPC layer がこれを CommandError として renderer に返す経路。
+    #[test]
+    fn invalid_field_type_rejected_with_validation_error() {
+        let bad = json!({ "claudeArgs": 12345 });
+        let res: Result<Settings, _> = serde_json::from_value(bad);
+        assert!(res.is_err());
+    }
+
+    /// `customAgents` の `cwd` / `color` は optional。両方欠落しても deserialize できる。
+    #[test]
+    fn agent_config_optional_fields() {
+        let raw = json!({
+            "customAgents": [
+                { "id": "x", "name": "X", "command": "x", "args": "" }
+            ]
+        });
+        let s: Settings = serde_json::from_value(raw).unwrap();
+        let agents = s.custom_agents.unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].id, "x");
+        assert!(agents[0].cwd.is_none());
+        assert!(agents[0].color.is_none());
+    }
+
+    /// 未知フィールドは silent に drop される (forward-compat 寄り、内部仕様)。
+    /// 重要: 既知フィールドの型ミスマッチは reject、未知フィールドは無視。
+    #[test]
+    fn unknown_fields_are_ignored() {
+        let raw = json!({
+            "language": "ja",
+            "futureField": "future-value"
+        });
+        let s: Settings = serde_json::from_value(raw).unwrap();
+        assert_eq!(s.language, "ja");
+        // future-value は drop される (deny_unknown_fields は使っていない)
+        let back = serde_json::to_value(&s).unwrap();
+        assert!(back.get("futureField").is_none());
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -210,19 +210,12 @@ pub fn run() {
             // までの空白で「透過 conf.json なのに effect 未適用 → 完全透明」になるのを防ぐ)。
             let app_handle_for_root = app.handle().clone();
             spawn_observed("settings_restore", async move {
+                // Issue #493: settings_load は Settings struct を返すようになった。
+                // last_opened_root を優先し、空なら claudeCwd を fallback。
                 let settings = commands::settings::settings_load().await;
-                let root = settings
-                    .get("lastOpenedRoot")
-                    .and_then(|v| v.as_str())
-                    .map(str::to_owned)
+                let root = Some(settings.last_opened_root.clone())
                     .filter(|s| !s.trim().is_empty())
-                    .or_else(|| {
-                        settings
-                            .get("claudeCwd")
-                            .and_then(|v| v.as_str())
-                            .map(str::to_owned)
-                            .filter(|s| !s.trim().is_empty())
-                    });
+                    .or_else(|| Some(settings.claude_cwd.clone()).filter(|s| !s.trim().is_empty()));
                 if let Some(root) = root {
                     let state = app_handle_for_root.state::<state::AppState>();
                     // Issue #147: poison でも recovery
@@ -239,8 +232,7 @@ pub fn run() {
                 // - glass テーマは renderer のテーマ適用直後に Acrylic が乗るが、settings_load の
                 //   disk read を待つ僅かな時間だけ「不透明 #171716 の上に panel が薄く乗る」状態
                 //   になる。実機検証で気になるなら PR-2 でカスタム title bar 化と同時に再評価する。
-                let theme = settings.get("theme").and_then(|v| v.as_str()).unwrap_or("");
-                if theme == "glass" {
+                if settings.theme == "glass" {
                     if let Some(win) = app_handle_for_root.get_webview_window("main") {
                         let res = commands::app::apply_window_effects_for_startup(&win, true);
                         tracing::info!(

--- a/src-tauri/src/team_hub/error.rs
+++ b/src-tauri/src/team_hub/error.rs
@@ -1,45 +1,8 @@
-// Issue #342 Phase 1 / Phase 3: 構造化エラー型。
+// Issue #342 Phase 1 / Phase 3 + Issue #493: Hub レベルの構造化エラー型。
 //
-// MCP の各ツール失敗を呼び出し側 (renderer / Claude / Codex) が `code` で機械的に
-// 分岐できるように、`result.content[0].text` の JSON 文字列内に詰める形で返す。
-// Phase 1 で `RecruitError` を追加し、Phase 3 (3.9) で `DismissError` / `SendError` /
-// `AssignError` を `ToolError` 共通型 + 型エイリアスで横展開した。
-// すべて `code` / `message` / `phase` / `elapsed_ms` の 4 フィールド共通形。
-
-use serde::Serialize;
-
-/// `team_recruit` 失敗時に MCP 戻り値へ詰める構造化エラー。
-///
-/// シリアライズ後の例:
-/// ```json
-/// {"code":"recruit_ack_timeout","message":"...","phase":"ack","elapsed_ms":5012}
-/// ```
-#[derive(Clone, Debug, Serialize)]
-pub struct RecruitError {
-    pub code: String,
-    pub message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub phase: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub elapsed_ms: Option<u64>,
-}
-
-impl std::fmt::Display for RecruitError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl RecruitError {
-    /// JSON 文字列化して `Err(String)` に詰めるヘルパ。
-    /// to_string() に失敗したら message だけを返す (生 String fallback)。
-    pub fn into_err_string(self) -> String {
-        match serde_json::to_string(&self) {
-            Ok(s) => s,
-            Err(_) => self.message,
-        }
-    }
-}
+// 旧 `RecruitError` / `ToolError` (各 MCP tool が `Err(String)` に詰める前段の構造化エラー) は
+// Issue #493 で `team_hub/protocol/tools/error.rs` に移動した。本ファイルには
+// recruit ack lifecycle / pending 管理の内部診断用 enum のみを残す。
 
 /// `app_recruit_ack` invoke で renderer から渡される失敗 phase。
 ///
@@ -96,43 +59,3 @@ impl std::fmt::Display for AckError {
         }
     }
 }
-
-/// Issue #342 Phase 3 (3.9): `team_dismiss` / `team_send` / `team_assign_task` の構造化エラー
-/// 共通型。`RecruitError` と同形 (code / message / phase / elapsed_ms) で、JSON 化してから
-/// `Err(String)` に詰めて MCP `result.content[0].text` のオブジェクト値として返す。
-///
-/// 呼び出し側は `code` で機械的に分岐できる:
-///   - `dismiss_*` (例: `dismiss_permission_denied`, `dismiss_not_found`)
-///   - `send_*`    (例: `send_payload_too_large`, `send_invalid_args`)
-///   - `assign_*`  (例: `assign_permission_denied`, `assign_unknown_assignee`)
-#[derive(Clone, Debug, Serialize)]
-pub struct ToolError {
-    pub code: String,
-    pub message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub phase: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub elapsed_ms: Option<u64>,
-}
-
-impl std::fmt::Display for ToolError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl ToolError {
-    pub fn into_err_string(self) -> String {
-        match serde_json::to_string(&self) {
-            Ok(s) => s,
-            Err(_) => self.message,
-        }
-    }
-}
-
-/// `team_dismiss` 失敗用 (code 名前空間 `dismiss_*`)
-pub type DismissError = ToolError;
-/// `team_send` 失敗用 (code 名前空間 `send_*`)
-pub type SendError = ToolError;
-/// `team_assign_task` 失敗用 (code 名前空間 `assign_*`)
-pub type AssignError = ToolError;

--- a/src-tauri/src/team_hub/protocol/dynamic_role.rs
+++ b/src-tauri/src/team_hub/protocol/dynamic_role.rs
@@ -12,7 +12,7 @@ use super::consts::{
     MAX_DYNAMIC_DESCRIPTION_LEN, MAX_DYNAMIC_INSTRUCTIONS_LEN, MAX_DYNAMIC_LABEL_LEN,
     MAX_DYNAMIC_ROLES_PER_TEAM,
 };
-use super::permissions::caller_has_permission;
+use super::permissions::{check_permission, Permission};
 
 /// 動的ロール定義 1 件を検証 + 登録。team_recruit の role_definition / team_create_role の両方から使う。
 /// 既存 builtin (summary 上) と被る role_id は拒否、上限超過も拒否、長さ上限も拒否する。
@@ -26,12 +26,8 @@ pub(super) async fn validate_and_register_dynamic_role(
     instructions_ja: Option<&str>,
 ) -> Result<DynamicRole, String> {
     // 権限チェック (Leader だけが動的ロールを作れる)
-    if !caller_has_permission(hub, &ctx.role, "canCreateRoleProfile").await {
-        return Err(format!(
-            "permission denied: role '{}' cannot create role profiles",
-            ctx.role
-        ));
-    }
+    check_permission(&ctx.role, Permission::CreateRoleProfile)
+        .map_err(|e| e.into_message("create role profiles"))?;
     // バリデーション: id
     let role_id = role_id.trim();
     if role_id.is_empty() {

--- a/src-tauri/src/team_hub/protocol/permissions.rs
+++ b/src-tauri/src/team_hub/protocol/permissions.rs
@@ -1,4 +1,4 @@
-//! Issue #136 (Security): caller の role が要求された permission を持つか検証する。
+//! Issue #136 (Security) + Issue #493: caller の role が要求された permission を持つか検証する。
 //!
 //! 旧実装は renderer から同期された `role_profile_summary` の can_* フラグを SSOT に
 //! していた。renderer 内コード実行 (XSS 等) を獲得した攻撃者が任意 role に
@@ -10,36 +10,182 @@
 //! 常に can_* = false 扱い (recruit / dismiss / role 作成は不可)。
 //!
 //! Issue #373 Phase 2 で `protocol.rs` から切り出し。
+//! Issue #493: 旧 `caller_has_permission(_, role, "canRecruit")` の string-permission 引き渡しを
+//! `check_permission(role, Permission::Recruit)` の type-safe enum に統一。
+//! 各 tool は `check_permission()?` を呼んで `PermissionError::into_message("recruit")` 等で
+//! "permission denied: role 'X' cannot Y" 形のエラーメッセージを生成する。
 
-use crate::team_hub::TeamHub;
+use std::fmt;
 
-pub(super) async fn caller_has_permission(
-    _hub: &TeamHub,
-    caller_role: &str,
-    perm: &str,
-) -> bool {
-    builtin_role_permission(caller_role, perm)
+/// Hub 側で hardcode された権限カテゴリ。
+///
+/// 各 variant の `as_str()` は legacy 文字列キー (`canRecruit` 等) を返す。
+/// renderer 側の `RoleProfileSummary.canRecruit` 等と一致させているが、Hub 側は
+/// この enum を SSOT として扱い、renderer 文字列は信頼しない。
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum Permission {
+    /// `canRecruit` — `team_recruit` / `team_create_leader` / `team_switch_leader` /
+    /// `team_ack_handoff` で要求。
+    Recruit,
+    /// `canDismiss` — `team_dismiss` で要求。Leader 専権 (HR でも不可)。
+    Dismiss,
+    /// `canAssignTasks` — `team_assign_task` で要求。
+    AssignTasks,
+    /// `canCreateRoleProfile` — 動的ロール定義 (`validate_and_register_dynamic_role`) で要求。
+    CreateRoleProfile,
+    /// `canViewDiagnostics` — `team_diagnostics` で要求。server log path 等の秘匿パスを
+    /// 一般 worker に晒さないために leader/hr のみ許可。
+    ViewDiagnostics,
+}
+
+impl Permission {
+    /// renderer 側 `RoleProfileSummary` フィールド名 (camelCase) と一致。
+    /// 既存ログ / テストの "canXxx" 出力を維持するための文字列化。
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Recruit => "canRecruit",
+            Self::Dismiss => "canDismiss",
+            Self::AssignTasks => "canAssignTasks",
+            Self::CreateRoleProfile => "canCreateRoleProfile",
+            Self::ViewDiagnostics => "canViewDiagnostics",
+        }
+    }
+}
+
+/// `check_permission` の失敗値。`into_message(action)` で各 tool 固有の
+/// "permission denied: role 'X' cannot {action}" エラー文を組み立てる。
+#[derive(Clone, Debug)]
+pub(super) struct PermissionError {
+    pub role: String,
+    pub permission: Permission,
+}
+
+impl PermissionError {
+    /// 既存の各 tool が出していた "permission denied: role 'X' cannot Y" 形へ整形。
+    /// `action` は tool ごとに違う (例: "recruit" / "dismiss" / "assign tasks" /
+    /// "create role profiles" / "view diagnostics" / "ack handoff" / "create leader" /
+    /// "switch leader") ので呼び出し側で指定する。
+    pub(super) fn into_message(self, action: &str) -> String {
+        format!("permission denied: role '{}' cannot {action}", self.role)
+    }
+}
+
+impl fmt::Display for PermissionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "permission denied: role '{}' lacks permission {}",
+            self.role,
+            self.permission.as_str()
+        )
+    }
+}
+
+/// Issue #493: 各 tool が呼ぶ単一の権限チェック関数。
+///
+/// builtin role の hardcoded 権限テーブルだけを参照する (renderer の summary は信頼しない)。
+/// 動的 role や未知 role は常に `Err(PermissionError)` を返す。
+pub(super) fn check_permission(role: &str, perm: Permission) -> Result<(), PermissionError> {
+    if builtin_role_permission(role, perm) {
+        Ok(())
+    } else {
+        Err(PermissionError {
+            role: role.to_string(),
+            permission: perm,
+        })
+    }
 }
 
 /// builtin role の hardcoded 権限テーブル。
 /// renderer から差し替えられないため、ここで false のロールは絶対に該当 perm を持てない。
-pub(super) fn builtin_role_permission(role: &str, perm: &str) -> bool {
+///
+/// Issue #136: leader / hr 以外は全 false。動的 role (renderer が作った任意 id) も match
+/// しないので全 false (= Hub レベルでは何もできない)。
+/// Issue #342 Phase 3 (3.5): canViewDiagnostics は leader/hr のみ true。
+/// 一般ワーカーが server_log_path 等を覗けると秘匿パス漏えいになるため default false。
+fn builtin_role_permission(role: &str, perm: Permission) -> bool {
+    use Permission::*;
     match (role, perm) {
-        // Leader: 全権
-        ("leader", "canRecruit") => true,
-        ("leader", "canDismiss") => true,
-        ("leader", "canAssignTasks") => true,
-        ("leader", "canCreateRoleProfile") => true,
-        ("leader", "canViewDiagnostics") => true,
-        // HR: 採用 + タスク割振 + 動的ロール登録 (Leader 代理として) + 診断
-        ("hr", "canRecruit") => true,
-        ("hr", "canAssignTasks") => true,
-        ("hr", "canCreateRoleProfile") => true,
-        ("hr", "canViewDiagnostics") => true,
-        // 一般ワーカー (planner / programmer / researcher / reviewer 等) はいずれも不可。
-        // 動的ロール (renderer が作った任意 id) も match しないので全 false。
-        // Issue #342 Phase 3 (3.5): canViewDiagnostics は leader/hr のみ true。
-        // 一般ワーカーが server_log_path 等を覗けると秘匿パス漏えいになるため default false。
+        // Leader: 全権 (Recruit / Dismiss / AssignTasks / CreateRoleProfile / ViewDiagnostics)
+        (
+            "leader",
+            Recruit | Dismiss | AssignTasks | CreateRoleProfile | ViewDiagnostics,
+        ) => true,
+        // HR: 採用 + タスク割振 + 動的ロール登録 + 診断 (Leader 代理として)。
+        // Dismiss は意図的に持たない (Leader 専権)。
+        ("hr", Recruit | AssignTasks | CreateRoleProfile | ViewDiagnostics) => true,
+        // 一般ワーカー (planner / programmer / researcher / reviewer 等) と動的ロールはいずれも不可。
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leader_has_all_permissions() {
+        for perm in [
+            Permission::Recruit,
+            Permission::Dismiss,
+            Permission::AssignTasks,
+            Permission::CreateRoleProfile,
+            Permission::ViewDiagnostics,
+        ] {
+            assert!(
+                check_permission("leader", perm).is_ok(),
+                "leader should have {}",
+                perm.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn hr_has_recruit_assign_create_diagnostics_but_not_dismiss() {
+        assert!(check_permission("hr", Permission::Recruit).is_ok());
+        assert!(check_permission("hr", Permission::AssignTasks).is_ok());
+        assert!(check_permission("hr", Permission::CreateRoleProfile).is_ok());
+        assert!(check_permission("hr", Permission::ViewDiagnostics).is_ok());
+        assert!(check_permission("hr", Permission::Dismiss).is_err());
+    }
+
+    #[test]
+    fn worker_roles_have_nothing() {
+        for role in ["planner", "programmer", "researcher", "reviewer"] {
+            for perm in [
+                Permission::Recruit,
+                Permission::Dismiss,
+                Permission::AssignTasks,
+                Permission::CreateRoleProfile,
+                Permission::ViewDiagnostics,
+            ] {
+                assert!(
+                    check_permission(role, perm).is_err(),
+                    "role '{role}' should not have {}",
+                    perm.as_str()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dynamic_or_unknown_roles_have_nothing() {
+        for role in ["", "rogue", "vc-12345", "leader_v2", "leadeR"] {
+            assert!(check_permission(role, Permission::Recruit).is_err());
+            assert!(check_permission(role, Permission::Dismiss).is_err());
+        }
+    }
+
+    #[test]
+    fn permission_error_into_message_uses_caller_action_verb() {
+        let err = check_permission("planner", Permission::Recruit).unwrap_err();
+        assert_eq!(
+            err.clone().into_message("recruit"),
+            "permission denied: role 'planner' cannot recruit"
+        );
+        assert_eq!(
+            err.into_message("ack handoff"),
+            "permission denied: role 'planner' cannot ack handoff"
+        );
     }
 }

--- a/src-tauri/src/team_hub/protocol/tools/ack_handoff.rs
+++ b/src-tauri/src/team_hub/protocol/tools/ack_handoff.rs
@@ -1,24 +1,20 @@
 //! tool: `team_ack_handoff` — mark a handoff as read/acked by the replacement leader.
 
-use crate::team_hub::error::ToolError;
 use crate::team_hub::{CallContext, TeamHub};
 use serde_json::{json, Value};
 
-use super::super::permissions::caller_has_permission;
+use super::super::permissions::{check_permission, Permission};
+use super::error::ToolError;
 
 pub async fn team_ack_handoff(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
 ) -> Result<Value, String> {
-    if !caller_has_permission(hub, &ctx.role, "canRecruit").await {
-        return Err(ToolError {
-            code: "ack_handoff_permission_denied".into(),
-            message: format!("permission denied: role '{}' cannot ack handoff", ctx.role),
-            phase: None,
-            elapsed_ms: None,
-        }
-        .into_err_string());
+    if let Err(e) = check_permission(&ctx.role, Permission::Recruit) {
+        return Err(
+            ToolError::permission_denied("ack_handoff", &e.role, "ack handoff").into_err_string(),
+        );
     }
 
     let handoff_id = args

--- a/src-tauri/src/team_hub/protocol/tools/assign_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/assign_task.rs
@@ -2,14 +2,14 @@
 //!
 //! Issue #373 Phase 2 で `protocol.rs` から切り出し。
 
-use crate::team_hub::error::AssignError;
 use crate::team_hub::{CallContext, TeamHub, TeamTask};
 use chrono::Utc;
 use serde_json::{json, Value};
 
 use super::super::consts::{MAX_TASKS_PER_TEAM, SOFT_PAYLOAD_LIMIT};
 use super::super::helpers::resolve_targets;
-use super::super::permissions::caller_has_permission;
+use super::super::permissions::{check_permission, Permission};
+use super::error::AssignError;
 use super::send::team_send;
 
 pub async fn team_assign_task(
@@ -19,14 +19,10 @@ pub async fn team_assign_task(
 ) -> Result<Value, String> {
     // Issue #114: 旧実装は assignee / description の空チェックだけで権限を見ておらず、
     // canAssignTasks=false のロールでも task を作成できてしまっていた。先頭で必ず権限検証する。
-    if !caller_has_permission(hub, &ctx.role, "canAssignTasks").await {
-        return Err(AssignError {
-            code: "assign_permission_denied".into(),
-            message: format!("permission denied: role '{}' cannot assign tasks", ctx.role),
-            phase: None,
-            elapsed_ms: None,
-        }
-        .into_err_string());
+    if let Err(e) = check_permission(&ctx.role, Permission::AssignTasks) {
+        return Err(
+            AssignError::permission_denied("assign", &e.role, "assign tasks").into_err_string(),
+        );
     }
     let assignee_raw = args.get("assignee").and_then(|v| v.as_str()).unwrap_or("");
     let assignee = assignee_raw.trim();

--- a/src-tauri/src/team_hub/protocol/tools/create_leader.rs
+++ b/src-tauri/src/team_hub/protocol/tools/create_leader.rs
@@ -8,7 +8,6 @@
 //! 旧 leader はこの tool で新 leader を作ったあと `team_switch_leader` で
 //! active leader を切り替え、自身のカードを retire する流れを想定する。
 
-use crate::team_hub::error::RecruitError;
 use crate::team_hub::{CallContext, TeamHub};
 use serde_json::{json, Value};
 use std::time::Instant;
@@ -16,7 +15,8 @@ use tauri::Emitter;
 use uuid::Uuid;
 
 use super::super::consts::{RECRUIT_ACK_TIMEOUT, RECRUIT_TIMEOUT};
-use super::super::permissions::caller_has_permission;
+use super::super::permissions::{check_permission, Permission};
+use super::error::RecruitError;
 
 /// `team_create_leader` — 引き継ぎ用に同 teamId へ追加の leader カードを spawn する。
 ///
@@ -34,17 +34,11 @@ pub async fn team_create_leader(
     ctx: &CallContext,
     args: &Value,
 ) -> Result<Value, String> {
-    if !caller_has_permission(hub, &ctx.role, "canRecruit").await {
-        return Err(RecruitError {
-            code: "create_leader_permission_denied".into(),
-            message: format!(
-                "permission denied: role '{}' cannot create leader",
-                ctx.role
-            ),
-            phase: None,
-            elapsed_ms: None,
-        }
-        .into_err_string());
+    if let Err(e) = check_permission(&ctx.role, Permission::Recruit) {
+        return Err(
+            RecruitError::permission_denied("create_leader", &e.role, "create leader")
+                .into_err_string(),
+        );
     }
 
     let role_profile_id = "leader".to_string();

--- a/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
+++ b/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 
 use super::super::helpers::message_is_for_me;
-use super::super::permissions::caller_has_permission;
+use super::super::permissions::{check_permission, Permission};
 
 const STALLED_INBOUND_THRESHOLD_MS: i64 = 60_000;
 
@@ -104,12 +104,8 @@ fn build_member_diagnostics_row(
 }
 
 pub async fn team_diagnostics(hub: &TeamHub, ctx: &CallContext) -> Result<Value, String> {
-    if !caller_has_permission(hub, &ctx.role, "canViewDiagnostics").await {
-        return Err(format!(
-            "permission denied: role '{}' cannot view diagnostics",
-            ctx.role
-        ));
-    }
+    check_permission(&ctx.role, Permission::ViewDiagnostics)
+        .map_err(|e| e.into_message("view diagnostics"))?;
 
     let bindings_snapshot: HashMap<String, String>;
     let diag_snapshot: HashMap<String, MemberDiagnostics>;

--- a/src-tauri/src/team_hub/protocol/tools/dismiss.rs
+++ b/src-tauri/src/team_hub/protocol/tools/dismiss.rs
@@ -2,27 +2,22 @@
 //!
 //! Issue #373 Phase 2 で `protocol.rs` から切り出し。
 
-use crate::team_hub::error::DismissError;
 use crate::team_hub::{CallContext, TeamHub};
 use chrono::Utc;
 use serde_json::{json, Value};
 use tauri::Emitter;
 
-use super::super::permissions::caller_has_permission;
+use super::super::permissions::{check_permission, Permission};
+use super::error::DismissError;
 
 pub async fn team_dismiss(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
 ) -> Result<Value, String> {
-    if !caller_has_permission(hub, &ctx.role, "canDismiss").await {
-        return Err(DismissError {
-            code: "dismiss_permission_denied".into(),
-            message: format!("permission denied: role '{}' cannot dismiss", ctx.role),
-            phase: None,
-            elapsed_ms: None,
-        }
-        .into_err_string());
+    if let Err(e) = check_permission(&ctx.role, Permission::Dismiss) {
+        return Err(DismissError::permission_denied("dismiss", &e.role, "dismiss")
+            .into_err_string());
     }
     let agent_id = args
         .get("agent_id")
@@ -30,13 +25,7 @@ pub async fn team_dismiss(
         .unwrap_or("")
         .to_string();
     if agent_id.is_empty() {
-        return Err(DismissError {
-            code: "dismiss_invalid_args".into(),
-            message: "agent_id is required".into(),
-            phase: None,
-            elapsed_ms: None,
-        }
-        .into_err_string());
+        return Err(DismissError::invalid_args("dismiss", "agent_id is required").into_err_string());
     }
     if agent_id == ctx.agent_id {
         return Err(DismissError {

--- a/src-tauri/src/team_hub/protocol/tools/error.rs
+++ b/src-tauri/src/team_hub/protocol/tools/error.rs
@@ -1,0 +1,153 @@
+//! Issue #342 Phase 1 / Phase 3 + Issue #493: 各 MCP tool が Err 経路で返す構造化エラー型。
+//!
+//! MCP の各ツール失敗を呼び出し側 (renderer / Claude / Codex) が `code` で機械的に
+//! 分岐できるように、`result.content[0].text` の JSON 文字列内に詰める形で返す。
+//! Phase 1 で `RecruitError` を導入、Phase 3 (3.9) で `DismissError` / `SendError` /
+//! `AssignError` を `ToolError` 共通型 + 型エイリアスで横展開。
+//! Issue #493: 旧 `team_hub/error.rs` から移動して各 tool 専用の error 構成と
+//! 共通 helper (`permission_denied` / `invalid_args` / `with_phase` / `with_elapsed_ms`) を集約。
+//!
+//! `Serialize` 出力は全 tool 共通で **flat JSON** (`{"code": "...", "message": "...",
+//! "phase": "...", "elapsed_ms": 1234}`)。renderer 側は `code` 文字列から `recruit_*` /
+//! `dismiss_*` / `send_*` / `assign_*` / `ack_handoff_*` / `create_leader_*` /
+//! `switch_leader_*` の名前空間で機械的に分岐できる。
+//!
+//! 各 tool は型エイリアス (`RecruitError = ToolError` 等) を import するだけで、
+//! 既存の struct-literal による組み立て (`ToolError { code, message, phase, elapsed_ms }`)
+//! と新しい helper 経由のどちらでも同じ flat JSON を出力する。
+
+use serde::Serialize;
+
+/// 全 MCP tool が `Err(String)` に詰める前段に通す共通エラー型。
+///
+/// payload 後方互換のため flat JSON シリアライズを維持。
+/// `#[non_exhaustive]` は将来 (例: `caused_by` chain や `caller_agent_id` 等) のフィールド追加で
+/// 既存 caller を破壊しないためのマーカー。同 crate 内の struct-literal 構築は引き続き許可。
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize)]
+pub struct ToolError {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elapsed_ms: Option<u64>,
+}
+
+impl ToolError {
+    /// 任意 code / message でインスタンス化。`with_phase` / `with_elapsed_ms` で追加情報を載せる。
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            phase: None,
+            elapsed_ms: None,
+        }
+    }
+
+    /// "permission denied: role 'X' cannot {action}" 形のエラーを 1 行で組み立てる。
+    /// `code_prefix` は tool ごとの命名空間 (例: `"recruit"` / `"dismiss"`)、結果 code は
+    /// `{code_prefix}_permission_denied` になる。
+    pub fn permission_denied(code_prefix: &str, role: &str, action: &str) -> Self {
+        Self::new(
+            format!("{code_prefix}_permission_denied"),
+            format!("permission denied: role '{role}' cannot {action}"),
+        )
+    }
+
+    /// "{message}" + `code = {code_prefix}_invalid_args` の不正引数エラー。
+    pub fn invalid_args(code_prefix: &str, message: impl Into<String>) -> Self {
+        Self::new(format!("{code_prefix}_invalid_args"), message)
+    }
+
+    /// 失敗 phase ("ack" / "handshake" / "spawn" 等) を後付けする builder。
+    pub fn with_phase(mut self, phase: impl Into<String>) -> Self {
+        self.phase = Some(phase.into());
+        self
+    }
+
+    /// 経過ミリ秒を後付けする builder (timeout 等の調査に使う)。
+    pub fn with_elapsed_ms(mut self, ms: u64) -> Self {
+        self.elapsed_ms = Some(ms);
+        self
+    }
+
+    /// JSON 文字列化して `Err(String)` に詰めるヘルパ。
+    /// to_string() に失敗したら message だけを返す (生 String fallback)。
+    pub fn into_err_string(self) -> String {
+        match serde_json::to_string(&self) {
+            Ok(s) => s,
+            Err(_) => self.message,
+        }
+    }
+}
+
+impl std::fmt::Display for ToolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+/// `team_recruit` / `team_create_leader` 失敗用 (code 名前空間 `recruit_*` / `create_leader_*`)。
+/// flat JSON 出力は `ToolError` と完全同一。
+pub type RecruitError = ToolError;
+/// `team_dismiss` 失敗用 (code 名前空間 `dismiss_*`)。
+pub type DismissError = ToolError;
+/// `team_send` 失敗用 (code 名前空間 `send_*`)。
+pub type SendError = ToolError;
+/// `team_assign_task` 失敗用 (code 名前空間 `assign_*`)。
+pub type AssignError = ToolError;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flat_json_payload_is_preserved() {
+        let err = ToolError::new("dismiss_permission_denied", "permission denied: role 'planner' cannot dismiss");
+        let json = err.into_err_string();
+        // 旧 RecruitError / ToolError と同じ flat shape (`{"code":"...","message":"..."}`)。
+        assert!(json.contains("\"code\":\"dismiss_permission_denied\""));
+        assert!(json.contains("\"message\":\"permission denied: role 'planner' cannot dismiss\""));
+        // optional フィールドは skip_serializing_if で省略
+        assert!(!json.contains("\"phase\""));
+        assert!(!json.contains("\"elapsed_ms\""));
+    }
+
+    #[test]
+    fn permission_denied_helper_produces_canonical_message() {
+        let err = ToolError::permission_denied("recruit", "planner", "recruit");
+        assert_eq!(err.code, "recruit_permission_denied");
+        assert_eq!(err.message, "permission denied: role 'planner' cannot recruit");
+        assert!(err.phase.is_none());
+        assert!(err.elapsed_ms.is_none());
+    }
+
+    #[test]
+    fn invalid_args_helper_uses_code_prefix() {
+        let err = ToolError::invalid_args("send", "to and message are required");
+        assert_eq!(err.code, "send_invalid_args");
+        assert_eq!(err.message, "to and message are required");
+    }
+
+    #[test]
+    fn with_phase_and_elapsed_chain() {
+        let err = ToolError::new("recruit_handshake_timeout", "agent did not handshake within 30s")
+            .with_phase("handshake")
+            .with_elapsed_ms(30_004);
+        assert_eq!(err.phase.as_deref(), Some("handshake"));
+        assert_eq!(err.elapsed_ms, Some(30_004));
+    }
+
+    #[test]
+    fn type_aliases_are_same_type() {
+        // RecruitError / DismissError / SendError / AssignError は全て ToolError の alias で、
+        // 同じ struct-literal で構築でき、同じ flat JSON にシリアライズされる。
+        let dismiss: DismissError = ToolError::new("dismiss_not_found", "...");
+        let recruit: RecruitError = ToolError::new("recruit_failed", "...");
+        let send: SendError = ToolError::new("send_payload_too_large", "...");
+        let assign: AssignError = ToolError::new("assign_unknown_assignee", "...");
+        // 型として全て同一なので `Vec<ToolError>` に詰められる。
+        let _all: Vec<ToolError> = vec![dismiss, recruit, send, assign];
+    }
+}

--- a/src-tauri/src/team_hub/protocol/tools/mod.rs
+++ b/src-tauri/src/team_hub/protocol/tools/mod.rs
@@ -1,6 +1,7 @@
 //! `team_hub::protocol::tools` — MCP `tools/call` で dispatch される各 tool の実装。
 //!
 //! Issue #373 Phase 2 で `protocol.rs` から 11 個の tool 関数を切り出し。
+//! Issue #493: 各 tool が共通で使う構造化エラー型を `error` モジュールに集約。
 //! 各 tool は `pub(super) async fn team_xxx(...)` で公開され、
 //! 親 `protocol/mod.rs` の `dispatch_tool` から呼び出される。
 
@@ -9,6 +10,7 @@ mod assign_task;
 mod create_leader;
 mod diagnostics;
 mod dismiss;
+pub(super) mod error;
 mod get_tasks;
 mod info;
 mod list_role_profiles;

--- a/src-tauri/src/team_hub/protocol/tools/recruit.rs
+++ b/src-tauri/src/team_hub/protocol/tools/recruit.rs
@@ -2,7 +2,6 @@
 //!
 //! Issue #373 Phase 2 で `protocol.rs` から切り出し。
 
-use crate::team_hub::error::RecruitError;
 use crate::team_hub::{CallContext, DynamicRole, TeamHub};
 use serde_json::{json, Value};
 use std::time::Instant;
@@ -12,7 +11,8 @@ use uuid::Uuid;
 use super::super::consts::RECRUIT_ACK_TIMEOUT;
 use super::super::consts::RECRUIT_TIMEOUT;
 use super::super::dynamic_role::validate_and_register_dynamic_role;
-use super::super::permissions::caller_has_permission;
+use super::super::permissions::{check_permission, Permission};
+use super::error::RecruitError;
 
 /// team_recruit: 新メンバーをチームに追加する。Renderer に event::emit でカード生成を依頼し、
 /// その新 agentId が handshake してくるまで oneshot で待機 (timeout 30s)。
@@ -29,12 +29,8 @@ pub async fn team_recruit(
     ctx: &CallContext,
     args: &Value,
 ) -> Result<Value, String> {
-    if !caller_has_permission(hub, &ctx.role, "canRecruit").await {
-        return Err(format!(
-            "permission denied: role '{}' cannot recruit",
-            ctx.role
-        ));
-    }
+    check_permission(&ctx.role, Permission::Recruit)
+        .map_err(|e| e.into_message("recruit"))?;
     // role_id を主引数とする。後方互換のため `role_profile_id` も受け付ける。
     let role_profile_id = args
         .get("role_id")
@@ -249,13 +245,10 @@ pub async fn team_recruit(
                 } else {
                     format!("recruit failed: {reason}")
                 };
-                return Err(RecruitError {
-                    code: "recruit_failed".into(),
-                    message,
-                    phase: Some(phase_str),
-                    elapsed_ms: Some(started.elapsed().as_millis() as u64),
-                }
-                .into_err_string());
+                return Err(RecruitError::new("recruit_failed", message)
+                    .with_phase(phase_str)
+                    .with_elapsed_ms(started.elapsed().as_millis() as u64)
+                    .into_err_string());
             }
             Ok(Err(_)) => {
                 // ack_tx が drop された (renderer 側が pending を resolve せずに崩壊) — 緊急 cancel 扱い
@@ -266,12 +259,12 @@ pub async fn team_recruit(
                         json!({ "newAgentId": new_agent_id, "reason": "ack_dropped" }),
                     );
                 }
-                return Err(RecruitError {
-                    code: "recruit_ack_dropped".into(),
-                    message: "renderer ack channel was dropped before reply".into(),
-                    phase: Some("ack".into()),
-                    elapsed_ms: Some(started.elapsed().as_millis() as u64),
-                }
+                return Err(RecruitError::new(
+                    "recruit_ack_dropped",
+                    "renderer ack channel was dropped before reply",
+                )
+                .with_phase("ack")
+                .with_elapsed_ms(started.elapsed().as_millis() as u64)
                 .into_err_string());
             }
             Err(_) => {
@@ -283,15 +276,15 @@ pub async fn team_recruit(
                         json!({ "newAgentId": new_agent_id, "reason": "ack_timeout" }),
                     );
                 }
-                return Err(RecruitError {
-                    code: "recruit_ack_timeout".into(),
-                    message: format!(
+                return Err(RecruitError::new(
+                    "recruit_ack_timeout",
+                    format!(
                         "renderer did not ack recruit-request within {}s",
                         RECRUIT_ACK_TIMEOUT.as_secs()
                     ),
-                    phase: Some("ack".into()),
-                    elapsed_ms: Some(started.elapsed().as_millis() as u64),
-                }
+                )
+                .with_phase("ack")
+                .with_elapsed_ms(started.elapsed().as_millis() as u64)
                 .into_err_string());
             }
         }
@@ -321,12 +314,12 @@ pub async fn team_recruit(
             // 永久カウントされ、再起動まで採用不能化していた。
             hub.cancel_pending_recruit(&new_agent_id).await;
             // Issue #342 Phase 1: 構造化エラーで返す (cancelled は handshake 直前 cancel 等)
-            Err(RecruitError {
-                code: "recruit_cancelled".into(),
-                message: "recruit cancelled before handshake".into(),
-                phase: Some("handshake".into()),
-                elapsed_ms: Some(started.elapsed().as_millis() as u64),
-            }
+            Err(RecruitError::new(
+                "recruit_cancelled",
+                "recruit cancelled before handshake",
+            )
+            .with_phase("handshake")
+            .with_elapsed_ms(started.elapsed().as_millis() as u64)
             .into_err_string())
         }
         Err(_) => {
@@ -340,15 +333,15 @@ pub async fn team_recruit(
                 );
             }
             // Issue #342 Phase 1: 構造化エラー化
-            Err(RecruitError {
-                code: "recruit_handshake_timeout".into(),
-                message: format!(
+            Err(RecruitError::new(
+                "recruit_handshake_timeout",
+                format!(
                     "agent did not handshake within {}s",
                     RECRUIT_TIMEOUT.as_secs()
                 ),
-                phase: Some("handshake".into()),
-                elapsed_ms: Some(started.elapsed().as_millis() as u64),
-            }
+            )
+            .with_phase("handshake")
+            .with_elapsed_ms(started.elapsed().as_millis() as u64)
             .into_err_string())
         }
     }

--- a/src-tauri/src/team_hub/protocol/tools/send.rs
+++ b/src-tauri/src/team_hub/protocol/tools/send.rs
@@ -2,8 +2,9 @@
 //!
 //! Issue #373 Phase 2 で `protocol.rs` から切り出し。
 
-use crate::team_hub::error::SendError;
 use crate::team_hub::{inject, CallContext, MemberDiagnostics, TeamHub, TeamMessage};
+
+use super::error::SendError;
 use chrono::Utc;
 use serde_json::{json, Value};
 use std::collections::HashMap;

--- a/src-tauri/src/team_hub/protocol/tools/switch_leader.rs
+++ b/src-tauri/src/team_hub/protocol/tools/switch_leader.rs
@@ -9,30 +9,24 @@
 //! 旧 leader カードを「即座に閉じる」と MCP 応答が PTY に届く前に terminal が殺され、
 //! Claude/Codex の最終発話が消える。安全のため emit を **2 秒遅延** させて応答配送猶予を確保する。
 
-use crate::team_hub::error::ToolError;
 use crate::team_hub::{CallContext, TeamHub};
 use serde_json::{json, Value};
 use std::time::Duration;
 use tauri::Emitter;
 
-use super::super::permissions::caller_has_permission;
+use super::super::permissions::{check_permission, Permission};
+use super::error::ToolError;
 
 pub async fn team_switch_leader(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
 ) -> Result<Value, String> {
-    if !caller_has_permission(hub, &ctx.role, "canRecruit").await {
-        return Err(ToolError {
-            code: "switch_leader_permission_denied".into(),
-            message: format!(
-                "permission denied: role '{}' cannot switch leader",
-                ctx.role
-            ),
-            phase: None,
-            elapsed_ms: None,
-        }
-        .into_err_string());
+    if let Err(e) = check_permission(&ctx.role, Permission::Recruit) {
+        return Err(
+            ToolError::permission_denied("switch_leader", &e.role, "switch leader")
+                .into_err_string(),
+        );
     }
 
     let new_leader_agent_id = args


### PR DESCRIPTION
## Summary

Issue #493 (Rust 側 Phase 2 の構造リファクタ) の実装。3 つの直交するリファクタを 1 PR にバンドル。

### 1. TeamHub permissions 共通化

- 旧 `caller_has_permission(_, role, "canRecruit")` の string-permission 引き渡しを `Permission` enum + `check_permission(role, perm) -> Result<(), PermissionError>` に置換
- 各 tool (`recruit` / `dismiss` / `assign_task` / `ack_handoff` / `create_leader` / `switch_leader` / `diagnostics` / `dynamic_role`) は同じ `check_permission()?` を呼ぶ
- `PermissionError::into_message(action)` で tool 固有の "permission denied: role 'X' cannot {action}" メッセージを組み立て (verb は呼び出し側ごとに違う)
- 旧 `caller_has_permission` の `async` / `_hub` 引数を撤廃し純粋関数化
- hardcoded builtin 権限テーブル (Issue #136 の SSOT) は完全互換

### 2. Tool errors 統一

- 旧 `team_hub/error.rs` の `RecruitError` / `ToolError` / `DismissError` / `SendError` / `AssignError` を `team_hub/protocol/tools/error.rs` (新設) に集約
- `ToolError` 構造体に `#[non_exhaustive]` を付与し将来の field 追加に強く
- 共通 helper を提供:
  - `ToolError::new(code, message)`
  - `ToolError::permission_denied(code_prefix, role, action)`
  - `ToolError::invalid_args(code_prefix, message)`
  - `.with_phase(phase)` / `.with_elapsed_ms(ms)` builder
- flat JSON 出力 (`{code, message, phase?, elapsed_ms?}`) は完全互換
- `RecruitError` / `DismissError` / `SendError` / `AssignError` は `ToolError` の type alias として残し、既存の struct-literal も新 helper も同じ JSON を生成する
- `team_hub/error.rs` は `AckError` / `AckFailPhase` のみ保持 (recruit ack lifecycle 用、tool error ではない)

### 3. `commands/settings.rs` strong-typed

- 旧 `serde_json::Value` 直渡しを `Settings` + `AgentConfig` struct に置換
- `#[serde(rename_all = "camelCase")]` で renderer 側 `AppSettings` (`shared.ts`) と完全一致
- `#[serde(default = "...")]` で旧バージョン (schemaVersion=2 等) からの load を許容、欠損 field は per-field default
- 列挙系 (theme / density / language / statusMascotVariant) は `String` で受け、不正値は renderer 側 `migrateSettings` が default にフォールバック (silent loss 防止)
- 真の optional フィールドは `Option<T>` + `skip_serializing_if = "Option::is_none"` で missing を保持 (renderer migration の "存在しない" 判定を保つ)
- 不正型 (`claudeArgs: 12345` 等) は Tauri IPC layer で自動 reject → `CommandError::Validation` 経由で renderer の `invoke()` Promise reject に
- `lib.rs` の startup `settings_restore` は `settings.last_opened_root` / `settings.theme` の struct field access に書き換え

挙動・IPC payload・on-disk format は全て不変。

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 通過、warning 増えていない (pre-existing の team_hub/state.rs:144 のみ)
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`: **117 passed / 0 failed**
- [x] 新規追加 16 テスト全 pass:
  - `team_hub::protocol::permissions::tests` (5): leader 全権 / hr 部分権 / worker 無権限 / 動的 role 無権限 / `into_message` の verb ハンドリング
  - `team_hub::protocol::tools::error::tests` (5): flat JSON 互換 / permission_denied helper / invalid_args helper / phase+elapsed_ms chain / 4 alias の同型性
  - `commands::settings::tests` (6): default の camelCase shape / partial JSON load / legacy v0/v1 load / 不正型 reject / AgentConfig optional fields / unknown fields ignore
- [ ] 実機: 設定モーダルから保存 → 不正値 (`density: 'invalid'` 等) で Toast 表示
- [ ] 実機: TeamHub で recruit / dismiss / send を実行して挙動同等
- [x] `tauri-ipc-commands` skill の 5 点同期確認:
  - `shared.ts` AppSettings: 変更なし
  - `commands/settings.rs` Settings struct: `#[serde(rename_all = "camelCase")]` 付与済
  - `commands/mod.rs`: 既存 `pub mod settings;` のまま (新ファイルなし)
  - `lib.rs` invoke_handler!: `settings_load` / `settings_save` 既登録のまま
  - `tauri-api.ts`: 既存 wrapper のまま (IPC payload 互換のため変更不要)

Closes #493