### PR TITLE
feat(team-hub): update_task 構造化 report_payload + 統合フェーズ skill 追加 (#516)

### DIFF
--- a/.claude/skills/vibe-team/SKILL.md
+++ b/.claude/skills/vibe-team/SKILL.md
@@ -142,6 +142,45 @@ Leader が `team_recruit` を始める前に、必ず以下の 5 軸のうち **
 
 このチェックを通してから `team_recruit` を実行する。実装途中で軸の偏りが顕在化したら、その時点で 1 から再評価して `team_dismiss` / 追加 recruit で調整する。
 
+## 統合フェーズ (Leader が最後に通す 4 ステップ)
+
+5 軸の最終段「**統合 (integrate)**」は Leader (もしくは Leader が任命した integrator ロール) が責任を持って通す。複数 worker の成果が散逸しないよう、必ず以下 4 ステップを順に踏む。
+
+### Step 1: 収集 (gather)
+
+- すべての担当 worker から **構造化 report** を吸い上げる。
+- 各 worker は `team_update_task(task_id, "done", { ..., report_payload: { findings, proposal, risks, next_action, artifacts } })` で構造化レポートを返す (Issue #516)。
+  - `findings` — 調査・実装で得られた発見 (1〜数段落の markdown)
+  - `proposal` — 採用方針の推奨 (1 行で良い)
+  - `risks` — リスク・既知の懸念事項のリスト
+  - `next_action` — 次の handoff 先の作業 (top-level `next_action` と重複可)
+  - `artifacts` — 生成物のパス配列 (PR 番号 / ファイル / 計測結果 JSON 等)
+- 収集の起点は `team_get_tasks()` と Rust 側 `team-state/<project>/<team_id>.json` の `worker_reports[]`。Leader はチャット履歴ではなくこれらの構造化データを **唯一の正** とする。
+
+### Step 2: 矛盾抽出 (diff)
+
+- 複数 report を **軸ごとに横並び** にして読む (findings / proposal / risks / artifacts)。
+- 矛盾しやすい典型パターン:
+  - **proposal の対立** — 「memoize で解決」vs「アーキテクチャ作り直し」
+  - **risks の盲点** — A の findings に出ているリスクが B では未言及
+  - **artifacts のスコープ食い違い** — 同じファイルを 2 名以上が独立に変更して衝突
+- 矛盾が見つかったら、Leader はその 2〜3 名に `team_send` で **相互に共有** する (`[diff: A の proposal vs B の proposal]` と明示)。1 名に「他者の findings を読んで再評価して」と依頼してもよい。
+
+### Step 3: 優先度判定 (prioritize)
+
+- 残った提案を以下の 3 軸で優先度づけする:
+  1. **ユーザー要求への直接性** — 当初の指示にどれだけ直接答えているか
+  2. **リスクの残量** — risks が解消されているか / 受容可能か
+  3. **コスト** — 実装工数 / レビュー工数 / マージ後の保守負担
+- 同点なら「2. リスク残量が小さい方」を優先する。
+
+### Step 4: 採用方針 (decide & execute)
+
+- 採用する proposal を 1 つに確定し、`team_send('leader→all', "採用方針: ... (理由 1 行)")` で全員に通達する。
+- 採用された worker (もしくは integrator) が単一の PR にまとめて push する。**複数 worker の小 PR を並列に出さない** — bot レビューと merge が直列になり統合判断が崩れる。
+- PR 本文の `## Summary` には Step 2 で見つかった主要な矛盾と Step 4 の採用根拠を 2〜3 行で残す。後から「なぜこの選択をしたか」が辿れるようにする。
+- 統合専任の `integrator` ロールを使う場合のサンプル instructions は `src/renderer/src/lib/role-profiles-builtin.ts` の `INTEGRATOR_TEMPLATE_INSTRUCTIONS_JA` / `_EN` を参照 (`team_recruit({role_id:"integrator", instructions: ...})` でそのまま使える)。
+
 ## 名前空間 (vibe-editor 独自)
 
 - 環境変数: `VIBE_TEAM_*` / `VIBE_AGENT_ID`

--- a/src-tauri/src/commands/team_state.rs
+++ b/src-tauri/src/commands/team_state.rs
@@ -40,6 +40,31 @@ pub struct TeamTaskSnapshot {
     pub required_human_decision: Option<String>,
 }
 
+/// Issue #516: 統合フェーズで Leader が複数 worker の成果を突き合わせるための構造化フィールド。
+///
+/// 既存の単発フィールド (`summary` / `next_action` / `artifact_path`) と重複しても構わない設計で、
+/// 後方互換性のため全フィールドが optional。Leader が integrate するときに findings/proposal/risks
+/// を横断比較しやすくすることが目的。
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerReportPayload {
+    /// 調査・実装で得られた発見・観察結果 (markdown / プレーンテキスト)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub findings: Option<String>,
+    /// 採用方針の推奨 (Leader 向けの提案)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proposal: Option<String>,
+    /// リスク・既知の懸念事項 (Leader が他 worker と突き合わせる)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub risks: Vec<String>,
+    /// 次にやるべき具体的な行動 (top-level next_action と重複可)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_action: Option<String>,
+    /// 複数の生成物パス (top-level artifact_path より柔軟)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<String>,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkerReportSnapshot {
@@ -56,6 +81,9 @@ pub struct WorkerReportSnapshot {
     pub next_action: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact_path: Option<String>,
+    /// Issue #516: 構造化 report_payload (integrator が複数 worker の成果を突き合わせるため)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<WorkerReportPayload>,
     pub created_at: String,
 }
 

--- a/src-tauri/src/team_hub/protocol/tools/send.rs
+++ b/src-tauri/src/team_hub/protocol/tools/send.rs
@@ -174,6 +174,7 @@ pub async fn team_send(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result
                 blocked_reason: None,
                 next_action: None,
                 artifact_path: None,
+                payload: None,
                 created_at: timestamp.clone(),
             });
         while team.worker_reports.len() > 50 {

--- a/src-tauri/src/team_hub/protocol/tools/update_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/update_task.rs
@@ -21,6 +21,61 @@ fn optional_bool(args: &Value, snake: &str, camel: &str) -> Option<bool> {
         .and_then(|v| v.as_bool())
 }
 
+/// Issue #516: `report_payload` をネスト JSON / フラット object どちらでも受けてパースする。
+fn optional_report_payload(
+    args: &Value,
+) -> Option<crate::commands::team_state::WorkerReportPayload> {
+    let payload = args
+        .get("report_payload")
+        .or_else(|| args.get("reportPayload"))?;
+    if !payload.is_object() {
+        return None;
+    }
+    let pick_string = |snake: &str, camel: &str| -> Option<String> {
+        payload
+            .get(snake)
+            .or_else(|| payload.get(camel))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(ToOwned::to_owned)
+    };
+    let pick_string_array = |key: &str| -> Vec<String> {
+        payload
+            .get(key)
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    };
+    let findings = pick_string("findings", "findings");
+    let proposal = pick_string("proposal", "proposal");
+    let next_action = pick_string("next_action", "nextAction");
+    let risks = pick_string_array("risks");
+    let artifacts = pick_string_array("artifacts");
+    let all_empty = findings.is_none()
+        && proposal.is_none()
+        && next_action.is_none()
+        && risks.is_empty()
+        && artifacts.is_empty();
+    if all_empty {
+        return None;
+    }
+    Some(crate::commands::team_state::WorkerReportPayload {
+        findings,
+        proposal,
+        risks,
+        next_action,
+        artifacts,
+    })
+}
+
 fn looks_like_human_gate(text: &str) -> bool {
     let lower = text.to_ascii_lowercase();
     lower.contains("human")
@@ -40,8 +95,19 @@ pub async fn team_update_task(
     let status = args.get("status").and_then(|v| v.as_str()).unwrap_or("");
     let summary = optional_string(args, "summary", "summary");
     let blocked_reason = optional_string(args, "blocked_reason", "blockedReason");
-    let next_action = optional_string(args, "next_action", "nextAction");
-    let artifact_path = optional_string(args, "artifact_path", "artifactPath");
+    let report_payload = optional_report_payload(args);
+    // Issue #516: top-level next_action が無いとき report_payload.next_action を昇格させる。
+    let next_action = optional_string(args, "next_action", "nextAction").or_else(|| {
+        report_payload
+            .as_ref()
+            .and_then(|p| p.next_action.clone())
+    });
+    // Issue #516: top-level artifact_path が無いとき report_payload.artifacts[0] を昇格させる。
+    let artifact_path = optional_string(args, "artifact_path", "artifactPath").or_else(|| {
+        report_payload
+            .as_ref()
+            .and_then(|p| p.artifacts.first().cloned())
+    });
     let required_human_decision =
         optional_string(args, "required_human_decision", "requiredHumanDecision");
     let explicit_human_gate =
@@ -121,6 +187,7 @@ pub async fn team_update_task(
                     blocked_reason: blocked_reason.clone().or(task_blocked_reason),
                     next_action: next_action.clone().or(task_next_action),
                     artifact_path: artifact_path.clone().or(task_artifact_path),
+                    payload: report_payload.clone(),
                     created_at: now_iso.clone(),
                 });
             while team.worker_reports.len() > 50 {
@@ -254,5 +321,154 @@ mod tests {
             team.next_actions.back().map(String::as_str),
             Some("Wait for QA")
         );
+    }
+
+    /// Issue #516: `report_payload` (findings/proposal/risks/next_action/artifacts[]) を渡したとき
+    /// WorkerReportSnapshot.payload に保存され、artifacts[0] が top-level artifact_path に昇格し、
+    /// payload.next_action が top-level next_action に昇格することを確認する。
+    #[tokio::test]
+    async fn update_task_persists_structured_report_payload() {
+        let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+        let team_id = "team-516".to_string();
+        {
+            let mut state = hub.state.lock().await;
+            let team = state
+                .teams
+                .entry(team_id.clone())
+                .or_insert_with(TeamInfo::default);
+            team.tasks.push_back(TeamTask {
+                id: 11,
+                assigned_to: "researcher".into(),
+                description: "investigate canvas perf".into(),
+                status: "pending".into(),
+                created_by: "leader".into(),
+                created_at: "2026-05-07T10:00:00Z".into(),
+                updated_at: None,
+                summary: None,
+                blocked_reason: None,
+                next_action: None,
+                artifact_path: None,
+                blocked_by_human_gate: false,
+                required_human_decision: None,
+            });
+        }
+
+        let ctx = CallContext {
+            team_id: team_id.clone(),
+            role: "researcher".into(),
+            agent_id: "vc-r-1".into(),
+        };
+
+        team_update_task(
+            &hub,
+            &ctx,
+            &json!({
+                "task_id": 11,
+                "status": "done",
+                "summary": "Found 3 hot paths in canvas store selectors",
+                "report_payload": {
+                    "findings": "selectorA / selectorB / selectorC are recomputed every frame",
+                    "proposal": "memoize via zustand shallow + add equality fn",
+                    "risks": [
+                        "shallow ではネスト object の差分を取り損ねる可能性",
+                        "memoize の TTL を入れないと stale に読まれる"
+                    ],
+                    "next_action": "実装担当に hand off (selectorA から)",
+                    "artifacts": [
+                        "tasks/issue-516/findings.md",
+                        "tasks/issue-516/profile.json"
+                    ]
+                }
+            }),
+        )
+        .await
+        .expect("team_update_task ok");
+
+        let state = hub.state.lock().await;
+        let team = state.teams.get(&team_id).unwrap();
+        assert_eq!(team.worker_reports.len(), 1);
+        let report = team.worker_reports.back().unwrap();
+        let payload = report
+            .payload
+            .as_ref()
+            .expect("payload should be persisted");
+        assert_eq!(
+            payload.findings.as_deref(),
+            Some("selectorA / selectorB / selectorC are recomputed every frame")
+        );
+        assert_eq!(
+            payload.proposal.as_deref(),
+            Some("memoize via zustand shallow + add equality fn")
+        );
+        assert_eq!(payload.risks.len(), 2);
+        assert_eq!(payload.artifacts.len(), 2);
+        assert_eq!(
+            payload.next_action.as_deref(),
+            Some("実装担当に hand off (selectorA から)")
+        );
+        // top-level next_action / artifact_path への昇格を確認
+        assert_eq!(
+            report.next_action.as_deref(),
+            Some("実装担当に hand off (selectorA から)")
+        );
+        assert_eq!(
+            report.artifact_path.as_deref(),
+            Some("tasks/issue-516/findings.md")
+        );
+        // next_actions queue にも積まれているはず (payload.next_action 昇格経由)
+        assert_eq!(
+            team.next_actions.back().map(String::as_str),
+            Some("実装担当に hand off (selectorA から)")
+        );
+    }
+
+    /// Issue #516: `report_payload` 全フィールドが空 / 未指定なら payload を保存しない (None のまま)。
+    #[tokio::test]
+    async fn update_task_skips_empty_report_payload() {
+        let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+        let team_id = "team-516-empty".to_string();
+        {
+            let mut state = hub.state.lock().await;
+            let team = state
+                .teams
+                .entry(team_id.clone())
+                .or_insert_with(TeamInfo::default);
+            team.tasks.push_back(TeamTask {
+                id: 12,
+                assigned_to: "worker".into(),
+                description: "no payload".into(),
+                status: "pending".into(),
+                created_by: "leader".into(),
+                created_at: "2026-05-07T10:00:00Z".into(),
+                updated_at: None,
+                summary: None,
+                blocked_reason: None,
+                next_action: None,
+                artifact_path: None,
+                blocked_by_human_gate: false,
+                required_human_decision: None,
+            });
+        }
+        let ctx = CallContext {
+            team_id: team_id.clone(),
+            role: "worker".into(),
+            agent_id: "vc-w-1".into(),
+        };
+        team_update_task(
+            &hub,
+            &ctx,
+            &json!({
+                "task_id": 12,
+                "status": "done",
+                "summary": "trivial fix",
+                "report_payload": { "risks": [], "artifacts": [] }
+            }),
+        )
+        .await
+        .expect("team_update_task ok");
+        let state = hub.state.lock().await;
+        let team = state.teams.get(&team_id).unwrap();
+        let report = team.worker_reports.back().unwrap();
+        assert!(report.payload.is_none(), "empty payload should not persist");
     }
 }

--- a/src/renderer/src/lib/role-profiles-builtin.ts
+++ b/src/renderer/src/lib/role-profiles-builtin.ts
@@ -47,6 +47,59 @@ const LEADER_TEAM_COMPOSITION_RULE =
 const LEADER_ENGINE_CONSTRAINT_RULE =
   '10. Engine constraint preservation: If the user says Codex-only, multiple Codex, Codex only, or asks for a same-engine organization, every `team_recruit` call MUST carry `engine:"codex"` for HR and workers unless the user explicitly asks to mix Claude. For 3+ Codex-only specialists, recruit HR with `team_recruit({role_id:"hr", engine:"codex"})` and tell HR this is a same-engine Codex-only team.\n';
 
+/**
+ * Issue #516: 統合専任ロール `integrator` のサンプル instructions (英語版)。
+ *
+ * Leader が `team_recruit({ role_id: "integrator", engine: "claude", label: "Integrator",
+ * description: "...", instructions: INTEGRATOR_TEMPLATE_INSTRUCTIONS_EN })` のように
+ * そのまま流し込めるテンプレ。動的ワーカー扱いなので permission は composeWorkerProfile() に従う。
+ *
+ * 統合フェーズの 4 ステップ (収集 → 矛盾抽出 → 優先度判定 → 採用方針) は
+ * `.claude/skills/vibe-team/SKILL.md` の「## 統合フェーズ」と一致。
+ */
+export const INTEGRATOR_TEMPLATE_INSTRUCTIONS_EN =
+  'You are the Integrator. Your single responsibility is to **converge multiple workers\' results** into one PR.\n' +
+  '\n' +
+  'Run the 4-step integration flow (mirrors the `vibe-team` Skill "## 統合フェーズ" section):\n' +
+  '\n' +
+  '1. **Gather** — collect every worker\'s structured `report_payload` via `team_get_tasks()` and the\n' +
+  '   team-state `worker_reports[]`. Treat structured fields (findings / proposal / risks / next_action /\n' +
+  '   artifacts) as the single source of truth, not chat scrollback.\n' +
+  '2. **Diff** — line up each worker\'s report side-by-side (proposal vs proposal, risks vs risks, etc.)\n' +
+  '   and surface contradictions. When you find a conflict, use `team_send` to share the conflicting\n' +
+  '   excerpts back to the involved workers and ask them to re-evaluate.\n' +
+  '3. **Prioritize** — rank surviving proposals by (a) directness vs the user\'s ask, (b) residual risk,\n' +
+  '   (c) implementation + maintenance cost. Tie-break on (b).\n' +
+  '4. **Decide & execute** — pick exactly ONE proposal, broadcast the decision + 1-line rationale via\n' +
+  '   `team_send`, and bundle everything into ONE PR (do not allow parallel small PRs — bot review and\n' +
+  '   merge serialize and break the integration story). Document the chosen proposal and the main\n' +
+  '   contradictions in the PR\'s "## Summary".\n' +
+  '\n' +
+  'You may run `git`, `gh`, and `npm`/`cargo` to assemble the final PR; you do NOT design new features\n' +
+  'or write fresh implementation code yourself. Hand any new specialist work back to the Leader.';
+
+/** 日本語版 — 同上の Integrator サンプル instructions。 */
+export const INTEGRATOR_TEMPLATE_INSTRUCTIONS_JA =
+  'あなたは Integrator (統合担当)。**唯一の仕事は「複数 worker の成果を 1 つの PR にまとめる」こと**。\n' +
+  '\n' +
+  '統合フェーズ 4 ステップ (`vibe-team` Skill の「## 統合フェーズ」と完全一致) をこの順で実行する:\n' +
+  '\n' +
+  '1. **収集 (gather)** — 全 worker の構造化 `report_payload` を `team_get_tasks()` と team-state の \n' +
+  '   `worker_reports[]` から吸い上げる。構造化フィールド (findings / proposal / risks / next_action /\n' +
+  '   artifacts) を **唯一の正** とし、チャット履歴を真実とみなさない。\n' +
+  '2. **矛盾抽出 (diff)** — 各 worker の report を軸ごとに横並び (proposal vs proposal, risks vs risks…) \n' +
+  '   にして比較し、矛盾を抽出する。矛盾を見つけたら、関係 worker に `team_send` で該当箇所を共有し、\n' +
+  '   再評価を依頼する。\n' +
+  '3. **優先度判定 (prioritize)** — 残った提案を 3 軸でランク付け: (a) ユーザー要求への直接性 / \n' +
+  '   (b) リスクの残量 / (c) 実装＋保守コスト。同点は (b) リスク残量が小さい方を優先。\n' +
+  '4. **採用方針 (decide & execute)** — 採用案を 1 つに確定し、`team_send` で全員に「採用方針: ... \n' +
+  '   (理由 1 行)」を通達。全成果を **1 本の PR にまとめて push** (小 PR を並列に出すと bot レビュー \n' +
+  '   と merge が直列化して統合判断が崩れる)。PR 本文の「## Summary」に Step 2 で見つけた主要矛盾と \n' +
+  '   Step 4 の採用根拠を 2〜3 行で残し、後から辿れるようにする。\n' +
+  '\n' +
+  'PR 組み立てのために `git` / `gh` / `npm` / `cargo` は実行してよい。新機能の設計や新規実装コードの \n' +
+  '記述はあなたの仕事ではない (それは Leader 経由で specialist に再委譲する)。';
+
 const HR_ENGINE_CONSTRAINT_RULE =
   '6. Leader engine constraint: preserve the Leader request exactly. For Codex-only / same-engine hiring, every seat MUST use `engine:"codex"`. Do NOT substitute Claude or omit engine unless the Leader explicitly asks for Claude or mixed engines.\n';
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -467,6 +467,60 @@ export interface TeamOrchestrationSummary {
   updatedAt: string;
 }
 
+/**
+ * Issue #516: Leader が複数 worker の成果を統合フェーズで突き合わせるための構造化フィールド。
+ * 既存の単発 `summary` / `nextAction` / `artifactPath` と重複してもよい (後方互換目的)。
+ * 全フィールド optional で、必要な軸だけ埋めて返してよい。
+ */
+export interface WorkerReportPayload {
+  /** 調査・実装で得られた発見・観察結果 (markdown / プレーンテキスト) */
+  findings?: string;
+  /** 採用方針の推奨 (Leader 向けの提案) */
+  proposal?: string;
+  /** リスク・既知の懸念事項 (Leader が他 worker と突き合わせるリスト) */
+  risks?: string[];
+  /** 次にやるべき具体的な行動 (top-level nextAction と重複可) */
+  nextAction?: string;
+  /** 複数の生成物パス (top-level artifactPath より柔軟) */
+  artifacts?: string[];
+}
+
+/**
+ * `team_update_task` の引数スキーマ (TS 側でも参照できるよう再掲)。
+ * Issue #516 で `reportPayload` を追加。
+ */
+export interface UpdateTaskArgs {
+  taskId: number;
+  status: 'pending' | 'in_progress' | 'done' | 'completed' | 'blocked' | string;
+  summary?: string;
+  blockedReason?: string;
+  nextAction?: string;
+  artifactPath?: string;
+  blockedByHumanGate?: boolean;
+  requiredHumanDecision?: string;
+  reportKind?: string;
+  /** Issue #516: 構造化された worker report */
+  reportPayload?: WorkerReportPayload;
+}
+
+/**
+ * `worker_reports` の TS 投影。Rust 側 `WorkerReportSnapshot` (camelCase) と完全に一致させる。
+ */
+export interface WorkerReport {
+  id: string;
+  taskId?: number;
+  fromRole: string;
+  fromAgentId: string;
+  kind: string;
+  summary: string;
+  blockedReason?: string;
+  nextAction?: string;
+  artifactPath?: string;
+  /** Issue #516: 構造化 payload (Leader の統合フェーズで使う) */
+  payload?: WorkerReportPayload;
+  createdAt: string;
+}
+
 // ---------- ファイルツリー / 簡易エディタ ----------
 
 export interface FileNode {


### PR DESCRIPTION
## Summary

複数 worker の成果が Leader 任せで散逸する問題に対し、3 つの改善を 1 PR で投入します。

1. **構造化 `report_payload` を `update_task` に追加** — Leader が突き合わせ可能な形で worker の成果を吸い上げる
2. **Leader の「統合フェーズ」を skill 文書に明示** — 収集 → 矛盾抽出 → 優先度判定 → 採用方針 の 4 ステップ
3. **`integrator` ロールのサンプル instructions を export** — Leader が `team_recruit` でそのまま流し込める

## 主な変更

- `src-tauri/src/commands/team_state.rs`
  - `WorkerReportPayload` 型を追加 (findings / proposal / risks / next_action / artifacts[] — 全 optional)
  - `WorkerReportSnapshot.payload: Option<WorkerReportPayload>` を新設
- `src-tauri/src/team_hub/protocol/tools/update_task.rs`
  - `report_payload` arg をパース (snake/camel どちらも受ける)
  - top-level `next_action` / `artifact_path` が空のとき `payload.next_action` / `payload.artifacts[0]` を昇格させる fallback
  - **新規 Rust テスト 2 件** (構造化レポートの永続化 + 空 payload skip) を追加し既存テストもグリーン
- `src-tauri/src/team_hub/protocol/tools/send.rs` — 構造体追加に追従 (`payload: None`)
- `src/types/shared.ts` — `WorkerReportPayload` / `WorkerReport` / `UpdateTaskArgs` を追加 (Rust と camelCase 一致)
- `.claude/skills/vibe-team/SKILL.md` — `## 統合フェーズ` H2 セクションを `役職分担テンプレ` と `名前空間` の間に挿入
- `src/renderer/src/lib/role-profiles-builtin.ts` — `INTEGRATOR_TEMPLATE_INSTRUCTIONS_EN` / `_JA` を export

## 設計判断

- **後方互換性**: `report_payload` は完全に optional。既存の `summary` / `next_action` / `artifact_path` での通信は無変更で動く。
- **昇格 fallback**: top-level の単発フィールドが空でも `payload.next_action` / `payload.artifacts[0]` を昇格させるので、Leader 既存ロジック (`next_actions` queue / `artifact_path` UI) が破綻しない。
- **integrator は builtin にせず動的ロールテンプレ**: `BUILTIN_ROLE_PROFILES` を肥らせず、サンプル文字列のみ export して Leader が必要時に `team_recruit` で生成する想定。シングルトン化が必要になったら別 issue で `BUILTIN_ROLE_PROFILES` 化を検討。

## #507 との連動

#507 で追加した「最小フロー」「役職分担テンプレ」の最終段「統合 (integrate)」を、本 PR でフロー (skill) ・プロトコル (Rust) ・サンプル (TS) の 3 層で具体化したもの。Leader 単一ボトルネック解消の続編。

## Test plan

- [x] `npm run typecheck` — pass
- [x] `cargo test team_hub::protocol::tools::update_task` — 4 passed (新規 2 件含む)
- [x] 手動: SKILL.md の `## 統合フェーズ` 4 ステップが `役職分担テンプレ` と `名前空間` の間に正しく挿入されていることを目視確認
- [x] 手動: `INTEGRATOR_TEMPLATE_INSTRUCTIONS_JA` を `team_recruit` で渡せる文字列として完結していること (placeholder 漏れ無し) を目視確認

Closes #516

関連: #507 (最小フロー / 役職分担テンプレ), #515 (構造化テンプレ), #525 (HR 委譲), #527 (DoD evidence)