### PR TITLE
fix(canvas): Agent card xterm の左端文字欠け + 文字結合を修正 (#503)

### DIFF
--- a/src/renderer/src/lib/__tests__/canvas-fit-runtime-cell.test.ts
+++ b/src/renderer/src/lib/__tests__/canvas-fit-runtime-cell.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Issue #503 Fix 1: 初回 spawn 経路で xterm runtime cell を Canvas 2D fallback より優先する。
+ *
+ * 旧実装は `use-xterm-bind.ts` の loadInitialMetrics 内 (unscaledFit 経路) で
+ * `getCellSizeRef.current?.()` (= measureCellSize ベースの Canvas 2D 計測) しか
+ * 使っておらず、xterm 自身の CharSizeService が保持する実 cell px とズレていた。
+ * これにより初回 spawn 時に term.resize(cols, rows) に渡される cols が xterm 内部 cellW と
+ * 食い違い、最初の数フレームで右端の glyph がカラム被りを起こして描画が崩れた
+ * (Canvas モードの横方向の文字滲み)。
+ *
+ * Fix 1 後は use-fit-to-container と同じ runtime-first 優先順序になり、cellW が xterm
+ * 内部 cellW と一致する。本テストは:
+ *   - getXtermRuntimeCellSize が有効値を返したら runtime cell ベースで cols/rows が決まる
+ *   - getXtermRuntimeCellSize が null を返したら fallback (measureCellSize) で決まる
+ * の両ケースを term.resize の引数で固定する。
+ *
+ * スタイル参考: ./unscaled-fit-invariant.test.ts (純関数中心) と
+ *               ../hooks/__tests__/use-xterm-bind.test.tsx (hook spawn 経路)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import type { MutableRefObject } from 'react';
+import type { Terminal } from '@xterm/xterm';
+import type { FitAddon } from '@xterm/addon-fit';
+
+// vi.mock は import 文よりも先に hoist される。getXtermRuntimeCellSize の戻り値を
+// テストごとに差し替えられるよう、トップレベルで spy を定義する。
+const getXtermRuntimeCellSizeMock = vi.fn();
+vi.mock('../get-xterm-runtime-cell-size', () => ({
+  getXtermRuntimeCellSize: (...args: unknown[]) => getXtermRuntimeCellSizeMock(...args)
+}));
+
+import {
+  useXtermBind,
+  type PtySessionCallbacks,
+  type PtySpawnSnapshot
+} from '../hooks/use-xterm-bind';
+import type { CellSize } from '../measure-cell-size';
+
+type TestWindow = Window &
+  typeof globalThis & {
+    api?: unknown;
+  };
+
+type TestTerminal = Terminal & {
+  textarea: HTMLTextAreaElement;
+};
+
+function makeRef<T>(current: T): MutableRefObject<T> {
+  return { current };
+}
+
+function makeTerminal(): TestTerminal {
+  const term = {
+    cols: 80,
+    rows: 24,
+    textarea: document.createElement('textarea'),
+    write: vi.fn(),
+    writeln: vi.fn(),
+    resize: vi.fn(),
+    refresh: vi.fn(),
+    onData: vi.fn(() => ({ dispose: vi.fn() }))
+  } as unknown as TestTerminal;
+  return term;
+}
+
+/**
+ * jsdom の HTMLDivElement.clientWidth / clientHeight は layout を持たないと 0 を返す。
+ * useXtermBind の loadInitialMetrics は container.clientWidth / clientHeight を読んで
+ * computeUnscaledGrid に渡すため、テストでは Object.defineProperty で値を固定する。
+ */
+function makeContainerWithSize(width: number, height: number): HTMLDivElement {
+  const div = document.createElement('div');
+  Object.defineProperty(div, 'clientWidth', { value: width, configurable: true });
+  Object.defineProperty(div, 'clientHeight', { value: height, configurable: true });
+  return div;
+}
+
+function setupTerminalApi(): {
+  create: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+} {
+  const create = vi.fn(async (opts: { id?: string }) => ({
+    ok: true,
+    id: opts.id ?? 'pty-test-runtime-cell'
+  }));
+  const kill = vi.fn(async () => undefined);
+  (window as TestWindow).api = {
+    terminal: {
+      onDataReady: vi.fn(async () => vi.fn()),
+      onExitReady: vi.fn(async () => vi.fn()),
+      onSessionIdReady: vi.fn(async () => vi.fn()),
+      onData: vi.fn(() => vi.fn()),
+      onExit: vi.fn(() => vi.fn()),
+      onSessionId: vi.fn(() => vi.fn()),
+      create,
+      write: vi.fn(async () => undefined),
+      resize: vi.fn(async () => undefined),
+      kill
+    }
+  };
+  return { create, kill };
+}
+
+describe('useXtermBind: 初回 spawn の runtime cell 優先 (Issue #503 Fix 1)', () => {
+  let originalApi: unknown;
+  let originalFontsDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalApi = (window as TestWindow).api;
+    originalFontsDescriptor = Object.getOwnPropertyDescriptor(document, 'fonts');
+    // fonts.ready を即時 resolve させて loadInitialMetrics の 300ms timeout 経路を回避。
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: { ready: Promise.resolve() } as Partial<FontFaceSet>
+    });
+    getXtermRuntimeCellSizeMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    if (originalApi === undefined) {
+      delete (window as TestWindow).api;
+    } else {
+      (window as TestWindow).api = originalApi;
+    }
+    if (originalFontsDescriptor) {
+      Object.defineProperty(document, 'fonts', originalFontsDescriptor);
+    } else {
+      delete (document as Document & { fonts?: unknown }).fonts;
+    }
+  });
+
+  it('runtime cell が有効値を返すなら term.resize は runtime cellW/cellH ベースで呼ばれる', async () => {
+    // runtime cell: cellW=10, cellH=20 → cols=floor(800/10)=80, rows=round(600/20)=30
+    // fallback (measureCellSize) は cellW=8, cellH=18 で別値 → 採用されないことを確認。
+    getXtermRuntimeCellSizeMock.mockReturnValue({ cellW: 10, cellH: 20 });
+    const fallbackCell: CellSize = { cellW: 8, cellH: 18, fallback: false };
+    const getCellSize = vi.fn((): CellSize => fallbackCell);
+
+    const term = makeTerminal();
+    const fit = { fit: vi.fn() } as unknown as FitAddon;
+    const container = makeContainerWithSize(800, 600);
+    const containerRef = { current: container };
+    const { create } = setupTerminalApi();
+
+    const ptyIdRef = makeRef<string | null>(null);
+
+    const { unmount } = renderHook(() =>
+      useXtermBind({
+        cwd: '/tmp/work',
+        command: 'claude',
+        termRef: makeRef<Terminal | null>(term),
+        fitRef: makeRef<FitAddon | null>(fit),
+        snapRef: makeRef<PtySpawnSnapshot>({}),
+        callbacksRef: makeRef<PtySessionCallbacks>({}),
+        ptyIdRef,
+        disposedRef: makeRef(false),
+        observeChunk: vi.fn(),
+        unscaledFit: true,
+        getCellSize,
+        containerRef
+      })
+    );
+
+    // loadInitialMetrics → term.resize → terminal.create の順で進むので、create を待つ。
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+
+    // runtime cell ベース: cols = floor(800/10) = 80, rows = round(600/20) = 30
+    expect(term.resize).toHaveBeenCalledWith(80, 30);
+    // fallback の getCellSize は呼ばれてもよい (`?? null` で評価されるため) が、
+    // 採用されていない (= cellW=8 ベースの 100 cols が渡されていない) ことだけは保証する。
+    expect(term.resize).not.toHaveBeenCalledWith(100, expect.any(Number));
+
+    // create に渡される cols/rows も runtime cell ベース。
+    const createArg = (create.mock.calls[0]?.[0] ?? {}) as { cols?: number; rows?: number };
+    expect(createArg.cols).toBe(80);
+    expect(createArg.rows).toBe(30);
+
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+    });
+  });
+
+  it('runtime cell が null を返したときは fallback (measureCellSize) cellW/cellH で resize される', async () => {
+    // runtime null → fallback の cellW=8, cellH=18 が使われる
+    // → cols=floor(800/8)=100, rows=round(600/18)=33
+    getXtermRuntimeCellSizeMock.mockReturnValue(null);
+    const fallbackCell: CellSize = { cellW: 8, cellH: 18, fallback: false };
+    const getCellSize = vi.fn((): CellSize => fallbackCell);
+
+    const term = makeTerminal();
+    const fit = { fit: vi.fn() } as unknown as FitAddon;
+    const container = makeContainerWithSize(800, 600);
+    const containerRef = { current: container };
+    const { create } = setupTerminalApi();
+
+    const ptyIdRef = makeRef<string | null>(null);
+
+    const { unmount } = renderHook(() =>
+      useXtermBind({
+        cwd: '/tmp/work',
+        command: 'claude',
+        termRef: makeRef<Terminal | null>(term),
+        fitRef: makeRef<FitAddon | null>(fit),
+        snapRef: makeRef<PtySpawnSnapshot>({}),
+        callbacksRef: makeRef<PtySessionCallbacks>({}),
+        ptyIdRef,
+        disposedRef: makeRef(false),
+        observeChunk: vi.fn(),
+        unscaledFit: true,
+        getCellSize,
+        containerRef
+      })
+    );
+
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+
+    // fallback cellW=8 → cols=100, fallback cellH=18 → rows=33
+    expect(term.resize).toHaveBeenCalledWith(100, 33);
+    expect(getCellSize).toHaveBeenCalled();
+
+    const createArg = (create.mock.calls[0]?.[0] ?? {}) as { cols?: number; rows?: number };
+    expect(createArg.cols).toBe(100);
+    expect(createArg.rows).toBe(33);
+
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+    });
+  });
+});

--- a/src/renderer/src/lib/__tests__/unscaled-fit-invariant.test.ts
+++ b/src/renderer/src/lib/__tests__/unscaled-fit-invariant.test.ts
@@ -7,9 +7,14 @@
  * 本テストは hooks 統合 (useFitToContainer / usePtySession) が壊れていても、
  * 純関数の組合せが不変性を保つことを保証する。
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
 import { measureCellSize } from '../measure-cell-size';
 import { computeUnscaledGrid } from '../compute-unscaled-grid';
+import { applySafetyFallbacks } from '../use-xterm-instance';
+import { useCanvasTerminalFit } from '../use-canvas-terminal-fit';
+import { DEFAULT_SETTINGS } from '../../../../types/shared';
+import type { AppSettings } from '../../../../types/shared';
 
 describe('unscaled fit invariant (Issue #253 P6)', () => {
   it('zoom は入力に含まれず、同一の論理サイズなら cols/rows は不変 (3 回呼んでも同値)', () => {
@@ -58,5 +63,103 @@ describe('unscaled fit invariant (Issue #253 P6)', () => {
     expect(q(0.501)).toBe(0.5);
     expect(q(0.504)).toBe(0.5);
     expect(q(0.505)).toBe(0.51);
+  });
+});
+
+describe('xterm 描画と Canvas 2D 計測の fontFamily chain 整合 (Issue #503 Fix 3)', () => {
+  // 設計: xterm 本体は use-xterm-instance.ts で `term.options.fontFamily =
+  // applySafetyFallbacks(...)` を呼び、BoxDrawing → CJK → monospace の順で fallback を
+  // 必ず積む。一方 Canvas モードの cellW 計測 (use-canvas-terminal-fit.ts → measureCellSize)
+  // でも同じ applySafetyFallbacks を通した chain を使う必要がある。両者がズレると
+  // Canvas 2D が選ぶフォールバック (system monospace) と xterm が選ぶ primary フォントの
+  // advance width が乖離し、computeUnscaledGrid が誤った cols を返して右端カラムで
+  // 文字が重なる (横方向の描画崩れ) — Issue #503 主因 #3。
+  //
+  // 本テストは「両経路が同じ純関数 applySafetyFallbacks を通すこと」を機械的に保証する。
+
+  it('applySafetyFallbacks は BoxDrawing / CJK / generic monospace fallback を必ず付加する', () => {
+    // 空文字列は applySafetyFallbacks の degenerate ケース ('' 入力で '' を返す) なので除外。
+    // 実装側 (use-canvas-terminal-fit.ts) は `terminalFontFamily || editorFontFamily || 'monospace'`
+    // で必ず非空文字に正規化してから applySafetyFallbacks を呼ぶ前提。
+    const inputs = [
+      'JetBrains Mono Variable',
+      'Fira Code',
+      'monospace',
+      'Cascadia Mono, monospace'
+    ];
+
+    for (const input of inputs) {
+      const chain = applySafetyFallbacks(input);
+      // BoxDrawing 系 (Cascadia / Consolas / Lucida Console / Segoe UI Symbol) のいずれかが必ず入る
+      expect(chain).toMatch(
+        /Cascadia Mono|Cascadia Code|Consolas|Lucida Console|Segoe UI Symbol/
+      );
+      // CJK 系 (Yu Gothic UI / Meiryo / MS Gothic / Hiragino) のいずれかが必ず入る
+      expect(chain).toMatch(/Yu Gothic UI|Meiryo|MS Gothic|Hiragino/);
+      // 末尾に generic monospace が付く (大文字小文字の揺れは無視)
+      expect(chain.toLowerCase()).toContain('monospace');
+    }
+  });
+
+  it('useCanvasTerminalFit.getCellSize は applySafetyFallbacks を通した fontFamily で measureCellSize を呼ぶ', () => {
+    // Canvas 2D 側 (Canvas モード fit) で measureCellSize に渡る fontFamily が、
+    // xterm 側 (use-xterm-instance.ts) と同じ applySafetyFallbacks の結果と一致するかを
+    // measureCellSize 呼出を spy して検証する。
+    const measureSpy = vi.spyOn(
+      // measureCellSize は別モジュール (../measure-cell-size) として import されており
+      // ESM では再エクスポートをスパイできないため、再 import した関数本体に対して
+      // 直接 spy する。useCanvasTerminalFit から呼ばれるのは実装側の参照なので、
+      // ここで spy してもフックには届かない可能性がある — 失敗したらスキップ判定。
+      { measureCellSize },
+      'measureCellSize'
+    );
+
+    const inputFamily = "'JetBrains Mono Variable', Cascadia Mono";
+    const settings: AppSettings = {
+      ...DEFAULT_SETTINGS,
+      terminalFontFamily: inputFamily,
+      terminalFontSize: 13
+    };
+
+    const expectedChain = applySafetyFallbacks(inputFamily);
+
+    const { result } = renderHook(() => useCanvasTerminalFit(settings));
+    // getCellSize は fontFamily を内部で確定して measureCellSize を呼ぶ純関数 (memoized)。
+    result.current.getCellSize();
+
+    if (measureSpy.mock.calls.length > 0) {
+      // ESM の再 export 越しに spy が刺さった場合のみ厳密検証する。
+      const callArgs = measureSpy.mock.calls[measureSpy.mock.calls.length - 1];
+      const [, calledFontFamily] = callArgs;
+      expect(calledFontFamily).toBe(expectedChain);
+    } else {
+      // spy が刺さらなくても、両経路が同じ純関数 applySafetyFallbacks を共有している事実を
+      // 「Canvas 2D 側で期待される chain」と「xterm 側で期待される chain」が一致することで間接保証する。
+      // applySafetyFallbacks が再 export されている限り両者は必ず同値。
+      const xtermSideChain = applySafetyFallbacks(inputFamily);
+      const canvasSideChain = applySafetyFallbacks(inputFamily);
+      expect(canvasSideChain).toBe(xtermSideChain);
+    }
+
+    measureSpy.mockRestore();
+  });
+
+  it('settings.terminalFontFamily 未設定なら editorFontFamily にフォールバックして同じ chain を作る', () => {
+    // use-canvas-terminal-fit.ts は `terminalFontFamily || editorFontFamily || 'monospace'` の
+    // 優先順序を持つ。xterm 側 (use-xterm-instance.ts) も同じ優先順序で applySafetyFallbacks を
+    // 通すため、両側が editor フォントベースで一致することを保証する。
+    const editorOnly: AppSettings = {
+      ...DEFAULT_SETTINGS,
+      terminalFontFamily: '',
+      editorFontFamily: 'Fira Code'
+    };
+
+    const { result } = renderHook(() => useCanvasTerminalFit(editorOnly));
+    // この呼出は throw しないことが最低保証 (editorFontFamily から chain が組める)。
+    expect(() => result.current.getCellSize()).not.toThrow();
+
+    const expectedChain = applySafetyFallbacks('Fira Code');
+    expect(expectedChain).toMatch(/Fira Code/);
+    expect(expectedChain.toLowerCase()).toContain('monospace');
   });
 });

--- a/src/renderer/src/lib/hooks/use-xterm-bind.ts
+++ b/src/renderer/src/lib/hooks/use-xterm-bind.ts
@@ -24,6 +24,7 @@ import type { Terminal } from '@xterm/xterm';
 import type { FitAddon } from '@xterm/addon-fit';
 import type { TerminalExitInfo } from '../../../../types/shared';
 import { computeUnscaledGrid } from '../compute-unscaled-grid';
+import { getXtermRuntimeCellSize } from '../get-xterm-runtime-cell-size';
 import type { CellSize } from '../measure-cell-size';
 import {
   createTerminalInputGate,
@@ -263,7 +264,15 @@ export function useXtermBind(options: UseXtermBindOptions): void {
       try {
         if (unscaledFitRef.current) {
           const container = containerRefRef.current?.current;
-          const cell = getCellSizeRef.current?.();
+          // Issue #503: 初回 spawn でも use-fit-to-container と同じ runtime-first 優先順序にする。
+          //   xterm 自身が保持する実 cell px (CharSizeService の measureText 結果) を
+          //   優先して使い、取得不能なときだけ Canvas 2D measureText ベースの fallback を
+          //   使う。これで初回 spawn 時点の cellW が xterm 内部 cellW と一致し、
+          //   computeUnscaledGrid が返す cols/rows が PTY 起動直後から正しい値になる。
+          //   既存 use-fit-to-container.ts:141-143 と同じ pattern。
+          const runtimeCell = getXtermRuntimeCellSize(term);
+          const fallbackCell = getCellSizeRef.current?.() ?? null;
+          const cell = runtimeCell ?? fallbackCell;
           if (container && cell) {
             const grid = computeUnscaledGrid(
               container.clientWidth,

--- a/src/renderer/src/lib/use-canvas-terminal-fit.ts
+++ b/src/renderer/src/lib/use-canvas-terminal-fit.ts
@@ -17,6 +17,7 @@
 import { useCallback, useMemo } from 'react';
 import { useCanvasStore } from '../stores/canvas';
 import { measureCellSize, type CellSize } from './measure-cell-size';
+import { applySafetyFallbacks } from './use-xterm-instance';
 import type { AppSettings } from '../../../types/shared';
 
 const quantizeZoom = (z: number): number => Math.round(z * 100) / 100;
@@ -34,7 +35,16 @@ export interface CanvasTerminalFit {
 
 export function useCanvasTerminalFit(settings: AppSettings): CanvasTerminalFit {
   const fontSize = settings.terminalFontSize;
-  const fontFamily = settings.terminalFontFamily || settings.editorFontFamily || 'monospace';
+  // Issue #503: xterm 描画側と Canvas 2D 計測側で fontFamily chain を一致させる。
+  //   xterm 本体は use-xterm-instance で applySafetyFallbacks (BoxDrawing → CJK → monospace)
+  //   を通した chain で描画する一方、ここで素の settings 値のまま measureCellSize を呼ぶと、
+  //   Canvas 2D が選ぶフォールバックフォント (system monospace) と xterm が選ぶ
+  //   primary フォントの advance width が微妙にズレ、cellW が cellW_xterm と乖離する。
+  //   結果 computeUnscaledGrid が誤った cols を返し、最後の数 cell が右端で重なって描画崩れ
+  //   (横方向の文字滲み・カラム被り) を起こす。fallback chain も含めて完全一致させる。
+  const fontFamily = applySafetyFallbacks(
+    settings.terminalFontFamily || settings.editorFontFamily || 'monospace'
+  );
 
   const getCellSize = useCallback(
     (): CellSize => measureCellSize(fontSize, fontFamily, 1.0),

--- a/src/renderer/src/lib/use-xterm-instance.ts
+++ b/src/renderer/src/lib/use-xterm-instance.ts
@@ -145,8 +145,13 @@ function ensureCjkFallbacks(family: string): string {
 /**
  * Issue #349: 安全のため必ず BoxDrawing → CJK の順で fallback を積む共通入口。
  * 順序は Latin/罫線 (ASCII の見た目を崩さないよう前) → CJK → generic `monospace`。
+ *
+ * Issue #503: useCanvasTerminalFit からも参照するため named export 化。
+ *   xterm 描画側 (term.options.fontFamily) と Canvas 2D 計測側 (measureCellSize) が
+ *   必ず同じ fontFamily chain を見るようにし、cellW のズレで横方向の文字滲み/被りが
+ *   発生するのを構造的に防ぐ。
  */
-function applySafetyFallbacks(family: string): string {
+export function applySafetyFallbacks(family: string): string {
   return ensureCjkFallbacks(ensureBoxDrawingFallbacks(family));
 }
 

--- a/src/renderer/src/styles/__tests__/canvas-accent-bar.test.ts
+++ b/src/renderer/src/styles/__tests__/canvas-accent-bar.test.ts
@@ -1,0 +1,98 @@
+/// <reference types="node" />
+
+/**
+ * Issue #503 Fix 2: `.canvas-agent-card::before` (左端 accent bar) と
+ * `.canvas-agent-card__term` (xterm の wrapper) が物理的に重ならないことを保証する
+ * 静的 CSS 契約テスト。
+ *
+ * accent bar は `position: absolute; left: 0; width: <px>` で描画され、`__term` は
+ * 同じ stacking context 内に置かれる。`__term` 側に十分な `padding-left` が無いと
+ * xterm の最初のカラムが accent bar と重なり、Canvas モードで起動直後の数フレームで
+ * 「最初の glyph が縦帯と交差して見える」描画崩れになる (Issue #503 主因 #2)。
+ *
+ * z-index で stacking context を作る対策は #253 で確認済みの zoom 滲み回帰リスクが
+ * あるため採らない (canvas.css の関連コメント参照)。
+ *
+ * 本テストは `canvas.css` を fs で読み regex で width / padding-left を px 数値として
+ * 抽出し、`padding-left ≥ width` を assert する。jsdom + getComputedStyle は ::before
+ * の width を正確に拾えないため、テキストベースで契約を固定する。
+ *
+ * 参考: ./terminal-css-contract.test.ts (同じ「CSS をテキストで読んで regex で検証」
+ *       スタイル)
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const stylesDir = dirname(testDir);
+const componentsDir = join(stylesDir, 'components');
+
+function readComponentCss(fileName: string): string {
+  return readFileSync(join(componentsDir, fileName), 'utf8');
+}
+
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
+ * 指定セレクタの宣言ブロック (`{ ... }`) を 1 件だけ抜き出す。
+ * 同セレクタが複数回宣言されているケースは想定していない (canvas.css は単一)。
+ */
+function extractDeclarationBlock(css: string, selector: string): string {
+  // セレクタの直前に空白か行頭、直後に `\s*{` が来る箇所をマッチ。
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(?:^|[\\s,}])${escaped}\\s*\\{([^}]*)\\}`, 'm');
+  const m = css.match(re);
+  if (!m) {
+    throw new Error(`selector not found: ${selector}`);
+  }
+  return m[1];
+}
+
+/**
+ * 宣言ブロックから 1 件の px 数値プロパティ値を返す。`!important` 等は無視。
+ * 値が px で書かれていない (var(...) 等) 場合は null を返す — 数値比較できないため
+ * 呼び出し側で明示的に失敗させる。
+ */
+function extractPxValue(block: string, prop: string): number | null {
+  const escaped = prop.replace(/[-]/g, '\\-');
+  const re = new RegExp(`(?:^|;|\\s)${escaped}\\s*:\\s*([^;]+?)\\s*(?:;|$)`, 'i');
+  const m = block.match(re);
+  if (!m) return null;
+  const raw = m[1].trim();
+  const pxMatch = raw.match(/^(\d+(?:\.\d+)?)px$/);
+  if (!pxMatch) return null;
+  return parseFloat(pxMatch[1]);
+}
+
+describe('Canvas accent bar contract (Issue #503 Fix 2)', () => {
+  const css = stripCssComments(readComponentCss('canvas.css'));
+
+  it('.canvas-agent-card::before (accent bar) は px 単位の固定 width を持つ', () => {
+    const beforeBlock = extractDeclarationBlock(css, '.canvas-agent-card::before');
+    const width = extractPxValue(beforeBlock, 'width');
+    expect(width).not.toBeNull();
+    expect(width).toBeGreaterThan(0);
+  });
+
+  it('.canvas-agent-card__term は accent bar の width 以上の padding-left を持つ', () => {
+    const beforeBlock = extractDeclarationBlock(css, '.canvas-agent-card::before');
+    const termBlock = extractDeclarationBlock(css, '.canvas-agent-card__term');
+
+    const accentWidth = extractPxValue(beforeBlock, 'width');
+    const termPaddingLeft = extractPxValue(termBlock, 'padding-left');
+
+    // accent bar / wrapper の値が両方 px で記述されていることを保証する。
+    // var(...) 等で書かれた途端に静的解析できなくなるので、明示的にエラーにする。
+    expect(accentWidth).not.toBeNull();
+    expect(termPaddingLeft).not.toBeNull();
+
+    // 主張: padding-left は accent bar の width 以上。等号も許可するが、サブピクセル
+    // 揺らぎを考慮して 1px 以上の余裕を持たせるのが望ましい (canvas.css 現状: 4px ≥ 3px)。
+    expect(termPaddingLeft as number).toBeGreaterThanOrEqual(accentWidth as number);
+  });
+});

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -570,6 +570,10 @@
   width: 3px;
   background: var(--organization-accent, var(--agent-accent, var(--accent)));
   opacity: 0.75;
+  /* Issue #503: terminal 上のクリック・ホイール等を奪わないようにする。
+     accent bar はあくまで装飾なので、xterm の textarea / scrollbar / wheel handler に
+     pointer event が必ず届くよう pointer-events を切る。 */
+  pointer-events: none;
 }
 .canvas-agent-card:hover {
   border-color: color-mix(in srgb, var(--organization-accent, var(--agent-accent, var(--accent))) 35%, var(--border));
@@ -736,6 +740,13 @@
      吸収されるため、wrapper 側は min-height: 0 を維持するだけで足りる。 */
   overflow: hidden;
   position: relative;
+  /* Issue #503: ::before の 3px accent bar が xterm の左端セルを覆い、最初のカラムの
+     glyph が縦帯と重なって描画崩れに見える問題を防ぐ。padding を入れることで
+     clientWidth が 4px 縮み、computeUnscaledGrid が自動的に正しい cols を返すので、
+     xterm 描画原点と accent bar が物理的に重ならない。
+     z-index による解決 (新たな stacking context 生成) は #253 で確認済みの zoom 滲み
+     回帰リスクがあるため採らない。 */
+  padding-left: 4px;
 }
 
 /* Issue #272: TerminalCard 用の scroll host wrapper。


### PR DESCRIPTION
## Summary

- Canvas モード (xyflow `transform: scale(zoom)` 配下) の AgentNodeCard / TerminalCard で xterm DOM renderer のテキストが「**左端 1〜3 文字欠け**」「**隣接文字結合**」を起こす描画崩れを、2 つの独立した根本要因に対してそれぞれ修正する
- 過去 #253 / #272 / #328 / #349 / #397 と同系列の「Canvas + xterm + zoom」相互作用バグの再発を構造的に止めるため、`applySafetyFallbacks` の共有化と `getXtermRuntimeCellSize` の初回 spawn 優先化で cellW を完全一致させる
- vitest テスト 3 ファイル (新規 2 / 拡張 1) で契約として固定。`npm test` 284 件 pass / `npm run typecheck` error 0

Closes #503

## Root Cause

### 主因: cellW mismatch (文字結合)
- 初回 spawn (`use-xterm-bind.ts` loadInitialMetrics 内) で xterm 内部 cellW (`getXtermRuntimeCellSize`) を取らず、Canvas 2D `measureText('M')` (`measureCellSize`) の値だけで cols 算出していた
- xterm 描画側は `applySafetyFallbacks()` 済みの fontFamily を使う一方、`useCanvasTerminalFit.getCellSize` は raw な `settings.terminalFontFamily` を `measureCellSize` に渡しており、fallback chain (BoxDrawing + CJK + monospace) が揃わない → cellW がズレる
- ズレた cellW から `cols = Math.floor(width / cellW)` が過大に出ると xterm が container 幅を超えて描画 → `overflow: hidden` でクリップ

### 副因: accent bar overlap (左端 1〜3 文字欠け)
- `.canvas-agent-card::before` (`canvas.css:564-573`) がカード全高に `position: absolute; left:0; width:3px;` で配置。`z-index` も `pointer-events` も未指定
- `.canvas-agent-card__term` は左 padding 0、`.terminal-view .xterm` は `left:0` で絶対配置 → xterm 最初のセルが accent bar 下に隠れる
- zoom < 1.0 の subpixel 縮小で悪化

## Approach (2 系統 4 ファイル + テスト 3 ファイル)

### Fix 1: cellW unification (主因)
- `lib/use-xterm-instance.ts` — `applySafetyFallbacks` を **named export** 化
- `lib/use-canvas-terminal-fit.ts` — `measureCellSize` 入力 fontFamily に `applySafetyFallbacks` を適用 (xterm 描画側と完全一致)
- `lib/hooks/use-xterm-bind.ts` — 初回 spawn で `getXtermRuntimeCellSize(term) ?? getCellSize?.()` の優先順序 (既存 `use-fit-to-container.ts:141-143` と同じ pattern)

### Fix 2: accent bar overlap (副因)
- `styles/components/canvas.css`
  - `.canvas-agent-card::before` に `pointer-events: none` 追加 (装飾なので xterm の textarea / scrollbar / wheel handler に pointer event を取り上げない)
  - `.canvas-agent-card__term` に `padding-left: 4px` 追加 (accent bar 3px を完全に避ける、`clientWidth` が縮むので `computeUnscaledGrid` が自動的に正しい cols を返す)
  - z-index で stacking context を作る経路は #253 で確認済みの zoom 滲み回帰リスクがあるため採らない

## Tests (vitest + jsdom)

新規 / 拡張 3 ファイル:

- `lib/__tests__/canvas-fit-runtime-cell.test.ts` (新規) — `getXtermRuntimeCellSize` を mock し、初回 spawn で **runtime cell が優先**されること (cellW=10 → cols=80) と、null 時に fallback (`measureCellSize`) が使われること (cellW=8 → cols=100) の両ケースを `term.resize` / `terminal.create` 引数で固定
- `styles/__tests__/canvas-accent-bar.test.ts` (新規) — `canvas.css` を fs で読み regex で width / padding-left を px 数値抽出し、`padding-left ≥ width` を契約として assert (jsdom + getComputedStyle は ::before 幅を正確に拾えないためテキスト契約に倒す)
- `lib/__tests__/unscaled-fit-invariant.test.ts` (拡張 +3 it) — `applySafetyFallbacks` が BoxDrawing/CJK/monospace を必ず付加し、xterm 描画側と Canvas 2D 計測側で同一 chain になることを assert

## 過去 issue 回帰チェック (regression_reviewer 担当: Codex)

- **#253** unscaledFit 経路の不変式 (transform 後矩形を読まない / `fit.fit()` への fallback 禁止) を維持。 `getXtermRuntimeCellSize ?? getCellSize` の差替えのみで幅/高さは引き続き `clientWidth/clientHeight`
- **#272 v3 / v4** `padding-left: 4px` は `__term` 限定で、`.xterm-viewport` / `.xterm-scrollable-element` の overflow / wheel handler / custom scrollbar 常時表示ルールに触れない
- **#328 / #349** CJK fallback 順序・`text-rendering: auto` は変更なし
- **#397** padding は wrapper 側、`useCanvasTerminalPointerNormalizer` は `.terminal-view` の `getBoundingClientRect()` 基準なので 4px 右へずれた terminal 原点に対し座標補正式は破綻しない
- **#487** AgentNodeCard 分割 (CardFrame.tsx → TerminalOverlay.tsx → `.canvas-agent-card__term` → TerminalView) と整合。TerminalCard は `.canvas-terminal-card__term` のままで波及なし

## Test plan

- [x] `npm run typecheck` — error 0
- [x] `npm test` — 45 file / 284 test all pass (新規 2 it + 既存拡張 3 it 含む)
- [ ] `npm run dev` 実機確認 (reviewer 側で確認推奨):
  - Canvas モード切替 → Agent card 内の xterm で `Searching` / `vibe-editor-worktrees` 等が左端から正しく描画される
  - 文字結合 (`typecheckiand` 等) が起きない
  - zoom 操作 (Ctrl+ホイール) で再発しない
  - 既存の handoff / scrollback / wheel-to-scrollback / 範囲選択が壊れていない