### PR TITLE
chore(release): bump version to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5218,7 +5218,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.5.0"
+version = "1.5.1"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## Summary

vibe-editor v1.5.1 リリース。**v1.5.0 → 22 commits** を反映する patch リリース (ユーザー指示で patch 番号採用 — 厳密 semver なら feat 含むため minor 相当)。version 三点 + Cargo.lock の 4 ファイル同期のみ。

## v1.5.1 — 2026-05-07 (CHANGELOG 草案 / Release notes 用)

### ✨ Features
- feat(vibe-team): Canvas に Team 管理ダッシュボードを追加 (#514, PR #539)
- feat(vibe-team): team preset の保存と再構築機能を追加 (#522, PR #534)
- feat(team-hub): update_task 構造化 report_payload + 統合フェーズ skill 追加 (#516, PR #531)
- feat(canvas): agent card 状態要約 UI 強化 (#521, PR #529)

### 🛠️ Enhancements
- enhancement(team-hub): 動的ロール責務境界 lint で重複採用 / タスク領域またぎを warn (#517, PR #540)
- enhancement(team-hub): 動的ロール instructions に必須テンプレ + Worktree Rule validation (#508, PR #533)
- enhancement(team-hub): team_send に delivery_status と unread age を露出して読了確認 UX を強化 (#509, PR #535)

### 🐛 Bug fixes
- fix(team-hub): 動的ロール定義を role-profiles.json に永続化し再起動後も復元する (#513, PR #541)
- fix(team-hub): PTY 出力アクティビティで status staleness を補正し autoStale を可視化 (#524, PR #538)
- fix(team-hub): PTY bracketed-paste 失敗を細分化 (#511, PR #532)
- fix(canvas): Agent card xterm の左端文字欠け + 文字結合を修正 (#503, PR #504)
- fix(terminal): IDE scrollbar 操作不可を修正 + Canvas ターミナル初期サイズを拡大 (#496 / #497, PR #498)

### 🔒 Security
- security(team-hub): 動的ロール instructions の禁止句 lint (#519, PR #530)

### 📝 Documentation
- docs(vibe-team): worker 採用直後の Worktree 隔離を運用 invariant として明文化 (#536, PR #537)
- docs(vibe-team): Leader 最小フロー / 5 軸役職分担テンプレ追加 (#507, PR #528)

### ♻️ Refactor / Performance
- refactor(rail): 履歴アイコンの未確認件数バッジを削除 (#505, PR #506)
- refactor(rust): TeamHub permissions / tool errors を統一し AppSettings を serde struct 化 (#493, PR #501)
- refactor(rust): split commands/app, team_hub/mod, pty/session and unify path/error (PR #492)
- refactor(renderer): canvas store selectors, persist migrations, theme tokens, i18n hardcodes (PR #491)
- refactor(renderer): split App.tsx phase 2, giant hooks, AgentNodeCard (PR #489)

### 🧪 Tests
- test(rust): commands / team_hub / pty レイヤに integration test を追加 (#494, PR #502)
- test(renderer): canvas card / terminal hook / settings の振る舞いテストを追加 (#495, PR #499)

## Test plan

- [x] `bump-version.ps1 -DryRun` で 3 ファイル + Cargo.lock の差分を事前確認
- [x] 書き換え後の version 整合性検証 (3 ファイルとも 1.5.1 に揃っていることを script が自動検証)
- [x] `git diff --cached` で 4 ファイル限定であることを確認 (4 insertions(+), 4 deletions(-))
- [ ] bot review APPROVED → auto-merge
- [ ] merge 後 main に v1.5.1 タグを push、release.yml が発火して全 OS バイナリ + latest.json が draft で生成されること
- [ ] draft 全 asset 揃ったら publish

Closes (release): v1.5.1