### PR TITLE
fix(team-hub): 動的ロール定義を role-profiles.json に永続化し再起動後も復元する (#513)

### DIFF
--- a/.claude/skills/vibe-team/SKILL.md
+++ b/.claude/skills/vibe-team/SKILL.md
@@ -40,6 +40,14 @@ team_recruit({ role_id: "hr", engine: "claude" })
 team_recruit({ role_id: "marketing_chief", engine: "claude" })  // 2 人目を採用
 ```
 
+> **動的ロールは永続化されます** (Issue #513): `team_recruit({ role_definition: ... })` で
+> 作成した動的ロールの label / description / instructions / instructionsJa は
+> `~/.vibe-editor/role-profiles.json#dynamic[]` に保存され、アプリ再起動 / Canvas 復元時に
+> 自動的に Hub の `dynamic_roles` map へ replay されます。なので **再起動後も同じ
+> `role_definition` を再投入する必要はなく**、`team_recruit({ role_id: "marketing_chief" })` のように
+> id だけ指定すれば既存定義をそのまま使えます。古い定義の意味的更新が必要なときだけ、
+> 同 `role_id` で新しい `role_definition` を渡して上書きしてください。
+
 ## 役割別の振る舞い
 
 ### 1. Leader

--- a/src-tauri/src/commands/vibe_team_skill_body.md
+++ b/src-tauri/src/commands/vibe_team_skill_body.md
@@ -39,6 +39,14 @@ team_recruit({ role_id: "hr", engine: "claude" })
 team_recruit({ role_id: "marketing_chief", engine: "claude" })  // 2 人目を採用
 ```
 
+> **動的ロールは永続化されます** (Issue #513): `team_recruit({ role_definition: ... })` で
+> 作成した動的ロールの label / description / instructions / instructionsJa は
+> `~/.vibe-editor/role-profiles.json#dynamic[]` に保存され、アプリ再起動 / Canvas 復元時に
+> 自動的に Hub の `dynamic_roles` map へ replay されます。なので **再起動後も同じ
+> `role_definition` を再投入する必要はなく**、`team_recruit({ role_id: "marketing_chief" })` のように
+> id だけ指定すれば既存定義をそのまま使えます。古い定義の意味的更新が必要なときだけ、
+> 同 `role_id` で新しい `role_definition` を渡して上書きしてください。
+
 ## 役割別の振る舞い
 
 ### 1. Leader

--- a/src-tauri/src/team_hub/protocol/dynamic_role.rs
+++ b/src-tauri/src/team_hub/protocol/dynamic_role.rs
@@ -2,6 +2,7 @@
 //!
 //! Issue #373 Phase 2 で `protocol.rs` から切り出し。
 //! Issue #508 で必須テンプレ / 曖昧名 / Worktree Isolation Rule の validation を追加 (deny→拒否、warn→outcome に同梱)。
+//! Issue #513 で永続化 (`role-profiles.json#dynamic[]`) からの replay hook を追加 (`replay_persisted_dynamic_roles_for_team`)。
 //!
 //! 呼び出し元: `tools/recruit.rs` の `team_recruit` のみ。過去の docstring に記載されていた
 //! `team_create_role` MCP tool は実装されておらず、現状は `team_recruit` (role_definition 同梱)
@@ -10,6 +11,7 @@
 //! 既存 builtin (summary 上) と被る role_id は拒否、上限超過も拒否、長さ上限も拒否する。
 
 use crate::team_hub::{CallContext, DynamicRole, TeamHub};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tauri::Emitter;
 
@@ -159,4 +161,181 @@ pub(super) async fn validate_and_register_dynamic_role(
         role,
         template_warnings,
     })
+}
+
+/// Issue #513: `~/.vibe-editor/role-profiles.json#dynamic[]` の 1 件分エントリ (Rust 側 view)。
+///
+/// renderer 側 `DynamicRoleEntry` (camelCase) と `#[serde(rename_all = "camelCase")]` で対応。
+/// `register_team` 経路で「該当 team_id の entry だけ」を抽出して `replay_persisted_dynamic_roles_for_team`
+/// に渡し、Hub の `dynamic_roles` map を再構成する。validation は **意図的に走らせない**:
+/// 永続化済みの entry は過去の `validate_and_register_dynamic_role` を通っているはずなので、
+/// 二度の検証で「既存 dynamic ロールを使っているチームを起動したら lint 規約変更で弾かれた」
+/// 事故を避ける (= 永続化されたデータは新検証ルールに対し forward-compatible に扱う)。
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedDynamicRoleEntry {
+    pub id: String,
+    pub team_id: String,
+    pub label: String,
+    pub description: String,
+    pub instructions: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions_ja: Option<String>,
+    pub created_by_role: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    /// 任意の有効期限 (RFC3339)。経過済みの entry は `replay` でスキップされる。
+    /// 現状の writer 側は設定しない (= 永続的扱い)、future scope の自動 GC 用予備。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+}
+
+impl PersistedDynamicRoleEntry {
+    /// `expires_at` が現在時刻 (RFC3339 解釈) より過去なら `true`。`None` / parse 失敗時は `false`。
+    /// `replay_persisted_dynamic_roles_for_team` で expired entry をスキップする判定に使う。
+    fn is_expired(&self, now_iso: &str) -> bool {
+        let Some(expires_at) = self.expires_at.as_deref() else {
+            return false;
+        };
+        let Ok(expires) = chrono::DateTime::parse_from_rfc3339(expires_at) else {
+            return false;
+        };
+        let Ok(now) = chrono::DateTime::parse_from_rfc3339(now_iso) else {
+            return false;
+        };
+        expires < now
+    }
+
+    /// Hub の in-memory `DynamicRole` 形に変換 (永続化外フィールドである `created_at` /
+    /// `expires_at` は drop される — そちらは再 save 時に renderer 側 cache から再構成する)。
+    fn to_dynamic_role(&self) -> DynamicRole {
+        DynamicRole {
+            id: self.id.clone(),
+            label: self.label.clone(),
+            description: self.description.clone(),
+            instructions: self.instructions.clone(),
+            instructions_ja: self.instructions_ja.clone(),
+            team_id: self.team_id.clone(),
+            created_by_role: self.created_by_role.clone(),
+        }
+    }
+}
+
+/// Issue #513: 起動時 / `register_team` 経路で永続化された動的ロール定義を Hub に投入する。
+///
+/// 呼び出し側 (`state::TeamHub::register_team`) が role-profiles.json から **該当 team_id の
+/// entry だけ抽出した** Vec を渡し、本関数は expired を除外してから `replace_dynamic_roles`
+/// で Hub state に流し込む。`replace_dynamic_roles` は既存 `dynamic_roles[team_id]` を
+/// 完全置換するため、再起動時に「同 team_id だけど persistent と in-memory が混在」
+/// する race を起こさない (= permission check も走らせず、信頼境界内の永続化データを直接投入)。
+///
+/// 戻り値はスキップされた entry 数 (= 期限切れ + 例外的に id 重複した数の合計)。
+/// caller 側でログに残す目的のみで、エラー状態としては扱わない。
+pub async fn replay_persisted_dynamic_roles_for_team(
+    hub: &TeamHub,
+    team_id: &str,
+    entries: Vec<PersistedDynamicRoleEntry>,
+) -> usize {
+    if team_id.trim().is_empty() {
+        return 0;
+    }
+    let now_iso = chrono::Utc::now().to_rfc3339();
+    let mut skipped: usize = 0;
+    let mut roles: Vec<DynamicRole> = Vec::with_capacity(entries.len());
+    let mut seen_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for entry in entries {
+        // 永続化された team_id と register_team の team_id がズレていたらスキップ
+        // (renderer 側で誤って混入した entry を防御的に弾く)
+        if entry.team_id != team_id {
+            tracing::warn!(
+                "[dynamic-role/replay] entry team_id '{}' does not match register_team '{}', skipping role_id '{}'",
+                entry.team_id,
+                team_id,
+                entry.id
+            );
+            skipped += 1;
+            continue;
+        }
+        if entry.is_expired(&now_iso) {
+            tracing::info!(
+                "[dynamic-role/replay] skipping expired entry team={team_id} role_id={} (expires_at={:?})",
+                entry.id,
+                entry.expires_at
+            );
+            skipped += 1;
+            continue;
+        }
+        if !seen_ids.insert(entry.id.clone()) {
+            tracing::warn!(
+                "[dynamic-role/replay] duplicate role_id '{}' in persisted dynamic[] for team {}, keeping first",
+                entry.id,
+                team_id
+            );
+            skipped += 1;
+            continue;
+        }
+        roles.push(entry.to_dynamic_role());
+    }
+    let role_count = roles.len();
+    hub.replace_dynamic_roles(team_id, roles).await;
+    tracing::info!(
+        "[dynamic-role/replay] team={team_id} replayed {role_count} dynamic role(s) (skipped {skipped})"
+    );
+    skipped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str, team_id: &str, expires_at: Option<&str>) -> PersistedDynamicRoleEntry {
+        PersistedDynamicRoleEntry {
+            id: id.to_string(),
+            team_id: team_id.to_string(),
+            label: format!("{id}-label"),
+            description: format!("{id}-description"),
+            instructions: "do work".into(),
+            instructions_ja: None,
+            created_by_role: "leader".into(),
+            created_at: Some("2026-05-07T00:00:00Z".into()),
+            expires_at: expires_at.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn is_expired_returns_false_for_no_expiry() {
+        let e = entry("r1", "team-a", None);
+        assert!(!e.is_expired("2026-05-07T12:00:00Z"));
+    }
+
+    #[test]
+    fn is_expired_returns_true_when_expires_before_now() {
+        let e = entry("r1", "team-a", Some("2026-05-01T00:00:00Z"));
+        assert!(e.is_expired("2026-05-07T12:00:00Z"));
+    }
+
+    #[test]
+    fn is_expired_returns_false_when_expires_after_now() {
+        let e = entry("r1", "team-a", Some("2026-06-01T00:00:00Z"));
+        assert!(!e.is_expired("2026-05-07T12:00:00Z"));
+    }
+
+    #[test]
+    fn is_expired_returns_false_for_unparseable_expires_at() {
+        let e = entry("r1", "team-a", Some("not-a-date"));
+        assert!(!e.is_expired("2026-05-07T12:00:00Z"));
+    }
+
+    #[test]
+    fn to_dynamic_role_round_trips_core_fields() {
+        let e = entry("planner", "team-a", None);
+        let role = e.to_dynamic_role();
+        assert_eq!(role.id, "planner");
+        assert_eq!(role.team_id, "team-a");
+        assert_eq!(role.label, "planner-label");
+        assert_eq!(role.description, "planner-description");
+        assert_eq!(role.instructions, "do work");
+        assert_eq!(role.created_by_role, "leader");
+        assert!(role.instructions_ja.is_none());
+    }
 }

--- a/src-tauri/src/team_hub/protocol/mod.rs
+++ b/src-tauri/src/team_hub/protocol/mod.rs
@@ -18,7 +18,10 @@
 // 旧 `mod consts` (private) を `team_hub` サブツリー全体に公開する。
 // `pub(crate)` まで広げる必要は無く、外部 (commands 等) には依然非可視のまま。
 pub(in crate::team_hub) mod consts;
-mod dynamic_role;
+// Issue #513: `state::TeamHub::register_team` (sibling 親 module) から
+// `replay_persisted_dynamic_roles_for_team` / `PersistedDynamicRoleEntry` を参照するため、
+// `team_hub` サブツリー全体に公開する。`pub(crate)` まで広げる必要は無い。
+pub(in crate::team_hub) mod dynamic_role;
 mod helpers;
 // Issue #519: 動的 instructions の禁止句 lint。recruit 段階で逸脱指示を弾く。
 mod instruction_lint;

--- a/src-tauri/src/team_hub/state.rs
+++ b/src-tauri/src/team_hub/state.rs
@@ -836,6 +836,12 @@ impl TeamHub {
             }
             None => None,
         };
+        // Issue #513: ~/.vibe-editor/role-profiles.json#dynamic[] から該当 team_id の entry を抽出。
+        // role-profiles.json は user-global (project_root 非依存) なので、project_root の有無に
+        // 関わらず実行する。読み込み失敗 / 古い JSON (dynamic フィールドなし) は空配列扱い。
+        // state.lock の前に async I/O を済ませ、lock を保持中に file read をしないようにしている。
+        let persisted_dynamic_entries = load_persisted_dynamic_for_team(team_id).await;
+
         let mut s = self.state.lock().await;
         s.active_teams.insert(team_id.to_string());
         let team = s
@@ -874,6 +880,25 @@ impl TeamHub {
             }
             if persisted.human_gate.blocked {
                 team.human_gate = persisted.human_gate;
+            }
+        }
+        drop(s);
+        // Issue #513: state.lock を drop した後で `replay_persisted_dynamic_roles_for_team` を呼ぶ。
+        // この関数は内部で hub.state.lock() を取るので、外側 lock を保持したまま呼ぶと deadlock する。
+        // 永続化が空 (entry 0 件) のチームは `replace_dynamic_roles` で空集合を投入することになるが、
+        // 既存 in-memory が空のままなら no-op、既存に entry が居れば「永続化済 = 真の状態」として
+        // 完全置換する設計 (= renderer 側 cache が永続化と乖離していた場合に永続化を勝者とする)。
+        if !persisted_dynamic_entries.is_empty() {
+            let skipped = crate::team_hub::protocol::dynamic_role::replay_persisted_dynamic_roles_for_team(
+                self,
+                team_id,
+                persisted_dynamic_entries,
+            )
+            .await;
+            if skipped > 0 {
+                tracing::warn!(
+                    "[register_team] team={team_id}: {skipped} persisted dynamic entries skipped (expired / mismatch)"
+                );
             }
         }
     }
@@ -991,4 +1016,58 @@ impl TeamHub {
         }
         self.persist_team_state(team_id).await
     }
+}
+
+/// Issue #513: `~/.vibe-editor/role-profiles.json#dynamic[]` から **指定 team_id に紐付く
+/// entry だけ** を抽出して返す内部 helper。`register_team` の前段で呼び、Hub state.lock を
+/// 取らずに async I/O を済ませてから replay する設計。
+///
+/// 失敗時 (file 不在 / parse 失敗 / dynamic フィールドなし) は **空配列** を返す
+/// (= 「永続化された動的ロールがない」と意味的に等価)。parse 失敗時は警告ログを残すが、
+/// チーム起動自体は失敗させない (= ユーザーが旧 builtin / custom フィールドだけで運用していた
+/// 環境で、dynamic フィールドの有無に依存して team が立ち上がらないのを防ぐ)。
+///
+/// `tokio::fs::read` を使うので state.lock を保持中に呼ばないこと (deadlock はしないが
+/// blocking I/O で hub の lock holder time が伸びるため)。
+async fn load_persisted_dynamic_for_team(
+    team_id: &str,
+) -> Vec<crate::team_hub::protocol::dynamic_role::PersistedDynamicRoleEntry> {
+    if team_id.trim().is_empty() {
+        return Vec::new();
+    }
+    let path = crate::util::config_paths::role_profiles_path();
+    let bytes = match tokio::fs::read(&path).await {
+        Ok(b) => b,
+        Err(_) => return Vec::new(), // file 不在は normal (初回起動 / 動的ロールを使わない運用)
+    };
+    let value: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                "[register_team] role-profiles.json parse failed when loading dynamic[]: {e}"
+            );
+            return Vec::new();
+        }
+    };
+    let Some(arr) = value.get("dynamic").and_then(|v| v.as_array()) else {
+        // 古い JSON (dynamic フィールドなし) は no-op で OK。新規 save 時に renderer が追加する。
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for item in arr {
+        let entry: crate::team_hub::protocol::dynamic_role::PersistedDynamicRoleEntry =
+            match serde_json::from_value(item.clone()) {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!(
+                        "[register_team] skipping malformed dynamic[] entry: {e}"
+                    );
+                    continue;
+                }
+            };
+        if entry.team_id == team_id {
+            out.push(entry);
+        }
+    }
+    out
 }

--- a/src/renderer/src/lib/role-profiles-context.tsx
+++ b/src/renderer/src/lib/role-profiles-context.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import type {
+  DynamicRoleEntry,
   Language,
   RoleProfile,
   RoleProfilesFile
@@ -30,22 +31,14 @@ import {
 } from './role-profiles-builtin';
 
 /**
- * Leader が team_create_role / team_recruit(role_definition=...) で動的に作成したワーカーロール。
- * RoleProfilesContext の memory 内 cache に保持され、`compose()` 時に builtin/custom と合成される。
- * 永続化はしない (プロセス再起動で消える) ので、canvas 復元時には Tauri 側 TeamHub にも
- * 再投入する必要がある (現状は recruit-request payload に同梱される dynamicRole 経由で受け取る)。
+ * Issue #513: 旧 local 定義 `DynamicRoleEntry` を shared.ts に集約。
+ * `createdByRole` / `createdAt` / `expiresAt` が増えたが、`composeWorkerProfile()` は
+ * `id / label / description / instructions / instructionsJa` しか参照しないので互換維持。
+ * 永続化のため `team:role-created` 受信時に file.dynamic[] にも append し、
+ * 起動時に file.dynamic[] を memory cache へ投入することで、再起動 / Canvas 復元後も
+ * Hub 側の `replay_persisted_dynamic_roles_for_team` (state.rs) と協調して動的ロールが生き続ける。
  */
-export interface DynamicRoleEntry {
-  /** 通常 snake_case (例: "marketing_chief") */
-  id: string;
-  /** 表示名 */
-  label: string;
-  description: string;
-  instructions: string;
-  instructionsJa?: string;
-  /** どのチームスコープか (チーム間で id 衝突を許容するため必要) */
-  teamId: string;
-}
+export type { DynamicRoleEntry };
 
 interface RoleProfilesContextValue {
   /** 合成後の effective profiles (id → profile) */
@@ -155,7 +148,8 @@ export function RoleProfilesProvider({ children }: { children: ReactNode }): JSX
    */
   const [dynamic, setDynamic] = useState<Record<string, DynamicRoleEntry>>({});
 
-  // 起動時に 1 回ロード
+  // 起動時に 1 回ロード。Issue #513: file.dynamic[] (= 永続化された Leader 動的ロール)
+  // も同時に memory cache (dynamic state) に投入する。再起動後も `team_recruit` で参照可能になる。
   useEffect(() => {
     let cancelled = false;
     void window.api.roleProfiles
@@ -168,8 +162,20 @@ export function RoleProfilesProvider({ children }: { children: ReactNode }): JSX
             overrides: loaded.overrides ?? {},
             custom: loaded.custom ?? [],
             globalPreamble: loaded.globalPreamble,
-            messageTagFormat: loaded.messageTagFormat
+            messageTagFormat: loaded.messageTagFormat,
+            dynamic: loaded.dynamic ?? []
           });
+          // Issue #513: 永続化された動的ロールを memory cache に投入。
+          // `compose()` 時に dynamic state が builtin/custom と合成されて effective profiles に乗る。
+          // file.dynamic[] と memory cache (dynamic) は同じ Source of Truth (= file 側) を反映する
+          // 形で同期する。後続の `team:role-created` event はその up-to-date な状態に追加する。
+          if (Array.isArray(loaded.dynamic) && loaded.dynamic.length > 0) {
+            const seeded: Record<string, DynamicRoleEntry> = {};
+            for (const entry of loaded.dynamic) {
+              seeded[entry.id] = entry;
+            }
+            setDynamic((prev) => ({ ...seeded, ...prev }));
+          }
         }
       })
       .catch((err) => {
@@ -181,7 +187,10 @@ export function RoleProfilesProvider({ children }: { children: ReactNode }): JSX
     };
   }, []);
 
-  // Tauri 側 TeamHub からの team:role-created を購読してメモリキャッシュへ反映
+  // Tauri 側 TeamHub からの team:role-created を購読してメモリキャッシュ + file.dynamic[] に反映。
+  // Issue #513: 旧実装は memory cache のみで再起動時に動的ロールが消える事故が起きていた
+  // (= worker 復元時に `roleProfileId` が「未知のロール」へ fallback)。本フックで file.dynamic[]
+  // にも append + saveFile() で persist することで、再起動後も同一動的ロールを使える。
   useEffect(() => {
     let unlisten: UnlistenFn | null = null;
     let disposed = false;
@@ -193,21 +202,45 @@ export function RoleProfilesProvider({ children }: { children: ReactNode }): JSX
         description: string;
         instructions: string;
         instructionsJa?: string;
+        createdByRole?: string;
       };
     }>('team:role-created', (e) => {
       if (disposed) return;
       const { role, teamId } = e.payload;
+      const createdAt = new Date().toISOString();
+      const entry: DynamicRoleEntry = {
+        id: role.id,
+        label: role.label,
+        description: role.description,
+        instructions: role.instructions,
+        instructionsJa: role.instructionsJa,
+        teamId,
+        createdByRole: role.createdByRole ?? 'leader',
+        createdAt
+      };
       setDynamic((prev) => ({
         ...prev,
-        [role.id]: {
-          id: role.id,
-          label: role.label,
-          description: role.description,
-          instructions: role.instructions,
-          instructionsJa: role.instructionsJa,
-          teamId
-        }
+        [role.id]: entry
       }));
+      // file.dynamic[] にも append。同 (teamId, id) の重複は新しい方で上書き
+      // (= Leader が同じ id で role_definition を再投入した場合の意味的に正しい動作)。
+      setFile((prevFile) => {
+        const prevDynamic = prevFile.dynamic ?? [];
+        const filtered = prevDynamic.filter(
+          (d) => !(d.teamId === teamId && d.id === role.id)
+        );
+        const next: RoleProfilesFile = {
+          ...prevFile,
+          dynamic: [...filtered, entry]
+        };
+        // 永続化は fire-and-forget (UI block しない)。失敗しても memory cache は最新なので
+        // 当該プロセス内では問題なく動く。次回起動時は最新 entry が無いだけで old entry が
+        // 残るリスクはあるが、その場合も `team:role-created` の再 emit で復旧する。
+        void window.api.roleProfiles.save(next).catch((err) => {
+          console.warn('[role-profiles] persist dynamic entry failed:', err);
+        });
+        return next;
+      });
     }).then((u) => {
       if (disposed) {
         u();

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -295,6 +295,44 @@ export interface RoleProfile {
   singleton?: boolean;
 }
 
+/**
+ * Issue #513: 動的ロール (Leader が `team_recruit({ role_definition: ... })` で生成した
+ * ロール定義) を永続化する 1 件分のエントリ。
+ *
+ * Hub state 内の `DynamicRole` (Rust struct) と camelCase 互換 (`#[serde(rename_all =
+ * "camelCase")]`)。`team_id` を持つことで「どのチームで作られたか」を保持し、再起動時の
+ * `register_team` 経路で該当 team_id の entries だけを `replace_dynamic_roles()` で
+ * Hub に投入する。
+ *
+ * `expiresAt` は将来的な「使い捨てロールの自動 GC」用予備フィールド (現状未使用)。
+ */
+export interface DynamicRoleEntry {
+  /** ロール識別子 (ASCII alnum + `_-`、最大 80 byte) */
+  id: string;
+  /** どのチームで作られたか (再起動時の Hub 投入で team 単位に振り分けるため) */
+  teamId: string;
+  /** 表示ラベル (英語) */
+  label: string;
+  /** 概要説明 */
+  description: string;
+  /** 役職特有の振る舞い (worker テンプレの `{dynamicInstructions}` に流し込まれる) */
+  instructions: string;
+  /** 日本語 instructions (任意)。未指定なら instructions が両言語に使われる */
+  instructionsJa?: string;
+  /** 作成者 role (例: `leader`) */
+  createdByRole: string;
+  /**
+   * 作成時刻 (RFC3339)。後方互換のため optional だが、新規 persist 時は必ず保存する。
+   * 古い JSON (このフィールドを持たない) を読む場合は load 側で `null` 扱いで継続。
+   */
+  createdAt?: string;
+  /**
+   * 有効期限 (RFC3339)。設定された場合、Hub 起動時に経過済み entry をスキップして load する。
+   * 現状の writer 側は使わない (= 任意フィールド扱い、将来 settings UI から手動設定可能にする予定)。
+   */
+  expiresAt?: string;
+}
+
 /** ~/.vibe-editor/role-profiles.json のスキーマ */
 export interface RoleProfilesFile {
   schemaVersion: 1;
@@ -306,6 +344,13 @@ export interface RoleProfilesFile {
   globalPreamble?: { en?: string; ja?: string };
   /** 受信時のメッセージタグ書式。default = "[Team <- {fromLabel}] {message}" */
   messageTagFormat?: string;
+  /**
+   * Issue #513: 動的ロール定義の永続化リスト。
+   * Leader が `team_recruit({ role_definition: ... })` で生成した entry がここに保存され、
+   * アプリ再起動 / Canvas 復元時に Hub の `dynamic_roles` map に replay される。
+   * 古い JSON (このフィールドが無い) は空配列として扱われ、後方互換性を保つ。
+   */
+  dynamic?: DynamicRoleEntry[];
 }
 
 /** ランタイムのみ（永続化不要）。チーム所属タブは teamId で紐付く */


### PR DESCRIPTION
## Summary

Leader が `team_recruit({ role_definition: ... })` で生成した動的ロールが in-memory のみで管理されていたため、アプリ再起動 / Canvas 復元時に Hub の `dynamic_roles` map から消失して worker が「未知のロール」へ fallback する事故を構造的に解消する。

### Rust (team_hub)
- `protocol/dynamic_role.rs` に `PersistedDynamicRoleEntry` (`#[serde(rename_all = "camelCase")]`) と `replay_persisted_dynamic_roles_for_team()` を追加
- 永続化済み entry は過去の `validate_and_register_dynamic_role` を通っているため意図的に re-validation を skip (新検証ルール (例: #519 lint) を後方互換で forward-compatible に扱う)
- `expires_at` 経過済み / team_id mismatch / id 重複は防御的にスキップ + ログ
- `state.rs::register_team` の lock 取得 **前** に role-profiles.json を読み、該当 team_id の entries だけ抽出。lock を drop した後 (deadlock 回避) に `replay_persisted_dynamic_roles_for_team` を呼び `replace_dynamic_roles` で投入
- `protocol/mod.rs` の `mod dynamic_role;` を `pub(in crate::team_hub)` に緩和 (state.rs から `PersistedDynamicRoleEntry` 参照のため。`team_hub/mod.rs` は触らないので #517 (`pub mod role_lint;`) と物理衝突 0)

### Renderer
- `shared.ts` に `DynamicRoleEntry` を canonical 化 (旧 role-profiles-context.tsx の local 定義を廃止し、`createdByRole` / `createdAt` / `expiresAt` を加えた共通型に集約)
- `RoleProfilesFile.dynamic?: DynamicRoleEntry[]` を追加
- `role-profiles-context.tsx`:
  - 起動時 load で `file.dynamic[]` を memory cache に投入
  - `team:role-created` event 受信時に memory cache + `file.dynamic[]` の両方に append し、`window.api.roleProfiles.save()` を fire-and-forget で呼んで永続化
  - 同 `(teamId, id)` 重複は最新で上書き (= Leader が同 id で `role_definition` を再投入した場合の意味的に正しい動作)

### Skill
- vibe-team SKILL.md (Rust install template + plugin 両方) に「動的ロールは永続化される」旨を明記し、再起動後は `team_recruit({ role_id: "marketing_chief" })` のように id だけで再採用可能であることを Leader 行動規約に追加

## Coordination

- **#517 (`team_hub/role_lint.rs`)** との協調確認済み (rust_team_hub_core と直接合意):
  - 私の replay 経路は `team_recruit` を通らないので lint は発火しない (= 永続化 entry は元 recruit 時点で lint 済、二重発火 noise を避ける意図通り)
  - lint ルールが後から変わっても既存 worker を「過去のルール基準」で持続させる UX (新ルール適用には `team_dismiss` → 再 `team_recruit` で明示)
  - replay 後の新規 `team_recruit` では `compute_role_overlap` が永続化ロール群を「既存メンバー」として正しく重複比較対象に含める (= 永続化した A と類似の B を新規採用しようとすると warn される)
- **#522 (renderer_canvas_ui の `team_presets`)** とは `lib.rs` `invoke_handler!` を触らないので非競合 (新 IPC 追加なし)
- **#514 (renderer_canvas_ui の Team Dashboard)** とも完全分離

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 通過
- [x] `cargo test --manifest-path src-tauri/Cargo.toml team_hub` 83 passed (既存 + 新規 5 件)
- [x] `npm run typecheck` 0 errors
- [ ] 手動: `team_recruit({ role_definition: ... })` で marketing_chief を採用
- [ ] 手動: アプリを再起動して `~/.vibe-editor/role-profiles.json` の `dynamic[]` に entry が残っていることを確認
- [ ] 手動: Canvas restore 後、worker のカードが「未知のロール」ではなく元の動的ロール表示になっていることを確認
- [ ] 手動: 同じ id で再 `team_recruit({ role_definition: ..., instructions: "...更新版..." })` → file.dynamic[] が新しい entry で上書きされること

## Related

- Issue #511 (PR #532): PTY inject 失敗の細分化 → main にマージ済み
- Issue #509 (PR #535): team_send delivery_status (pending/readSoFar) + unread badge → main にマージ済み
- Issue #524 (PR #538): PTY 出力 staleness 補正 → main にマージ済み
- Issue #517 (PR #540): 動的ロール類似度 lint → main にマージ済み (rust_team_hub_core)

Closes #513