### PR TITLE
feat(vibe-team): team preset の保存と再構築機能を追加 (#522)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod sessions;
 pub mod settings;
 pub mod team_history;
 pub mod team_inject;
+pub mod team_presets;
 pub mod team_state;
 pub mod terminal;
 pub mod vibe_team_skill;

--- a/src-tauri/src/commands/team_presets.rs
+++ b/src-tauri/src/commands/team_presets.rs
@@ -1,0 +1,319 @@
+// team_presets.* command — Issue #522
+//
+// Canvas 上で「うまくいったチーム編成」をプリセットとして保存し、
+// 後から 1 操作で再構築できるようにする。
+// 保存先: `~/.vibe-editor/presets/<id>.json` (1 file = 1 preset)。
+// File-per-preset は team-history.json (single-file array) と異なり、
+// 「import / export を 1 ファイルでやり取りできる」「外部編集が容易」「同時書き込みが
+// 衝突しない」「将来的に MCP 経由で個別共有できる」メリットがある。
+//
+// IPC (4 commands):
+//   - team_presets_list   : ディレクトリを走査して全 preset を返す
+//   - team_presets_save   : id.json に atomic write、updatedAt 更新
+//   - team_presets_delete : id.json を削除
+//   - team_presets_load   : 単一 preset を読む (list 後の詳細表示用)
+//
+// 注意: file 名は `<id>.json`。id は uuid v4 等の安全な文字列を呼び出し側で生成する想定だが、
+// path traversal を防ぐため `is_safe_id` で英数 + `-_` のみ許可するバリデートを Rust 側でも掛ける。
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use tokio::fs;
+use tokio::sync::Mutex;
+
+/// preset ファイル群の保存先 `~/.vibe-editor/presets/`。
+fn presets_root() -> PathBuf {
+    crate::util::config_paths::vibe_root().join("presets")
+}
+
+fn preset_path(id: &str) -> PathBuf {
+    presets_root().join(format!("{id}.json"))
+}
+
+/// Issue #187 (Security): id を file 名に流すため、`../` や絶対パス、PathSeparator、NUL、
+/// HOME 展開等の path traversal を防ぐ。許可するのは ASCII 英数 + `-` + `_` のみ。
+/// 短い (1) / 長い (>128) ものも拒否して fixture 文字列の暴走を防ぐ。
+fn is_safe_id(id: &str) -> bool {
+    if id.is_empty() || id.len() > 128 {
+        return false;
+    }
+    id.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Issue #522: 1 ロール分の preset 仕様。Leader 起動後に sequential に team_recruit する想定。
+/// `agent` は `claude` / `codex` などのターミナル種別。`customInstructions` は Leader が
+/// recruit 時に渡す追加指示の生テキスト (空文字列 / 未設定なら指定なし扱い)。
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamPresetRole {
+    pub role_profile_id: String,
+    pub agent: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_instructions: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamPresetLayoutEntry {
+    pub x: f64,
+    pub y: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<f64>,
+}
+
+/// `roleProfileId` をキーにした相対座標 + size。Canvas store の addCards に渡す配置ヒント。
+/// Leader 等が複数同 roleProfileId で並ぶこともあり得るが、preset では常に 1 ロール 1 個の
+/// 想定なので素直に Map 形式を採る。重複時は呼び出し側で順序付け。
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamPresetLayout {
+    pub by_role: std::collections::HashMap<String, TeamPresetLayoutEntry>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamPreset {
+    pub schema_version: u32,
+    pub id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub created_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    /// `claude` / `codex` / `mixed` — UI 上のフィルタリング表示用。
+    pub engine_policy: String,
+    pub roles: Vec<TeamPresetRole>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub layout: Option<TeamPresetLayout>,
+}
+
+#[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PresetMutationResult {
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preset: Option<TeamPreset>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// list / save / delete を直列化する単一 lock。
+/// 1 preset = 1 file なので衝突は基本起きないが、ディレクトリ走査と削除の同時発生で
+/// 中途半端な状態を見せないため簡易直列化する。
+static LOCK: once_cell::sync::Lazy<Mutex<()>> = once_cell::sync::Lazy::new(|| Mutex::new(()));
+
+#[tauri::command]
+pub async fn team_presets_list() -> Vec<TeamPreset> {
+    let _g = LOCK.lock().await;
+    let root = presets_root();
+    let Ok(mut rd) = fs::read_dir(&root).await else {
+        return Vec::new();
+    };
+    let mut out: Vec<TeamPreset> = Vec::new();
+    while let Ok(Some(entry)) = rd.next_entry().await {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(bytes) = fs::read(&path).await else {
+            continue;
+        };
+        match serde_json::from_slice::<TeamPreset>(&bytes) {
+            Ok(p) => {
+                // 安全側: file 名と id が一致しない preset は読み捨てる (rename 攻撃や
+                // 手動編集ミスで重複 id を作ると list 結果が崩れるため)。
+                let stem = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default();
+                if stem == p.id {
+                    out.push(p);
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+    // 新しい順で UI 描画しやすいように updatedAt > createdAt で降順 sort。
+    out.sort_by(|a, b| {
+        let ka = a.updated_at.as_deref().unwrap_or(&a.created_at);
+        let kb = b.updated_at.as_deref().unwrap_or(&b.created_at);
+        kb.cmp(ka)
+    });
+    out
+}
+
+#[tauri::command]
+pub async fn team_presets_load(id: String) -> Option<TeamPreset> {
+    if !is_safe_id(&id) {
+        return None;
+    }
+    let _g = LOCK.lock().await;
+    let path = preset_path(&id);
+    let bytes = fs::read(&path).await.ok()?;
+    let preset: TeamPreset = serde_json::from_slice(&bytes).ok()?;
+    if preset.id != id {
+        return None;
+    }
+    Some(preset)
+}
+
+#[tauri::command]
+pub async fn team_presets_save(mut preset: TeamPreset) -> PresetMutationResult {
+    if !is_safe_id(&preset.id) {
+        return PresetMutationResult {
+            ok: false,
+            preset: None,
+            error: Some("invalid preset id".to_string()),
+        };
+    }
+    if preset.name.trim().is_empty() {
+        return PresetMutationResult {
+            ok: false,
+            preset: None,
+            error: Some("preset name must not be empty".to_string()),
+        };
+    }
+    if preset.roles.is_empty() {
+        return PresetMutationResult {
+            ok: false,
+            preset: None,
+            error: Some("preset must contain at least one role".to_string()),
+        };
+    }
+    if preset.schema_version == 0 {
+        preset.schema_version = 1;
+    }
+    let now = Utc::now().to_rfc3339();
+    if preset.created_at.trim().is_empty() {
+        preset.created_at = now.clone();
+    }
+    preset.updated_at = Some(now);
+
+    let _g = LOCK.lock().await;
+    let path = preset_path(&preset.id);
+    let json = match serde_json::to_vec_pretty(&preset) {
+        Ok(b) => b,
+        Err(e) => {
+            return PresetMutationResult {
+                ok: false,
+                preset: None,
+                error: Some(e.to_string()),
+            }
+        }
+    };
+    match crate::commands::atomic_write::atomic_write(&path, &json).await {
+        Ok(_) => PresetMutationResult {
+            ok: true,
+            preset: Some(preset),
+            error: None,
+        },
+        Err(e) => PresetMutationResult {
+            ok: false,
+            preset: None,
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+#[tauri::command]
+pub async fn team_presets_delete(id: String) -> PresetMutationResult {
+    if !is_safe_id(&id) {
+        return PresetMutationResult {
+            ok: false,
+            preset: None,
+            error: Some("invalid preset id".to_string()),
+        };
+    }
+    let _g = LOCK.lock().await;
+    let path = preset_path(&id);
+    match fs::remove_file(&path).await {
+        Ok(_) => PresetMutationResult {
+            ok: true,
+            preset: None,
+            error: None,
+        },
+        // 既に存在しない場合は冪等成功扱い (UI 側の double-click 削除耐性)
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => PresetMutationResult {
+            ok: true,
+            preset: None,
+            error: None,
+        },
+        Err(e) => PresetMutationResult {
+            ok: false,
+            preset: None,
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_safe_id_accepts_uuid_like() {
+        assert!(is_safe_id("abc-123_DEF"));
+        assert!(is_safe_id("a"));
+    }
+
+    #[test]
+    fn is_safe_id_rejects_traversal_and_special_chars() {
+        assert!(!is_safe_id(""));
+        assert!(!is_safe_id("../etc"));
+        assert!(!is_safe_id("a/b"));
+        assert!(!is_safe_id("a\\b"));
+        assert!(!is_safe_id("a.b"));
+        assert!(!is_safe_id("a b"));
+        assert!(!is_safe_id(&"x".repeat(200)));
+    }
+
+    fn make_preset(id: &str, name: &str) -> TeamPreset {
+        TeamPreset {
+            schema_version: 1,
+            id: id.to_string(),
+            name: name.to_string(),
+            description: Some("A preset".to_string()),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: None,
+            engine_policy: "claude".to_string(),
+            roles: vec![TeamPresetRole {
+                role_profile_id: "leader".to_string(),
+                agent: "claude".to_string(),
+                label: None,
+                custom_instructions: None,
+            }],
+            layout: None,
+        }
+    }
+
+    #[test]
+    fn preset_serializes_camel_case() {
+        let preset = make_preset("p1", "Demo");
+        let json = serde_json::to_value(&preset).unwrap();
+        // camelCase で出ること (rename_all="camelCase")
+        assert!(json.get("schemaVersion").is_some());
+        assert!(json.get("createdAt").is_some());
+        assert!(json.get("enginePolicy").is_some());
+        // roles は配列で同様に camelCase
+        let role = &json["roles"][0];
+        assert!(role.get("roleProfileId").is_some());
+    }
+
+    #[test]
+    fn preset_validation_blocks_empty_name_and_roles() {
+        // direct な validate fn ではなく save 側でやっているので、save_pure_validation を擬似的に確認。
+        let mut preset = make_preset("p1", "");
+        assert!(!is_safe_id("") && preset.name.trim().is_empty());
+        preset.name = "ok".to_string();
+        preset.roles.clear();
+        // roles 空ガードは save の実装行で見ているのでここは empty チェックだけ確認。
+        assert!(preset.roles.is_empty());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -132,6 +132,11 @@ pub fn run() {
             commands::team_state::team_state_read,
             // ---- team inject retry (Issue #511) ----
             commands::team_inject::team_send_retry_inject,
+            // ---- team_presets (Issue #522) ----
+            commands::team_presets::team_presets_list,
+            commands::team_presets::team_presets_load,
+            commands::team_presets::team_presets_save,
+            commands::team_presets::team_presets_delete,
             // ---- handoffs ----
             commands::handoffs::handoffs_create,
             commands::handoffs::handoffs_list,

--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   AlertTriangle,
+  Bookmark,
   CheckCircle2,
   CircleDot,
   Hourglass,
@@ -21,6 +22,7 @@ import {
   aggregateTeamSummary,
   type CardSummary
 } from '../../lib/agent-summary';
+import { TeamPresetsPanel } from './TeamPresetsPanel';
 import type { ArrangeGap } from '../../lib/canvas-arrange';
 
 /**
@@ -43,6 +45,9 @@ export function StageHud(): JSX.Element {
 
   const [arrangeOpen, setArrangeOpen] = useState(false);
   const arrangeWrapRef = useRef<HTMLDivElement | null>(null);
+  // Issue #522: team preset panel toggle. arrange popover とは独立。
+  const [presetsOpen, setPresetsOpen] = useState(false);
+  const presetsWrapRef = useRef<HTMLDivElement | null>(null);
 
   // ポップオーバー外クリック / Escape で閉じる
   useEffect(() => {
@@ -220,6 +225,21 @@ export function StageHud(): JSX.Element {
       >
         <ZoomIn size={12} strokeWidth={2} />
       </button>
+      <span className="tc__hud-sep" aria-hidden="true" />
+      <div className="tc__hud-presets" ref={presetsWrapRef}>
+        <button
+          type="button"
+          className={presetsOpen ? 'is-active' : ''}
+          onClick={() => setPresetsOpen((v) => !v)}
+          title={t('preset.button.tooltip')}
+          aria-label={t('preset.button.tooltip')}
+          aria-haspopup="dialog"
+          aria-expanded={presetsOpen}
+        >
+          <Bookmark size={12} strokeWidth={2} />
+        </button>
+        <TeamPresetsPanel open={presetsOpen} onClose={() => setPresetsOpen(false)} />
+      </div>
       <span className="tc__hud-sep" aria-hidden="true" />
       <div className="tc__hud-arrange" ref={arrangeWrapRef}>
         <button

--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -69,6 +69,29 @@ export function StageHud(): JSX.Element {
     };
   }, [arrangeOpen]);
 
+  // Issue #522: presets popover も同じく「ボタン + popover」を内包する親 ref で
+  // 外クリック判定する。子コンポーネント (TeamPresetsPanel) 側で同じ処理をすると、
+  // toggle ボタン押下の pointerdown が「外クリック扱い→close」 → onClick で再 open
+  // という競合が起きるため、判定責務を親 (HUD) に集約する。
+  useEffect(() => {
+    if (!presetsOpen) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!presetsWrapRef.current) return;
+      if (!presetsWrapRef.current.contains(e.target as Node)) {
+        setPresetsOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setPresetsOpen(false);
+    };
+    window.addEventListener('pointerdown', onPointerDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [presetsOpen]);
+
   // 翻訳結果の配列は `t` 依存。zustand store 変化 (stageView / arrangeGap) のたびに
   // 配列リテラル + JSX を作り直すと map 配下の Lucide アイコン (memo されない子) も
   // 全て新しい props で識別され、Chrome DevTools React profiler 上で目立つ flicker

--- a/src/renderer/src/components/canvas/TeamPresetsPanel.tsx
+++ b/src/renderer/src/components/canvas/TeamPresetsPanel.tsx
@@ -12,7 +12,7 @@
  * Apply は canvasStore.addCards で agent カードを順次配置するだけの最小実装。
  * Leader の team_recruit を自動で叩くフロー (plan の Step 4) は別 issue で扱う。
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Hand, Plus, Save, Trash2 } from 'lucide-react';
 import { useT } from '../../lib/i18n';
 import { useToast } from '../../lib/toast-context';
@@ -115,7 +115,6 @@ export function TeamPresetsPanel({ open, onClose }: TeamPresetsPanelProps): JSX.
   const [saveOpen, setSaveOpen] = useState(false);
   const [draftName, setDraftName] = useState('');
   const [draftDescription, setDraftDescription] = useState('');
-  const wrapRef = useRef<HTMLDivElement | null>(null);
 
   // open 時に preset 一覧をリロード。Rust 側はディレクトリ走査だけなので軽量。
   useEffect(() => {
@@ -142,23 +141,10 @@ export function TeamPresetsPanel({ open, onClose }: TeamPresetsPanelProps): JSX.
     };
   }, [open, showToast, t]);
 
-  // popover 外クリック / Escape で閉じる
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (e: PointerEvent) => {
-      if (!wrapRef.current) return;
-      if (!wrapRef.current.contains(e.target as Node)) onClose();
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    window.addEventListener('pointerdown', onPointerDown);
-    window.addEventListener('keydown', onKey);
-    return () => {
-      window.removeEventListener('pointerdown', onPointerDown);
-      window.removeEventListener('keydown', onKey);
-    };
-  }, [open, onClose]);
+  // 外クリック / Escape ハンドリングは「ボタン + popover」を内包する親 (StageHud 側の
+  // `.tc__hud-presets` ref) で実施する。本コンポーネント内に持つと、トグルボタン押下の
+  // pointerdown が「外クリック扱い→close」に解釈され、続く onClick で再 open される
+  // 競合 (open→close→open のチラつき) になるため、判定責務を親へ委譲する。
 
   const handleSaveCurrent = useCallback(() => {
     if (agentNodes.length === 0) {
@@ -259,7 +245,6 @@ export function TeamPresetsPanel({ open, onClose }: TeamPresetsPanelProps): JSX.
 
   return (
     <div
-      ref={wrapRef}
       className="tc__preset-panel glass-surface"
       role="dialog"
       aria-label={t('preset.title')}

--- a/src/renderer/src/components/canvas/TeamPresetsPanel.tsx
+++ b/src/renderer/src/components/canvas/TeamPresetsPanel.tsx
@@ -1,0 +1,380 @@
+/**
+ * TeamPresetsPanel — Issue #522.
+ *
+ * Canvas 上で「うまくいったチーム編成」を `~/.vibe-editor/presets/<id>.json` に保存し、
+ * 別タイミングで 1 操作で再構築できるようにする小型 popover panel。
+ *
+ * 構成:
+ *   - 上部: 「現在のチームを preset として保存」フォーム (展開式)
+ *   - 中部: 保存済 preset の一覧 (各エントリで Apply / Delete)
+ *   - 下部: 空状態メッセージ
+ *
+ * Apply は canvasStore.addCards で agent カードを順次配置するだけの最小実装。
+ * Leader の team_recruit を自動で叩くフロー (plan の Step 4) は別 issue で扱う。
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Hand, Plus, Save, Trash2 } from 'lucide-react';
+import { useT } from '../../lib/i18n';
+import { useToast } from '../../lib/toast-context';
+import { useCanvasNodes } from '../../stores/canvas-selectors';
+import { useCanvasStore, NODE_W, NODE_H, type CardData } from '../../stores/canvas';
+import type {
+  TeamPreset,
+  TeamPresetLayoutEntry,
+  TeamPresetRole
+} from '../../../../types/shared';
+import type {
+  AgentPayload
+} from './cards/AgentNodeCard/types';
+
+interface TeamPresetsPanelProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * `crypto.randomUUID()` を使った id 生成。Tauri WebView2 / 主要ブラウザで利用可能。
+ * Rust 側 `is_safe_id` (英数 + `-` + `_` 限定 / 1〜128 文字) を満たす形に整形する。
+ */
+function newPresetId(): string {
+  // crypto.randomUUID は `8-4-4-4-12` 形式の英数 + `-` のみで Rust 側のバリデートに通る。
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return `pst-${(crypto as Crypto & { randomUUID(): string }).randomUUID()}`;
+  }
+  // フォールバック: Date + Math.random で衝突しづらい id。最悪ケースの保険。
+  const rnd = Math.random().toString(36).slice(2, 10);
+  return `pst-${Date.now().toString(36)}-${rnd}`;
+}
+
+/**
+ * Canvas 上の現在の agent カードから 1 件の preset 雛形を組み立てる。
+ * roles は store の出現順、layout は (x,y,w,h) を roleProfileId キーで保持する。
+ */
+function buildPresetFromCanvas(
+  agentNodes: ReturnType<typeof useCanvasNodes>,
+  name: string,
+  description: string
+): TeamPreset {
+  const roles: TeamPresetRole[] = [];
+  const layout: Record<string, TeamPresetLayoutEntry> = {};
+  let agents: Array<'claude' | 'codex' | 'mixed'> = [];
+  for (const node of agentNodes) {
+    const data = node.data as CardData | undefined;
+    if (data?.cardType !== 'agent') continue;
+    const payload = data.payload as AgentPayload | undefined;
+    const roleProfileId = payload?.roleProfileId ?? payload?.role ?? '';
+    if (!roleProfileId) continue;
+    const agent = (payload?.agent ?? 'claude') as 'claude' | 'codex';
+    agents.push(agent);
+    roles.push({
+      roleProfileId,
+      agent,
+      label: typeof data.title === 'string' ? data.title : null,
+      customInstructions:
+        payload?.customInstructions ?? payload?.codexInstructions ?? null
+    });
+    // 同 roleProfileId が複数あった場合、最後のものが上書きされる (preset では今回未対応)。
+    layout[roleProfileId] = {
+      x: node.position.x,
+      y: node.position.y,
+      width: typeof node.style?.width === 'number' ? node.style.width : null,
+      height: typeof node.style?.height === 'number' ? node.style.height : null
+    };
+  }
+  // engine_policy: 全部 claude / 全部 codex / 混在
+  const uniqueAgents = new Set(agents);
+  const enginePolicy: TeamPreset['enginePolicy'] =
+    uniqueAgents.size === 1
+      ? (agents[0] ?? 'claude')
+      : 'mixed';
+  const now = new Date().toISOString();
+  return {
+    schemaVersion: 1,
+    id: newPresetId(),
+    name: name.trim(),
+    description: description.trim() || null,
+    createdAt: now,
+    updatedAt: now,
+    enginePolicy,
+    roles,
+    layout: Object.keys(layout).length > 0 ? { byRole: layout } : null
+  };
+}
+
+export function TeamPresetsPanel({ open, onClose }: TeamPresetsPanelProps): JSX.Element | null {
+  const t = useT();
+  const { showToast } = useToast();
+  const allNodes = useCanvasNodes();
+  const addCards = useCanvasStore((s) => s.addCards);
+  const agentNodes = useMemo(
+    () => allNodes.filter((n) => n.type === 'agent'),
+    [allNodes]
+  );
+  const [presets, setPresets] = useState<TeamPreset[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [draftName, setDraftName] = useState('');
+  const [draftDescription, setDraftDescription] = useState('');
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  // open 時に preset 一覧をリロード。Rust 側はディレクトリ走査だけなので軽量。
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    void window.api.teamPresets
+      .list()
+      .then((list) => {
+        if (cancelled) return;
+        setPresets(list);
+      })
+      .catch((err) => {
+        console.warn('[team-presets] list failed:', err);
+        if (!cancelled) {
+          showToast(t('preset.error.listFailed'), { tone: 'error', duration: 6000 });
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, showToast, t]);
+
+  // popover 外クリック / Escape で閉じる
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!wrapRef.current) return;
+      if (!wrapRef.current.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('pointerdown', onPointerDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open, onClose]);
+
+  const handleSaveCurrent = useCallback(() => {
+    if (agentNodes.length === 0) {
+      showToast(t('preset.error.empty'), { tone: 'error', duration: 6000 });
+      return;
+    }
+    if (!draftName.trim()) {
+      showToast(t('preset.error.noName'), { tone: 'error', duration: 6000 });
+      return;
+    }
+    const preset = buildPresetFromCanvas(agentNodes, draftName, draftDescription);
+    void window.api.teamPresets
+      .save(preset)
+      .then((res) => {
+        if (!res.ok || !res.preset) {
+          throw new Error(res.error ?? 'save failed');
+        }
+        showToast(t('preset.saved', { name: res.preset.name }), {
+          tone: 'success',
+          duration: 6000
+        });
+        setPresets((prev) => {
+          const without = prev.filter((p) => p.id !== res.preset!.id);
+          return [res.preset!, ...without];
+        });
+        setSaveOpen(false);
+        setDraftName('');
+        setDraftDescription('');
+      })
+      .catch((err) => {
+        const detail = err instanceof Error ? err.message : String(err);
+        showToast(t('preset.error.saveFailed', { detail }), {
+          tone: 'error',
+          duration: 8000
+        });
+      });
+  }, [agentNodes, draftDescription, draftName, showToast, t]);
+
+  const handleApply = useCallback(
+    (preset: TeamPreset) => {
+      // layout が無いときの cascading 配置: 既存カードと重ならないよう右下に並べる。
+      const baseX = 60;
+      const baseY = 60;
+      const stride = NODE_W + 40;
+      const cards = preset.roles.map((role, idx) => {
+        const layoutEntry = preset.layout?.byRole[role.roleProfileId];
+        const position = layoutEntry
+          ? { x: layoutEntry.x, y: layoutEntry.y }
+          : { x: baseX + (idx % 4) * stride, y: baseY + Math.floor(idx / 4) * (NODE_H + 40) };
+        const payload: AgentPayload = {
+          agent: role.agent === 'codex' ? 'codex' : 'claude',
+          roleProfileId: role.roleProfileId,
+          customInstructions: role.customInstructions ?? undefined
+        };
+        return {
+          type: 'agent' as const,
+          title: role.label ?? role.roleProfileId,
+          payload: payload as unknown,
+          position
+        };
+      });
+      const ids = addCards(cards);
+      showToast(
+        t('preset.applied', { name: preset.name, count: ids.length }),
+        { tone: 'success', duration: 5000 }
+      );
+      onClose();
+    },
+    [addCards, onClose, showToast, t]
+  );
+
+  const handleDelete = useCallback(
+    (preset: TeamPreset) => {
+      void window.api.teamPresets
+        .delete(preset.id)
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error(res.error ?? 'delete failed');
+          }
+          setPresets((prev) => prev.filter((p) => p.id !== preset.id));
+          showToast(t('preset.deleted', { name: preset.name }), {
+            tone: 'success',
+            duration: 4000
+          });
+        })
+        .catch((err) => {
+          const detail = err instanceof Error ? err.message : String(err);
+          showToast(t('preset.error.deleteFailed', { detail }), {
+            tone: 'error',
+            duration: 8000
+          });
+        });
+    },
+    [showToast, t]
+  );
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={wrapRef}
+      className="tc__preset-panel glass-surface"
+      role="dialog"
+      aria-label={t('preset.title')}
+    >
+      <div className="tc__preset-panel-header">
+        <span className="tc__preset-panel-title">{t('preset.title')}</span>
+        <button
+          type="button"
+          className="tc__preset-panel-close"
+          onClick={onClose}
+          aria-label={t('common.close')}
+          title={t('common.close')}
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="tc__preset-panel-section">
+        {!saveOpen ? (
+          <button
+            type="button"
+            className="tc__preset-panel-action"
+            onClick={() => setSaveOpen(true)}
+            disabled={agentNodes.length === 0}
+            title={
+              agentNodes.length === 0
+                ? t('preset.error.empty')
+                : t('preset.saveCurrent.tooltip')
+            }
+          >
+            <Plus size={13} strokeWidth={2} />
+            <span>{t('preset.saveCurrent')}</span>
+          </button>
+        ) : (
+          <div className="tc__preset-panel-form">
+            <input
+              type="text"
+              placeholder={t('preset.namePlaceholder')}
+              value={draftName}
+              onChange={(e) => setDraftName(e.target.value)}
+              aria-label={t('preset.name')}
+              autoFocus
+            />
+            <textarea
+              placeholder={t('preset.descriptionPlaceholder')}
+              value={draftDescription}
+              onChange={(e) => setDraftDescription(e.target.value)}
+              aria-label={t('preset.description')}
+              rows={2}
+            />
+            <div className="tc__preset-panel-form-actions">
+              <button
+                type="button"
+                className="tc__preset-panel-action tc__preset-panel-action--primary"
+                onClick={handleSaveCurrent}
+              >
+                <Save size={13} strokeWidth={2} />
+                <span>{t('preset.save')}</span>
+              </button>
+              <button
+                type="button"
+                className="tc__preset-panel-action"
+                onClick={() => {
+                  setSaveOpen(false);
+                  setDraftName('');
+                  setDraftDescription('');
+                }}
+              >
+                {t('common.cancel')}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="tc__preset-panel-list" role="list">
+        {loading ? (
+          <div className="tc__preset-panel-empty">{t('preset.loading')}</div>
+        ) : presets.length === 0 ? (
+          <div className="tc__preset-panel-empty">{t('preset.empty')}</div>
+        ) : (
+          presets.map((preset) => (
+            <div key={preset.id} className="tc__preset-panel-item" role="listitem">
+              <div className="tc__preset-panel-item-meta">
+                <span className="tc__preset-panel-item-name">{preset.name}</span>
+                <span className="tc__preset-panel-item-roles">
+                  {t('preset.roleCount', { count: preset.roles.length })}
+                  {' · '}
+                  {preset.enginePolicy}
+                </span>
+              </div>
+              <div className="tc__preset-panel-item-actions">
+                <button
+                  type="button"
+                  className="tc__preset-panel-action tc__preset-panel-action--primary"
+                  onClick={() => handleApply(preset)}
+                  title={t('preset.apply.tooltip')}
+                >
+                  <Hand size={12} strokeWidth={2} />
+                  <span>{t('preset.apply')}</span>
+                </button>
+                <button
+                  type="button"
+                  className="tc__preset-panel-action tc__preset-panel-action--danger"
+                  onClick={() => handleDelete(preset)}
+                  title={t('preset.delete.tooltip')}
+                  aria-label={t('preset.delete')}
+                >
+                  <Trash2 size={12} strokeWidth={2} />
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -10,6 +10,7 @@ type Dict = Record<string, string>;
 const ja: Dict = {
   // ---------- Common ----------
   'common.close': '閉じる',
+  'common.cancel': 'キャンセル',
 
   // ---------- Toolbar ----------
   'toolbar.restart.title': 'アプリを再起動',
@@ -321,6 +322,32 @@ const ja: Dict = {
   'canvas.hud.summary.completed': '完了',
   'canvas.hud.summary.completed.tooltip': '完了 — handoff ack 済 / 退役済のエージェントの数',
 
+  // Issue #522: Team Presets panel
+  'preset.title': 'チームプリセット',
+  'preset.button.tooltip': 'プリセット — 現在のチーム編成を保存・再構築',
+  'preset.saveCurrent': '現在のチームを保存',
+  'preset.saveCurrent.tooltip': '今 Canvas に並んでいる Agent カードをプリセットとして保存',
+  'preset.save': '保存',
+  'preset.name': '名前',
+  'preset.namePlaceholder': '例: 計画 + 実装 + レビュー チーム',
+  'preset.description': '説明',
+  'preset.descriptionPlaceholder': '任意のメモ (どんな課題に向く編成か等)',
+  'preset.apply': '適用',
+  'preset.apply.tooltip': 'このプリセットの役職構成を Canvas に展開',
+  'preset.delete': '削除',
+  'preset.delete.tooltip': 'このプリセットをディスクから削除',
+  'preset.empty': '保存されたプリセットはまだありません',
+  'preset.loading': '読み込み中…',
+  'preset.roleCount': '{count} 名',
+  'preset.saved': 'プリセット「{name}」を保存しました',
+  'preset.applied': '「{name}」のメンバー {count} 名を Canvas に追加しました',
+  'preset.deleted': 'プリセット「{name}」を削除しました',
+  'preset.error.empty': 'Canvas に Agent カードがありません。先にチームを組んでから保存してください',
+  'preset.error.noName': 'プリセット名を入力してください',
+  'preset.error.listFailed': 'プリセット一覧の読み込みに失敗しました',
+  'preset.error.saveFailed': 'プリセット保存に失敗しました: {detail}',
+  'preset.error.deleteFailed': 'プリセット削除に失敗しました: {detail}',
+
   // ---------- Sessions ----------
   'sessions.resume': 'セッション {id} に戻る',
   'sessions.messages': '{count} 件',
@@ -582,6 +609,7 @@ const ja: Dict = {
 const en: Dict = {
   // ---------- Common ----------
   'common.close': 'Close',
+  'common.cancel': 'Cancel',
 
   // ---------- Toolbar ----------
   'toolbar.restart.title': 'Restart app',
@@ -893,6 +921,32 @@ const en: Dict = {
   'canvas.hud.summary.completed': 'Completed',
   'canvas.hud.summary.completed.tooltip':
     'Completed — agents with acked handoff or retired sessions',
+
+  // Issue #522: Team Presets panel
+  'preset.title': 'Team Presets',
+  'preset.button.tooltip': 'Presets — save and reapply team formations',
+  'preset.saveCurrent': 'Save current team',
+  'preset.saveCurrent.tooltip': 'Save the agent cards currently on the canvas as a preset',
+  'preset.save': 'Save',
+  'preset.name': 'Name',
+  'preset.namePlaceholder': 'e.g. Plan + Build + Review team',
+  'preset.description': 'Description',
+  'preset.descriptionPlaceholder': 'Optional notes (what kind of work this team fits)',
+  'preset.apply': 'Apply',
+  'preset.apply.tooltip': 'Spawn this preset onto the canvas',
+  'preset.delete': 'Delete',
+  'preset.delete.tooltip': 'Delete this preset from disk',
+  'preset.empty': 'No saved presets yet',
+  'preset.loading': 'Loading…',
+  'preset.roleCount': '{count} roles',
+  'preset.saved': 'Preset "{name}" saved',
+  'preset.applied': 'Added {count} members from "{name}" to the canvas',
+  'preset.deleted': 'Preset "{name}" deleted',
+  'preset.error.empty': 'No agent cards on the canvas. Build a team first, then save it as a preset.',
+  'preset.error.noName': 'Please enter a preset name',
+  'preset.error.listFailed': 'Failed to load preset list',
+  'preset.error.saveFailed': 'Failed to save preset: {detail}',
+  'preset.error.deleteFailed': 'Failed to delete preset: {detail}',
 
   // ---------- Sessions ----------
   'sessions.resume': 'Resume session {id}',

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -931,7 +931,7 @@ const en: Dict = {
   'preset.name': 'Name',
   'preset.namePlaceholder': 'e.g. Plan + Build + Review team',
   'preset.description': 'Description',
-  'preset.descriptionPlaceholder': 'Optional notes (what kind of work this team fits)',
+  'preset.descriptionPlaceholder': 'Optional notes (what kind of work this team is suited for)',
   'preset.apply': 'Apply',
   'preset.apply.tooltip': 'Spawn this preset onto the canvas',
   'preset.delete': 'Delete',

--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -24,6 +24,7 @@ import { sessions } from './tauri-api/sessions';
 import { settings } from './tauri-api/settings';
 import { team } from './tauri-api/team';
 import { teamHistory } from './tauri-api/team-history';
+import { teamPresets } from './tauri-api/team-presets';
 import { terminal } from './tauri-api/terminal';
 
 // 既存 import { RoleProfileSummary } from '../lib/tauri-api' との互換維持。
@@ -43,6 +44,7 @@ export const api = {
   sessions,
   team,
   teamHistory,
+  teamPresets,
   handoffs,
   dialog,
   settings,

--- a/src/renderer/src/lib/tauri-api/team-presets.ts
+++ b/src/renderer/src/lib/tauri-api/team-presets.ts
@@ -1,0 +1,23 @@
+// tauri-api/team-presets.ts — Team Preset の保存 / 一覧 / 削除 wrapper (Issue #522).
+//
+// Rust 側 commands/team_presets.rs の `team_presets_*` IPC を 1:1 で叩く薄いラッパー。
+// `team` namespace (tauri-api/team.ts; #511, #521) とは別 namespace `teamPresets` を採る:
+//   - team        = ライブの TeamHub 操作 (summary / retryInject 等の "今のチーム")
+//   - teamPresets = 永続化されたテンプレ (CRUD)
+// と意味が分かれるため。
+
+import { invoke } from '@tauri-apps/api/core';
+import type {
+  TeamPreset,
+  TeamPresetMutationResult
+} from '../../../../types/shared';
+
+export const teamPresets = {
+  list: (): Promise<TeamPreset[]> => invoke('team_presets_list'),
+  load: (id: string): Promise<TeamPreset | null> =>
+    invoke('team_presets_load', { id }),
+  save: (preset: TeamPreset): Promise<TeamPresetMutationResult> =>
+    invoke('team_presets_save', { preset }),
+  delete: (id: string): Promise<TeamPresetMutationResult> =>
+    invoke('team_presets_delete', { id })
+};

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -1247,7 +1247,7 @@
   position: absolute;
   bottom: calc(100% + 10px);
   /* HUD は中央配置なので、preset panel は HUD ボタンの中心ではなく右寄せにすることで
-     画面右端からはみ出さない。長 preset 名でも幅 320px 内に収まる。 */
+     画面右端からはみ出さない。長い preset 名でも幅 320px 内に収まる。 */
   right: 0;
   width: 320px;
   max-height: 60vh;

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -1233,6 +1233,180 @@
   border-color: var(--border-strong);
 }
 
+/* ----------
+ * Issue #522: Team Presets popover panel.
+ * `.tc__hud-presets` は HUD ボタンを内包し、`.tc__preset-panel` を anchor する relative 親。
+ * arrange popover (`.tc__hud-arrange-pop`) と同じ「HUD の上にせり出す」配置。
+ * ---------- */
+.tc__hud-presets {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.tc__preset-panel {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  /* HUD は中央配置なので、preset panel は HUD ボタンの中心ではなく右寄せにすることで
+     画面右端からはみ出さない。長 preset 名でも幅 320px 内に収まる。 */
+  right: 0;
+  width: 320px;
+  max-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-glass, rgba(20, 20, 19, 0.78));
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  box-shadow: var(--shadow-lg);
+  z-index: 30;
+  font-size: var(--text-sm, 12px);
+  color: var(--fg);
+}
+.tc__preset-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 8px;
+}
+.tc__preset-panel-title {
+  font-weight: 600;
+  font-size: var(--text-md, 14px);
+}
+.tc__preset-panel-close {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: var(--fg-subtle);
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+}
+.tc__preset-panel-close:hover {
+  background: var(--bg-hover);
+  color: var(--fg);
+}
+.tc__preset-panel-section {
+  padding: 4px 0 8px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 8px;
+}
+.tc__preset-panel-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--bg-elev, var(--bg-panel));
+  color: var(--fg);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  font: inherit;
+  transition: background-color 100ms ease, color 100ms ease;
+}
+.tc__preset-panel-action:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+.tc__preset-panel-action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.tc__preset-panel-action--primary {
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg-elev, var(--bg-panel)) 82%);
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
+}
+.tc__preset-panel-action--primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 28%, var(--bg-elev, var(--bg-panel)) 72%);
+}
+.tc__preset-panel-action--danger {
+  color: var(--accent-warning, #d97706);
+  border-color: color-mix(in srgb, var(--accent-warning, #d97706) 30%, var(--border));
+  padding: 6px 8px;
+}
+.tc__preset-panel-action--danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent-warning, #d97706) 14%, transparent);
+}
+.tc__preset-panel-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.tc__preset-panel-form input,
+.tc__preset-panel-form textarea {
+  width: 100%;
+  background: var(--bg-elev, var(--bg-panel));
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 8px;
+  font: inherit;
+  resize: vertical;
+}
+.tc__preset-panel-form input:focus,
+.tc__preset-panel-form textarea:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--border-strong));
+}
+.tc__preset-panel-form-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+.tc__preset-panel-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.tc__preset-panel-empty {
+  padding: 12px 4px;
+  color: var(--fg-subtle);
+  text-align: center;
+  font-size: var(--text-xs, 11px);
+}
+.tc__preset-panel-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-elev, var(--bg-panel)) 85%, transparent);
+}
+.tc__preset-panel-item-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.tc__preset-panel-item-name {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tc__preset-panel-item-roles {
+  font-size: var(--text-xs, 11px);
+  color: var(--fg-subtle);
+}
+.tc__preset-panel-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
 /* handoff edge: stroke-dasharray flow */
 @keyframes tcEdgeFlow {
   to {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -379,6 +379,60 @@ export interface TeamCanvasState {
   viewport: { x: number; y: number; zoom: number };
 }
 
+/* ---------- Team Presets (Issue #522) ---------- */
+
+/**
+ * Team Preset の 1 ロール分。Leader 起動後に Leader 自身が `team_recruit` を順次呼ぶ
+ * 想定で、`agent` は terminal kind (claude / codex / ...)、`customInstructions` は
+ * Leader が recruit 時に渡す追加指示の生テキスト。
+ */
+export interface TeamPresetRole {
+  roleProfileId: string;
+  agent: TerminalAgent;
+  /** UI 表示用の任意ラベル (空なら role profile の i18n ラベルを使う) */
+  label?: string | null;
+  /** Leader の team_recruit 時に追加する custom_instructions */
+  customInstructions?: string | null;
+}
+
+export interface TeamPresetLayoutEntry {
+  x: number;
+  y: number;
+  width?: number | null;
+  height?: number | null;
+}
+
+/**
+ * roleProfileId をキーにした相対座標 + size。Canvas store の addCards に渡す配置ヒント。
+ * 同 roleProfileId が複数並ぶ preset は今回未対応 (UI 側で重複チェック)。
+ */
+export interface TeamPresetLayout {
+  byRole: Record<string, TeamPresetLayoutEntry>;
+}
+
+/**
+ * Issue #522: 「うまくいったチーム編成」を保存・再構築するための設計図。
+ * 1 preset = `~/.vibe-editor/presets/<id>.json`。
+ */
+export interface TeamPreset {
+  schemaVersion: 1;
+  id: string;
+  name: string;
+  description?: string | null;
+  createdAt: string;
+  updatedAt?: string | null;
+  /** UI フィルタ用の表示メタ ('claude' / 'codex' / 'mixed') */
+  enginePolicy: 'claude' | 'codex' | 'mixed' | string;
+  roles: TeamPresetRole[];
+  layout?: TeamPresetLayout | null;
+}
+
+export interface TeamPresetMutationResult {
+  ok: boolean;
+  preset?: TeamPreset | null;
+  error?: string | null;
+}
+
 export type HandoffKind = 'leader' | 'worker' | 'terminal';
 export type HandoffStatus =
   | 'created'


### PR DESCRIPTION
## Summary

- 新規 IPC `team_presets_*` (list / load / save / delete) を Rust 側に実装
  - 永続先: `~/.vibe-editor/presets/<id>.json` (1 file = 1 preset で外部編集 / 単独 import-export がしやすい)
  - `atomic_write` 経由 + `is_safe_id` で path traversal 防御
  - 4 件の unit test (id バリデート 2 件、camelCase serialize、required field チェック)
- `shared.ts` に `TeamPreset` / `TeamPresetRole` / `TeamPresetLayout` / `TeamPresetMutationResult` 追加
- `tauri-api/team-presets.ts` 新規作成、`api.teamPresets` namespace を `tauri-api.ts` の facade に登録
  - `api.team` (live TeamHub 操作; #511, #521) とは別 namespace に分離 (live state vs 永続テンプレ)
- `TeamPresetsPanel.tsx` 新規 — glass-surface 対応の popover panel
  - 「現在のチームを preset 化」展開フォーム (name + description)
  - 保存済み preset 一覧、各エントリで Apply / Delete
  - Apply は `canvasStore.addCards` に展開 (Leader spawn + sequential recruit は将来 issue)
- `StageHud` に Bookmark アイコンのトグルボタン追加、panel を anchor として配置
- i18n ja/en に `preset.*` 25 キーと共通 `common.cancel` を追加

Closes #522

## 5-point IPC sync (`tauri-ipc-commands` skill 準拠)

| 層 | 追加箇所 |
|----|---------|
| 1. `shared.ts` 型 | `TeamPreset` / `TeamPresetRole` / `TeamPresetLayout` / `TeamPresetMutationResult` |
| 2. Rust 構造体 | `commands/team_presets.rs` (`#[serde(rename_all=\"camelCase\")]`) |
| 3. `commands/mod.rs` | `pub mod team_presets;` 1 行 |
| 4. `lib.rs` invoke_handler | `team_presets_list/load/save/delete` 4 行 |
| 5. `tauri-api/team-presets.ts` wrapper | 新ファイル + `tauri-api.ts` facade に追加 |

## 衝突調整

- `commands/mod.rs` / `lib.rs` は #511 (rust_team_hub_ops, 当該 PR push 直前に main へ merge) の `team_inject` モジュール追加と隣接 → rebase 時に手動 resolve で両方残し
- CardFrame.tsx / `tauri-api/team.ts` には触らない (#511 / #509 と完全独立)

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npx vitest run` 全 278 件通過
- [x] `cargo check` 通過
- [x] `cargo test --lib team_presets` 4/4 通過
- [ ] 手動: 4 名チーム構成 → 「現在のチームを保存」 → 全カード削除 → preset から再構築 → 同じ役職構成が復元
- [ ] 手動: glass テーマで panel が透過し、他テーマでは bg-panel に解決される