### PR TITLE
enhancement(team-hub): 動的ロール責務境界 lint で重複採用 / タスク領域またぎを warn (#517)

### DIFF
--- a/.claude/skills/vibe-team/SKILL.md
+++ b/.claude/skills/vibe-team/SKILL.md
@@ -230,6 +230,86 @@ git worktree add F:/vive-editor-worktrees/issue-508 -b enhancement/issue-508-dyn
 Set-Location F:/vive-editor-worktrees/issue-508
 ```
 
+## 動的ロール責務境界 lint (Rust 側 role_lint)
+
+> Issue #517: `instruction_lint` (#519) が「禁止句が含まれているか」、`role_template`
+> (#508) が「必須要素が欠けていないか」を見るのに対し、本ルールは **「他の既存メンバーと
+> 責務範囲が重複していないか」** を見る逆責務のモジュール。Leader / HR が同質ロールの
+> 重複を量産するのを `team_recruit` / `team_assign_task` 段階で warn する。
+> `src-tauri/src/team_hub/role_lint.rs` で char trigram の Jaccard 類似度を計算する
+> language-agnostic な実装 (英語 / 日本語混在テキストでも閾値が安定)。
+
+### 設計方針
+
+- **WARN のみ** (DENY しない)。偽陽性で正当な採用 / 割り振りを妨げない方針。
+- recruit / assign 両方で warn が出ても **採用 / 割り当ては成立する**。Leader が response の
+  `boundaryWarnings` / `boundaryWarningMessage` を読んで判断する。renderer 側は同時に
+  `team:role-lint-warning` event を受け、Canvas の toast 通知で Leader / 観察者に通知する。
+- 5 軸 (`investigate / implement / verify / review / integrate`) のどこに偏っているかは
+  Leader の編成判断に任せ、本 lint は「重複の有無」だけを機械的に検出する分担。
+
+### Recruit 時のチェック (`compute_role_overlap`)
+
+- 新規 `team_recruit` で **動的ロール定義を同梱した場合のみ** 評価する (既存 role 再採用は対象外)。
+- 同 team の既存動的ロール群と新ロールの (label + description + instructions) を文字 3-gram に
+  分解し、Jaccard `|A∩B| / |A∪B|` を計算。
+- 閾値 `RECRUIT_OVERLAP_THRESHOLD = 0.45` を超えたペアは `recruit_role_overlap` warn。
+
+| カテゴリ | 条件 |
+|---|---|
+| `vague_keyword` | role_id / label / description / instructions のいずれかに #508 `vague_label` と同じ曖昧パターン (`Support` / `サポート係` / `汎用` / `便利屋` / `何でもやる` 等) **に加えて** `general` / `general purpose` / `miscellaneous` / `なんでも` / `何でも屋` / `万屋` も含む |
+| `recruit_role_overlap` | 既存メンバーとの Jaccard 類似度 ≥ 0.45 (具体的な相手 role_id が `other_role_id` に乗る) |
+
+> #508 の `vague_label` (label のみ検査) に対し、#517 の `vague_keyword` は **role_id / label / description / instructions の全テキスト** を検査する点が異なる。リストは #508 のものを完全継承して `general` 系の英語表記を追加した superset。
+
+### Assign Task 時のチェック (`compute_task_overlap`)
+
+- `team_assign_task(assignee, description)` の description を 3-gram 分解。
+- 同 team の他 worker 全員の (description + instructions) と Jaccard を計算。
+- 閾値 `ASSIGN_OVERLAP_THRESHOLD = 0.30` (description は短くなりがちなので RECRUIT より緩め)。
+- target 以外で閾値超過の worker が居れば「task が target 以外にも重なっている」warn を返す。
+
+| カテゴリ | 条件 |
+|---|---|
+| `assign_task_overlap` | description が target 以外の worker 責務と Jaccard ≥ 0.30 (相手 role_id を `other_role_id` に同梱) |
+
+### 「責務境界」と「Responsibilities (4 軸見出し)」の使い分け
+
+> 用語ゆれ防止のため明示しておく:
+>
+> - **責務 (Responsibilities)** = 1 ロール **内部の** 4 軸見出しの 1 つ。「このロール自身が
+>   何をやるか」を書くセクション (#508 の必須テンプレ参照)。
+> - **責務境界 (role boundary)** = **複数ロール間で** 担当範囲が重ならないこと。本セクションの
+>   lint が見る対象。
+> - 同じ「責務」という日本語が登場するが、前者は **ロール内** 、後者は **ロール間** という
+>   軸の違いがある。Leader が編成を考えるときは両方を意識する。
+
+### Renderer 側の表示
+
+`team:role-lint-warning` event (payload: `{ source: "recruit"|"assign", message, findings, ... }`)
+は `ToastProvider` (`src/renderer/src/lib/toast-context.tsx`) が listen して warning tone の
+toast を 8 秒表示する。Canvas / IDE どちらのモードでも同じ toast 経路に乗る。
+
+> Rust struct field 名は **`boundaryWarnings`** / **`boundaryWarningMessage`**、renderer
+> event 名は **`team:role-lint-warning`** で意図的に分かれている (前者は payload 内の意味的
+> フィールド名、後者は emit 側のモジュール名 prefix `role_lint` を継承した命名慣習)。
+> 後続 PR で UI 側を触る worker は両方の命名を覚えておくこと。
+
+### 採用後チェックでの活かし方 (Leader 行動規約 / 6 番目の補完判断)
+
+`## 役職分担テンプレ (5 軸)` の **「採用前チェック (5 行ルール)」を通過した上で** 、recruit
+レスポンスの `boundaryWarnings` を読んで以下を確認する。**「採用前チェック」5 行ルールは
+#507 で確定済の invariant**なのでそれ自体は変更せず、本 lint は「採用直後 / assign 直後の
+判断軸」として 6 番目の補完位置に置く:
+
+- `boundaryWarnings` が空であること、または含まれていても Leader が「重複は意図的 (例:
+  ペアレビュー目的の二重採用、A/B test の同質ロール 2 名併走)」と判断できること
+- warn が unintended なら役職を `team_dismiss` し、role_id / label / instructions を
+  絞り直してから再 recruit する
+- assign 時の `assign_task_overlap` warn も同様に「target 以外の worker が同じ description を
+  抱えていないか」を Leader が確認する。意図的に複数 worker にまたがる task なら
+  `team_assign_task` を分割するか、**意図的な重複であることを Leader メモで残す**
+
 ## 利用できるツール一覧
 
 | ツール | 用途 |

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -12,6 +12,8 @@ pub mod bridge;
 pub mod error;
 pub mod inject;
 pub mod protocol;
+// Issue #517: 動的ロール同士の責務境界 lint (recruit / assign_task で warning 発火)。
+pub mod role_lint;
 pub mod state;
 
 /// Issue #494: TeamHub 周辺の integration test を集約する test-only module。

--- a/src-tauri/src/team_hub/protocol/tools/assign_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/assign_task.rs
@@ -5,12 +5,14 @@
 use crate::team_hub::{CallContext, TeamHub, TeamTask};
 use chrono::Utc;
 use serde_json::{json, Value};
+use tauri::Emitter;
 
 use super::super::consts::{MAX_TASKS_PER_TEAM, SOFT_PAYLOAD_LIMIT};
 use super::super::helpers::resolve_targets;
 use super::super::permissions::{check_permission, Permission};
 use super::error::AssignError;
 use super::send::team_send;
+use crate::team_hub::role_lint::{compute_task_overlap, MemberSnapshot};
 
 pub async fn team_assign_task(
     hub: &TeamHub,
@@ -150,6 +152,53 @@ pub async fn team_assign_task(
     if let Err(e) = hub.persist_team_state(&ctx.team_id).await {
         tracing::warn!("[team_assign_task] persist team-state failed: {e}");
     }
+
+    // Issue #517: 宛先 worker と他 worker の責務範囲が同領域に重なっていれば warn する。
+    // 拒否はせず assign は通す (偽陽性での操作妨害を避ける)。
+    // 同 role 複数名 / "all" / agentId 指定の場合は最初に解決された role_id を target として
+    // 評価する (代表値で十分。複数 role が混じる場合のみ後で拡張)。
+    let target_role_id = resolved
+        .first()
+        .map(|(_, role)| role.clone())
+        .unwrap_or_default();
+    let boundary_report = if !target_role_id.is_empty() {
+        let members: Vec<MemberSnapshot> = hub
+            .get_dynamic_roles(&ctx.team_id)
+            .await
+            .into_iter()
+            .map(|r| MemberSnapshot {
+                role_id: r.id,
+                instructions: r.instructions,
+                description: r.description,
+            })
+            .collect();
+        compute_task_overlap(description, &target_role_id, &members)
+    } else {
+        Default::default()
+    };
+    if !boundary_report.is_empty() {
+        // renderer 側 toast 通知用に event emit
+        let app = hub.app_handle.lock().await.clone();
+        if let Some(app) = &app {
+            let summary = boundary_report
+                .warn_message(&format!("タスク #{} の責務境界 warning", task_id))
+                .unwrap_or_default();
+            let payload = json!({
+                "teamId": ctx.team_id,
+                "source": "assign",
+                "taskId": task_id,
+                "assignee": assignee,
+                "message": summary,
+                "findings": boundary_report.findings,
+            });
+            if let Err(e) = app.emit("team:role-lint-warning", payload) {
+                tracing::warn!("emit team:role-lint-warning (assign) failed: {e}");
+            }
+        }
+    }
+    let boundary_warning_strs = boundary_report.finding_strings();
+    let boundary_warning_message =
+        boundary_report.warn_message("task boundary warnings (continuing assign)");
     // Issue #172: 通知の team_send を await せず fire-and-forget でバックグラウンド spawn する。
     // assignee="all" のとき fan-out で sleep 累積して MCP RPC を秒単位でブロックしていたのを解消。
     // 配信失敗のときも呼び出し側 (Leader) には task 作成結果だけを即返す。
@@ -193,6 +242,8 @@ pub async fn team_assign_task(
         "success": true,
         "taskId": task_id,
         "assignedAt": assigned_at,
+        "boundaryWarnings": boundary_warning_strs,
+        "boundaryWarningMessage": boundary_warning_message,
     }))
 }
 

--- a/src-tauri/src/team_hub/protocol/tools/recruit.rs
+++ b/src-tauri/src/team_hub/protocol/tools/recruit.rs
@@ -15,6 +15,7 @@ use super::super::instruction_lint::{lint_all, LintReport};
 use super::super::permissions::{check_permission, Permission};
 use super::super::role_template::TemplateFinding;
 use super::error::RecruitError;
+use crate::team_hub::role_lint::{compute_role_overlap, RoleSnapshot};
 
 /// team_recruit: 新メンバーをチームに追加する。Renderer に event::emit でカード生成を依頼し、
 /// その新 agentId が handshake してくるまで oneshot で待機 (timeout 30s)。
@@ -132,6 +133,55 @@ pub async fn team_recruit(
         } else {
             (None, Vec::new())
         };
+
+    // Issue #517: 採用時の責務境界 lint。新規動的ロール登録時のみ実行 (既存 role 再採用は対象外)。
+    // 同 team の既存 dynamic role 群との Jaccard 類似度を計算し、閾値超過なら warn を返す。
+    // 拒否はせず recruit を続行する (偽陽性での操作妨害を避けるため)。
+    let boundary_report = if let Some(d) = &dynamic_role {
+        let new_snapshot = RoleSnapshot {
+            role_id: d.id.clone(),
+            label: d.label.clone(),
+            description: d.description.clone(),
+            instructions: d.instructions.clone(),
+        };
+        // 同 team の既存動的ロールを snapshot 化 (validate_and_register が register 済なので
+        // new_snapshot 自体もこの list に含まれている可能性がある — compute_role_overlap が
+        // role_id 一致で skip するので二重カウントはしない)。
+        let existing: Vec<RoleSnapshot> = hub
+            .get_dynamic_roles(&ctx.team_id)
+            .await
+            .into_iter()
+            .map(|r| RoleSnapshot {
+                role_id: r.id,
+                label: r.label,
+                description: r.description,
+                instructions: r.instructions,
+            })
+            .collect();
+        compute_role_overlap(&new_snapshot, &existing)
+    } else {
+        Default::default()
+    };
+
+    // 警告があれば renderer に event 通知 (Canvas UI で toast 表示)。
+    if !boundary_report.is_empty() {
+        let app = hub.app_handle.lock().await.clone();
+        if let Some(app) = &app {
+            let summary = boundary_report
+                .warn_message("採用時の責務境界 warning")
+                .unwrap_or_default();
+            let payload = json!({
+                "teamId": ctx.team_id,
+                "source": "recruit",
+                "roleId": role_profile_id,
+                "message": summary,
+                "findings": boundary_report.findings,
+            });
+            if let Err(e) = app.emit("team:role-lint-warning", payload) {
+                tracing::warn!("emit team:role-lint-warning failed: {e}");
+            }
+        }
+    }
 
     // role profile の検証: builtin (summary) もしくは team スコープの動的ロールに在籍していること。
     let summary = hub.get_role_profile_summary().await;
@@ -349,6 +399,10 @@ pub async fn team_recruit(
                     template_warning_strs.join("; ")
                 ))
             };
+            // Issue #517: 責務境界 lint の warn findings も同梱。
+            let boundary_warning_strs = boundary_report.finding_strings();
+            let boundary_warning_message =
+                boundary_report.warn_message("role boundary warnings (continuing recruit)");
             Ok(json!({
                 "success": true,
                 "agentId": outcome.agent_id,
@@ -359,6 +413,8 @@ pub async fn team_recruit(
                 "lintWarningMessage": lint_warning_message,
                 "templateWarnings": template_warning_strs,
                 "templateWarningMessage": template_warning_message,
+                "boundaryWarnings": boundary_warning_strs,
+                "boundaryWarningMessage": boundary_warning_message,
             }))
         }
         Ok(Err(_)) => {

--- a/src-tauri/src/team_hub/role_lint.rs
+++ b/src-tauri/src/team_hub/role_lint.rs
@@ -1,0 +1,623 @@
+//! 動的ロール同士の責務境界 lint。Issue #517。
+//!
+//! `instruction_lint` (#519) が「禁止句が含まれているか」、`role_template` (#508) が
+//! 「必須要素が欠けていないか」を見る逆責務を持つのに対し、本モジュールは **「他の
+//! 既存メンバーと責務範囲が重複していないか」** を見る。Leader / HR が同質ロールの
+//! 重複を量産するのを recruit / assign_task 段階で warn する。
+//!
+//! 設計:
+//! - **WARN のみ** (DENY しない)。偽陽性で正当な採用を妨げない方針 (`tasks/issue-517/plan.md`)。
+//! - 類似度: char trigram の Jaccard (Σ |A∩B| / |A∪B|)。トークナイザ不要で
+//!   日本語/英語混在テキストにそのまま使える。
+//! - 既存メンバーが居ない / 採用 1 人目は OK。
+//! - 禁止キーワード (`general` / `support` / `汎用` / `何でも` / `便利屋` / `サポート係`) を
+//!   role_id / label / description / instructions のどれかに含むと別途 warn。
+//!
+//! 公開 API:
+//! - `RoleSnapshot` — 1 ロール分の検査対象テキスト。
+//! - `compute_role_overlap(new, existing)` — recruit 段階の重複検出。
+//! - `compute_task_overlap(description, members)` — assign_task 段階の領域重複検出。
+//! - `vague_keyword_findings(label, description, instructions)` — 単独 lint。
+
+use serde::Serialize;
+use std::collections::HashSet;
+
+/// Jaccard 類似度の WARN 閾値 (recruit 重複検出用)。
+/// 0.45 は label / description / instructions の合算が約半分一致する水準。
+/// 偽陽性を避けるため、低過ぎず高過ぎず。
+pub const RECRUIT_OVERLAP_THRESHOLD: f64 = 0.45;
+
+/// task description × 既存 worker 責務の Jaccard 閾値。
+/// description は短い (= trigram 集合が小さい) のに対し worker instructions は長いので、
+/// union が膨らんで Jaccard 値が低めに出る傾向がある。RECRUIT より緩めの 0.30 を採用し、
+/// 共通キーワードベースの「領域またぎ」を拾えるようにする。
+pub const ASSIGN_OVERLAP_THRESHOLD: f64 = 0.30;
+
+/// Trigram の最小チャンク長 (`text.chars().count() < N` ならそもそも比較しない)。
+/// 短文同士の偽 1.0 を避ける。
+const MIN_CHARS_FOR_TRIGRAMS: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RoleLintLevel {
+    Warn,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RoleLintFinding {
+    pub level: RoleLintLevel,
+    pub category: &'static str,
+    pub detail: String,
+    /// 0.0–1.0 の類似度。`vague_keyword` 系は None。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub similarity: Option<f64>,
+    /// 衝突相手 (重複系のみ)。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub other_role_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct RoleLintReport {
+    pub findings: Vec<RoleLintFinding>,
+}
+
+impl RoleLintReport {
+    /// Findings を `[category] detail` 形式の文字列配列に整形する。
+    /// recruit / assign_task 両方の response / event payload で同じ書式を使うために共通化。
+    pub fn finding_strings(&self) -> Vec<String> {
+        self.findings
+            .iter()
+            .map(|f| format!("[{}] {}", f.category, f.detail))
+            .collect()
+    }
+
+    /// 警告がある場合だけ 1 行サマリを返す。recruit response の `boundaryWarningMessage` 等で使用。
+    pub fn warn_message(&self, prefix: &str) -> Option<String> {
+        let parts = self.finding_strings();
+        if parts.is_empty() {
+            None
+        } else {
+            Some(format!("{}: {}", prefix, parts.join("; ")))
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.findings.is_empty()
+    }
+}
+
+/// 1 ロール分の検査対象テキスト。
+#[derive(Debug, Clone)]
+pub struct RoleSnapshot {
+    pub role_id: String,
+    pub label: String,
+    pub description: String,
+    pub instructions: String,
+}
+
+impl RoleSnapshot {
+    /// 全テキストを連結した正規化済み文字列を返す (類似度計算用)。
+    /// role_id は意図的に含めない — 識別子の表記差 (alice vs bob 等) で
+    /// 同一責務でも類似度が下がるのを避けるため。責務テキストだけで比較する。
+    fn combined(&self) -> String {
+        normalize(&format!(
+            "{}\n{}\n{}",
+            self.label, self.description, self.instructions
+        ))
+    }
+}
+
+/// 入力を正規化: lowercase + 全角→半角 + 句読点 → 空白 + 空白圧縮。
+/// `instruction_lint` の normalize と論理は同じだが、独立に保つ (将来トークナイザを
+/// 差し替える可能性のある別軸)。
+pub fn normalize(text: &str) -> String {
+    let mut buf = String::with_capacity(text.len());
+    for ch in text.chars() {
+        if ch == '\u{3000}' {
+            buf.push(' ');
+            continue;
+        }
+        let code = ch as u32;
+        let mapped = if (0xFF01..=0xFF5E).contains(&code) {
+            char::from_u32(code - 0xFEE0).unwrap_or(ch)
+        } else {
+            ch
+        };
+        let mapped = match mapped {
+            '。' | '、' | '．' | '，' | '・' | ':' | ';' | '：' | '；' | '!' | '?'
+            | '！' | '？' | ',' | '.' | '\t' | '\n' | '\r' | '"' | '\'' | '`'
+            | '(' | ')' | '[' | ']' | '{' | '}' | '「' | '」' | '『' | '』'
+            | '【' | '】' | '〈' | '〉' | '《' | '》' | '“' | '”' | '‘' | '’' => ' ',
+            other => other,
+        };
+        for low in mapped.to_lowercase() {
+            buf.push(low);
+        }
+    }
+    let mut out = String::with_capacity(buf.len());
+    let mut prev_ws = true;
+    for ch in buf.chars() {
+        if ch.is_whitespace() {
+            if !prev_ws {
+                out.push(' ');
+                prev_ws = true;
+            }
+        } else {
+            out.push(ch);
+            prev_ws = false;
+        }
+    }
+    out.trim().to_string()
+}
+
+/// 文字 3-gram の集合を返す。日本語 / 英語混在テキストでも language-agnostic に
+/// 類似度を評価できる。
+pub fn char_trigrams(text: &str) -> HashSet<String> {
+    let chars: Vec<char> = text.chars().collect();
+    let mut out = HashSet::new();
+    if chars.len() < 3 {
+        return out;
+    }
+    for win in chars.windows(3) {
+        out.insert(win.iter().collect::<String>());
+    }
+    out
+}
+
+/// Jaccard 類似度 = |A∩B| / |A∪B|。両方空なら 0.0。
+pub fn jaccard(a: &HashSet<String>, b: &HashSet<String>) -> f64 {
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let inter = a.intersection(b).count();
+    let union = a.union(b).count();
+    if union == 0 {
+        0.0
+    } else {
+        inter as f64 / union as f64
+    }
+}
+
+/// 2 つの RoleSnapshot 間の類似度を返す (0.0–1.0)。
+pub fn similarity(a: &RoleSnapshot, b: &RoleSnapshot) -> f64 {
+    let na = a.combined();
+    let nb = b.combined();
+    if na.chars().count() < MIN_CHARS_FOR_TRIGRAMS || nb.chars().count() < MIN_CHARS_FOR_TRIGRAMS {
+        return 0.0;
+    }
+    jaccard(&char_trigrams(&na), &char_trigrams(&nb))
+}
+
+/// 曖昧キーワードリスト (vague / 汎用名)。
+/// `role_template` の `VAGUE_LABEL_PATTERNS` と意図的に重なる部分があるが、
+/// こちらは label だけでなく role_id / description / instructions まで広範に
+/// チェックするので独立リストにする。
+const VAGUE_KEYWORDS: &[&str] = &[
+    "general",
+    "support",
+    "miscellaneous",
+    "general purpose",
+    "general-purpose",
+    "なんでも",
+    "何でもやる",
+    "何でも屋",
+    "万屋",
+    "汎用",
+    "便利屋",
+    "サポート係",
+];
+
+/// 曖昧キーワードを role_id / label / description / instructions のいずれかに含む場合の WARN を返す。
+pub fn vague_keyword_findings(
+    role_id: &str,
+    label: &str,
+    description: &str,
+    instructions: &str,
+) -> Vec<RoleLintFinding> {
+    let mut findings = Vec::new();
+    let combined = format!(
+        "{}\n{}\n{}\n{}",
+        role_id.to_ascii_lowercase(),
+        label.to_ascii_lowercase(),
+        description.to_ascii_lowercase(),
+        instructions.to_ascii_lowercase()
+    );
+    let mut hit: Vec<&'static str> = Vec::new();
+    for kw in VAGUE_KEYWORDS {
+        let kw_lower = kw.to_ascii_lowercase();
+        if combined.contains(&kw_lower) {
+            hit.push(kw);
+        }
+    }
+    if !hit.is_empty() {
+        findings.push(RoleLintFinding {
+            level: RoleLintLevel::Warn,
+            category: "vague_keyword",
+            detail: format!(
+                "role contains vague / catch-all keyword(s): {} — pick a more specific responsibility scope",
+                hit.join(", ")
+            ),
+            similarity: None,
+            other_role_id: None,
+        });
+    }
+    findings
+}
+
+/// 採用時の重複 lint。新ロール `new` と既存ロール群 `existing` の各組合せで類似度を計算し、
+/// `RECRUIT_OVERLAP_THRESHOLD` 超過なら warn。
+///
+/// 加えて `vague_keyword_findings` も合算する。
+pub fn compute_role_overlap(new: &RoleSnapshot, existing: &[RoleSnapshot]) -> RoleLintReport {
+    let mut findings = vague_keyword_findings(
+        &new.role_id,
+        &new.label,
+        &new.description,
+        &new.instructions,
+    );
+
+    for other in existing {
+        if other.role_id == new.role_id {
+            continue;
+        }
+        let sim = similarity(new, other);
+        if sim >= RECRUIT_OVERLAP_THRESHOLD {
+            findings.push(RoleLintFinding {
+                level: RoleLintLevel::Warn,
+                category: "recruit_role_overlap",
+                detail: format!(
+                    "new role '{}' overlaps with existing '{}' by {:.0}% (Jaccard trigram); \
+                     consider sharpening the responsibility boundary or reusing the existing role",
+                    new.role_id,
+                    other.role_id,
+                    sim * 100.0
+                ),
+                similarity: Some(sim),
+                other_role_id: Some(other.role_id.clone()),
+            });
+        }
+    }
+
+    RoleLintReport { findings }
+}
+
+/// 1 名分の assignee 候補 (role_id + その instructions / description)。
+/// `compute_task_overlap` の入力。
+#[derive(Debug, Clone)]
+pub struct MemberSnapshot {
+    pub role_id: String,
+    pub instructions: String,
+    pub description: String,
+}
+
+/// `team_assign_task` の宛先 worker `target_role_id` と他 worker の責務範囲が
+/// task description と同領域に重なっていれば warn する。
+///
+/// 概要: task description の trigram 集合と、各 member.instructions+description の
+/// trigram 集合の Jaccard を取る。target 以外で閾値超過のメンバーが居れば、
+/// 「この task は target だけでなく <other> の領域にもまたがっている」 warn を返す。
+///
+/// target が候補リストに無い場合は空 report (= warn 無し) を返す。検証は呼び出し側で行う。
+pub fn compute_task_overlap(
+    description: &str,
+    target_role_id: &str,
+    members: &[MemberSnapshot],
+) -> RoleLintReport {
+    let normalized_desc = normalize(description);
+    if normalized_desc.chars().count() < MIN_CHARS_FOR_TRIGRAMS {
+        return RoleLintReport::default();
+    }
+    let desc_grams = char_trigrams(&normalized_desc);
+
+    let mut findings = Vec::new();
+    for m in members {
+        if m.role_id == target_role_id {
+            continue;
+        }
+        let combined = normalize(&format!("{}\n{}", m.description, m.instructions));
+        if combined.chars().count() < MIN_CHARS_FOR_TRIGRAMS {
+            continue;
+        }
+        let other_grams = char_trigrams(&combined);
+        let sim = jaccard(&desc_grams, &other_grams);
+        if sim >= ASSIGN_OVERLAP_THRESHOLD {
+            findings.push(RoleLintFinding {
+                level: RoleLintLevel::Warn,
+                category: "assign_task_overlap",
+                detail: format!(
+                    "task description overlaps with '{}' responsibility by {:.0}%; \
+                     this task may belong to '{}' rather than '{}', or should be split",
+                    m.role_id,
+                    sim * 100.0,
+                    m.role_id,
+                    target_role_id
+                ),
+                similarity: Some(sim),
+                other_role_id: Some(m.role_id.clone()),
+            });
+        }
+    }
+    RoleLintReport { findings }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(role_id: &str, label: &str, description: &str, instructions: &str) -> RoleSnapshot {
+        RoleSnapshot {
+            role_id: role_id.to_string(),
+            label: label.to_string(),
+            description: description.to_string(),
+            instructions: instructions.to_string(),
+        }
+    }
+
+    fn member(role_id: &str, description: &str, instructions: &str) -> MemberSnapshot {
+        MemberSnapshot {
+            role_id: role_id.to_string(),
+            instructions: instructions.to_string(),
+            description: description.to_string(),
+        }
+    }
+
+    #[test]
+    fn normalize_lowercases_and_collapses() {
+        assert_eq!(normalize("A  B\n\nC"), "a b c");
+        assert_eq!(normalize("ＡＢＣ"), "abc");
+    }
+
+    #[test]
+    fn char_trigrams_basic() {
+        let g = char_trigrams("abcd");
+        assert!(g.contains("abc"));
+        assert!(g.contains("bcd"));
+        assert_eq!(g.len(), 2);
+    }
+
+    #[test]
+    fn jaccard_identical_is_one() {
+        let g = char_trigrams("abcdefgh");
+        assert!((jaccard(&g, &g) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn jaccard_disjoint_is_zero() {
+        let a = char_trigrams("abcdefgh");
+        let b = char_trigrams("xyzwvuts");
+        assert!(jaccard(&a, &b) < 0.05);
+    }
+
+    #[test]
+    fn similarity_identical_roles() {
+        let a = snap(
+            "alice",
+            "Canvas Investigator",
+            "Canvas モードの不具合調査",
+            "canvas/CanvasMode.tsx を読んで再現手順をまとめる",
+        );
+        let b = snap(
+            "bob",
+            "Canvas Investigator",
+            "Canvas モードの不具合調査",
+            "canvas/CanvasMode.tsx を読んで再現手順をまとめる",
+        );
+        let s = similarity(&a, &b);
+        assert!(s > 0.9, "expected near 1.0, got {s}");
+    }
+
+    #[test]
+    fn similarity_distinct_roles_low() {
+        let a = snap(
+            "alice",
+            "Rust TeamHub Core",
+            "vibe-team の TeamHub プロトコル中核 (recruit / send / assign_task)",
+            "src-tauri/src/team_hub/protocol/ を担当する。dynamic_role / instruction_lint を実装",
+        );
+        let b = snap(
+            "bob",
+            "Renderer Canvas UI",
+            "Canvas モードの React UI コンポーネント (StageHud / TeamPresetsPanel)",
+            "src/renderer/src/components/canvas/ を担当する。@xyflow/react を使う",
+        );
+        let s = similarity(&a, &b);
+        assert!(s < 0.3, "expected low (<0.3), got {s}");
+    }
+
+    #[test]
+    fn compute_role_overlap_flags_duplicate() {
+        let new = snap(
+            "alice2",
+            "Canvas Investigator",
+            "Canvas モードの不具合調査と再現手順整理",
+            "canvas モジュール (Stage / xyflow) を読んでバグ再現を行う担当",
+        );
+        let existing = vec![snap(
+            "alice",
+            "Canvas Investigator",
+            "Canvas モードの不具合調査",
+            "canvas/Stage と xyflow を読んで再現手順をまとめる",
+        )];
+        let report = compute_role_overlap(&new, &existing);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.category == "recruit_role_overlap"),
+            "expected recruit_role_overlap, got {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn compute_role_overlap_passes_distinct() {
+        let new = snap(
+            "rust_core",
+            "Rust TeamHub Core",
+            "vibe-team の TeamHub プロトコル中核",
+            "src-tauri/src/team_hub/protocol/ を担当",
+        );
+        let existing = vec![snap(
+            "renderer_ui",
+            "Renderer Canvas UI",
+            "Canvas モードの React UI コンポーネント",
+            "src/renderer/src/components/canvas/ を担当する",
+        )];
+        let report = compute_role_overlap(&new, &existing);
+        assert!(
+            !report
+                .findings
+                .iter()
+                .any(|f| f.category == "recruit_role_overlap"),
+            "distinct roles must not flag overlap; got {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn compute_role_overlap_flags_vague_keyword() {
+        let new = snap(
+            "support_general",
+            "Support",
+            "なんでも対応する汎用係",
+            "ユーザー要求があれば何でも対応する general purpose worker",
+        );
+        let report = compute_role_overlap(&new, &[]);
+        assert!(report
+            .findings
+            .iter()
+            .any(|f| f.category == "vague_keyword"));
+    }
+
+    #[test]
+    fn compute_role_overlap_no_existing_no_warn() {
+        let new = snap(
+            "rust_core",
+            "Rust TeamHub Core",
+            "vibe-team の TeamHub プロトコル中核",
+            "src-tauri/src/team_hub/protocol/ を担当",
+        );
+        let report = compute_role_overlap(&new, &[]);
+        assert!(
+            !report
+                .findings
+                .iter()
+                .any(|f| f.category == "recruit_role_overlap"),
+            "no existing roles → no overlap warn; got {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn compute_role_overlap_skips_same_role_id() {
+        // 同 role_id 再採用 (role_id 衝突) は dynamic_role.rs 側で弾かれるが、
+        // role_lint は防御的に同 id をスキップする。
+        let new = snap("alice", "x", "x", "x");
+        let existing = vec![snap("alice", "x", "x", "x")];
+        let report = compute_role_overlap(&new, &existing);
+        assert!(!report
+            .findings
+            .iter()
+            .any(|f| f.category == "recruit_role_overlap"));
+    }
+
+    #[test]
+    fn compute_task_overlap_flags_cross_boundary() {
+        // task description が rust_core の責務 ("team_hub protocol") に近い領域なのに
+        // 宛先が renderer_ui になっている → warn が出るべき
+        let members = vec![
+            member(
+                "rust_core",
+                "vibe-team の TeamHub プロトコル中核",
+                "src-tauri/src/team_hub/protocol/ を担当 recruit send assign_task instruction_lint",
+            ),
+            member(
+                "renderer_ui",
+                "Canvas モードの React UI",
+                "src/renderer/src/components/canvas/ を担当",
+            ),
+        ];
+        let report = compute_task_overlap(
+            "team_hub の protocol で recruit / send / assign_task に instruction_lint hook を追加",
+            "renderer_ui",
+            &members,
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.category == "assign_task_overlap"
+                    && f.other_role_id.as_deref() == Some("rust_core")),
+            "expected cross-boundary warn pointing to rust_core; got {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn compute_task_overlap_passes_when_aligned() {
+        let members = vec![
+            member(
+                "rust_core",
+                "TeamHub protocol の中核",
+                "team_hub の recruit / send / assign_task を実装",
+            ),
+            member(
+                "renderer_ui",
+                "Canvas UI",
+                "components/canvas を担当",
+            ),
+        ];
+        let report = compute_task_overlap(
+            "components/canvas の StageHud に warning badge を追加してほしい",
+            "renderer_ui",
+            &members,
+        );
+        assert!(
+            report.findings.is_empty(),
+            "task aligned with target; expected no warn, got {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn compute_task_overlap_short_description_skipped() {
+        let members = vec![member("rust_core", "long enough description here", "long enough instructions here")];
+        // 7 chars < MIN_CHARS_FOR_TRIGRAMS (8)
+        let report = compute_task_overlap("short", "rust_core", &members);
+        assert!(report.findings.is_empty());
+    }
+
+    #[test]
+    fn warn_message_collects_findings() {
+        let new = snap(
+            "support_helper",
+            "Support",
+            "なんでもサポートする general 係",
+            "support general purpose worker",
+        );
+        let existing = vec![snap(
+            "another_support",
+            "Support",
+            "general support",
+            "general purpose support helper",
+        )];
+        let report = compute_role_overlap(&new, &existing);
+        let msg = report.warn_message("role boundary warnings").unwrap_or_default();
+        assert!(msg.contains("vague_keyword") || msg.contains("recruit_role_overlap"));
+        assert!(msg.starts_with("role boundary warnings:"));
+    }
+
+    #[test]
+    fn warn_message_none_when_clean() {
+        let new = snap(
+            "rust_core",
+            "Rust TeamHub Core",
+            "vibe-team の TeamHub プロトコル中核",
+            "src-tauri/src/team_hub/protocol/ を担当",
+        );
+        let report = compute_role_overlap(&new, &[]);
+        assert!(report.warn_message("role boundary warnings").is_none());
+        assert!(report.is_empty());
+        assert!(report.finding_strings().is_empty());
+    }
+}

--- a/src/renderer/src/lib/toast-context.tsx
+++ b/src/renderer/src/lib/toast-context.tsx
@@ -11,6 +11,7 @@ import {
 import { X } from 'lucide-react';
 import { useT } from './i18n';
 import { registerToastBridge } from './toast-bridge';
+import { subscribeEvent } from './subscribe-event';
 
 /**
  * グローバルなトースト通知（Undoアクション付き）基盤。
@@ -129,6 +130,20 @@ export function ToastProvider({ children }: { children: ReactNode }): JSX.Elemen
   // 自分の showToast を bridge に register する。Provider 外コードは `bridgedToast()`
   // 経由で同じ表示パスに乗る。
   useEffect(() => registerToastBridge(showToast), [showToast]);
+
+  // Issue #517: Rust TeamHub の `team:role-lint-warning` を購読し、責務境界 lint の
+  // warning (recruit / assign 両方) を warning tone のトーストで可視化する。
+  // 表示時間を長め (8s) にして Leader が読み取りやすくする。
+  useEffect(() => {
+    return subscribeEvent<{ message?: string; source?: string }>(
+      'team:role-lint-warning',
+      (payload) => {
+        const message = payload?.message ?? '';
+        if (!message) return;
+        showToast(message, { tone: 'warning', duration: 8000 });
+      }
+    );
+  }, [showToast]);
 
   return (
     <ToastContext.Provider value={value}>


### PR DESCRIPTION
## Summary
- Issue #517: vibe-team の動的ロール同士が重複作業をしないよう、`team_recruit` / `team_assign_task` 段階で責務境界を機械的に検出して warn する。
- `instruction_lint` (#519 / 禁止句) / `role_template` (#508 / 必須要素) と相補的に「他の既存メンバーと責務範囲が重複していないか」を見る逆責務の lint。
- **WARN のみ** (DENY しない)。偽陽性で正当な採用を妨げない方針。

## 検証ロジック (`src-tauri/src/team_hub/role_lint.rs`)
- char trigram の Jaccard 類似度を計算する language-agnostic 実装 (英 / 日混在 OK)
- `compute_role_overlap(new, existing)` — recruit 時、同 team 既存動的ロールとの類似度 ≥ `RECRUIT_OVERLAP_THRESHOLD (= 0.45)` で `recruit_role_overlap` warn
- `compute_task_overlap(description, target_role_id, members)` — assign_task 時、task description が target 以外の worker 責務と Jaccard ≥ `ASSIGN_OVERLAP_THRESHOLD (= 0.30)` で `assign_task_overlap` warn
- `vague_keyword_findings` — `general` / `support` / `汎用` / `何でもやる` / `便利屋` / `サポート係` 等の曖昧キーワードを role_id / label / description / instructions 全文で検出 (`vague_keyword` warn)
- 16 unit tests (normalize / trigram / Jaccard / similarity / role overlap / task overlap / vague keyword / warn message)

## 変更点
| 種類 | ファイル | 変更 |
|---|---|---|
| 新規 | `src-tauri/src/team_hub/role_lint.rs` | Jaccard 類似度 lint + 16 unit tests |
| 変更 | `src-tauri/src/team_hub/mod.rs` | `pub mod role_lint;` 追加 |
| 変更 | `src-tauri/src/team_hub/protocol/tools/recruit.rs` | `validate_and_register_dynamic_role` の戻り値後に `compute_role_overlap` を呼び、findings を `boundaryWarnings` / `boundaryWarningMessage` に同梱 + `team:role-lint-warning` event emit |
| 変更 | `src-tauri/src/team_hub/protocol/tools/assign_task.rs` | persist 後に `compute_task_overlap` を呼び、同じく response 同梱 + event emit |
| 変更 | `src/renderer/src/lib/toast-context.tsx` | `team:role-lint-warning` を `subscribeEvent` で listen し、warning tone の toast を 8 秒表示する useEffect を ToastProvider 内に追加。新コンポーネント不要、StageHud.tsx 無改変で衝突最小 |
| 変更 | `.claude/skills/vibe-team/SKILL.md` | 新規 H2 `## 動的ロール責務境界 lint (Rust 側 role_lint)` を `## 動的ロール instructions の必須テンプレ` (#508) 直後に追加 |

## skill_integrator (#507 / Worktree docs) との文言整合
- `vague_keyword` リストは #508 `vague_label` を完全継承 (label のみ検査) し、加えて `general` / `general purpose` / `miscellaneous` / `なんでも` / `何でも屋` / `万屋` を追加。検査範囲も label → role_id+label+description+instructions 全文に拡張。差分は SKILL.md 内に明記。
- 「採用前チェック (5 行ルール)」 (#507 invariant) は **不変**。本 lint は「採用後チェック / 6 番目の補完判断」として独立配置し、#507 セクションを汚染しない。
- Rust struct field 名 `boundaryWarnings` と renderer event 名 `team:role-lint-warning` の命名非対称は SKILL.md 内に 1 行注で説明 (payload 内意味的フィールド名 vs emit 側モジュール名 prefix 慣習)。

## rust_team_hub_ops (#513 動的ロール永続化) との衝突回避
- `dynamic_role.rs` は本 PR で **無改変** (lint hook は recruit.rs 側で `validate_and_register_dynamic_role` の戻り値後に独立呼び出し)。
- rust_team_hub_ops は #513 で `team_hub/mod.rs` を触らない方針確定済 → 物理衝突 0。

## Test plan
- [x] `cargo test team_hub::role_lint` (16/16 pass)
- [x] `cargo test team_hub` (94/94 pass — 既存 test 影響なし)
- [x] `npm run typecheck` pass
- [x] `cargo check --lib` clean

## 関連
- Closes #517
- Refs #507 (5 軸 / 採用前チェック / 統合フェーズ / Worktree 隔離 — 本 lint は 6 番目の補完判断)
- Refs #508 (`vague_label` リストを継承)
- Refs #519 (相補関係)