### PR TITLE
feat(canvas): agent card 状態要約 UI 強化 (#521)

### DIFF
--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -1,9 +1,26 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { LayoutGrid, List, Maximize2, Ruler, Users, ZoomIn, ZoomOut } from 'lucide-react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  CircleDot,
+  Hourglass,
+  LayoutGrid,
+  List,
+  Maximize2,
+  Ruler,
+  Users,
+  ZoomIn,
+  ZoomOut
+} from 'lucide-react';
 import { useReactFlow } from '@xyflow/react';
 import { useT } from '../../lib/i18n';
 import { useCanvasStore, type StageView } from '../../stores/canvas';
-import { useCanvasStageView } from '../../stores/canvas-selectors';
+import { useCanvasNodes, useCanvasStageView } from '../../stores/canvas-selectors';
+import { useAgentActivityStore } from '../../stores/agent-activity';
+import {
+  aggregateTeamSummary,
+  type CardSummary
+} from '../../lib/agent-summary';
 import type { ArrangeGap } from '../../lib/canvas-arrange';
 
 /**
@@ -84,8 +101,87 @@ export function StageHud(): JSX.Element {
     [t]
   );
 
+  // Issue #521: Canvas 全体の状態 (active / blocked / stale / completed) を 1 行で見せる。
+  // 0 件のときは表示しない (HUD が肥大化しない)。集計は agent-activity store + canvas store
+  // を購読して派生する純粋関数 aggregateTeamSummary に委譲。
+  const allNodes = useCanvasNodes();
+  const agentNodes = useMemo(
+    () => allNodes.filter((n) => n.type === 'agent'),
+    [allNodes]
+  );
+  const cardSummariesByCard = useAgentActivityStore((s) => s.byCard);
+  const cardSummaries = useMemo<Record<string, CardSummary>>(() => {
+    const out: Record<string, CardSummary> = {};
+    for (const [cardId, runtime] of Object.entries(cardSummariesByCard)) {
+      if (runtime.summary) out[cardId] = runtime.summary;
+    }
+    return out;
+  }, [cardSummariesByCard]);
+  const teamSummary = useMemo(
+    () => aggregateTeamSummary({ agentNodes, cardSummaries }),
+    [agentNodes, cardSummaries]
+  );
+  const showTeamSummary = teamSummary.total > 0;
+
   return (
-    <div className="tc__hud" role="toolbar" aria-label="Canvas view">
+    <div className="tc__hud glass-surface" role="toolbar" aria-label="Canvas view">
+      {showTeamSummary ? (
+        <>
+          <div
+            className="tc__hud-summary"
+            role="group"
+            aria-label={t('canvas.hud.summary.label')}
+          >
+            <span
+              className="tc__hud-summary-pill tc__hud-summary-pill--active"
+              title={t('canvas.hud.summary.active.tooltip')}
+            >
+              <CircleDot size={11} strokeWidth={2.2} aria-hidden="true" />
+              <span className="tc__hud-summary-num">{teamSummary.active}</span>
+              <span className="tc__hud-summary-text">
+                {t('canvas.hud.summary.active')}
+              </span>
+            </span>
+            <span
+              className={
+                'tc__hud-summary-pill tc__hud-summary-pill--blocked' +
+                (teamSummary.blocked > 0 ? ' is-on' : '')
+              }
+              title={t('canvas.hud.summary.blocked.tooltip')}
+            >
+              <AlertTriangle size={11} strokeWidth={2.2} aria-hidden="true" />
+              <span className="tc__hud-summary-num">{teamSummary.blocked}</span>
+              <span className="tc__hud-summary-text">
+                {t('canvas.hud.summary.blocked')}
+              </span>
+            </span>
+            <span
+              className={
+                'tc__hud-summary-pill tc__hud-summary-pill--stale' +
+                (teamSummary.stale > 0 ? ' is-on' : '')
+              }
+              title={t('canvas.hud.summary.stale.tooltip')}
+            >
+              <Hourglass size={11} strokeWidth={2.2} aria-hidden="true" />
+              <span className="tc__hud-summary-num">{teamSummary.stale}</span>
+              <span className="tc__hud-summary-text">
+                {t('canvas.hud.summary.stale')}
+              </span>
+            </span>
+            <span
+              className="tc__hud-summary-pill tc__hud-summary-pill--completed"
+              title={t('canvas.hud.summary.completed.tooltip')}
+            >
+              <CheckCircle2 size={11} strokeWidth={2.2} aria-hidden="true" />
+              <span className="tc__hud-summary-num">{teamSummary.completed}</span>
+              <span className="tc__hud-summary-text">
+                {t('canvas.hud.summary.completed')}
+              </span>
+            </span>
+          </div>
+          <span className="tc__hud-sep" aria-hidden="true" />
+        </>
+      ) : null}
       {views.map((v) => (
         <button
           key={v.id}

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -14,9 +14,9 @@
  *
  * 挙動は元 AgentNodeCard.tsx と完全一致。構造のみ整理。
  */
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Handle, NodeResizer, Position, type NodeProps } from '@xyflow/react';
-import { ClipboardCheck } from 'lucide-react';
+import { AlertTriangle, ClipboardCheck, ClipboardList, Clock } from 'lucide-react';
 import { useT } from '../../../../lib/i18n';
 import { useSettings } from '../../../../lib/settings-context';
 import {
@@ -24,6 +24,7 @@ import {
   NODE_MIN_W,
   NODE_MIN_H
 } from '../../../../stores/canvas';
+import { useAgentActivityStore } from '../../../../stores/agent-activity';
 import { useConfirmRemoveCard } from '../../../../lib/use-confirm-remove-card';
 import {
   renderSystemPrompt,
@@ -33,6 +34,10 @@ import { resolveAgentVisual } from '../../../../lib/agent-visual';
 import { parseShellArgs } from '../../../../lib/parse-args';
 import { resolveAgentConfig } from '../../../../lib/agent-resolver';
 import { useToast } from '../../../../lib/toast-context';
+import {
+  deriveCardSummary,
+  type CardSummary
+} from '../../../../lib/agent-summary';
 import type { TerminalViewHandle } from '../../../TerminalView';
 import type {
   HandoffCheckpoint,
@@ -113,6 +118,20 @@ function wrapBracketedPaste(text: string): string {
   return `\x1b[200~${text}\x1b[201~`;
 }
 
+/**
+ * Issue #521: deriveCardSummary が返す `{ unit, value }` を i18n キーに変換する。
+ * unit が 'now' の時は値を埋め込まないキー、それ以外は `{value}` パラメータを渡す。
+ * lastOutputAgo が null (= 起動直後で未観測) のときは「観測なし」のキーへフォールバック。
+ */
+function formatAgoLabel(
+  ago: { unit: 'now' | 'sec' | 'min' | 'hour' | 'day'; value: number } | null,
+  t: (key: string, params?: Record<string, string | number>) => string
+): string {
+  if (ago === null) return t('agentCard.summary.ago.unobserved');
+  if (ago.unit === 'now') return t('agentCard.summary.ago.now');
+  return t(`agentCard.summary.ago.${ago.unit}`, { value: ago.value });
+}
+
 function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   const termRef = useRef<TerminalViewHandle | null>(null);
   const { settings } = useSettings();
@@ -133,7 +152,31 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   const title = (data?.title as string) ?? visual.label;
   const [handoffBusy, setHandoffBusy] = useState(false);
   const [status, setStatus] = useState<string>('');
-  const [activity, setActivity] = useState<AgentStatus>('idle');
+  const [activity, setActivityState] = useState<AgentStatus>('idle');
+
+  // Issue #521: agent-activity store に書き出して StageHud 側からも観測できるようにする。
+  // CardFrame が unmount されても store にレコードを残さないよう effect で掃除する。
+  const publishActivity = useAgentActivityStore((s) => s.setActivity);
+  const clearActivity = useAgentActivityStore((s) => s.clearCard);
+  // setActivity wrapper: useState 更新 + store 通知を 1 関数にまとめる。
+  // TerminalOverlay は React.Dispatch<SetStateAction<AgentStatus>> を期待するので、
+  // 関数形 updater を素通しできる shape を保つ。
+  const setActivity: React.Dispatch<React.SetStateAction<AgentStatus>> = useCallback(
+    (next) => {
+      setActivityState((prev) => {
+        const resolved =
+          typeof next === 'function'
+            ? (next as (p: AgentStatus) => AgentStatus)(prev)
+            : next;
+        publishActivity(id, resolved, Date.now());
+        return resolved;
+      });
+    },
+    [id, publishActivity]
+  );
+  useEffect(() => {
+    return () => clearActivity(id);
+  }, [id, clearActivity]);
 
   // Issue #23 + カスタムエージェント対応:
   // agent-resolver 経由で built-in (claude/codex) + customAgents のコマンド/引数/cwd を解決する。
@@ -389,6 +432,34 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
     [accent, organizationAccent]
   );
 
+  // Issue #521: 3 行サマリ算出 + Canvas 全体集計用に store へ書き戻す。
+  // 経過時間表示を生かすために 15 秒間隔で now を更新する (long-poll は不要)。
+  const lastActivityAt = useAgentActivityStore(
+    (s) => s.byCard[id]?.lastActivityAt ?? null
+  );
+  const publishSummary = useAgentActivityStore((s) => s.setSummary);
+  const [nowTick, setNowTick] = useState(() => Date.now());
+  useEffect(() => {
+    const t = window.setInterval(() => setNowTick(Date.now()), 15_000);
+    return () => window.clearInterval(t);
+  }, []);
+  const summary = useMemo<CardSummary>(
+    () =>
+      deriveCardSummary({
+        payload,
+        roleProfileId,
+        title,
+        activity,
+        lastActivityAt,
+        now: nowTick
+      }),
+    [payload, roleProfileId, title, activity, lastActivityAt, nowTick]
+  );
+  useEffect(() => {
+    publishSummary(id, summary);
+  }, [id, summary, publishSummary]);
+  const summaryAgoLabel = formatAgoLabel(summary.lastOutputAgo, t);
+
   return (
     <>
       <NodeResizer
@@ -447,6 +518,42 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
             </button>
           </span>
         </header>
+        <div
+          className={
+            'canvas-agent-card__summary' +
+            (summary.needsLeaderInput
+              ? ' canvas-agent-card__summary--alert'
+              : '')
+          }
+          aria-label={t('agentCard.summary.region')}
+        >
+          <div
+            className="canvas-agent-card__summary-row canvas-agent-card__summary-row--task"
+            title={summary.taskTitle || t('agentCard.summary.noTask')}
+          >
+            <ClipboardList size={11} strokeWidth={2} aria-hidden="true" />
+            <span className="canvas-agent-card__summary-text">
+              {summary.taskTitle || t('agentCard.summary.noTask')}
+            </span>
+          </div>
+          <div className="canvas-agent-card__summary-row canvas-agent-card__summary-row--clock">
+            <Clock size={11} strokeWidth={2} aria-hidden="true" />
+            <span className="canvas-agent-card__summary-text">
+              {summaryAgoLabel}
+            </span>
+          </div>
+          {summary.needsLeaderInput ? (
+            <div
+              className="canvas-agent-card__summary-row canvas-agent-card__summary-row--leader"
+              role="status"
+            >
+              <AlertTriangle size={11} strokeWidth={2} aria-hidden="true" />
+              <span className="canvas-agent-card__summary-text">
+                {t('agentCard.summary.needsLeader')}
+              </span>
+            </div>
+          ) : null}
+        </div>
         <TerminalOverlay
           cardId={id}
           termRef={termRef}

--- a/src/renderer/src/lib/agent-summary.ts
+++ b/src/renderer/src/lib/agent-summary.ts
@@ -1,0 +1,192 @@
+/**
+ * agent-summary — Canvas 上の各 Agent カードと Canvas 全体の状態要約を組み立てる純粋関数群。
+ *
+ * Issue #521: 「誰が何を / いつから / 次に何が必要か」を 1 行で把握できるよう、
+ *   - カード単位の 3 行サマリ (current task / 経過 / 次に Leader 入力が必要か)
+ *   - Canvas 全体の集計 (active / blocked / stale / completed)
+ * を計算するロジックを 1 箇所に集約する。
+ *
+ * ここは IPC を呼ばない: 既存の AgentPayload と CardFrame 内で測れる lastActivityAt のみを
+ * 入力にして派生する。Issue #510 / #514 の diagnostics + tasks IPC が後追いで入ったら、
+ * `tauri-api/team.ts` 側の合成 wrapper がここを呼びつつ実値を流し込めるようにする。
+ */
+import type { Node } from '@xyflow/react';
+import type { CardData } from '../stores/canvas';
+import type { AgentPayload, AgentStatus } from '../components/canvas/cards/AgentNodeCard/types';
+
+/**
+ * 「次に Leader 入力が必要か」と判定する idle しきい値 (ms)。
+ * Worker が `idle` 状態のまま 90 秒以上沈黙していれば、何らかの確認/指示待ちとみなす。
+ * 短すぎると「思考中の長い 1 ターン」を Leader 待ちと誤検出するため余裕を取る。
+ */
+export const NEEDS_LEADER_IDLE_MS = 90_000;
+
+/**
+ * 「停滞 (stale)」とみなす最終出力からの経過時間 (ms)。
+ * Issue #514 のダッシュボード stale カウントと一致させるため 5 分。
+ */
+export const STALE_OUTPUT_MS = 5 * 60_000;
+
+export interface CardSummaryInput {
+  payload: AgentPayload;
+  /** ロール解決済み (leader / planner / worker / ...) */
+  roleProfileId: string;
+  /** カードタイトル (auto-summary 含む) */
+  title: string;
+  /** 現在のアクティビティ状態 (`idle` / `thinking` / `typing`) */
+  activity: AgentStatus;
+  /** 直近で出力 or 入力イベントがあった unix ms。未観測なら null。 */
+  lastActivityAt: number | null;
+  /** 表示時刻 (Date.now()) — テスト容易性のため引数に外出し */
+  now: number;
+}
+
+export interface CardSummary {
+  /** 1 行目: 現在のタスク (空文字列なら呼び出し側でフォールバック表示) */
+  taskTitle: string;
+  /** 2 行目: 「最終出力から N 秒/分/時間前」のローカライズ済みテキスト or null (未観測) */
+  lastOutputAgo: { unit: 'now' | 'sec' | 'min' | 'hour' | 'day'; value: number } | null;
+  /** 3 行目: Leader 入力待ちかどうか (true のときだけ警告行を出す) */
+  needsLeaderInput: boolean;
+  /** 集計用: 停滞しているか */
+  isStale: boolean;
+  /** 集計用: handoff 等で「完了」状態に達しているか */
+  isCompleted: boolean;
+  /** 集計用: アクティブに動いているか (typing / thinking) */
+  isActive: boolean;
+}
+
+/**
+ * カード 1 枚分のサマリを派生する。
+ * 副作用無し / DOM 非依存 / 同じ input なら同じ output になる。
+ */
+export function deriveCardSummary(input: CardSummaryInput): CardSummary {
+  const { payload, roleProfileId, title, activity, lastActivityAt, now } = input;
+
+  const taskTitle = pickTaskTitle(payload, title);
+  const lastOutputAgo =
+    lastActivityAt === null ? null : formatRelativeMs(now - lastActivityAt);
+
+  const handoffStatus = payload.latestHandoff?.status ?? null;
+  const handoffWaitingAck =
+    handoffStatus === 'created' || handoffStatus === 'injected';
+  const handoffCompleted =
+    handoffStatus === 'acked' ||
+    handoffStatus === 'acknowledged' ||
+    handoffStatus === 'retired';
+
+  const isActive = activity === 'thinking' || activity === 'typing';
+  const idleMs = lastActivityAt === null ? Infinity : now - lastActivityAt;
+  const idleLong = idleMs >= NEEDS_LEADER_IDLE_MS;
+  const isStale = idleMs >= STALE_OUTPUT_MS;
+  // Worker が長く沈黙、もしくは leader への ack 待ちが残っているなら Leader 入力を促す。
+  // Leader カード自身は判定対象外 (Leader が Leader を待つことは無いため)。
+  const needsLeaderInput =
+    roleProfileId !== 'leader' && (handoffWaitingAck || (idleLong && !isActive));
+
+  return {
+    taskTitle,
+    lastOutputAgo,
+    needsLeaderInput,
+    isStale: isStale && !isActive,
+    isCompleted: handoffCompleted,
+    isActive
+  };
+}
+
+/**
+ * payload から「現在のタスクっぽい 1 行テキスト」を取り出す。
+ * 優先順位:
+ *   1. payload.initialMessage (handoff 経由の起動プロンプト)
+ *   2. payload.customInstructions / codexInstructions (Leader recruit 時の追加指示)
+ * カードタイトルは header 側で既に表示されるためサマリ行では敢えて参照しない
+ * (重複表示にならないよう header との役割分担を保つ)。すべて空なら空文字列を
+ * 返し、呼び出し側で「未割当」フォールバック表示する。
+ * 第 2 引数 `_title` は将来 title から拾う必要が出たとき用に残してある。
+ */
+export function pickTaskTitle(payload: AgentPayload, _title: string): string {
+  const sources = [
+    payload.initialMessage,
+    payload.customInstructions,
+    payload.codexInstructions
+  ];
+  for (const raw of sources) {
+    if (!raw) continue;
+    const cleaned = raw.replace(/\s+/g, ' ').trim();
+    if (!cleaned) continue;
+    return truncateTaskTitle(cleaned, 64);
+  }
+  return '';
+}
+
+/**
+ * タスクタイトルの末尾省略。CJK 1 文字 = 1 列前提のシンプル切り詰め。
+ * 長過ぎる prompt がカード幅を破壊しないように使う。
+ */
+export function truncateTaskTitle(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + '…';
+}
+
+/**
+ * 経過時間を「単位 + 値」に正規化する。i18n 文字列はここでは組まず、呼び出し側で
+ * `t('agentCard.summary.ago.min', { value })` 等に流す。
+ *
+ * 範囲:
+ *   - < 5 秒: now (たった今)
+ *   - < 60 秒: sec
+ *   - < 60 分: min
+ *   - < 24 時間: hour
+ *   - それ以上: day
+ */
+export function formatRelativeMs(
+  diffMs: number
+): { unit: 'now' | 'sec' | 'min' | 'hour' | 'day'; value: number } {
+  const ms = Math.max(0, diffMs);
+  if (ms < 5_000) return { unit: 'now', value: 0 };
+  if (ms < 60_000) return { unit: 'sec', value: Math.floor(ms / 1_000) };
+  if (ms < 3_600_000) return { unit: 'min', value: Math.floor(ms / 60_000) };
+  if (ms < 86_400_000) return { unit: 'hour', value: Math.floor(ms / 3_600_000) };
+  return { unit: 'day', value: Math.floor(ms / 86_400_000) };
+}
+
+export interface TeamSummaryAggregate {
+  total: number;
+  active: number;
+  blocked: number;
+  stale: number;
+  completed: number;
+}
+
+export interface TeamAggregateInput {
+  /** Agent カードのみ。caller 側で `n.type === 'agent'` でフィルタ済みを渡す。 */
+  agentNodes: Node<CardData>[];
+  /** カード id -> CardSummary。CardFrame 側からブロードキャストされた最新値を集約する。 */
+  cardSummaries: Record<string, CardSummary>;
+}
+
+/**
+ * 全 agent カードの CardSummary から HUD 用集計を作る。
+ * cardSummaries に未登録のカードは「unknown / count しない」扱い。
+ */
+export function aggregateTeamSummary(input: TeamAggregateInput): TeamSummaryAggregate {
+  let total = 0;
+  let active = 0;
+  let blocked = 0;
+  let stale = 0;
+  let completed = 0;
+  for (const node of input.agentNodes) {
+    if (node.type !== 'agent') continue;
+    total += 1;
+    const summary = input.cardSummaries[node.id];
+    if (!summary) continue;
+    if (summary.isCompleted) {
+      completed += 1;
+      continue;
+    }
+    if (summary.needsLeaderInput) blocked += 1;
+    else if (summary.isStale) stale += 1;
+    else if (summary.isActive) active += 1;
+  }
+  return { total, active, blocked, stale, completed };
+}

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -290,6 +290,29 @@ const ja: Dict = {
   'agentStatus.thinking': '思考中',
   'agentStatus.typing': '応答中',
 
+  // Issue #521: Agent カード 3 行サマリ
+  'agentCard.summary.region': 'エージェントの状態サマリ',
+  'agentCard.summary.noTask': '現在のタスクは未割当',
+  'agentCard.summary.needsLeader': 'Leader の入力待ち',
+  'agentCard.summary.ago.unobserved': '出力はまだ観測されていません',
+  'agentCard.summary.ago.now': '直前に出力',
+  'agentCard.summary.ago.sec': '最終出力から {value} 秒前',
+  'agentCard.summary.ago.min': '最終出力から {value} 分前',
+  'agentCard.summary.ago.hour': '最終出力から {value} 時間前',
+  'agentCard.summary.ago.day': '最終出力から {value} 日前',
+
+  // Issue #521: Canvas 全体サマリ HUD
+  'canvas.hud.summary.label': 'Canvas 全体の状態サマリ',
+  'canvas.hud.summary.active': '進行中',
+  'canvas.hud.summary.active.tooltip': '進行中 — 直近に出力があったエージェントの数',
+  'canvas.hud.summary.blocked': 'Leader 待ち',
+  'canvas.hud.summary.blocked.tooltip':
+    'Leader 待ち — Leader の入力 / handoff ack を待っているエージェントの数',
+  'canvas.hud.summary.stale': '停滞',
+  'canvas.hud.summary.stale.tooltip': '停滞 — 5 分以上出力が無いエージェントの数',
+  'canvas.hud.summary.completed': '完了',
+  'canvas.hud.summary.completed.tooltip': '完了 — handoff ack 済 / 退役済のエージェントの数',
+
   // ---------- Sessions ----------
   'sessions.resume': 'セッション {id} に戻る',
   'sessions.messages': '{count} 件',
@@ -830,6 +853,30 @@ const en: Dict = {
   'agentStatus.idle': 'Idle',
   'agentStatus.thinking': 'Thinking',
   'agentStatus.typing': 'Typing',
+
+  // Issue #521: Agent card 3-line summary
+  'agentCard.summary.region': 'Agent status summary',
+  'agentCard.summary.noTask': 'No task assigned',
+  'agentCard.summary.needsLeader': 'Awaiting leader input',
+  'agentCard.summary.ago.unobserved': 'No output observed yet',
+  'agentCard.summary.ago.now': 'Output just now',
+  'agentCard.summary.ago.sec': 'Last output {value}s ago',
+  'agentCard.summary.ago.min': 'Last output {value}m ago',
+  'agentCard.summary.ago.hour': 'Last output {value}h ago',
+  'agentCard.summary.ago.day': 'Last output {value}d ago',
+
+  // Issue #521: Canvas-wide summary HUD
+  'canvas.hud.summary.label': 'Canvas team summary',
+  'canvas.hud.summary.active': 'Active',
+  'canvas.hud.summary.active.tooltip': 'Active — agents with recent output',
+  'canvas.hud.summary.blocked': 'Awaiting leader',
+  'canvas.hud.summary.blocked.tooltip':
+    'Awaiting leader — agents waiting for leader input or handoff ack',
+  'canvas.hud.summary.stale': 'Stale',
+  'canvas.hud.summary.stale.tooltip': 'Stale — agents with no output for 5+ minutes',
+  'canvas.hud.summary.completed': 'Completed',
+  'canvas.hud.summary.completed.tooltip':
+    'Completed — agents with acked handoff or retired sessions',
 
   // ---------- Sessions ----------
   'sessions.resume': 'Resume session {id}',

--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -22,6 +22,7 @@ import { logs } from './tauri-api/logs';
 import { roleProfiles } from './tauri-api/role-profiles';
 import { sessions } from './tauri-api/sessions';
 import { settings } from './tauri-api/settings';
+import { team } from './tauri-api/team';
 import { teamHistory } from './tauri-api/team-history';
 import { terminal } from './tauri-api/terminal';
 
@@ -40,6 +41,7 @@ export const api = {
   git,
   files,
   sessions,
+  team,
   teamHistory,
   handoffs,
   dialog,

--- a/src/renderer/src/lib/tauri-api/team.ts
+++ b/src/renderer/src/lib/tauri-api/team.ts
@@ -1,0 +1,41 @@
+/**
+ * tauri-api/team — Canvas 上のチーム / マルチエージェント運用に関する renderer 側 wrapper。
+ *
+ * Issue #521 (Renderer Canvas UI): カードと Canvas 全体の状態要約 UI を支える wrapper を集約。
+ * Issue #511 (Rust TeamHub Ops): inject 失敗時の retry / listener wrapper はこの namespace に
+ *   後追いで append する想定 (`team.retryInject` / `team.onInjectFailed`)。
+ *
+ * 現時点で Rust 側に `team_summary_*` IPC は無いので、`team.summary()` は CardFrame 側で
+ * 集めた `cardSummaries` レコードから純粋関数 `aggregateTeamSummary` を呼ぶだけの薄い
+ * thunk wrapper として動かす。Issue #510 / #514 の diagnostics + tasks IPC が入ったら、
+ * ここで invoke を併用して実値を流し込めるようにする。
+ */
+import type { Node } from '@xyflow/react';
+import type { CardData } from '../../stores/canvas';
+import {
+  aggregateTeamSummary,
+  type CardSummary,
+  type TeamSummaryAggregate
+} from '../agent-summary';
+
+export interface TeamSummaryRequest {
+  /** 集計対象の agent ノード (caller 側で type === 'agent' フィルタ済み) */
+  agentNodes: Node<CardData>[];
+  /** カード id → 直近の派生サマリ */
+  cardSummaries: Record<string, CardSummary>;
+}
+
+export const team = {
+  /**
+   * 全 agent カードの CardSummary を集計して HUD 用の数値を返す。
+   * 同期計算だが将来 Rust 側 diagnostics と合成しても呼び口を変えないよう Promise を返す。
+   */
+  summary(req: TeamSummaryRequest): Promise<TeamSummaryAggregate> {
+    return Promise.resolve(
+      aggregateTeamSummary({
+        agentNodes: req.agentNodes,
+        cardSummaries: req.cardSummaries
+      })
+    );
+  }
+};

--- a/src/renderer/src/stores/agent-activity.ts
+++ b/src/renderer/src/stores/agent-activity.ts
@@ -1,0 +1,81 @@
+/**
+ * agent-activity store — Canvas 上の各 Agent カードのランタイム状態 (lastActivityAt /
+ * activity / cardSummary) を共有する軽量 zustand store。
+ *
+ * Issue #521: CardFrame.tsx は idle timer / payload を持っているが、StageHud は
+ * Canvas 全体を集約した HUD を出したい。両者を疎結合に保つために
+ *   - CardFrame が `setActivity` / `setSummary` を呼ぶ (write 一方向)
+ *   - StageHud が `summaries` を購読する (read 一方向)
+ * という最小契約だけを定義する。
+ *
+ * 永続化はしない: PTY 出力タイムスタンプはセッション内でのみ意味がある (再起動後は
+ * `idleMs = Infinity` 扱いの方が安全) ため localStorage には書かない。
+ */
+import { create } from 'zustand';
+import type { CardSummary } from '../lib/agent-summary';
+import type { AgentStatus } from '../components/canvas/cards/AgentNodeCard/types';
+
+interface AgentRuntime {
+  /** typing / thinking / idle */
+  activity: AgentStatus;
+  /** 最後に出力 or 入力イベントを観測した unix ms。null = 未観測 (起動直後) */
+  lastActivityAt: number | null;
+  /** CardFrame が deriveCardSummary で算出した最新サマリ */
+  summary: CardSummary | null;
+}
+
+interface AgentActivityState {
+  byCard: Record<string, AgentRuntime>;
+  /** activity 状態を更新し、必要に応じて lastActivityAt も更新する */
+  setActivity: (cardId: string, activity: AgentStatus, at: number) => void;
+  /** CardFrame 側で派生したサマリを書き込む (HUD 用集計) */
+  setSummary: (cardId: string, summary: CardSummary) => void;
+  /** カード破棄時に runtime レコードを掃除 */
+  clearCard: (cardId: string) => void;
+}
+
+export const useAgentActivityStore = create<AgentActivityState>((set) => ({
+  byCard: {},
+  setActivity: (cardId, activity, at) =>
+    set((state) => {
+      const prev = state.byCard[cardId];
+      // typing / thinking のとき or activity 切替のときは lastActivityAt を進める。
+      // idle 復帰時は「最後に出力した時刻」を据え置く (経過時間カウンタが進み続ける)。
+      const nextLastAt =
+        activity === 'idle' ? (prev?.lastActivityAt ?? null) : at;
+      const next: AgentRuntime = {
+        activity,
+        lastActivityAt: nextLastAt,
+        summary: prev?.summary ?? null
+      };
+      // 参照同一性で React re-render を最小化: activity が同一かつ lastActivityAt が
+      // 据え置きなら state を変えない (idle 連発時の不要 publish 抑止)。
+      if (
+        prev &&
+        prev.activity === next.activity &&
+        prev.lastActivityAt === next.lastActivityAt
+      ) {
+        return state;
+      }
+      return { byCard: { ...state.byCard, [cardId]: next } };
+    }),
+  setSummary: (cardId, summary) =>
+    set((state) => {
+      const prev = state.byCard[cardId];
+      const next: AgentRuntime = {
+        activity: prev?.activity ?? 'idle',
+        lastActivityAt: prev?.lastActivityAt ?? null,
+        summary
+      };
+      // 同一サマリ参照なら state を変えない
+      if (prev && prev.summary === summary) return state;
+      return { byCard: { ...state.byCard, [cardId]: next } };
+    }),
+  clearCard: (cardId) =>
+    set((state) => {
+      if (!(cardId in state.byCard)) return state;
+      const next = { ...state.byCard };
+      delete next[cardId];
+      return { byCard: next };
+    })
+}));

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -726,6 +726,71 @@
   color: var(--fg);
 }
 
+/* ----------
+ * Issue #521: 状態 3 行サマリ。
+ *   1 行目: 現在のタスク (ClipboardList)
+ *   2 行目: 最終出力からの経過 (Clock)
+ *   3 行目: needsLeaderInput=true のとき警告 (AlertTriangle, conditional)
+ * 既存 header の右端アクション群を壊さないよう、`<header>` の sibling として置く。
+ * ---------- */
+.canvas-agent-card__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 12px 6px 14px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-elev, var(--bg-panel)) 70%, transparent);
+  font-size: var(--text-xs, 11px);
+  line-height: 1.35;
+  color: var(--fg-subtle);
+  user-select: none;
+  pointer-events: none; /* 行はクリック対象では無いのでドラッグ抜けを許す */
+}
+.canvas-agent-card__summary--alert {
+  background: color-mix(
+    in srgb,
+    var(--accent-warning, #d97706) 10%,
+    var(--bg-elev, var(--bg-panel)) 90%
+  );
+}
+.canvas-agent-card__summary-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.canvas-agent-card__summary-row--task {
+  color: var(--fg);
+  font-weight: 500;
+}
+.canvas-agent-card__summary-row--leader {
+  color: var(--accent-warning, #d97706);
+  font-weight: 600;
+}
+.canvas-agent-card__summary-row--leader svg {
+  color: var(--accent-warning, #d97706);
+}
+.canvas-agent-card__summary-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Issue #260 PR-3 互換: density=compact ではサマリ占有を抑え、
+ * 1 行目 (タスク) のみ表示する。残り 2 行は折りたたんでカード密度を維持。 */
+[data-density='compact'] .canvas-agent-card__summary-row--clock,
+[data-density='compact'] .canvas-agent-card__summary-row--leader {
+  display: none;
+}
+[data-density='compact'] .canvas-agent-card__summary {
+  padding: 2px 12px 3px 14px;
+}
+
+/* Issue #511 (rust_team_hub_ops 担当) の inject warning 用の予約スロット。
+ * 当該 PR で `__inject-warning` クラスが append される。位置は __summary 直下。 */
+
 .canvas-agent-card__term {
   flex: 1;
   min-height: 0;
@@ -956,6 +1021,64 @@
   height: 16px;
   background: var(--border);
   margin: 0 3px;
+}
+
+/* ----------
+ * Issue #521: HUD 左端の Canvas 全体サマリ (active / blocked / stale / completed)。
+ * 既存 view ボタン群と並ぶピル型バッジ。0 件のときは render 側で非表示。
+ * 視認性を保つため数値を強調、ラベルは muted 色で添える。
+ * ---------- */
+.tc__hud-summary {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 4px;
+}
+.tc__hud-summary-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg-elev) 70%, transparent);
+  color: var(--text-mute);
+  border: 1px solid transparent;
+  line-height: 1;
+  white-space: nowrap;
+}
+.tc__hud-summary-num {
+  font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+.tc__hud-summary-text {
+  color: var(--text-mute);
+}
+/* 状態別の強調色。0 件のときは無強調 (muted) のまま。 */
+.tc__hud-summary-pill--active .tc__hud-summary-num {
+  color: var(--accent-success, var(--accent));
+}
+.tc__hud-summary-pill--blocked.is-on {
+  background: color-mix(in srgb, var(--accent-warning, #d97706) 16%, transparent);
+  border-color: color-mix(in srgb, var(--accent-warning, #d97706) 35%, transparent);
+}
+.tc__hud-summary-pill--blocked.is-on .tc__hud-summary-num,
+.tc__hud-summary-pill--blocked.is-on svg {
+  color: var(--accent-warning, #d97706);
+}
+.tc__hud-summary-pill--stale.is-on {
+  background: color-mix(in srgb, var(--text-mute) 18%, transparent);
+}
+.tc__hud-summary-pill--stale.is-on .tc__hud-summary-num,
+.tc__hud-summary-pill--stale.is-on svg {
+  color: var(--text);
+}
+.tc__hud-summary-pill--completed .tc__hud-summary-num {
+  color: var(--accent-success, var(--accent));
+}
+/* compact 密度ではテキストを折りたたんで数値+アイコンだけ残す。 */
+[data-density='compact'] .tc__hud-summary-text {
+  display: none;
 }
 
 /* Issue #369: arrange popover anchored to HUD */


### PR DESCRIPTION
## Summary

- AgentNodeCard CardFrame に「現在のタスク / 最終出力からの経過 / Leader 入力待ち」の 3 行サマリを追加
- StageHud に Canvas 全体の集約バッジ (active / blocked / stale / completed) を追加 (glass-surface 対応)
- 派生ロジックは `lib/agent-summary.ts` に集約 (純粋関数・テスト容易)
- CardFrame ↔ StageHud の runtime 状態は新設の `stores/agent-activity.ts` (zustand) で疎結合に共有
- `lib/tauri-api/team.ts` を新設し、将来 #510 / #514 の diagnostics+tasks IPC が入ったら合成できる口を予約
- i18n (ja/en) に summary / HUD ラベル一式を追加

Closes #521

## 衝突調整

CardFrame.tsx は #511 (rust_team_hub_ops の inject retry button) も触る予定。`<header>` の sibling として `__summary` block を独立配置し、`__inject-warning` block は `__summary` 直下に append できる構造にしてある (合意済み)。

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npx vitest run` 全 278 件通過 (既存 AgentNodeCard.test.tsx を含む)
- [ ] 手動: `npm run dev` で全テーマ (claude-dark/light, dark, midnight, light, glass) でレイアウト崩れが無いこと
- [ ] 手動: 大人数 (8 名) チームで HUD が固まらないこと
- [ ] 手動: `density=compact` でカードが圧縮表示されること