### PR TITLE
feat(vibe-team): Canvas に Team 管理ダッシュボードを追加 (#514)

### DIFF
--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -4,6 +4,7 @@ import {
   Bookmark,
   CheckCircle2,
   CircleDot,
+  ClipboardList,
   Hourglass,
   LayoutGrid,
   List,
@@ -15,7 +16,8 @@ import {
 } from 'lucide-react';
 import { useReactFlow } from '@xyflow/react';
 import { useT } from '../../lib/i18n';
-import { useCanvasStore, type StageView } from '../../stores/canvas';
+import { useSettings } from '../../lib/settings-context';
+import { useCanvasStore, type StageView, type CardData } from '../../stores/canvas';
 import { useCanvasNodes, useCanvasStageView } from '../../stores/canvas-selectors';
 import { useAgentActivityStore } from '../../stores/agent-activity';
 import {
@@ -23,6 +25,8 @@ import {
   type CardSummary
 } from '../../lib/agent-summary';
 import { TeamPresetsPanel } from './TeamPresetsPanel';
+import { TeamDashboard } from './TeamDashboard';
+import type { AgentPayload } from './cards/AgentNodeCard/types';
 import type { ArrangeGap } from '../../lib/canvas-arrange';
 
 /**
@@ -48,6 +52,9 @@ export function StageHud(): JSX.Element {
   // Issue #522: team preset panel toggle. arrange popover とは独立。
   const [presetsOpen, setPresetsOpen] = useState(false);
   const presetsWrapRef = useRef<HTMLDivElement | null>(null);
+  // Issue #514: team dashboard panel toggle.
+  const [dashboardOpen, setDashboardOpen] = useState(false);
+  const dashboardWrapRef = useRef<HTMLDivElement | null>(null);
 
   // ポップオーバー外クリック / Escape で閉じる
   useEffect(() => {
@@ -68,6 +75,26 @@ export function StageHud(): JSX.Element {
       window.removeEventListener('keydown', onKey);
     };
   }, [arrangeOpen]);
+
+  // Issue #514: dashboard も同じく親 ref で外クリック判定 (#522 同パターン)。
+  useEffect(() => {
+    if (!dashboardOpen) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!dashboardWrapRef.current) return;
+      if (!dashboardWrapRef.current.contains(e.target as Node)) {
+        setDashboardOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setDashboardOpen(false);
+    };
+    window.addEventListener('pointerdown', onPointerDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [dashboardOpen]);
 
   // Issue #522: presets popover も同じく「ボタン + popover」を内包する親 ref で
   // 外クリック判定する。子コンポーネント (TeamPresetsPanel) 側で同じ処理をすると、
@@ -150,6 +177,23 @@ export function StageHud(): JSX.Element {
     [agentNodes, cardSummaries]
   );
   const showTeamSummary = teamSummary.total > 0;
+
+  // Issue #514: dashboard に渡す teamId / projectRoot を canvas state + settings から導出。
+  // 複数 team が並ぶ稀なケースは「Leader カードがある team を優先」、無ければ最初の agent team を採る。
+  const { settings } = useSettings();
+  const dashboardTeamId = useMemo<string | null>(() => {
+    let leaderTeam: string | null = null;
+    let firstTeam: string | null = null;
+    for (const node of agentNodes) {
+      const payload = (node.data as CardData | undefined)?.payload as AgentPayload | undefined;
+      if (!payload?.teamId) continue;
+      if (firstTeam === null) firstTeam = payload.teamId;
+      const role = payload.roleProfileId ?? payload.role;
+      if (role === 'leader' && leaderTeam === null) leaderTeam = payload.teamId;
+    }
+    return leaderTeam ?? firstTeam;
+  }, [agentNodes]);
+  const dashboardProjectRoot = settings.lastOpenedRoot || null;
 
   return (
     <div className="tc__hud glass-surface" role="toolbar" aria-label="Canvas view">
@@ -249,6 +293,26 @@ export function StageHud(): JSX.Element {
         <ZoomIn size={12} strokeWidth={2} />
       </button>
       <span className="tc__hud-sep" aria-hidden="true" />
+      <div className="tc__hud-dashboard" ref={dashboardWrapRef}>
+        <button
+          type="button"
+          className={dashboardOpen ? 'is-active' : ''}
+          onClick={() => setDashboardOpen((v) => !v)}
+          title={t('dashboard.button.tooltip')}
+          aria-label={t('dashboard.button.tooltip')}
+          aria-haspopup="dialog"
+          aria-expanded={dashboardOpen}
+        >
+          <ClipboardList size={12} strokeWidth={2} />
+        </button>
+        {dashboardOpen ? (
+          <TeamDashboard
+            teamId={dashboardTeamId}
+            projectRoot={dashboardProjectRoot}
+            onClose={() => setDashboardOpen(false)}
+          />
+        ) : null}
+      </div>
       <div className="tc__hud-presets" ref={presetsWrapRef}>
         <button
           type="button"

--- a/src/renderer/src/components/canvas/TeamDashboard.tsx
+++ b/src/renderer/src/components/canvas/TeamDashboard.tsx
@@ -1,0 +1,211 @@
+/**
+ * TeamDashboard — Issue #514.
+ *
+ * Canvas 上のチーム (= 同 teamId の agent カード群) を一覧化する集約 UI。
+ * 4 名以上のチームでも Leader が状態を破綻させず把握できることをゴールとする。
+ *
+ * 設計:
+ *   - 親 (StageHud) が popover として表示する。teamId は active leader 経由で受け取る。
+ *   - 行データは `useTeamDashboard` hook が canvas + agent-activity + team_state_read を
+ *     合成して返す。本コンポーネントは表示のみに集中する。
+ *   - 状態色: active=success, blocked=warning, stale=info-mute, completed=accent。
+ *   - 0 件 / teamId 未確定時は空状態メッセージを出す。
+ */
+import { useMemo } from 'react';
+import { AlertTriangle, CheckCircle2, CircleDot, Hourglass, MoonStar } from 'lucide-react';
+import { useT } from '../../lib/i18n';
+import { useTeamDashboard, type TeamDashboardRow } from '../../lib/use-team-dashboard';
+
+interface TeamDashboardProps {
+  teamId: string | null;
+  projectRoot: string | null;
+  onClose: () => void;
+}
+
+function formatRelative(now: number, ts: number | null): string | null {
+  if (ts === null) return null;
+  const diff = Math.max(0, now - ts);
+  if (diff < 5_000) return 'now';
+  if (diff < 60_000) return `${Math.floor(diff / 1_000)}s`;
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h`;
+  return `${Math.floor(diff / 86_400_000)}d`;
+}
+
+function StateBadge({ state }: { state: TeamDashboardRow['state'] }): JSX.Element {
+  const t = useT();
+  const cls = `tc__dash-state tc__dash-state--${state}`;
+  switch (state) {
+    case 'active':
+      return (
+        <span className={cls}>
+          <CircleDot size={11} strokeWidth={2.2} aria-hidden="true" />
+          <span>{t('dashboard.state.active')}</span>
+        </span>
+      );
+    case 'blocked':
+      return (
+        <span className={cls}>
+          <AlertTriangle size={11} strokeWidth={2.2} aria-hidden="true" />
+          <span>{t('dashboard.state.blocked')}</span>
+        </span>
+      );
+    case 'stale':
+      return (
+        <span className={cls}>
+          <Hourglass size={11} strokeWidth={2.2} aria-hidden="true" />
+          <span>{t('dashboard.state.stale')}</span>
+        </span>
+      );
+    case 'completed':
+      return (
+        <span className={cls}>
+          <CheckCircle2 size={11} strokeWidth={2.2} aria-hidden="true" />
+          <span>{t('dashboard.state.completed')}</span>
+        </span>
+      );
+    default:
+      return (
+        <span className={cls}>
+          <MoonStar size={11} strokeWidth={2.2} aria-hidden="true" />
+          <span>{t('dashboard.state.idle')}</span>
+        </span>
+      );
+  }
+}
+
+export function TeamDashboard({ teamId, projectRoot, onClose }: TeamDashboardProps): JSX.Element {
+  const t = useT();
+  const { rows, aggregate, state, empty } = useTeamDashboard({ teamId, projectRoot });
+  // 表示用の "now" は描画タイミングで固定。15 秒間隔の親 StageHud 再 render に乗る想定で
+  // ここではフレーム単位の固定値とし、相対時間がチラつかないようにする。
+  const now = useMemo(() => Date.now(), [rows.length, aggregate.hasAttention, state?.updatedAt]);
+
+  return (
+    <div
+      className="tc__dashboard glass-surface"
+      role="dialog"
+      aria-label={t('dashboard.title')}
+    >
+      <div className="tc__dashboard-header">
+        <span className="tc__dashboard-title">{t('dashboard.title')}</span>
+        <span className="tc__dashboard-count">
+          {t('dashboard.count', { count: aggregate.total })}
+        </span>
+        <button
+          type="button"
+          className="tc__dashboard-close"
+          onClick={onClose}
+          aria-label={t('common.close')}
+          title={t('common.close')}
+        >
+          ×
+        </button>
+      </div>
+
+      {state?.humanGate?.blocked ? (
+        <div className="tc__dashboard-banner" role="status">
+          <AlertTriangle size={12} strokeWidth={2} aria-hidden="true" />
+          <span>{state.humanGate.reason ?? t('dashboard.banner.humanGate')}</span>
+        </div>
+      ) : null}
+
+      {empty ? (
+        <div className="tc__dashboard-empty">
+          {teamId
+            ? t('dashboard.empty.noMembers')
+            : t('dashboard.empty.noTeam')}
+        </div>
+      ) : (
+        <table className="tc__dashboard-table">
+          <thead>
+            <tr>
+              <th scope="col">{t('dashboard.col.member')}</th>
+              <th scope="col">{t('dashboard.col.state')}</th>
+              <th scope="col">{t('dashboard.col.task')}</th>
+              <th scope="col">{t('dashboard.col.lastSeen')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr
+                key={row.cardId}
+                className={
+                  'tc__dashboard-row tc__dashboard-row--' + row.state
+                }
+              >
+                <td>
+                  <div className="tc__dashboard-member">
+                    <span className="tc__dashboard-member-title">{row.title}</span>
+                    <span className="tc__dashboard-member-meta">
+                      {row.roleProfileId} · {row.agent}
+                    </span>
+                  </div>
+                </td>
+                <td>
+                  <StateBadge state={row.state} />
+                  {row.alert ? (
+                    <div className="tc__dashboard-alert" title={row.alert}>
+                      {row.alert}
+                    </div>
+                  ) : null}
+                </td>
+                <td className="tc__dashboard-task">
+                  {row.task ? (
+                    <>
+                      <div
+                        className="tc__dashboard-task-title"
+                        title={row.task.summary ?? row.task.description}
+                      >
+                        {row.task.summary ?? row.task.description}
+                      </div>
+                      <div className="tc__dashboard-task-meta">
+                        #{row.task.id} · {row.task.status}
+                      </div>
+                    </>
+                  ) : (
+                    <span className="tc__dashboard-task-empty">
+                      {t('dashboard.task.unassigned')}
+                    </span>
+                  )}
+                </td>
+                <td className="tc__dashboard-cell-num">
+                  {formatRelative(now, row.lastActivityAt) ??
+                    t('dashboard.lastSeen.never')}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <div className="tc__dashboard-footer">
+        <span className="tc__dashboard-foot-pill tc__dashboard-foot-pill--active">
+          {t('dashboard.state.active')}: {aggregate.active}
+        </span>
+        <span
+          className={
+            'tc__dashboard-foot-pill tc__dashboard-foot-pill--blocked' +
+            (aggregate.blocked > 0 ? ' is-on' : '')
+          }
+        >
+          {t('dashboard.state.blocked')}: {aggregate.blocked}
+        </span>
+        <span
+          className={
+            'tc__dashboard-foot-pill tc__dashboard-foot-pill--stale' +
+            (aggregate.stale > 0 ? ' is-on' : '')
+          }
+        >
+          {t('dashboard.state.stale')}: {aggregate.stale}
+        </span>
+        <span className="tc__dashboard-foot-pill tc__dashboard-foot-pill--completed">
+          {t('dashboard.state.completed')}: {aggregate.completed}
+        </span>
+        <span className="tc__dashboard-foot-pill tc__dashboard-foot-pill--idle">
+          {t('dashboard.state.idle')}: {aggregate.idle}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -365,7 +365,7 @@ const ja: Dict = {
   'dashboard.state.stale': '停滞',
   'dashboard.state.completed': '完了',
   'dashboard.state.idle': '待機',
-  'dashboard.task.unassigned': 'タスク未割当',
+  'dashboard.task.unassigned': 'タスク未割り当て',
   'dashboard.lastSeen.never': '未観測',
   'dashboard.empty.noTeam':
     '対象のチームが Canvas にありません。Agent カードを 1 枚以上配置してください',

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -352,6 +352,27 @@ const ja: Dict = {
   'preset.error.saveFailed': 'プリセット保存に失敗しました: {detail}',
   'preset.error.deleteFailed': 'プリセット削除に失敗しました: {detail}',
 
+  // Issue #514: Team Dashboard
+  'dashboard.title': 'チームダッシュボード',
+  'dashboard.button.tooltip': 'チームダッシュボード — 全メンバーの状態 / タスク / 経過を一覧',
+  'dashboard.count': '{count} 名',
+  'dashboard.col.member': 'メンバー',
+  'dashboard.col.state': '状態',
+  'dashboard.col.task': '担当タスク',
+  'dashboard.col.lastSeen': '最終出力',
+  'dashboard.state.active': '進行中',
+  'dashboard.state.blocked': 'Leader 待ち',
+  'dashboard.state.stale': '停滞',
+  'dashboard.state.completed': '完了',
+  'dashboard.state.idle': '待機',
+  'dashboard.task.unassigned': 'タスク未割当',
+  'dashboard.lastSeen.never': '未観測',
+  'dashboard.empty.noTeam':
+    '対象のチームが Canvas にありません。Agent カードを 1 枚以上配置してください',
+  'dashboard.empty.noMembers':
+    'このチームにはまだメンバーがいません。Leader から `team_recruit` でメンバーを招集してください',
+  'dashboard.banner.humanGate': 'Human gate が blocked: Leader の判断待ちです',
+
   // ---------- Sessions ----------
   'sessions.resume': 'セッション {id} に戻る',
   'sessions.messages': '{count} 件',
@@ -955,6 +976,28 @@ const en: Dict = {
   'preset.error.listFailed': 'Failed to load preset list',
   'preset.error.saveFailed': 'Failed to save preset: {detail}',
   'preset.error.deleteFailed': 'Failed to delete preset: {detail}',
+
+  // Issue #514: Team Dashboard
+  'dashboard.title': 'Team Dashboard',
+  'dashboard.button.tooltip':
+    'Team dashboard — overview of every member with state, task, and last activity',
+  'dashboard.count': '{count} members',
+  'dashboard.col.member': 'Member',
+  'dashboard.col.state': 'State',
+  'dashboard.col.task': 'Task',
+  'dashboard.col.lastSeen': 'Last seen',
+  'dashboard.state.active': 'Active',
+  'dashboard.state.blocked': 'Awaiting leader',
+  'dashboard.state.stale': 'Stale',
+  'dashboard.state.completed': 'Completed',
+  'dashboard.state.idle': 'Idle',
+  'dashboard.task.unassigned': 'No task assigned',
+  'dashboard.lastSeen.never': 'never',
+  'dashboard.empty.noTeam':
+    'No agent team on this canvas. Add at least one agent card to use the dashboard.',
+  'dashboard.empty.noMembers':
+    'This team has no members yet. Recruit members from the Leader using `team_recruit`.',
+  'dashboard.banner.humanGate': 'Human gate blocked: waiting for leader decision',
 
   // ---------- Sessions ----------
   'sessions.resume': 'Resume session {id}',

--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -25,6 +25,7 @@ import { settings } from './tauri-api/settings';
 import { team } from './tauri-api/team';
 import { teamHistory } from './tauri-api/team-history';
 import { teamPresets } from './tauri-api/team-presets';
+import { teamState } from './tauri-api/team-state';
 import { terminal } from './tauri-api/terminal';
 
 // 既存 import { RoleProfileSummary } from '../lib/tauri-api' との互換維持。
@@ -45,6 +46,7 @@ export const api = {
   team,
   teamHistory,
   teamPresets,
+  teamState,
   handoffs,
   dialog,
   settings,

--- a/src/renderer/src/lib/tauri-api/team-state.ts
+++ b/src/renderer/src/lib/tauri-api/team-state.ts
@@ -1,0 +1,18 @@
+// tauri-api/team-state.ts — TeamHub orchestration state の renderer 側 wrapper (Issue #514).
+//
+// Rust 側 `commands/team_state.rs` の `team_state_read` IPC を 1:1 で叩く薄いラッパー。
+// project_root + team_id を指定して `~/.vibe-editor/team-state/<projectKey>/<teamId>.json`
+// から persistence された orchestration state (tasks / worker_reports / human_gate /
+// handoff_events) を読み出す。
+//
+// 既に読み出し系のみ存在する API。書き出しは MCP 経由で agent から行うため renderer 側
+// wrapper は read のみ用意する (write は agent が `team_assign_task` 等を MCP で叩く)。
+
+import { invoke } from '@tauri-apps/api/core';
+import type { TeamOrchestrationState } from '../../../../types/shared';
+
+export const teamState = {
+  /** 永続化されたチームの orchestration state を読み出す。未保存なら null。 */
+  read: (projectRoot: string, teamId: string): Promise<TeamOrchestrationState | null> =>
+    invoke('team_state_read', { projectRoot, teamId })
+};

--- a/src/renderer/src/lib/use-team-dashboard.ts
+++ b/src/renderer/src/lib/use-team-dashboard.ts
@@ -1,0 +1,239 @@
+/**
+ * use-team-dashboard — Issue #514.
+ *
+ * Canvas 上の Agent カード群と TeamHub orchestration state を合成して、
+ * チーム単位の集約ダッシュボードに必要な行データを返す React hook。
+ *
+ * 現時点では「Rust 側 diagnostics IPC は MCP 専用で renderer から呼べない」という
+ * 制約を踏まえ、以下 3 ソースの合成だけで dashboard を組み立てる:
+ *   1. canvas store: agentId / role / agent kind (claude/codex) / cardId / title
+ *   2. agent-activity store (#521): activity (idle/typing/thinking) / lastActivityAt
+ *      / 派生サマリ (CardSummary)
+ *   3. `team_state_read` IPC: tasks (assignedTo / status / blockedReason / nextAction
+ *      / requiredHumanDecision / blockedByHumanGate) / human_gate / latestHandoff
+ *
+ * 5 秒間隔で `team_state_read` を poll する (UI が固まらないことを優先する設計判断)。
+ * 将来 Rust 側 diagnostics IPC が生えたら ここから列を追加する想定。
+ */
+import { useEffect, useMemo, useState } from 'react';
+import type { Node } from '@xyflow/react';
+import { useCanvasNodes } from '../stores/canvas-selectors';
+import { useAgentActivityStore } from '../stores/agent-activity';
+import type { CardData } from '../stores/canvas';
+import type {
+  TeamOrchestrationState,
+  TeamTaskSnapshot
+} from '../../../../types/shared';
+import type {
+  AgentPayload,
+  AgentStatus
+} from '../components/canvas/cards/AgentNodeCard/types';
+
+const POLL_INTERVAL_MS = 5_000;
+
+/** 1 行 = 1 agent カード分の dashboard 行データ。 */
+export interface TeamDashboardRow {
+  /** カード id (canvas store の node id) */
+  cardId: string;
+  /** TeamHub 側の agentId。未設定 (canvas のみ) なら null。 */
+  agentId: string | null;
+  /** 表示用ラベル (カードタイトル) */
+  title: string;
+  /** ロール識別子 (`leader` / `planner` / ...) */
+  roleProfileId: string;
+  /** terminal 種別 (`claude` / `codex`) */
+  agent: string;
+  /** 画面表示用の集約ステータス */
+  state: 'active' | 'blocked' | 'stale' | 'idle' | 'completed';
+  /** activity store のリアルタイム値 */
+  activity: AgentStatus;
+  /** 最後に出力 or 入力イベントを観測した unix ms。null = 未観測。 */
+  lastActivityAt: number | null;
+  /** assigned task (1 件目)。複数あれば in_progress を優先。 */
+  task: TeamTaskSnapshot | null;
+  /** Leader 側で対応が要る理由 (blockedReason / handoff_pending / stale など) */
+  alert: string | null;
+}
+
+/** dashboard サマリ用の集計値。 */
+export interface TeamDashboardAggregate {
+  total: number;
+  active: number;
+  blocked: number;
+  stale: number;
+  completed: number;
+  idle: number;
+  /** Leader が必ず確認すべき行が 1 つ以上あるか */
+  hasAttention: boolean;
+}
+
+export interface TeamDashboardData {
+  rows: TeamDashboardRow[];
+  aggregate: TeamDashboardAggregate;
+  /** team_state_read 由来。Leader 行の表示や handoff バナーに使う。 */
+  state: TeamOrchestrationState | null;
+  /** dashboard が活きていない (= teamId が無い / カード 0 / projectRoot 不明) 状態 */
+  empty: boolean;
+}
+
+/**
+ * dashboard 用の集約データを返す。teamId / projectRoot が確定していない間は空 rows を返す。
+ */
+export function useTeamDashboard(input: {
+  teamId: string | null;
+  projectRoot: string | null;
+}): TeamDashboardData {
+  const { teamId, projectRoot } = input;
+
+  const allNodes = useCanvasNodes();
+  const agentNodes = useMemo<Node<CardData>[]>(
+    () =>
+      allNodes.filter((n) => {
+        if (n.type !== 'agent') return false;
+        const payload = (n.data as CardData | undefined)?.payload as AgentPayload | undefined;
+        return !teamId || payload?.teamId === teamId;
+      }),
+    [allNodes, teamId]
+  );
+
+  const byCard = useAgentActivityStore((s) => s.byCard);
+
+  const [state, setState] = useState<TeamOrchestrationState | null>(null);
+  // poll 起動条件: teamId と projectRoot が両方ある場合だけ。状態が変わったら再起動。
+  useEffect(() => {
+    if (!teamId || !projectRoot) {
+      setState(null);
+      return;
+    }
+    let cancelled = false;
+    const tick = () => {
+      window.api.teamState
+        .read(projectRoot, teamId)
+        .then((next) => {
+          if (cancelled) return;
+          // 参照同一性で React の再レンダーを抑制: 直近の updatedAt が同じなら更新しない。
+          setState((prev) => {
+            if (prev && next && prev.updatedAt === next.updatedAt) return prev;
+            return next;
+          });
+        })
+        .catch((err) => {
+          if (!cancelled) console.warn('[team-dashboard] read failed:', err);
+        });
+    };
+    tick();
+    const id = window.setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [teamId, projectRoot]);
+
+  const rows = useMemo<TeamDashboardRow[]>(() => {
+    if (agentNodes.length === 0) return [];
+    return agentNodes.map((node) => {
+      const data = node.data as CardData | undefined;
+      const payload = data?.payload as AgentPayload | undefined;
+      const agentId = payload?.agentId ?? null;
+      const roleProfileId = payload?.roleProfileId ?? payload?.role ?? 'unknown';
+      const agentKind = payload?.agent ?? 'claude';
+      const title = typeof data?.title === 'string' ? data.title : roleProfileId;
+      const runtime = byCard[node.id];
+      const activity = runtime?.activity ?? 'idle';
+      const lastActivityAt = runtime?.lastActivityAt ?? null;
+      const summary = runtime?.summary ?? null;
+
+      // task 抽出: agentId が assignedTo に一致する未完了タスクを優先。
+      // 同一 agent に複数 task があれば in_progress > pending > その他の優先順位。
+      const candidateTasks = state
+        ? state.tasks.filter((t) => agentId !== null && t.assignedTo === agentId)
+        : [];
+      const orderedTasks = candidateTasks.slice().sort((a, b) => {
+        const score = (s: string) => (s === 'in_progress' ? 0 : s === 'pending' ? 1 : 2);
+        return score(a.status) - score(b.status);
+      });
+      const task = orderedTasks[0] ?? null;
+
+      // 集約ステータス: handoff acked → completed、blocked task / human_gate → blocked、
+      // summary.isStale → stale、active → active、それ以外 → idle。
+      let computed: TeamDashboardRow['state'] = 'idle';
+      if (summary?.isCompleted) computed = 'completed';
+      else if (
+        task?.status === 'blocked' ||
+        task?.blockedByHumanGate ||
+        summary?.needsLeaderInput
+      )
+        computed = 'blocked';
+      else if (summary?.isStale) computed = 'stale';
+      else if (summary?.isActive) computed = 'active';
+
+      const alert = (() => {
+        if (computed === 'blocked') {
+          return (
+            task?.blockedReason ??
+            task?.requiredHumanDecision ??
+            (state?.humanGate.blocked ? state.humanGate.reason ?? null : null) ??
+            'Leader 入力待ち'
+          );
+        }
+        if (computed === 'stale') return '5 分以上出力なし';
+        return null;
+      })();
+
+      return {
+        cardId: node.id,
+        agentId,
+        title,
+        roleProfileId,
+        agent: agentKind,
+        state: computed,
+        activity,
+        lastActivityAt,
+        task,
+        alert
+      };
+    });
+  }, [agentNodes, byCard, state]);
+
+  const aggregate = useMemo<TeamDashboardAggregate>(() => {
+    let active = 0;
+    let blocked = 0;
+    let stale = 0;
+    let completed = 0;
+    let idle = 0;
+    for (const r of rows) {
+      switch (r.state) {
+        case 'active':
+          active += 1;
+          break;
+        case 'blocked':
+          blocked += 1;
+          break;
+        case 'stale':
+          stale += 1;
+          break;
+        case 'completed':
+          completed += 1;
+          break;
+        default:
+          idle += 1;
+      }
+    }
+    return {
+      total: rows.length,
+      active,
+      blocked,
+      stale,
+      completed,
+      idle,
+      hasAttention: blocked > 0 || stale > 0
+    };
+  }, [rows]);
+
+  return {
+    rows,
+    aggregate,
+    state,
+    empty: rows.length === 0
+  };
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -39,6 +39,7 @@ import './styles/components/menu.css';
 import './styles/components/toast.css';
 import './styles/components/claude-not-found.css';
 import './styles/components/canvas.css';
+import './styles/components/team-dashboard.css';
 import './styles/components/claude-patterns.css';
 import './styles/components/shell.css';
 import './styles/components/glass.css';

--- a/src/renderer/src/styles/components/team-dashboard.css
+++ b/src/renderer/src/styles/components/team-dashboard.css
@@ -1,0 +1,279 @@
+/* ===========================================================================
+ * Team Dashboard — Issue #514
+ *
+ * Canvas 中央下部の StageHud から popover として開く集約 dashboard。
+ * 行 = agent、列 = member / state / task / lastSeen。
+ * canvas.css の `.tc__hud-presets` / `.tc__preset-panel` と同じ glass-surface 系。
+ * ========================================================================= */
+
+.tc__hud-dashboard {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.tc__dashboard {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  /* HUD 中央配置に対し dashboard は HUD の上に大きく開く。長 task 名や 8 名チームでも
+     UI が崩れないよう min-width を 480px、max-height を 60vh で制限する。 */
+  right: 0;
+  width: 520px;
+  max-width: calc(100vw - 32px);
+  max-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-glass, rgba(20, 20, 19, 0.82));
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  box-shadow: var(--shadow-lg);
+  z-index: 30;
+  font-size: var(--text-sm, 12px);
+  color: var(--fg);
+}
+
+.tc__dashboard-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 8px;
+}
+.tc__dashboard-title {
+  font-weight: 600;
+  font-size: var(--text-md, 14px);
+  flex: 0 0 auto;
+}
+.tc__dashboard-count {
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-subtle);
+  flex: 1 1 auto;
+}
+.tc__dashboard-close {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: var(--fg-subtle);
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+}
+.tc__dashboard-close:hover {
+  background: var(--bg-hover);
+  color: var(--fg);
+}
+
+/* human_gate 警告バナー: blocked=true のときに最上部に出す */
+.tc__dashboard-banner {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  margin-bottom: 8px;
+  border-radius: 8px;
+  background: color-mix(
+    in srgb,
+    var(--accent-warning, #d97706) 18%,
+    var(--bg-elev, var(--bg-panel)) 82%
+  );
+  border: 1px solid color-mix(in srgb, var(--accent-warning, #d97706) 35%, var(--border));
+  color: var(--accent-warning, #d97706);
+  font-weight: 500;
+  font-size: var(--text-xs, 11px);
+}
+
+.tc__dashboard-empty {
+  padding: 24px 8px;
+  text-align: center;
+  color: var(--fg-subtle);
+  font-size: var(--text-xs, 11px);
+}
+
+/* ----------
+ * テーブル本体
+ * ---------- */
+.tc__dashboard-table {
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+  border-collapse: collapse;
+  overflow-y: auto;
+  display: block;
+}
+.tc__dashboard-table thead,
+.tc__dashboard-table tbody {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+}
+.tc__dashboard-table thead {
+  position: sticky;
+  top: 0;
+  background: color-mix(in srgb, var(--bg-elev, var(--bg-panel)) 92%, transparent);
+  z-index: 1;
+}
+.tc__dashboard-table th {
+  text-align: left;
+  padding: 6px 8px;
+  font-weight: 500;
+  font-size: var(--text-xs, 11px);
+  color: var(--fg-subtle);
+  border-bottom: 1px solid var(--border);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.tc__dashboard-table td {
+  padding: 8px;
+  vertical-align: top;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+}
+.tc__dashboard-table tr:last-child td {
+  border-bottom: 0;
+}
+.tc__dashboard-cell-num {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  color: var(--fg-subtle);
+  width: 64px;
+}
+
+/* row 状態によるトーン */
+.tc__dashboard-row--blocked {
+  background: color-mix(in srgb, var(--accent-warning, #d97706) 8%, transparent);
+}
+.tc__dashboard-row--stale {
+  background: color-mix(in srgb, var(--text-mute) 6%, transparent);
+}
+.tc__dashboard-row--completed {
+  opacity: 0.65;
+}
+
+/* member 列 */
+.tc__dashboard-member {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.tc__dashboard-member-title {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tc__dashboard-member-meta {
+  font-size: var(--text-xs, 11px);
+  color: var(--fg-subtle);
+}
+
+/* state 列のバッジ */
+.tc__dash-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: var(--text-xs, 11px);
+  font-weight: 500;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.tc__dash-state--active {
+  color: var(--accent-success, var(--accent));
+  background: color-mix(in srgb, var(--accent-success, var(--accent)) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent-success, var(--accent)) 30%, transparent);
+}
+.tc__dash-state--blocked {
+  color: var(--accent-warning, #d97706);
+  background: color-mix(in srgb, var(--accent-warning, #d97706) 18%, transparent);
+  border-color: color-mix(in srgb, var(--accent-warning, #d97706) 35%, transparent);
+}
+.tc__dash-state--stale {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--text-mute) 16%, transparent);
+  border-color: color-mix(in srgb, var(--text-mute) 28%, transparent);
+}
+.tc__dash-state--completed {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+.tc__dash-state--idle {
+  color: var(--fg-subtle);
+  background: transparent;
+  border-color: var(--border);
+}
+.tc__dashboard-alert {
+  margin-top: 4px;
+  font-size: var(--text-xs, 11px);
+  color: var(--accent-warning, #d97706);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* task 列 */
+.tc__dashboard-task {
+  min-width: 0;
+}
+.tc__dashboard-task-title {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tc__dashboard-task-meta {
+  font-size: var(--text-xs, 11px);
+  color: var(--fg-subtle);
+  font-variant-numeric: tabular-nums;
+}
+.tc__dashboard-task-empty {
+  color: var(--fg-subtle);
+  font-style: italic;
+}
+
+/* ----------
+ * footer aggregate
+ * ---------- */
+.tc__dashboard-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  margin-top: 8px;
+  font-size: var(--text-xs, 11px);
+}
+.tc__dashboard-foot-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg-elev, var(--bg-panel)) 80%, transparent);
+  color: var(--fg-subtle);
+  border: 1px solid transparent;
+  font-variant-numeric: tabular-nums;
+}
+.tc__dashboard-foot-pill--blocked.is-on {
+  color: var(--accent-warning, #d97706);
+  border-color: color-mix(in srgb, var(--accent-warning, #d97706) 35%, transparent);
+}
+.tc__dashboard-foot-pill--stale.is-on {
+  color: var(--fg);
+}
+
+/* density=compact では footer の pill 群と member meta を縮める */
+[data-density='compact'] .tc__dashboard {
+  width: 440px;
+}
+[data-density='compact'] .tc__dashboard-member-meta,
+[data-density='compact'] .tc__dashboard-task-meta {
+  display: none;
+}

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -522,6 +522,58 @@ export interface TeamOrchestrationSummary {
 }
 
 /**
+ * Issue #514: TeamHub orchestration state の TS 投影。
+ * Rust 側 `commands/team_state.rs` の `TeamOrchestrationState` (camelCase) に揃える。
+ * dashboard / 履歴復元 / 統合フェーズビューなど renderer 全体で参照する。
+ */
+export interface TeamTaskSnapshot {
+  id: number;
+  assignedTo: string;
+  description: string;
+  status: string;
+  createdBy: string;
+  createdAt: string;
+  updatedAt?: string | null;
+  summary?: string | null;
+  blockedReason?: string | null;
+  nextAction?: string | null;
+  artifactPath?: string | null;
+  blockedByHumanGate?: boolean;
+  requiredHumanDecision?: string | null;
+}
+
+export interface HumanGateState {
+  blocked?: boolean;
+  reason?: string | null;
+  requiredDecision?: string | null;
+  source?: string | null;
+  updatedAt?: string | null;
+}
+
+export interface HandoffLifecycleEvent {
+  handoffId: string;
+  status: string;
+  agentId?: string | null;
+  note?: string | null;
+  createdAt: string;
+}
+
+export interface TeamOrchestrationState {
+  schemaVersion: number;
+  projectRoot: string;
+  teamId: string;
+  activeLeaderAgentId?: string | null;
+  latestHandoff?: HandoffReference | null;
+  tasks: TeamTaskSnapshot[];
+  pendingTasks: TeamTaskSnapshot[];
+  workerReports: WorkerReport[];
+  humanGate: HumanGateState;
+  nextActions: string[];
+  handoffEvents: HandoffLifecycleEvent[];
+  updatedAt: string;
+}
+
+/**
  * Issue #516: Leader が複数 worker の成果を統合フェーズで突き合わせるための構造化フィールド。
  * 既存の単発 `summary` / `nextAction` / `artifactPath` と重複してもよい (後方互換目的)。
  * 全フィールド optional で、必要な軸だけ埋めて返してよい。


### PR DESCRIPTION
## Summary

4 名以上のチームでも Leader が状態を破綻させずに把握できるよう、Canvas 中央下部の StageHud から開く集約ダッシュボードを追加。

- `TeamDashboard.tsx` (新規) — テーブル UI: member / state / task / lastSeen
- `useTeamDashboard` hook — canvas store + agent-activity store (#521) + `team_state_read` IPC を合成、5 秒間隔で poll、`updatedAt` 比較で参照同一性 re-render 抑止
- `tauri-api/team-state.ts` (新規) + `api.teamState.read()` wrapper
- `shared.ts` に `TeamOrchestrationState` / `TeamTaskSnapshot` / `HumanGateState` / `HandoffLifecycleEvent` 型追加
- StageHud に ClipboardList トグルボタン (#522 Bookmark の sibling、outside-click ハンドラを親 ref で集約)
- `team-dashboard.css` (新規) — テーブル + state バッジ + footer 集計ピル + glass-surface 対応
- i18n ja/en に dashboard.* + 空状態キー一式追加

Closes #514

## 設計判断 (Rust 側 0 行触らず)

`team_diagnostics` / `team_get_tasks` は MCP socket 専用 (Permission::ViewDiagnostics 内部 check) で renderer から直接呼べない。新 IPC を生やすと #524 (rust_team_hub_ops) の `diagnostics.rs` 編集と隣接する触り合いリスクがあるため、本 PR は **renderer-side composition のみ**で MVP を出す:
- `team_state_read` (既存 IPC、disk persistence) → tasks / blockedReason / nextAction / requiredHumanDecision / human_gate / handoff_events
- canvas store + agent-activity store (#521) → agentId / role / agent kind / activity / lastActivityAt / 派生サマリ

これで `pendingInbox` / `stalledInbound` 以外の主要フィールドは揃い、リッチな dashboard が組める。phase 2 で diagnostics IPC を生やしてから #524 で追加された 5 fields (`lastPtyOutputAt` / `autoStale` 等) を取り込む二段構え。

## 衝突調整 (前 issue の知見を反映)

- StageHud.tsx → ClipboardList トグルボタンは Bookmark (#522) の **直前** に sibling として配置、outside-click ハンドラは `dashboardWrapRef` で集約 (#522 で確立した親 ref パターン)
- shared.ts → `TeamOrchestrationState` 系の追加は `TeamOrchestrationSummary` の直後に append、既存型と完全独立
- tauri-api.ts → `teamState` namespace を append (既存 `team` / `teamHistory` / `teamPresets` と並列)
- Rust 完全 0 touched → #524 (merge 直前) と物理的 0 競合

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npx vitest run` 全 278 件通過
- [ ] 手動: 6 名チームで dashboard を開き、1 名 stale / 1 名 blocked が一覧で識別できる
- [ ] 手動: human_gate.blocked のとき banner が出る
- [ ] 手動: density=compact で width 縮小 + meta 列折りたたみ
- [ ] 手動: 全テーマ (claude-dark/light, dark, midnight, light, glass) で配色破綻なし