### PR TITLE
fix(team-hub): PTY 出力アクティビティで status staleness を補正し autoStale を可視化 (#524)

### DIFF
--- a/src-tauri/src/pty/batcher.rs
+++ b/src-tauri/src/pty/batcher.rs
@@ -5,10 +5,20 @@
 
 use crate::pty::scrollback::{append_scrollback, Scrollback};
 use bytes::BytesMut;
+use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc;
 use tokio::time::interval;
+
+/// Issue #524: PTY から実際に出力 byte が flush されたタイミングを呼び出し側に通知する callback。
+/// `spawn_session` が agent_id を持っているとき、ここで TeamHub の `member_diagnostics`
+/// `last_pty_output_at` を update する closure を構築して渡す。pty/ レイヤから直接
+/// team_hub を呼ばないことで、循環依存と layer 違反を避ける。
+///
+/// callback は flush ごとに呼ばれるが、頻度を抑えるための dedup (例: 1 秒間隔) は呼び出し側
+/// (closure 内部) の責務 — batcher は単に「データが流れた」事実だけを通知する。
+pub type PtyOutputObserver = Arc<dyn Fn() + Send + Sync>;
 
 const FLUSH_INTERVAL_MS: u64 = 16;
 const FLUSH_BYTES: usize = 32 * 1024;
@@ -38,6 +48,7 @@ pub fn spawn_batcher(
     data_event_name: String,
     mut rx: mpsc::Receiver<Vec<u8>>,
     scrollback: Scrollback,
+    on_output: Option<PtyOutputObserver>,
 ) {
     tokio::spawn(async move {
         // 旧 post-subscribe 経路互換のための短い猶予 (詳細は STARTUP_DELAY_MS コメント)。
@@ -53,19 +64,19 @@ pub fn spawn_batcher(
                             buf.extend_from_slice(&chunk);
                             // Issue #494: 閾値判定はテストと共有する pure 関数経由。
                             if should_flush_after_recv(buf.len()) {
-                                flush(&app, &data_event_name, &mut buf, &scrollback);
+                                flush(&app, &data_event_name, &mut buf, &scrollback, on_output.as_ref());
                             }
                         }
                         None => {
                             // reader thread が exit。最後にまとめて flush。
-                            flush(&app, &data_event_name, &mut buf, &scrollback);
+                            flush(&app, &data_event_name, &mut buf, &scrollback, on_output.as_ref());
                             break;
                         }
                     }
                 }
                 _ = tick.tick() => {
                     if should_flush_on_tick(buf.len()) {
-                        flush(&app, &data_event_name, &mut buf, &scrollback);
+                        flush(&app, &data_event_name, &mut buf, &scrollback, on_output.as_ref());
                     }
                 }
             }
@@ -73,7 +84,13 @@ pub fn spawn_batcher(
     });
 }
 
-fn flush(app: &AppHandle, event: &str, buf: &mut BytesMut, scrollback: &Scrollback) {
+fn flush(
+    app: &AppHandle,
+    event: &str,
+    buf: &mut BytesMut,
+    scrollback: &Scrollback,
+    on_output: Option<&PtyOutputObserver>,
+) {
     let Some(text) = extract_emit_payload(buf, scrollback) else {
         return;
     };
@@ -81,6 +98,12 @@ fn flush(app: &AppHandle, event: &str, buf: &mut BytesMut, scrollback: &Scrollba
     match app.emit(event, text) {
         Ok(_) => tracing::debug!("[batcher] emit {event} {len}B ok"),
         Err(e) => tracing::warn!("emit {event} failed: {e}"),
+    }
+    // Issue #524: 「実際に PTY 出力 byte が renderer に向けて流れた」事実を呼び出し側に通知する。
+    // emit 失敗時もデータは届いていない可能性が高いが、PTY → batcher 受信は起きているので
+    // 「PTY 上で agent process が動いている」物理シグナルとして扱える。
+    if let Some(observer) = on_output {
+        observer();
     }
 }
 

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -3,7 +3,7 @@
 // 旧 ipc/terminal.ts の `pty.spawn(...)` 部分を移植。
 // portable-pty + tokio + tauri::Emitter で同等機能を再現。
 
-use crate::pty::batcher::spawn_batcher;
+use crate::pty::batcher::{spawn_batcher, PtyOutputObserver};
 use crate::pty::scrollback::{
     scrollback_to_string, Scrollback, WriteBudget, MAX_TERMINAL_WRITE_BYTES_PER_CALL,
     MAX_TERMINAL_WRITE_BYTES_PER_SEC, TERMINAL_WRITE_WINDOW,
@@ -14,9 +14,9 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::mpsc;
 
 #[derive(Serialize, Clone)]
@@ -390,7 +390,54 @@ pub fn spawn_session(
     // Issue #285 follow-up: scrollback リングバッファ。batcher と SessionHandle で共有。
     let scrollback = crate::pty::scrollback::new_scrollback();
 
-    spawn_batcher(app.clone(), data_event, rx, scrollback.clone());
+    // Issue #524: agent カードに紐付く PTY のみ、出力 batch flush ごとに TeamHub の
+    // `member_diagnostics[agent_id].last_pty_output_at` を update する observer を渡す。
+    // ターミナルタブ等の agent_id 無し PTY では None で no-op。
+    //
+    // closure 内 dedup: 1 秒間隔でしか hub.state lock を取らない。flush は最短 16ms 間隔
+    // (FLUSH_INTERVAL_MS) で起こり得るので、生の flush ごとに lock 取得すると `inject` /
+    // `team_send` 等の MCP tool と競合して latency 悪化を招く。
+    let on_output: Option<PtyOutputObserver> = opts.agent_id.as_ref().map(|aid| {
+        let aid = aid.clone();
+        let app_for_obs = app.clone();
+        let last_update: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
+        Arc::new(move || {
+            // dedup: 1 秒以内の連続 flush は no-op
+            {
+                let now = Instant::now();
+                let mut guard = match last_update.try_lock() {
+                    Ok(g) => g,
+                    // 別 worker が ちょうど update 中なら今回はスキップ (1s 後に拾える)
+                    Err(_) => return,
+                };
+                match *guard {
+                    Some(prev) if now.duration_since(prev) < Duration::from_secs(1) => return,
+                    _ => *guard = Some(now),
+                }
+            }
+            // hub.state.lock() は async なので tokio task に逃がす (flush は同期 callback)
+            let aid = aid.clone();
+            let app = app_for_obs.clone();
+            tauri::async_runtime::spawn(async move {
+                let state = match app.try_state::<crate::state::AppState>() {
+                    Some(s) => s,
+                    None => {
+                        tracing::trace!(
+                            "[pty-observer] AppState not available; skipping last_pty_output_at update"
+                        );
+                        return;
+                    }
+                };
+                let hub = state.team_hub.clone();
+                let now_iso = chrono::Utc::now().to_rfc3339();
+                let mut s = hub.state.lock().await;
+                let diag = s.member_diagnostics.entry(aid).or_default();
+                diag.last_pty_output_at = Some(now_iso);
+            });
+        }) as PtyOutputObserver
+    });
+
+    spawn_batcher(app.clone(), data_event, rx, scrollback.clone(), on_output);
 
     // exit watcher (blocking child.wait → emit exit event)
     // Issue #152: child.wait() の後に registry からも remove して、孤立 entry が

--- a/src-tauri/src/team_hub/protocol/consts.rs
+++ b/src-tauri/src/team_hub/protocol/consts.rs
@@ -56,3 +56,11 @@ pub(crate) const INJECT_MAX_PAYLOAD: usize = 32 * 1024;
 pub(crate) const INJECT_MAX_RETRY: u32 = 1;
 /// リトライ前の backoff (millis)。session が ack されきっていない初期 race 用。
 pub(crate) const INJECT_RETRY_BACKOFF_MS: u64 = 200;
+
+// ---------- Issue #524: status staleness threshold ----------
+
+/// `team_status` 自己申告 (= `last_status_at`) からこの秒数以上更新が無ければ、
+/// `team_diagnostics` の `autoStale: true` を立てる。
+/// 5 分は「主要 shell コマンド (cargo build / npm test / 長めの Claude 思考) より長く、
+/// かつ 30 分のような長すぎる threshold で督促が遅れる事故を避けた中間値」。
+pub(crate) const STATUS_STALE_THRESHOLD_SECS: u64 = 300;

--- a/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
+++ b/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
@@ -5,6 +5,7 @@ use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
+use super::super::consts::STATUS_STALE_THRESHOLD_SECS;
 use super::super::helpers::message_is_for_me;
 use super::super::permissions::{check_permission, Permission};
 
@@ -80,6 +81,31 @@ fn build_member_diagnostics_row(
 ) -> Value {
     let pending = pending_inbox_summary(messages, agent_id, role, now);
     let pending_count = pending.ids.len();
+
+    // Issue #524: 自己申告 (`team_status`) と物理シグナル (PTY 出力) の age を計算。
+    // age が無い (= 一度も観測されていない) ケースは `None` のまま JSON `null` として返す。
+    let last_status_age_ms = diagnostics
+        .last_status_at
+        .as_deref()
+        .and_then(parse_rfc3339_utc)
+        .map(|t| (now - t).num_milliseconds().max(0));
+    let last_pty_activity_age_ms = diagnostics
+        .last_pty_output_at
+        .as_deref()
+        .and_then(parse_rfc3339_utc)
+        .map(|t| (now - t).num_milliseconds().max(0));
+
+    // `autoStale` の意味的定義:
+    //   - 自己申告が無い / 古い (`last_status_at` が None または age が threshold 超過)
+    //   - **かつ** PTY も物理的に動いていない (`last_pty_output_at` の age が threshold 超過か None)
+    // PTY が直近に活動している場合は「動いてはいるが status 申告だけ古い」だけなので
+    // `autoStale: false` を維持する (= Leader が脅威認識を起こさない)。これにより、
+    // 「team_status は忘れがちだが実は cargo build を回している worker」を誤って退場させない。
+    let stale_threshold_ms: i64 = (STATUS_STALE_THRESHOLD_SECS as i64) * 1000;
+    let status_is_stale = last_status_age_ms.is_none_or(|s| s >= stale_threshold_ms);
+    let pty_is_recently_active = last_pty_activity_age_ms.is_some_and(|p| p < stale_threshold_ms);
+    let auto_stale = status_is_stale && !pty_is_recently_active;
+
     json!({
         "agentId": agent_id,
         "role": role,
@@ -100,6 +126,12 @@ fn build_member_diagnostics_row(
         "stalledInbound": pending.stalled,
         "currentStatus": diagnostics.current_status,
         "lastStatusAt": diagnostics.last_status_at,
+        // Issue #524: PTY 出力アクティビティ + staleness 自動判定
+        "lastPtyOutputAt": diagnostics.last_pty_output_at,
+        "lastStatusAgeMs": last_status_age_ms,
+        "lastPtyActivityAgeMs": last_pty_activity_age_ms,
+        "autoStale": auto_stale,
+        "stalenessThresholdMs": stale_threshold_ms,
     })
 }
 

--- a/src-tauri/src/team_hub/state.rs
+++ b/src-tauri/src/team_hub/state.rs
@@ -77,6 +77,12 @@ pub struct MemberDiagnostics {
     pub current_status: Option<String>,
     /// Issue #409: `current_status` を更新した最終時刻 (RFC3339)。
     pub last_status_at: Option<String>,
+    /// Issue #524: PTY から最後に出力 byte が流れた時刻 (RFC3339)。
+    /// agent process が「ハングしているか / 単に待機中か」を Leader が判定する物理シグナルとして使う。
+    /// `team_status` の自己申告と乖離した場合 (例: status は "running tests" だが PTY 出力が 5 分間無い)
+    /// に diagnostics 側で `autoStale: true` を立てる元データ。
+    /// 大量出力で hub の lock 競合を避けるため、PTY batcher が 1 秒間隔で dedup して update する。
+    pub last_pty_output_at: Option<String>,
 }
 
 /// Issue #342 Phase 3 (3.11): tracing-appender が書き出すログファイルの絶対パスを

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -760,6 +760,60 @@ export interface TeamInboxReadEvent {
   readAt: string;
 }
 
+// ---------- TeamHub diagnostics staleness (Issue #524) ----------
+
+/**
+ * Issue #524: `team_diagnostics` MCP tool の `members[i]` row 形 (camelCase JSON)。
+ * Leader / HR が member の活動状況・自己申告と物理シグナル (PTY 出力) の乖離を判定する。
+ *
+ * `team_diagnostics` 自体は MCP tool で agent process が呼ぶ形 (renderer 側 IPC ではない)
+ * だが、将来 Canvas Dashboard (#514) で Tauri IPC 経由でも露出するため、型の正本としてここに置く。
+ * 既存フィールドは Issue #409 (`currentStatus` / `lastStatusAt`) と Issue #511 / #509 で
+ * 整備した `pendingInbox*` / `stalledInbound` を踏襲。
+ */
+export interface TeamDiagnosticsMemberRow {
+  agentId: string;
+  role: string;
+  online: boolean;
+  inconsistent: boolean;
+  recruitedAt: string;
+  lastHandshakeAt: string | null;
+  lastSeenAt: string | null;
+  lastAgentActivityAt: string | null;
+  lastMessageInAt: string | null;
+  lastMessageOutAt: string | null;
+  messagesInCount: number;
+  messagesOutCount: number;
+  tasksClaimedCount: number;
+  pendingInbox: number[];
+  pendingInboxCount: number;
+  oldestPendingInboxAgeMs: number | null;
+  stalledInbound: boolean;
+  /** Issue #409: `team_status(status)` で agent が自己申告した最新ステータス文字列。 */
+  currentStatus: string | null;
+  /** Issue #409: `currentStatus` を更新した最終時刻 (RFC3339)。 */
+  lastStatusAt: string | null;
+  /**
+   * Issue #524: PTY から最後に出力 byte が流れた時刻 (RFC3339)。
+   * agent process がハングしているか / 動いているかの物理シグナル。
+   * batcher 側で 1 秒間隔の dedup を経て update されるので、`null` のまま長時間 (分単位)
+   * 続いた場合は実際にプロセスが動いていない可能性が高い。
+   */
+  lastPtyOutputAt: string | null;
+  /** `lastStatusAt` から現在までの経過 ms (`null` なら一度も自己申告がない)。 */
+  lastStatusAgeMs: number | null;
+  /** `lastPtyOutputAt` から現在までの経過 ms (`null` なら一度も PTY 出力が観測されていない)。 */
+  lastPtyActivityAgeMs: number | null;
+  /**
+   * 自動 stale 判定: 自己申告が古く / 無く、かつ PTY 出力も threshold を超過 (or 無い) ならば true。
+   * PTY が直近に活動している場合は「動いている」ので false (= 誤検知防止)。
+   * Leader / Canvas dashboard の警告バッジに使う。
+   */
+  autoStale: boolean;
+  /** `autoStale` の閾値 (ms)。Hub 側の `STATUS_STALE_THRESHOLD_SECS` を ms 換算したもの。 */
+  stalenessThresholdMs: number;
+}
+
 // ---------- Window Effects (Issue #260) ----------
 
 /**


### PR DESCRIPTION
## Summary

`team_update_task` / `team_status` の自己申告依存で「実は cargo build を回している worker」を誤って stale 扱いしてしまう問題を、PTY 出力 byte の flush 時刻という **物理シグナル** で補正する。

- `state.rs` の `MemberDiagnostics` に `last_pty_output_at: Option<String>` (RFC3339) を追加
- `pty/batcher.rs` の flush に `PtyOutputObserver` callback を新引数で受け、flush ごとに observer を呼ぶ (emit success/failure に関わらず PTY → batcher 受信は発生しているので物理活動の証拠)
- `pty/session.rs::spawn_session` は `opts.agent_id` がある PTY のみ observer closure を構築:
  - 1 秒 dedup (`Mutex<Option<Instant>>`) で hub.state lock の競合を抑制 (60 Hz 級の flush でも 1 秒に 1 回しか lock を取らない)
  - `tauri::async_runtime::spawn` で `hub.state.member_diagnostics[agent_id].last_pty_output_at` を非同期に更新
  - AppState 取得は `app.try_state()` で fail-soft (ログだけ trace)
- `diagnostics.rs::build_member_diagnostics_row` の json! に `lastPtyOutputAt` / `lastStatusAgeMs` / `lastPtyActivityAgeMs` / `autoStale` / `stalenessThresholdMs` を append
- `autoStale` は「自己申告が古い (`last_status_at` が None または age が threshold 超過) **AND** PTY も threshold 超過 (or 無い)」の AND 条件で計算。PTY が直近に活動していれば `false` (= 動いている worker を誤検知しない)
- `consts.rs` に `STATUS_STALE_THRESHOLD_SECS = 300` (5 分) を追加
- `shared.ts` に `TeamDiagnosticsMemberRow` 型を追加 (#514 phase 2 dashboard で再利用予定)

**Layer 違反回避**: `pty/` から `team_hub::*` を直接 import せず、`PtyOutputObserver` callback を介して反応する。closure 構築は `pty/session.rs` 側で行い、`tauri::async_runtime::spawn` 内で AppState 経由で hub にアクセスする (= 既存の AppHandle ルート)。

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 通過 (warning は #519 由来の既存 dead_code、本 PR と無関係)
- [x] `cargo test --manifest-path src-tauri/Cargo.toml team_hub` 78 passed (既存テストすべて + Issue #511/#509 のテストも含む)
- [x] `npm run typecheck` 0 errors
- [ ] 手動: 2 名構成で worker を起動して 5 分以内に PTY 出力がある間は `team_diagnostics` の `autoStale` が false のままであること
- [ ] 手動: worker を `sleep 600` でハングさせて `lastPtyActivityAgeMs > 300_000` && `lastStatusAgeMs > 300_000` のとき `autoStale: true` になること
- [ ] 手動: `team_status('working...')` を直前に呼んで `lastStatusAgeMs < 300_000` なら `autoStale: false` になること

## Coordination / Conflict avoidance

- **#522 (renderer_canvas_ui の TeamPresetsPanel)** とは `lib.rs` `invoke_handler!` を **触らないので非競合**
- **#514 (renderer_canvas_ui の Team Dashboard)** は最終的に **Rust 完全に触らない第一案 PURE** (`team_state_read` + canvas store + agent-activity store の合成) で進めることが事前合意済み。本 PR の `TeamDiagnosticsMemberRow` 型は #514 phase 2 (Rust IPC を生やすバージョン) で再利用される
- **#533 (#508 / rust_team_hub_core)** との recruit.rs 衝突は無し

## Related

- Issue #511 (PR #532): PTY inject 失敗の細分化 → main にマージ済み
- Issue #509 (PR #535): team_send delivery_status (pending/readSoFar) + unread badge → main にマージ済み
- Issue #514: Team Dashboard (renderer_canvas_ui 進行中)
- Issue #510: dashboard 連携 (future scope)

Closes #524