### PR TITLE
test(rust): commands / team_hub / pty レイヤに integration test を追加 (#494)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5215,6 +5221,7 @@ name = "vibe-editor"
 version = "1.5.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -5235,6 +5242,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-appender",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,6 +56,15 @@ encoding_rs = "0.8"
 # Issue #119: open 時のコンテンツハッシュで「同サイズ・1秒以内」の外部変更を検出する用
 sha2 = "0.11"
 
+[dev-dependencies]
+# Issue #494: integration test 用に tempfile を導入。fixture 用の tempdir を作成し、
+# `~/.vibe-editor/settings.json` / `~/.claude/projects/<encoded>/*.jsonl` /
+# git fixture repo を tempdir 配下にスタブする。
+tempfile = "3"
+# `Result` の `Err` variant を assert する際に backtrace 付きで panic させる用。
+# 旧 `assert_matches!` (nightly) の安定版代替。
+assert_matches = "1"
+
 [features]
 # デフォルトで dev tools 有効
 default = ["custom-protocol"]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -20,6 +20,12 @@ pub mod team_state;
 pub mod terminal;
 pub mod vibe_team_skill;
 
+/// Issue #494: `commands/*.rs` の integration test を集約する test-only module。
+/// Phase 1/2 で固まった IPC 境界 (settings load/save / git status/diff / sessions list /
+/// atomic_write) を tempdir + fixture で end-to-end に走らせる。
+#[cfg(test)]
+mod tests;
+
 #[tauri::command]
 pub fn ping() -> &'static str {
     "pong"

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -143,7 +143,10 @@ pub async fn sessions_list(project_root: String) -> Vec<SessionInfo> {
 ///   - message_count の「正確な数」は UI で "500+" 等と見せれば十分なので、
 ///     先頭 HEAD_LIMIT_LINES = 2000 行まで数え、超えたら上限値を返す
 ///     (正確な行数は fs::metadata の行数相当だと OS 依存で取れないので割り切る)
-async fn read_jsonl_summary(path: &std::path::Path) -> (String, u32, Option<String>) {
+///
+/// Issue #494: integration test (`commands/tests/sessions.rs`) から fixture jsonl に対して
+/// 直接呼べるよう `pub(crate)` で expose。Tauri command 経由ではないので AppHandle / State 不要。
+pub(crate) async fn read_jsonl_summary(path: &std::path::Path) -> (String, u32, Option<String>) {
     const HEAD_LIMIT_LINES: u32 = 2000;
     let Ok(f) = tokio::fs::File::open(path).await else {
         return (String::new(), 0, None);

--- a/src-tauri/src/commands/tests/git.rs
+++ b/src-tauri/src/commands/tests/git.rs
@@ -1,0 +1,210 @@
+//! Issue #494: `commands::git` の integration test。
+//!
+//! 本物の `git` バイナリで初期化した tempdir 配下の fixture repo に対して
+//! `git_status` / `git_diff` を走らせる。
+//!
+//! 実行マシンに `git` が無い CI 環境でも skip するため、各 test は冒頭で
+//! `git --version` を `which git` ではなく `Command::new("git").arg("--version").status()`
+//! で確認し、不在なら early return する (= "ok-skip" 扱い)。
+
+use crate::commands::git::{git_diff, git_status};
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+/// `git` バイナリが PATH にあるか軽量チェック。CI / 実機どちらでも `git --version` で十分。
+fn git_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// fixture repo: `git init` + identity 設定 + 初回 commit までを行う最小ヘルパ。
+/// global hook / GPG / fsmonitor を自リポ内で off にして CI に依存しないようにする。
+fn init_fixture_repo(dir: &Path) {
+    let run = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .expect("git command failed");
+        assert!(status.success(), "git {:?} failed", args);
+    };
+    run(&["init", "--initial-branch=main"]);
+    run(&["config", "user.email", "test@example.com"]);
+    run(&["config", "user.name", "Test"]);
+    run(&["config", "commit.gpgsign", "false"]);
+    run(&["config", "tag.gpgsign", "false"]);
+}
+
+fn commit_all(dir: &Path, message: &str) {
+    let run = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .expect("git command failed");
+        assert!(status.success(), "git {:?} failed", args);
+    };
+    run(&["add", "-A"]);
+    run(&["commit", "-m", message, "--no-verify"]);
+}
+
+#[tokio::test]
+async fn git_status_reports_modified_and_untracked_files() {
+    if !git_available() {
+        eprintln!("[git_test] git not available, skipping");
+        return;
+    }
+    let dir = tempdir().unwrap();
+    init_fixture_repo(dir.path());
+
+    // 初期 commit
+    tokio::fs::write(dir.path().join("a.txt"), b"hello\n")
+        .await
+        .unwrap();
+    commit_all(dir.path(), "init");
+
+    // a.txt を modify、b.txt を新規追加
+    tokio::fs::write(dir.path().join("a.txt"), b"hello\nworld\n")
+        .await
+        .unwrap();
+    tokio::fs::write(dir.path().join("b.txt"), b"new file\n")
+        .await
+        .unwrap();
+
+    let project_root = dir.path().to_string_lossy().to_string();
+    let status = git_status(project_root).await;
+    assert!(status.ok, "git_status failed: {:?}", status.error);
+    assert!(status.repo_root.is_some());
+    assert_eq!(status.branch.as_deref(), Some("main"));
+    let paths: Vec<&str> = status.files.iter().map(|f| f.path.as_str()).collect();
+    assert!(paths.contains(&"a.txt"), "expected a.txt in status");
+    assert!(paths.contains(&"b.txt"), "expected b.txt in status");
+    let modified = status.files.iter().find(|f| f.path == "a.txt").unwrap();
+    assert_eq!(modified.label, "Modified");
+    let untracked = status.files.iter().find(|f| f.path == "b.txt").unwrap();
+    assert_eq!(untracked.label, "Untracked");
+}
+
+#[tokio::test]
+async fn git_diff_returns_head_and_worktree_for_modified_file() {
+    if !git_available() {
+        return;
+    }
+    let dir = tempdir().unwrap();
+    init_fixture_repo(dir.path());
+    tokio::fs::write(dir.path().join("README.md"), b"line1\nline2\n")
+        .await
+        .unwrap();
+    commit_all(dir.path(), "init");
+    // 編集
+    tokio::fs::write(dir.path().join("README.md"), b"line1\nLINE2\nline3\n")
+        .await
+        .unwrap();
+
+    let res = git_diff(
+        dir.path().to_string_lossy().to_string(),
+        "README.md".into(),
+        None,
+    )
+    .await;
+    assert!(res.ok);
+    assert!(!res.is_new);
+    assert!(!res.is_deleted);
+    assert!(!res.is_binary);
+    assert_eq!(res.original.lines().count(), 2);
+    assert_eq!(res.modified.lines().count(), 3);
+    assert!(res.original.contains("line2"));
+    assert!(res.modified.contains("LINE2"));
+}
+
+#[tokio::test]
+async fn git_diff_marks_new_file_as_is_new() {
+    if !git_available() {
+        return;
+    }
+    let dir = tempdir().unwrap();
+    init_fixture_repo(dir.path());
+    tokio::fs::write(dir.path().join("a.txt"), b"hello\n")
+        .await
+        .unwrap();
+    commit_all(dir.path(), "init");
+    // 新規 untracked file
+    tokio::fs::write(dir.path().join("new.txt"), b"new content\n")
+        .await
+        .unwrap();
+
+    let res = git_diff(
+        dir.path().to_string_lossy().to_string(),
+        "new.txt".into(),
+        None,
+    )
+    .await;
+    assert!(res.ok);
+    assert!(res.is_new, "untracked file must be marked is_new");
+    // is_new の場合 head は "(skipped: file too large or new)" になり original は空文字
+    assert_eq!(res.original, "");
+    assert!(res.modified.contains("new content"));
+}
+
+#[tokio::test]
+async fn git_diff_rejects_path_traversal_attempt() {
+    if !git_available() {
+        return;
+    }
+    let dir = tempdir().unwrap();
+    init_fixture_repo(dir.path());
+    tokio::fs::write(dir.path().join("a.txt"), b"x\n")
+        .await
+        .unwrap();
+    commit_all(dir.path(), "init");
+
+    // Issue #134 で塞いだ traversal 攻撃 (rel_path = "../../.env" 等) を再現。
+    let res = git_diff(
+        dir.path().to_string_lossy().to_string(),
+        "../etc/passwd".into(),
+        None,
+    )
+    .await;
+    assert!(!res.ok, "traversal must reject");
+    assert!(res.error.unwrap().contains("invalid"));
+}
+
+#[tokio::test]
+async fn git_diff_rejects_head_path_starting_with_dash() {
+    if !git_available() {
+        return;
+    }
+    let dir = tempdir().unwrap();
+    init_fixture_repo(dir.path());
+    tokio::fs::write(dir.path().join("a.txt"), b"x\n")
+        .await
+        .unwrap();
+    commit_all(dir.path(), "init");
+
+    // CLI option 偽装: original_rel_path が "-foo" のようなとき early reject。
+    let res = git_diff(
+        dir.path().to_string_lossy().to_string(),
+        "a.txt".into(),
+        Some("-foo".into()),
+    )
+    .await;
+    assert!(!res.ok);
+    assert!(res.error.unwrap().contains("invalid head path"));
+}
+
+#[tokio::test]
+async fn git_status_returns_ok_false_on_non_repo_directory() {
+    if !git_available() {
+        return;
+    }
+    // git init していない tempdir → rev-parse --show-toplevel が失敗するはず
+    let dir = tempdir().unwrap();
+    let project_root = dir.path().to_string_lossy().to_string();
+    let status = git_status(project_root).await;
+    assert!(!status.ok);
+    assert!(status.error.is_some());
+}

--- a/src-tauri/src/commands/tests/mod.rs
+++ b/src-tauri/src/commands/tests/mod.rs
@@ -1,0 +1,14 @@
+//! Issue #494: `commands/*.rs` の integration test 集約モジュール。
+//!
+//! Phase 1 (PR #492) で固まった `commands/error.rs` / `util/config_paths.rs` 統一、
+//! Phase 2 (PR #501) で固まった `Settings` strong-typed serde struct を活用し、
+//! IPC 境界に対する end-to-end テストをここに置く。
+//!
+//! 構成:
+//! - `settings` — `commands::settings::Settings` の serde / atomic_write 経由 round-trip
+//! - `git` — `git_status` / `git_diff` を fixture repo (tempdir + git CLI) に対して走らせる
+//! - `sessions` — `read_jsonl_summary` を fixture jsonl に対して走らせる
+
+mod git;
+mod sessions;
+mod settings;

--- a/src-tauri/src/commands/tests/sessions.rs
+++ b/src-tauri/src/commands/tests/sessions.rs
@@ -1,0 +1,187 @@
+//! Issue #494: `commands::sessions::read_jsonl_summary` の integration test。
+//!
+//! 本物の `~/.claude/projects/<encoded>/*.jsonl` を fixture として tempdir に作り、
+//! title / cwd / message_count の抽出が期待通り動くことを検証する。
+
+use crate::commands::sessions::read_jsonl_summary;
+use serde_json::json;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+/// fixture jsonl を tempdir 配下に書き出すヘルパ。各 line は JSON object 1 件。
+async fn write_jsonl(path: &PathBuf, lines: &[serde_json::Value]) {
+    let body = lines
+        .iter()
+        .map(|v| serde_json::to_string(v).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    tokio::fs::write(path, body).await.unwrap();
+}
+
+#[tokio::test]
+async fn extracts_title_from_first_user_message_string_content() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("session-1.jsonl");
+    write_jsonl(
+        &path,
+        &[
+            json!({
+                "type": "user",
+                "cwd": "/home/user/proj",
+                "message": { "content": "最初のユーザーメッセージ — これがタイトルになる" }
+            }),
+            json!({
+                "type": "assistant",
+                "message": { "content": "返事..." }
+            }),
+        ],
+    )
+    .await;
+
+    let (title, count, cwd) = read_jsonl_summary(&path).await;
+    assert!(title.starts_with("最初のユーザーメッセージ"));
+    assert_eq!(count, 2);
+    assert_eq!(cwd.as_deref(), Some("/home/user/proj"));
+}
+
+#[tokio::test]
+async fn extracts_title_from_first_user_message_array_content() {
+    // 新形式: message.content が `[{ type: "text", text: "..." }, ...]` の場合
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("session-2.jsonl");
+    write_jsonl(
+        &path,
+        &[json!({
+            "type": "user",
+            "cwd": "C:\\repo\\proj",
+            "message": {
+                "content": [
+                    { "type": "text", "text": "Hello, can you check this?" }
+                ]
+            }
+        })],
+    )
+    .await;
+
+    let (title, count, cwd) = read_jsonl_summary(&path).await;
+    assert_eq!(title, "Hello, can you check this?");
+    assert_eq!(count, 1);
+    assert_eq!(cwd.as_deref(), Some("C:\\repo\\proj"));
+}
+
+/// title が 1 行 80 文字で truncate されること。
+#[tokio::test]
+async fn title_truncates_to_first_line_80_chars() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("session-long.jsonl");
+    let long = "あ".repeat(200); // 200 文字 (UTF-8 3 byte/char)
+    write_jsonl(
+        &path,
+        &[json!({
+            "type": "user",
+            "cwd": "/x",
+            "message": { "content": long }
+        })],
+    )
+    .await;
+
+    let (title, _count, _cwd) = read_jsonl_summary(&path).await;
+    // chars().take(80) なので 80 文字までで止まる (バイト数ではなく char count)
+    assert_eq!(title.chars().count(), 80);
+    assert_eq!(title, "あ".repeat(80));
+}
+
+/// `\n` を含むメッセージは最初の行だけ title になる (改行で truncate)。
+#[tokio::test]
+async fn title_takes_first_line_only() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("session-multiline.jsonl");
+    write_jsonl(
+        &path,
+        &[json!({
+            "type": "user",
+            "cwd": "/x",
+            "message": { "content": "first line\nsecond line\nthird line" }
+        })],
+    )
+    .await;
+
+    let (title, _count, _cwd) = read_jsonl_summary(&path).await;
+    assert_eq!(title, "first line");
+}
+
+/// 空行 / 不正 JSON 行は parse error 扱いで count に加算されない (空行) ようにする。
+#[tokio::test]
+async fn empty_lines_are_skipped_in_count() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("session-blank.jsonl");
+    let body = format!(
+        "\n\n{}\n\n{}\n",
+        json!({"type": "user", "cwd": "/x", "message": {"content": "hi"}}),
+        json!({"type": "assistant", "message": {"content": "hello"}})
+    );
+    tokio::fs::write(&path, body).await.unwrap();
+
+    let (title, count, cwd) = read_jsonl_summary(&path).await;
+    assert_eq!(title, "hi");
+    assert_eq!(count, 2, "blank lines must not be counted");
+    assert_eq!(cwd.as_deref(), Some("/x"));
+}
+
+/// 存在しないファイルは empty triple を返す (panic しない)。
+#[tokio::test]
+async fn missing_file_returns_empty_triple() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("nonexistent.jsonl");
+    let (title, count, cwd) = read_jsonl_summary(&path).await;
+    assert_eq!(title, "");
+    assert_eq!(count, 0);
+    assert!(cwd.is_none());
+}
+
+/// HEAD_LIMIT_LINES (= 2000) で count が打ち切られる。
+/// 2500 行書いて count == 2000 を確認する。
+#[tokio::test]
+async fn message_count_caps_at_head_limit() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("session-huge.jsonl");
+    let mut lines: Vec<serde_json::Value> = Vec::with_capacity(2500);
+    lines.push(json!({
+        "type": "user",
+        "cwd": "/x",
+        "message": { "content": "title here" }
+    }));
+    for _ in 0..2499 {
+        lines.push(json!({
+            "type": "assistant",
+            "message": { "content": "reply" }
+        }));
+    }
+    write_jsonl(&path, &lines).await;
+
+    let (title, count, _cwd) = read_jsonl_summary(&path).await;
+    assert_eq!(title, "title here");
+    assert_eq!(count, 2000, "should cap at HEAD_LIMIT_LINES");
+}
+
+/// title / cwd が先頭 8 行内に無くても、count は最後まで (上限まで) カウントされる。
+/// 旧 Issue #106 互換: 取れなくても break しない。
+#[tokio::test]
+async fn missing_title_and_cwd_does_not_block_count() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("session-no-title.jsonl");
+    let lines: Vec<serde_json::Value> = (0..50)
+        .map(|i| {
+            json!({
+                "type": "system",
+                "message": { "content": format!("system msg {i}") }
+            })
+        })
+        .collect();
+    write_jsonl(&path, &lines).await;
+
+    let (title, count, cwd) = read_jsonl_summary(&path).await;
+    assert_eq!(title, "");
+    assert!(cwd.is_none());
+    assert_eq!(count, 50);
+}

--- a/src-tauri/src/commands/tests/settings.rs
+++ b/src-tauri/src/commands/tests/settings.rs
@@ -1,0 +1,192 @@
+//! Issue #494: `commands::settings` の integration test。
+//!
+//! Phase 2 (PR #501 / Issue #493) で `Settings` を strong-typed serde struct 化したので、
+//! ここでは `Settings` ⇔ disk JSON ⇔ atomic_write の round-trip を tempdir 配下で走らせる。
+//! `settings_load` / `settings_save` は内部で `~/.vibe-editor/settings.json` を直接さわる
+//! Tauri command なので、env (USERPROFILE / HOME) 操作はせず代わりに Settings 単体の
+//! roundtrip + atomic_write の組み合わせで cover する。
+
+use crate::commands::atomic_write::atomic_write;
+use crate::commands::settings::{AgentConfig, Settings, APP_SETTINGS_SCHEMA_VERSION};
+use serde_json::json;
+use tempfile::tempdir;
+
+/// `Settings::default()` を JSON にして atomic_write し、読み戻して deserialize できる。
+/// renderer 側 `migrateSettings` が見る wire shape が壊れないことを担保する。
+#[tokio::test]
+async fn default_settings_roundtrip_through_atomic_write() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("settings.json");
+
+    // save
+    let settings = Settings::default();
+    let json = serde_json::to_vec_pretty(&settings).unwrap();
+    atomic_write(&path, &json).await.unwrap();
+
+    // load
+    let bytes = tokio::fs::read(&path).await.unwrap();
+    let loaded: Settings = serde_json::from_slice(&bytes).unwrap();
+
+    // 主要フィールドが round-trip 後も同値
+    assert_eq!(loaded.schema_version, Some(APP_SETTINGS_SCHEMA_VERSION));
+    assert_eq!(loaded.language, "ja");
+    assert_eq!(loaded.theme, "claude-dark");
+    assert_eq!(loaded.density, "normal");
+    assert_eq!(loaded.claude_command, "claude");
+    assert_eq!(loaded.codex_command, "codex");
+    assert_eq!(loaded.ui_font_size, 14.0);
+    assert_eq!(loaded.editor_font_size, 13.0);
+    assert_eq!(loaded.terminal_font_size, 13.0);
+    assert_eq!(loaded.sidebar_width, 272.0);
+    assert_eq!(loaded.claude_code_panel_width, 460.0);
+    assert_eq!(loaded.has_completed_onboarding, Some(false));
+    assert_eq!(loaded.mcp_auto_setup, Some(true));
+}
+
+/// 旧バージョン (schemaVersion=2) の minimal JSON を保存 → load しても deserialize 可能。
+/// renderer 側の `migrateSettings` が schemaVersion を見て v2→v10 migration を回す前提。
+#[tokio::test]
+async fn legacy_v2_json_loads_and_default_fills_missing_fields() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("settings.json");
+
+    let legacy = json!({
+        "schemaVersion": 2,
+        "language": "en",
+        "theme": "dark",
+        "uiFontFamily": "Arial",
+        "uiFontSize": 12,
+        "editorFontFamily": "Consolas",
+        "editorFontSize": 11,
+        "terminalFontSize": 11,
+        "density": "compact",
+        "claudeCommand": "claude",
+        "claudeArgs": "",
+        "claudeCwd": "/home/user/proj",
+        "lastOpenedRoot": "/home/user/proj",
+        "recentProjects": ["/home/user/proj"],
+        "workspaceFolders": [],
+        "claudeCodePanelWidth": 400,
+        "sidebarWidth": 250,
+        "codexCommand": "codex",
+        "codexArgs": "",
+        "notepad": ""
+        // hasCompletedOnboarding / customAgents / mcpAutoSetup / fileTreeExpanded は未追加 (= v2 時代)
+    });
+    let bytes = serde_json::to_vec(&legacy).unwrap();
+    atomic_write(&path, &bytes).await.unwrap();
+
+    let raw = tokio::fs::read(&path).await.unwrap();
+    let loaded: Settings = serde_json::from_slice(&raw).unwrap();
+
+    assert_eq!(loaded.schema_version, Some(2));
+    assert_eq!(loaded.language, "en");
+    assert_eq!(loaded.theme, "dark");
+    assert_eq!(loaded.claude_cwd, "/home/user/proj");
+    assert_eq!(loaded.recent_projects, vec!["/home/user/proj".to_string()]);
+    // missing optional は None / default
+    assert!(loaded.has_completed_onboarding.is_none());
+    assert!(loaded.custom_agents.is_none());
+    assert!(loaded.mcp_auto_setup.is_none());
+    assert!(loaded.file_tree_expanded.is_none());
+}
+
+/// 不正な型 (`claudeArgs: 12345` = number) は deserialize で reject。
+/// renderer 側 `invoke('settings_save', { settings: bad })` が Promise reject になる経路の根拠。
+#[tokio::test]
+async fn invalid_claude_args_type_rejected_on_load() {
+    let bad = json!({
+        "language": "ja",
+        "claudeArgs": 12345
+    });
+    let res: Result<Settings, _> = serde_json::from_value(bad);
+    assert!(res.is_err(), "claudeArgs as number must reject");
+}
+
+/// `customAgents` の各エントリの `cwd` / `color` は optional。両方欠けても deserialize できる。
+#[tokio::test]
+async fn agent_config_minimal_entry_loads() {
+    let raw = json!({
+        "customAgents": [
+            { "id": "x", "name": "X", "command": "x", "args": "" }
+        ]
+    });
+    let loaded: Settings = serde_json::from_value(raw).unwrap();
+    let agents = loaded.custom_agents.unwrap();
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0].id, "x");
+    assert!(agents[0].cwd.is_none());
+    assert!(agents[0].color.is_none());
+}
+
+/// `customAgents` の `cwd` / `color` 完備バージョンも round-trip 可能。
+#[tokio::test]
+async fn agent_config_full_entry_round_trips() {
+    let mut s = Settings::default();
+    s.custom_agents = Some(vec![AgentConfig {
+        id: "claude-dev".into(),
+        name: "Claude (dev)".into(),
+        command: "claude".into(),
+        args: "--debug".into(),
+        cwd: Some("/tmp".into()),
+        color: Some("#ff0000".into()),
+    }]);
+
+    let bytes = serde_json::to_vec(&s).unwrap();
+    let back: Settings = serde_json::from_slice(&bytes).unwrap();
+    let agents = back.custom_agents.unwrap();
+    assert_eq!(agents[0].id, "claude-dev");
+    assert_eq!(agents[0].name, "Claude (dev)");
+    assert_eq!(agents[0].args, "--debug");
+    assert_eq!(agents[0].cwd.as_deref(), Some("/tmp"));
+    assert_eq!(agents[0].color.as_deref(), Some("#ff0000"));
+}
+
+/// 未知フィールドは silent に drop される (forward-compat 寄り)。renderer 側で
+/// 拡張 field を先に追加 → Rust 側はまだ知らないという過渡期も deserialize は成功させる。
+#[tokio::test]
+async fn unknown_fields_are_silently_dropped() {
+    let raw = json!({
+        "language": "ja",
+        "theme": "claude-dark",
+        "futureField": "future-value",
+        "anotherUnknown": [1, 2, 3]
+    });
+    let loaded: Settings = serde_json::from_value(raw).unwrap();
+    assert_eq!(loaded.language, "ja");
+    assert_eq!(loaded.theme, "claude-dark");
+    // re-serialize したときに drop されている
+    let back = serde_json::to_value(&loaded).unwrap();
+    assert!(back.get("futureField").is_none());
+    assert!(back.get("anotherUnknown").is_none());
+}
+
+/// 並列に多数 atomic_write → 最終 read で valid JSON で読める (atomic 性の sanity check)。
+/// `commands/atomic_write.rs::tests` で個別カバー済みだが、Settings shape との組み合わせを
+/// integration として一回回しておく。
+#[tokio::test]
+async fn concurrent_atomic_writes_leave_valid_settings_json() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("settings.json");
+
+    let mut handles = Vec::new();
+    for i in 0..16 {
+        let path_clone = path.clone();
+        handles.push(tokio::spawn(async move {
+            let mut s = Settings::default();
+            s.notepad = format!("write-{i}");
+            s.ui_font_size = 14.0 + (i as f64);
+            let json = serde_json::to_vec_pretty(&s).unwrap();
+            atomic_write(&path_clone, &json).await.unwrap();
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    // 最後に書かれた内容が valid Settings として deserialize できる
+    let bytes = tokio::fs::read(&path).await.unwrap();
+    let loaded: Settings = serde_json::from_slice(&bytes).unwrap();
+    assert!(loaded.notepad.starts_with("write-"));
+    assert!(loaded.ui_font_size >= 14.0);
+}

--- a/src-tauri/src/pty/batcher.rs
+++ b/src-tauri/src/pty/batcher.rs
@@ -51,7 +51,8 @@ pub fn spawn_batcher(
                     match maybe {
                         Some(chunk) => {
                             buf.extend_from_slice(&chunk);
-                            if buf.len() >= FLUSH_BYTES {
+                            // Issue #494: 閾値判定はテストと共有する pure 関数経由。
+                            if should_flush_after_recv(buf.len()) {
                                 flush(&app, &data_event_name, &mut buf, &scrollback);
                             }
                         }
@@ -63,7 +64,7 @@ pub fn spawn_batcher(
                     }
                 }
                 _ = tick.tick() => {
-                    if !buf.is_empty() {
+                    if should_flush_on_tick(buf.len()) {
                         flush(&app, &data_event_name, &mut buf, &scrollback);
                     }
                 }
@@ -73,8 +74,28 @@ pub fn spawn_batcher(
 }
 
 fn flush(app: &AppHandle, event: &str, buf: &mut BytesMut, scrollback: &Scrollback) {
-    if buf.is_empty() {
+    let Some(text) = extract_emit_payload(buf, scrollback) else {
         return;
+    };
+    let len = text.len();
+    match app.emit(event, text) {
+        Ok(_) => tracing::debug!("[batcher] emit {event} {len}B ok"),
+        Err(e) => tracing::warn!("emit {event} failed: {e}"),
+    }
+}
+
+/// Issue #494: `flush()` から Tauri `app.emit` を除いた pure な部分。
+///
+/// `buf` の先頭から「UTF-8 として完結しているバイト列」を切り出して `String` を返し、
+/// 切り出した分は `buf` から消費する。同時に `scrollback` リングバッファにも push する。
+/// emit 対象のバイト列が無い (= empty / 全部マルチバイト途中) 場合は `None`。
+///
+/// テストから直接呼べるよう `pub(super)`。spawn_batcher の流れと同じ契約に揃えてある:
+///   - 末尾がマルチバイト途中 (Issue #48) なら境界手前で切る
+///   - in-place 圧縮 (Issue #285 follow-up) で alloc を 1 件減らす
+pub(super) fn extract_emit_payload(buf: &mut BytesMut, scrollback: &Scrollback) -> Option<String> {
+    if buf.is_empty() {
+        return None;
     }
     // Issue #48: buf 末尾がマルチバイト UTF-8 文字の途中だと from_utf8_lossy が
     // U+FFFD に置換してしまう (日本語・絵文字・Box drawing が文字化けする原因)。
@@ -82,7 +103,7 @@ fn flush(app: &AppHandle, event: &str, buf: &mut BytesMut, scrollback: &Scrollba
     let safe_end = safe_utf8_boundary(buf);
     if safe_end == 0 {
         // 先頭もマルチバイト途中 → 次 flush まで保留 (emit しない)
-        return;
+        return None;
     }
     // Issue #285 follow-up: emit する確定済みバイト列を scrollback にも反映する。
     // 容量超過分は前から drop されるので、attach 経路では「最近 64 KiB」だけ replay される。
@@ -94,16 +115,37 @@ fn flush(app: &AppHandle, event: &str, buf: &mut BytesMut, scrollback: &Scrollba
     let emit_slice = &buf[..safe_end];
     append_scrollback(scrollback, emit_slice);
     let text = String::from_utf8_lossy(emit_slice).into_owned();
-    let len = safe_end;
     let remainder_len = buf.len() - safe_end;
     if remainder_len > 0 {
         buf.copy_within(safe_end.., 0);
     }
     buf.truncate(remainder_len);
-    match app.emit(event, text) {
-        Ok(_) => tracing::debug!("[batcher] emit {event} {len}B ok"),
-        Err(e) => tracing::warn!("emit {event} failed: {e}"),
-    }
+    Some(text)
+}
+
+/// Issue #494: spawn_batcher の `recv` 側 flush 判定。32 KiB を超えたらフラッシュする
+/// 単純な閾値関数。spawn_batcher 内のロジックと統一して、テスト側からも同じ関数で
+/// 検証できるようにする。
+pub(super) fn should_flush_after_recv(buf_len: usize) -> bool {
+    buf_len >= FLUSH_BYTES
+}
+
+/// Issue #494: tick (16 ms) 経路で flush するかの判定。tick 自体のタイミングは
+/// `tokio::time::interval` が司り、本関数は「buffer に何かあるか?」だけを純粋に判定する。
+pub(super) fn should_flush_on_tick(buf_len: usize) -> bool {
+    buf_len > 0
+}
+
+/// テスト経路用 const アクセサ (production code では `FLUSH_BYTES` / `FLUSH_INTERVAL_MS` を直接参照)。
+/// `#[cfg(test)]` でテストビルドにのみ含めることで、lib ビルド側に dead_code 警告を出さない。
+#[cfg(test)]
+pub(super) const fn flush_bytes_threshold() -> usize {
+    FLUSH_BYTES
+}
+
+#[cfg(test)]
+pub(super) const fn flush_interval_ms() -> u64 {
+    FLUSH_INTERVAL_MS
 }
 
 /// Issue #48: buf のうち、完結した UTF-8 文字境界までのバイト長を返す。

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -18,5 +18,9 @@ pub mod registry;
 pub mod scrollback;
 pub mod session;
 
+/// Issue #494: PTY (`batcher` flush 境界条件等) の integration test を集約する test-only module。
+#[cfg(test)]
+mod tests;
+
 pub use registry::SessionRegistry;
 pub use session::{spawn_session, SpawnOptions, UserWriteOutcome};

--- a/src-tauri/src/pty/tests/batcher.rs
+++ b/src-tauri/src/pty/tests/batcher.rs
@@ -1,0 +1,184 @@
+//! Issue #494: `pty::batcher` の境界条件 + flush 閾値の integration test。
+//!
+//! `flush()` 本体は Tauri `AppHandle.emit` に依存するためテスト困難だが、
+//! Issue #494 で抽出した pure helper (`extract_emit_payload` /
+//! `should_flush_after_recv` / `should_flush_on_tick` / `flush_*_threshold`) を
+//! 経由して、production と同じ判定ロジックをここで網羅する。
+//!
+//! 既存の `batcher::boundary_tests` は `safe_utf8_boundary` の単体テストのみだったので、
+//! ここでは UTF-8 境界 + scrollback 連携 + flush 閾値の組み合わせをカバーする。
+
+use crate::pty::batcher::{
+    extract_emit_payload, flush_bytes_threshold, flush_interval_ms, safe_utf8_boundary,
+    should_flush_after_recv, should_flush_on_tick, PTY_CHANNEL_CAPACITY,
+};
+use crate::pty::scrollback::{new_scrollback, scrollback_to_string, SCROLLBACK_CAPACITY};
+use bytes::BytesMut;
+
+/// 16ms / 32 KiB の閾値が想定値から動いていないこと。
+/// renderer 側 60Hz レンダリングと PTY backpressure の両立に効く重要定数なので
+/// 静的に snapshot しておく。
+#[test]
+fn flush_thresholds_are_pinned_to_expected_values() {
+    assert_eq!(flush_interval_ms(), 16, "flush tick must be ~60Hz (16ms)");
+    assert_eq!(flush_bytes_threshold(), 32 * 1024, "flush byte threshold = 32KiB");
+    assert_eq!(
+        PTY_CHANNEL_CAPACITY, 256,
+        "bounded channel must keep ~4MiB backpressure buffer"
+    );
+}
+
+#[test]
+fn should_flush_after_recv_triggers_at_or_above_threshold() {
+    let threshold = flush_bytes_threshold();
+    assert!(!should_flush_after_recv(0));
+    assert!(!should_flush_after_recv(threshold - 1));
+    assert!(should_flush_after_recv(threshold));
+    assert!(should_flush_after_recv(threshold + 1));
+}
+
+#[test]
+fn should_flush_on_tick_only_when_buffered() {
+    assert!(!should_flush_on_tick(0));
+    assert!(should_flush_on_tick(1));
+    assert!(should_flush_on_tick(flush_bytes_threshold()));
+}
+
+/// `extract_emit_payload`: ASCII のみなら全部 emit され、buffer は空になる。
+#[test]
+fn extract_emit_payload_drains_ascii_buffer() {
+    let mut buf = BytesMut::from(&b"hello world"[..]);
+    let scrollback = new_scrollback();
+    let text = extract_emit_payload(&mut buf, &scrollback).unwrap();
+    assert_eq!(text, "hello world");
+    assert!(buf.is_empty(), "ascii buffer must drain completely");
+    // scrollback にも反映されている
+    assert_eq!(scrollback_to_string(&scrollback).as_deref(), Some("hello world"));
+}
+
+/// `extract_emit_payload`: 末尾がマルチバイト UTF-8 の途中 (Issue #48) なら手前で切り、
+/// 残りバイトを buffer に残す。
+#[test]
+fn extract_emit_payload_holds_back_partial_multibyte_tail() {
+    // "あ" = E3 81 82。末尾 2 バイト欠落 → "ab" だけ emit、E3 は残す。
+    let mut buf = BytesMut::from(&[b'a', b'b', 0xE3][..]);
+    let scrollback = new_scrollback();
+    let text = extract_emit_payload(&mut buf, &scrollback).unwrap();
+    assert_eq!(text, "ab");
+    assert_eq!(buf.as_ref(), &[0xE3]);
+    assert_eq!(scrollback_to_string(&scrollback).as_deref(), Some("ab"));
+}
+
+/// `extract_emit_payload`: 完結したマルチバイト UTF-8 はそのまま emit される。
+#[test]
+fn extract_emit_payload_emits_complete_multibyte() {
+    // "あい" = E3 81 82 E3 81 84。完結。
+    let mut buf = BytesMut::from(&[0xE3, 0x81, 0x82, 0xE3, 0x81, 0x84][..]);
+    let scrollback = new_scrollback();
+    let text = extract_emit_payload(&mut buf, &scrollback).unwrap();
+    assert_eq!(text, "あい");
+    assert!(buf.is_empty());
+    assert_eq!(scrollback_to_string(&scrollback).as_deref(), Some("あい"));
+}
+
+/// `extract_emit_payload`: empty buffer は None。スプリアスな emit を起こさない。
+#[test]
+fn extract_emit_payload_returns_none_on_empty_buffer() {
+    let mut buf = BytesMut::new();
+    let scrollback = new_scrollback();
+    assert!(extract_emit_payload(&mut buf, &scrollback).is_none());
+}
+
+/// `extract_emit_payload`: 末尾近くにマルチバイト lead が無く全部 continuation の場合、
+/// `safe_utf8_boundary` は「切らない (= 通常あり得ない)」分岐に入って全長を返す。
+/// この場合は from_utf8_lossy で U+FFFD に置換されて emit される。テスト時点での挙動を pin する。
+#[test]
+fn extract_emit_payload_emits_full_buffer_when_all_continuation_bytes() {
+    let mut buf = BytesMut::from(&[0x81, 0x82][..]);
+    let scrollback = new_scrollback();
+    let result = extract_emit_payload(&mut buf, &scrollback);
+    // safe_utf8_boundary が n を返すケース → emit されて buf は drain される
+    assert!(result.is_some(), "all-continuation defers cut but still emits (lossy)");
+    assert!(buf.is_empty());
+    // 出力は U+FFFD で 2 バイト分置換 (from_utf8_lossy の挙動)
+    let text = result.unwrap();
+    assert!(text.contains('\u{FFFD}'));
+}
+
+/// `extract_emit_payload`: 先頭が continuation byte で始まり、その後に lead-byte 文字が続く
+/// 場合、from_utf8_lossy が先頭の continuation を U+FFFD にして emit する。
+#[test]
+fn extract_emit_payload_handles_leading_continuation_then_complete_char() {
+    // 0x81 (orphan continuation) + "ab"
+    let mut buf = BytesMut::from(&[0x81, b'a', b'b'][..]);
+    let scrollback = new_scrollback();
+    let text = extract_emit_payload(&mut buf, &scrollback).unwrap();
+    // U+FFFD + "ab"
+    assert!(text.starts_with('\u{FFFD}'));
+    assert!(text.ends_with("ab"));
+    assert!(buf.is_empty());
+}
+
+/// scrollback overflow: 64KiB を超える emit を続けると、scrollback は最新 64KiB のみ保持する。
+#[test]
+fn scrollback_caps_at_64kib_after_repeated_extracts() {
+    let scrollback = new_scrollback();
+    // 100 KiB の "a" を 8 KiB ずつ extract (= emit を擬似)。
+    let chunk = vec![b'a'; 8 * 1024];
+    for _ in 0..13 {
+        // 13 * 8KiB = 104 KiB
+        let mut buf = BytesMut::from(&chunk[..]);
+        extract_emit_payload(&mut buf, &scrollback).unwrap();
+    }
+    let snap = scrollback_to_string(&scrollback).unwrap();
+    assert_eq!(snap.len(), SCROLLBACK_CAPACITY);
+    // 全部 'a' で埋まっている
+    assert!(snap.chars().all(|c| c == 'a'));
+}
+
+/// Issue #48 のクリティカルケース: 「ちょうど 32KiB ぴったりだが末尾が日本語の途中」のとき、
+/// flush threshold を満たしていても境界手前まで emit される (= U+FFFD 化を防ぐ)。
+#[test]
+fn flush_threshold_with_partial_multibyte_tail_emits_safely() {
+    let scrollback = new_scrollback();
+    let threshold = flush_bytes_threshold();
+    // ASCII (threshold - 1 byte) + 0xE3 (3-byte char の先頭バイトのみ)
+    let mut buf = BytesMut::with_capacity(threshold + 1);
+    buf.extend_from_slice(&vec![b'x'; threshold - 1]);
+    buf.extend_from_slice(&[0xE3]);
+    assert!(should_flush_after_recv(buf.len()), "should hit recv threshold");
+    let text = extract_emit_payload(&mut buf, &scrollback).unwrap();
+    assert_eq!(text.len(), threshold - 1, "must NOT include the half-multibyte byte");
+    assert_eq!(buf.as_ref(), &[0xE3], "leftover continuation byte stays in buffer");
+}
+
+/// `safe_utf8_boundary` の追加エッジケース: 4-byte 文字 (絵文字相当) の途中。
+#[test]
+fn safe_utf8_boundary_truncates_4byte_char_partial_tail() {
+    // U+1F600 😀 = F0 9F 98 80。先頭 1 byte だけ。
+    let buf = vec![b'h', b'i', 0xF0];
+    assert_eq!(safe_utf8_boundary(&buf), 2);
+
+    // 先頭 2 byte
+    let buf = vec![b'h', b'i', 0xF0, 0x9F];
+    assert_eq!(safe_utf8_boundary(&buf), 2);
+
+    // 先頭 3 byte
+    let buf = vec![b'h', b'i', 0xF0, 0x9F, 0x98];
+    assert_eq!(safe_utf8_boundary(&buf), 2);
+
+    // 完結 (4 byte)
+    let buf = vec![b'h', b'i', 0xF0, 0x9F, 0x98, 0x80];
+    assert_eq!(safe_utf8_boundary(&buf), 6);
+}
+
+/// `safe_utf8_boundary` の追加エッジケース: 不正な lead byte (1111_1xxx) は手前でカット。
+#[test]
+fn safe_utf8_boundary_cuts_at_invalid_lead_byte() {
+    // 0xFC は UTF-8 として不正な lead (旧 6-byte UTF-8 拡張、現代 UTF-8 では reject)。
+    let buf = vec![b'a', b'b', 0xFC];
+    let cut = safe_utf8_boundary(&buf);
+    // 不正バイトは含めず手前まで
+    assert!(cut <= 3);
+    assert!(cut >= 2);
+}

--- a/src-tauri/src/pty/tests/mod.rs
+++ b/src-tauri/src/pty/tests/mod.rs
@@ -1,0 +1,6 @@
+//! Issue #494: PTY 周辺の integration test 集約モジュール。
+//!
+//! `batcher` の flush 境界条件 (UTF-8 安全境界 / 16ms tick / 32KiB バッファ閾値) を
+//! Tauri AppHandle に依存せず純粋関数経由で検証する。
+
+mod batcher;

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -14,6 +14,11 @@ pub mod inject;
 pub mod protocol;
 pub mod state;
 
+/// Issue #494: TeamHub 周辺の integration test を集約する test-only module。
+/// `protocol::permissions` の matrix 検証等を `tests/permissions.rs` に置く。
+#[cfg(test)]
+mod tests;
+
 pub use state::{
     server_log_path_for_diagnostics, set_server_log_path, CallContext, DynamicRole,
     MemberDiagnostics, RecruitAckOutcome, RoleProfileSummary, TeamInfo, TeamMessage, TeamTask,

--- a/src-tauri/src/team_hub/protocol/mod.rs
+++ b/src-tauri/src/team_hub/protocol/mod.rs
@@ -17,7 +17,10 @@
 mod consts;
 mod dynamic_role;
 mod helpers;
-mod permissions;
+// Issue #494: `team_hub/tests/permissions.rs` の matrix integration test から
+// `check_permission` / `Permission` を参照するため、`team_hub` サブツリー全体に公開する。
+// 旧 `mod permissions;` は protocol 内でのみ可視で、外部テストからアクセスできなかった。
+pub(in crate::team_hub) mod permissions;
 mod schema;
 mod tools;
 

--- a/src-tauri/src/team_hub/protocol/permissions.rs
+++ b/src-tauri/src/team_hub/protocol/permissions.rs
@@ -23,7 +23,7 @@ use std::fmt;
 /// renderer 側の `RoleProfileSummary.canRecruit` 等と一致させているが、Hub 側は
 /// この enum を SSOT として扱い、renderer 文字列は信頼しない。
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum Permission {
+pub(in crate::team_hub) enum Permission {
     /// `canRecruit` — `team_recruit` / `team_create_leader` / `team_switch_leader` /
     /// `team_ack_handoff` で要求。
     Recruit,
@@ -41,7 +41,7 @@ pub(super) enum Permission {
 impl Permission {
     /// renderer 側 `RoleProfileSummary` フィールド名 (camelCase) と一致。
     /// 既存ログ / テストの "canXxx" 出力を維持するための文字列化。
-    pub(super) fn as_str(self) -> &'static str {
+    pub(in crate::team_hub) fn as_str(self) -> &'static str {
         match self {
             Self::Recruit => "canRecruit",
             Self::Dismiss => "canDismiss",
@@ -55,7 +55,7 @@ impl Permission {
 /// `check_permission` の失敗値。`into_message(action)` で各 tool 固有の
 /// "permission denied: role 'X' cannot {action}" エラー文を組み立てる。
 #[derive(Clone, Debug)]
-pub(super) struct PermissionError {
+pub(in crate::team_hub) struct PermissionError {
     pub role: String,
     pub permission: Permission,
 }
@@ -65,7 +65,7 @@ impl PermissionError {
     /// `action` は tool ごとに違う (例: "recruit" / "dismiss" / "assign tasks" /
     /// "create role profiles" / "view diagnostics" / "ack handoff" / "create leader" /
     /// "switch leader") ので呼び出し側で指定する。
-    pub(super) fn into_message(self, action: &str) -> String {
+    pub(in crate::team_hub) fn into_message(self, action: &str) -> String {
         format!("permission denied: role '{}' cannot {action}", self.role)
     }
 }
@@ -85,7 +85,7 @@ impl fmt::Display for PermissionError {
 ///
 /// builtin role の hardcoded 権限テーブルだけを参照する (renderer の summary は信頼しない)。
 /// 動的 role や未知 role は常に `Err(PermissionError)` を返す。
-pub(super) fn check_permission(role: &str, perm: Permission) -> Result<(), PermissionError> {
+pub(in crate::team_hub) fn check_permission(role: &str, perm: Permission) -> Result<(), PermissionError> {
     if builtin_role_permission(role, perm) {
         Ok(())
     } else {

--- a/src-tauri/src/team_hub/tests/mod.rs
+++ b/src-tauri/src/team_hub/tests/mod.rs
@@ -1,0 +1,10 @@
+//! Issue #494: TeamHub の integration test 集約モジュール。
+//!
+//! Phase 2 (PR #501 / Issue #493) で `Permission` enum + `check_permission()` に統一した
+//! 権限チェック層を、各 role × tool のマトリクスで end-to-end に走らせる。
+//!
+//! recruit / dismiss / send / assign_task の RPC simulation は Tauri `AppHandle` の
+//! event emit を経由するため `cargo test` 単独では完結しない (mock framework 不採用)。
+//! ここでは Hub state 操作を伴わない pure な permission table を中心にカバーする。
+
+mod permissions;

--- a/src-tauri/src/team_hub/tests/permissions.rs
+++ b/src-tauri/src/team_hub/tests/permissions.rs
@@ -1,0 +1,161 @@
+//! Issue #494: `team_hub::protocol::permissions` の matrix integration test。
+//!
+//! Phase 2 (PR #501) で `Permission` enum + `check_permission()` に統一した権限チェックを、
+//! 各 role × tool のフル組み合わせで網羅する。
+//!
+//! Issue #136 / Issue #342 Phase 3 (3.5) の SSOT 性 (= renderer の summary に依存せず Rust 側
+//! hardcoded テーブルだけを参照) が崩れていないかをここで防衛する。matrix 化することで、
+//! 将来の権限テーブル変更時に「どの role に何の権限を付与/剥奪したか」が diff から一目瞭然になる。
+
+use crate::team_hub::protocol::permissions::{check_permission, Permission};
+
+/// `Permission` enum の全 variant。新 variant を増やしたら必ずここを更新する。
+const ALL_PERMISSIONS: &[Permission] = &[
+    Permission::Recruit,
+    Permission::Dismiss,
+    Permission::AssignTasks,
+    Permission::CreateRoleProfile,
+    Permission::ViewDiagnostics,
+];
+
+/// 既存 builtin role 一覧。動的 role (`vc-...`) は別 test で扱う。
+const BUILTIN_ROLES: &[&str] = &["leader", "hr"];
+
+/// Issue #136: 一般ワーカーの代表。`builtin_role_permission` のテーブル外 = 全 false。
+const WORKER_ROLES: &[&str] = &[
+    "planner",
+    "programmer",
+    "researcher",
+    "reviewer",
+    "rust_engineer",
+    "ui_fixer",
+    "renderer_tester",
+];
+
+/// 動的 / 未知 role の代表。renderer が任意 ID で作るパターンを想定。
+const DYNAMIC_OR_UNKNOWN_ROLES: &[&str] = &[
+    "",
+    "rogue",
+    "vc-12345-uuid-style",
+    "leader_v2",      // 表記揺れも builtin と一致しない
+    "leadeR",         // case mismatch
+    "Leader",         // case mismatch (capitalized)
+    "phone-engineer", // 動的 role の典型
+];
+
+/// Leader は ALL_PERMISSIONS を保持する (Issue #136)。
+#[test]
+fn leader_has_full_permission_matrix() {
+    for &perm in ALL_PERMISSIONS {
+        assert!(
+            check_permission("leader", perm).is_ok(),
+            "leader must have {}",
+            perm.as_str()
+        );
+    }
+}
+
+/// HR は Recruit / AssignTasks / CreateRoleProfile / ViewDiagnostics は持つが、
+/// Dismiss は持たない (Leader 専権)。
+#[test]
+fn hr_lacks_only_dismiss() {
+    assert!(check_permission("hr", Permission::Recruit).is_ok());
+    assert!(check_permission("hr", Permission::AssignTasks).is_ok());
+    assert!(check_permission("hr", Permission::CreateRoleProfile).is_ok());
+    assert!(check_permission("hr", Permission::ViewDiagnostics).is_ok());
+    let dismiss_err = check_permission("hr", Permission::Dismiss);
+    assert!(
+        dismiss_err.is_err(),
+        "HR must NOT have Dismiss (Issue #136 / Leader-only)"
+    );
+}
+
+/// 一般ワーカー role は ALL_PERMISSIONS のいずれも持たない。
+#[test]
+fn worker_roles_have_no_permissions() {
+    for &role in WORKER_ROLES {
+        for &perm in ALL_PERMISSIONS {
+            assert!(
+                check_permission(role, perm).is_err(),
+                "worker '{role}' must not have {}",
+                perm.as_str()
+            );
+        }
+    }
+}
+
+/// 動的 / 未知 role / 表記揺れ も全 false。
+/// Issue #136: renderer が作った任意 ID は Hub レベルで一切の権限を持たない。
+#[test]
+fn dynamic_and_unknown_roles_have_no_permissions() {
+    for &role in DYNAMIC_OR_UNKNOWN_ROLES {
+        for &perm in ALL_PERMISSIONS {
+            assert!(
+                check_permission(role, perm).is_err(),
+                "dynamic/unknown '{role}' must not have {}",
+                perm.as_str()
+            );
+        }
+    }
+}
+
+/// `Permission::as_str` は legacy "canXxx" 文字列キーに固定。
+/// renderer 側 `RoleProfileSummary.canRecruit` 等と表記が変わると
+/// 両側の一致が静かに崩れるため、ここでスナップショットする。
+#[test]
+fn permission_as_str_keeps_camel_case_keys() {
+    assert_eq!(Permission::Recruit.as_str(), "canRecruit");
+    assert_eq!(Permission::Dismiss.as_str(), "canDismiss");
+    assert_eq!(Permission::AssignTasks.as_str(), "canAssignTasks");
+    assert_eq!(Permission::CreateRoleProfile.as_str(), "canCreateRoleProfile");
+    assert_eq!(Permission::ViewDiagnostics.as_str(), "canViewDiagnostics");
+}
+
+/// builtin role × permission の **完全マトリクス**。
+/// テーブル変更時に、どこの cell が flip したかを一目で見せるため列挙する。
+#[test]
+fn full_role_permission_matrix_snapshot() {
+    fn allowed(role: &str, perm: Permission) -> bool {
+        check_permission(role, perm).is_ok()
+    }
+    // (role, [Recruit, Dismiss, AssignTasks, CreateRoleProfile, ViewDiagnostics])
+    let expected: &[(&str, [bool; 5])] = &[
+        ("leader", [true, true, true, true, true]),
+        ("hr", [true, false, true, true, true]),
+        ("planner", [false; 5]),
+        ("programmer", [false; 5]),
+        ("researcher", [false; 5]),
+        ("reviewer", [false; 5]),
+        ("", [false; 5]),
+        ("vc-anonymous", [false; 5]),
+    ];
+    for (role, expected_row) in expected {
+        let actual_row = [
+            allowed(role, Permission::Recruit),
+            allowed(role, Permission::Dismiss),
+            allowed(role, Permission::AssignTasks),
+            allowed(role, Permission::CreateRoleProfile),
+            allowed(role, Permission::ViewDiagnostics),
+        ];
+        assert_eq!(
+            &actual_row, expected_row,
+            "permission matrix mismatch for role={role}"
+        );
+    }
+}
+
+/// `BUILTIN_ROLES` と `WORKER_ROLES` の文字列が match arm の左辺と一致しているかの sanity check。
+/// 例えば "Leader" (大文字) を builtin と勘違いして書いていないかをここで弾く。
+#[test]
+fn builtin_role_strings_match_lowercase_keys() {
+    for &role in BUILTIN_ROLES {
+        // builtin は何らかの permission を持つはず
+        let has_any = ALL_PERMISSIONS
+            .iter()
+            .any(|&p| check_permission(role, p).is_ok());
+        assert!(
+            has_any,
+            "BUILTIN_ROLES contains '{role}' but it has no permissions — likely a typo (case mismatch?)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Issue #494 (Rust 側 Phase 3 のテスト基盤強化) の実装。Phase 1 (PR #492) と Phase 2 (PR #501) で固まったレイヤ境界に対して、Tauri 起動なしで `cargo test` だけで回せる integration test を追加する。Tauri AppHandle / State を必要とする経路は production と共有する pure helper を抽出してそこを cover する。

### 追加内容

#### `commands/tests/`

- `settings.rs` (7 tests) — `Settings::default()` の `atomic_write` 経由 round-trip / 旧 schemaVersion=2 minimal JSON load / 不正型 reject / `AgentConfig` cwd-color optional 欠落 + 完備 round-trip / 未知フィールド silent drop / 並列 atomic_write × 16
- `git.rs` (6 tests) — 本物の `git` で tempdir 配下に fixture repo を init / `git_status` の modified+untracked 判定 / `git_diff` modified+new file の HEAD/worktree / Issue #134 の path traversal reject / `-` 始まりの head_path reject / 非 git ディレクトリで ok=false。CI 環境差を考慮し `git --version` で early skip するガード付き
- `sessions.rs` (8 tests) — `read_jsonl_summary` を `pub(crate)` に格上げして fixture jsonl 経由で直接テスト。title 抽出 (string content / array content / 改行 truncate / 80 char cap) / cwd 抽出 / 空行 skip / 存在しないファイル / HEAD_LIMIT_LINES (2000) cap / 旧 Issue #106 の "title/cwd 取れなくても break しない" 挙動

#### `team_hub/tests/`

- `permissions.rs` (7 tests) — Phase 2 で統一した `check_permission(role, Permission)` を全 role × tool マトリクスで網羅。leader 全権 / hr 部分権 (Dismiss だけ無し) / worker 全 false / 動的 role 全 false / `Permission::as_str()` の "canXxx" 文字列キー pin / 完全マトリクス snapshot / BUILTIN_ROLES の lowercase 整合性 sanity
- `recruit_flow.rs` は Tauri AppHandle.emit 依存のため見送り。既存 `team_hub::bridge::tests` で MCP initialize / tools/list の no-env path を cover 済み

#### `pty/tests/`

- `batcher.rs` (12 tests) — `extract_emit_payload` (新設の pure helper) の境界条件 / `should_flush_after_recv` + `should_flush_on_tick` の閾値判定 / 16 ms / 32 KiB / `PTY_CHANNEL_CAPACITY = 256` の定数 pin / scrollback 64 KiB ring buffer の overflow / 32 KiB ぎりぎり末尾 multibyte 途中の Issue #48 ケース / 4-byte UTF-8 (絵文字相当) partial truncation / 不正 lead byte で手前カット

### 副次変更

#### `pty/batcher.rs` の pure 抽出

Tauri 非依存テストのため、\`flush()\` から emit 部分を分離した pure helper:
- \`extract_emit_payload(&mut buf, &scrollback) -> Option<String>\`
- \`should_flush_after_recv(buf_len) -> bool\`
- \`should_flush_on_tick(buf_len) -> bool\`
- test-only const accessor \`flush_bytes_threshold()\` / \`flush_interval_ms()\` (\`#[cfg(test)]\` で lib build には含めない)

\`spawn_batcher\` の hot loop も新 helper 経由に切り替え、production と test で同一の判定ロジックを保証する。出力 emit / scrollback push / buf 圧縮の挙動は完全互換。

#### visibility 拡張

- \`team_hub::protocol::permissions\` モジュール: \`mod permissions;\` → \`pub(in crate::team_hub) mod permissions;\`
- 内部の \`Permission\` / \`PermissionError\` / \`check_permission\` も \`pub(super)\` → \`pub(in crate::team_hub)\` (テストモジュールから参照可能に)
- \`commands::sessions::read_jsonl_summary\` を \`pub(crate)\` に格上げ

protocol 外部 (例: \`lib.rs\` / 他 \`commands/*\`) からは見えないままなので、public API surface は変わらない。

#### Cargo.toml dev-dependencies

- \`tempfile = \"3\"\` (fixture 用 tempdir)
- \`assert_matches = \"1\"\` (Result 系の assertion を読みやすく)

挙動・IPC payload・on-disk format は完全不変。テスト追加 + visibility 拡張 + test-only helper 抽出のみ。

## Test plan

- [x] \`cargo check --manifest-path src-tauri/Cargo.toml --tests\` 通過、warning は pre-existing の \`team_hub/state.rs:144 unused variable home\` のみ (本 PR では触らない)
- [x] \`cargo test --manifest-path src-tauri/Cargo.toml\`: **158 passed / 0 failed** (既存 117 + 新規 41)
- [x] git fixture テストは PATH に \`git\` が無い環境でも early-skip するガード入り
- [x] tempfile 経由の I/O テストは tempdir lifetime に紐付け、テスト終了時に自動 cleanup

Closes #494