### PR TITLE
fix(team-hub): worker のファイル編集衝突を advisory file lock + assign 時 peek で検知 (#526)

### DIFF
--- a/.claude/skills/vibe-team/SKILL.md
+++ b/.claude/skills/vibe-team/SKILL.md
@@ -310,21 +310,108 @@ toast を 8 秒表示する。Canvas / IDE どちらのモードでも同じ toa
   抱えていないか」を Leader が確認する。意図的に複数 worker にまたがる task なら
   `team_assign_task` を分割するか、**意図的な重複であることを Leader メモで残す**
 
+## ファイル編集の advisory lock (Rust 側 file_locks)
+
+> Issue #526: 複数 worker が同じファイルを silent overwrite して衝突するのを防ぐため、
+> worker 間で協調的 (advisory) なロック予約システムを Hub 内に持つ。
+> `src-tauri/src/team_hub/file_locks.rs` で in-memory map (`HashMap<(team_id, normalized_path), FileLock>`)
+> を管理し、`team_lock_files` / `team_unlock_files` で取得・解放、`team_assign_task(target_paths)`
+> で peek 競合検知する。**advisory** = 取得しなくても hard fail しないので、SKILL ガイド +
+> WORKER_TEMPLATE の運用ルールで補強する設計 (#519 / #517 と同じ思想)。
+
+### Lifetime / 永続性
+
+- **in-memory のみ**。Hub 再起動 (アプリ起動し直し) で全 lock が clear される。
+- **TTL (自動解放) は設けない**。worker が release し忘れたまま停止すると、その lock は
+  team_dismiss されるまで残る。
+- `team_dismiss(agent_id)` 成立時、対象 worker が握っていた **全 lock を漏れなく一括解放**
+  する (`tools/dismiss.rs` の末尾で `release_all_file_locks_for_agent` を呼ぶ)。
+  response にも `releasedFileLocks: <count>` で返るので Leader が確認できる。
+- 永続化は本 issue の out-of-scope。再起動を跨ぐ予約管理は将来 issue で別途検討。
+
+### MCP tool: `team_lock_files`
+
+```
+team_lock_files({ paths: ["src/foo.rs", "src/bar.rs"] })
+  → { success: true, locked: ["src/foo.rs"], conflicts: [LockConflict, ...] }
+```
+
+- worker が `Edit` / `Write` / `MultiEdit` をかける **前** に必ず呼ぶ運用。
+- **partial success** (= 一部 path が conflict でも残りは locked される)。caller が
+  all-or-nothing を要するなら、`conflicts` が空でないとき `locked` を即 `team_unlock_files`
+  で手動解放する (Hub 側は automatic rollback しない設計)。
+- 同 agent_id が再 lock した path は **idempotent** (再度 `locked` に積まれる、エラーにならない)。
+- 制限: 1 リクエスト最大 64 path、1 path 最大 4 KiB。超過は `lock_files_invalid_args` で拒否。
+
+`LockConflict` shape:
+
+```
+{
+  path: "src/foo.rs",
+  holderAgentId: "vc-...",
+  holderRole: "programmer",
+  acquiredAt: "2026-05-07T..."
+}
+```
+
+### MCP tool: `team_unlock_files`
+
+```
+team_unlock_files({ paths: ["src/foo.rs"] })
+  → { success: true, unlocked: ["src/foo.rs"] }
+```
+
+- worker の編集が終わったら必ず呼ぶ (失敗パスでも `try { ... } finally { unlock }` 相当の
+  運用)。
+- 自分が保持していなかった path は silent skip (= `unlocked` に乗らない、エラーは出ない)。
+
+### `team_assign_task(target_paths=[...])` での peek
+
+- `target_paths` は任意引数。指定すると Hub が現在の lock 表を peek して、target 以外の
+  worker が握っている path を `lockConflicts` として response に同梱する。
+- 同時に `team:file-lock-conflict` event を emit するので Canvas UI 側で toast 通知できる。
+- **競合があっても assign は成功する** (advisory: 拒否しない)。Leader が `lockConflicts`
+  を読んで「タスクを分割」「先に assignee 以外を dismiss」「意図的な重複として続行」を
+  判断する。
+
+### Path 正規化
+
+`team_lock_files` / `team_unlock_files` / `target_paths` のいずれも、Hub 側で次の正規化を行う:
+
+- backslash (`\`) → forward slash (`/`)
+- 連続 slash 圧縮 (`src//foo` → `src/foo`)
+- `./` プレフィックス除去
+- 末尾 `/` 除去 (root `/` だけは残る)
+- 前後 trim
+
+これにより worker が `src\foo.rs` / `./src/foo.rs` / `src/foo.rs` のいずれを送っても同一
+path として扱われる。
+
+### Worker 運用ルール (recommended)
+
+1. ファイル編集前に `team_lock_files({ paths: ["..."] })` を呼ぶ。`conflicts` が
+   非空なら、編集を止めて `team_send("leader", "lock 競合: ... → 調整依頼")` を返す。
+2. 編集中に追加 path が必要になったら、追加で `team_lock_files` を呼ぶ。
+3. 編集が完了 (または失敗) したら必ず `team_unlock_files` で解放する。
+4. 自分が `team_dismiss` される場合は Hub が自動解放するので明示的 unlock は不要。
+
 ## 利用できるツール一覧
 
 | ツール | 用途 |
 |---|---|
 | `team_recruit` | ロール定義＋採用 (1 コール完結) / 既存ロールの再採用 |
-| `team_dismiss` | メンバー解雇 (canvas のカードを閉じる、Leader 専用) |
+| `team_dismiss` | メンバー解雇 (canvas のカードを閉じる、Leader 専用)。worker の advisory lock も自動解放 |
 | `team_send(to, message)` | 別メンバーのプロンプトに直接メッセージ注入。成功は配送であり ACK ではない |
 | `team_read({unread_only})` | 自分宛の過去メッセージを読む (未読のみがデフォルト) |
 | `team_info()` | 現在のチーム名簿と自分の identity |
 | `team_status(status)` | 自分のステータスを informational に報告 |
-| `team_assign_task(assignee, description)` | タスクを割り当て (Leader / HR) |
+| `team_assign_task(assignee, description, target_paths?)` | タスクを割り当て (Leader / HR)。`target_paths` で advisory lock 競合を peek |
 | `team_get_tasks()` | チーム全体のタスク一覧 |
 | `team_update_task(task_id, status)` | タスク状態の更新 |
 | `team_list_role_profiles()` | 利用可能ロール一覧 (builtin + 動的) |
 | `team_diagnostics()` | Leader / HR 用。pendingInbox / stalledInbound で配送済み未読を確認 |
+| `team_lock_files(paths)` | ファイル編集前に advisory lock を取得 (partial success) |
+| `team_unlock_files(paths)` | 自分が保持する advisory lock を解放 |
 
 ## 最小フロー (調査 → 実装 → 検証 → レビュー → 統合)
 

--- a/src-tauri/src/team_hub/file_locks.rs
+++ b/src-tauri/src/team_hub/file_locks.rs
@@ -1,0 +1,479 @@
+//! vibe-team の advisory file locks。Issue #526。
+//!
+//! 複数 worker が同じファイルを silent overwrite するのを防ぐため、worker が edit 前後で
+//! `team_lock_files` / `team_unlock_files` を呼ぶ協調的 (advisory) ロック表を提供する。
+//! さらに `team_assign_task(target_paths=[...])` で渡された path に対する競合検知も担う。
+//!
+//! 設計:
+//! - **in-memory のみ**。永続化は本 issue の out-of-scope (再起動でロック clear)。
+//! - **advisory** = 取得しなくても hard fail しない。worker が呼ばないと lock されない。
+//!   WORKER_TEMPLATE / SKILL.md 側の運用ガイドで補強する想定 (#517 / #519 と同じ思想)。
+//! - 競合時は `team_recruit` の lint と同様に **warn 同梱** で続行 (Leader/worker 自身が判断)。
+//! - team_id でスコープ。同一 path でも team が違えば独立にロック可能。
+//! - path 正規化: backslash → forward slash、`./` prefix 除去、連続 slash 圧縮、末尾 slash 除去。
+//!
+//! 公開 API (本モジュール):
+//! - `FileLock` / `LockConflict` / `LockResult` 型
+//! - `normalize_path(raw)` — 正規化ヘルパ
+//! - `try_acquire`, `release`, `release_all_for_agent`, `peek`, `list_for_team` —
+//!   `HashMap<(team_id, path), FileLock>` を引数に取る純関数。HubState のミューテーション
+//!   を伴う部分は呼び出し側 (state.rs の TeamHub method) で wrap する。
+
+use chrono::Utc;
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// 1 path に対する 1 件のロック情報。
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FileLock {
+    pub path: String,
+    pub team_id: String,
+    pub agent_id: String,
+    pub role: String,
+    /// 取得時刻 (RFC 3339)。
+    pub acquired_at: String,
+}
+
+/// 競合した path 1 件 (= 既に他 agent が握っているロックの情報)。
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LockConflict {
+    pub path: String,
+    pub holder_agent_id: String,
+    pub holder_role: String,
+    pub acquired_at: String,
+}
+
+/// `try_acquire` の結果。`locked` と `conflicts` は path レベルで partition される
+/// (= **partial success** 設計。一部 path が conflict でも残りは locked される)。
+/// caller が all-or-nothing を要するなら、`conflicts` が空でない場合に得た `locked` を
+/// 手動で `release` し直すこと。
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LockResult {
+    pub locked: Vec<String>,
+    pub conflicts: Vec<LockConflict>,
+}
+
+impl LockResult {
+    pub fn has_conflicts(&self) -> bool {
+        !self.conflicts.is_empty()
+    }
+}
+
+/// `release` の結果 (unlocked path 配列)。response shape を語彙的に揃えるための型。
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnlockResult {
+    pub unlocked: Vec<String>,
+}
+
+/// path を正規化: backslash → slash、`./` prefix 除去、連続 slash 圧縮、末尾 slash 除去、trim。
+pub fn normalize_path(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    // backslash → forward slash
+    let unified: String = trimmed
+        .chars()
+        .map(|c| if c == '\\' { '/' } else { c })
+        .collect();
+    // 連続 slash を 1 個に圧縮
+    let mut compressed = String::with_capacity(unified.len());
+    let mut prev_slash = false;
+    for ch in unified.chars() {
+        if ch == '/' {
+            if !prev_slash {
+                compressed.push('/');
+                prev_slash = true;
+            }
+        } else {
+            compressed.push(ch);
+            prev_slash = false;
+        }
+    }
+    // `./foo` → `foo`
+    let mut out = if let Some(stripped) = compressed.strip_prefix("./") {
+        stripped.to_string()
+    } else {
+        compressed
+    };
+    // 末尾 slash 削除 (root `/` だけは残す)
+    while out.len() > 1 && out.ends_with('/') {
+        out.pop();
+    }
+    out
+}
+
+/// `paths` のうち取得できたものは map に追加し、既に他 agent が保持しているものは
+/// `conflicts` に積む。同一 agent_id が再 lock した場合は idempotent (`locked` に積む)。
+/// 空文字 path は skip。**partial success**: 一部 path で conflict が出ても残りは locked される。
+pub fn try_acquire(
+    map: &mut HashMap<(String, String), FileLock>,
+    team_id: &str,
+    agent_id: &str,
+    role: &str,
+    paths: &[String],
+) -> LockResult {
+    let now = Utc::now().to_rfc3339();
+    let mut locked = Vec::new();
+    let mut conflicts = Vec::new();
+    for raw in paths {
+        let path = normalize_path(raw);
+        if path.is_empty() {
+            continue;
+        }
+        let key = (team_id.to_string(), path.clone());
+        if let Some(existing) = map.get(&key) {
+            if existing.agent_id == agent_id {
+                // 自分が既に持っている → idempotent
+                locked.push(path);
+                continue;
+            }
+            conflicts.push(LockConflict {
+                path: existing.path.clone(),
+                holder_agent_id: existing.agent_id.clone(),
+                holder_role: existing.role.clone(),
+                acquired_at: existing.acquired_at.clone(),
+            });
+        } else {
+            map.insert(
+                key,
+                FileLock {
+                    path: path.clone(),
+                    team_id: team_id.to_string(),
+                    agent_id: agent_id.to_string(),
+                    role: role.to_string(),
+                    acquired_at: now.clone(),
+                },
+            );
+            locked.push(path);
+        }
+    }
+    LockResult { locked, conflicts }
+}
+
+/// `paths` のうち自分 (`agent_id`) が保持していたものを map から削除し、解放できた path を返す。
+/// 他 agent が保持している path は無視 (silent skip — release は宣言的なので過剰削除を避ける)。
+pub fn release(
+    map: &mut HashMap<(String, String), FileLock>,
+    team_id: &str,
+    agent_id: &str,
+    paths: &[String],
+) -> UnlockResult {
+    let mut unlocked = Vec::new();
+    for raw in paths {
+        let path = normalize_path(raw);
+        if path.is_empty() {
+            continue;
+        }
+        let key = (team_id.to_string(), path.clone());
+        if let Some(existing) = map.get(&key) {
+            if existing.agent_id == agent_id {
+                map.remove(&key);
+                unlocked.push(path);
+            }
+        }
+    }
+    UnlockResult { unlocked }
+}
+
+/// `agent_id` が `team_id` 内で保持している全ロックを解放する。
+/// `team_dismiss` 等で worker が消えるときの掃除用。返り値は解放数。
+pub fn release_all_for_agent(
+    map: &mut HashMap<(String, String), FileLock>,
+    team_id: &str,
+    agent_id: &str,
+) -> u32 {
+    let mut count: u32 = 0;
+    map.retain(|(tid, _path), lock| {
+        if tid == team_id && lock.agent_id == agent_id {
+            count += 1;
+            false
+        } else {
+            true
+        }
+    });
+    count
+}
+
+/// `paths` で指定された path のうち、現在ロックされているものの保持者情報を返す
+/// (assign_task の競合検知用、map は read-only)。`agent_id_filter` が `Some` なら
+/// その agent 自身が握る lock は除外する (= 他 agent の lock のみ返す)。
+pub fn peek(
+    map: &HashMap<(String, String), FileLock>,
+    team_id: &str,
+    agent_id_filter: Option<&str>,
+    paths: &[String],
+) -> Vec<LockConflict> {
+    let mut out = Vec::new();
+    for raw in paths {
+        let path = normalize_path(raw);
+        if path.is_empty() {
+            continue;
+        }
+        let key = (team_id.to_string(), path);
+        if let Some(existing) = map.get(&key) {
+            if let Some(self_aid) = agent_id_filter {
+                if existing.agent_id == self_aid {
+                    continue;
+                }
+            }
+            out.push(LockConflict {
+                path: existing.path.clone(),
+                holder_agent_id: existing.agent_id.clone(),
+                holder_role: existing.role.clone(),
+                acquired_at: existing.acquired_at.clone(),
+            });
+        }
+    }
+    out
+}
+
+/// team_id 内のロック一覧を返す (diagnostics / UI 表示用)。
+pub fn list_for_team(
+    map: &HashMap<(String, String), FileLock>,
+    team_id: &str,
+) -> Vec<FileLock> {
+    map.iter()
+        .filter(|((tid, _), _)| tid == team_id)
+        .map(|(_, lock)| lock.clone())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_map() -> HashMap<(String, String), FileLock> {
+        HashMap::new()
+    }
+
+    #[test]
+    fn normalize_path_handles_basic_cases() {
+        assert_eq!(normalize_path("src/foo.ts"), "src/foo.ts");
+        assert_eq!(normalize_path("  src/foo.ts  "), "src/foo.ts");
+        assert_eq!(normalize_path(""), "");
+        assert_eq!(normalize_path("   "), "");
+    }
+
+    #[test]
+    fn normalize_path_unifies_separators() {
+        assert_eq!(normalize_path(r"src\foo\bar.rs"), "src/foo/bar.rs");
+        assert_eq!(normalize_path("src/foo\\bar.rs"), "src/foo/bar.rs");
+    }
+
+    #[test]
+    fn normalize_path_compresses_double_slashes() {
+        assert_eq!(normalize_path("src//foo///bar.rs"), "src/foo/bar.rs");
+    }
+
+    #[test]
+    fn normalize_path_strips_dot_prefix() {
+        assert_eq!(normalize_path("./src/foo.ts"), "src/foo.ts");
+    }
+
+    #[test]
+    fn normalize_path_strips_trailing_slash() {
+        assert_eq!(normalize_path("src/foo/"), "src/foo");
+        assert_eq!(normalize_path("src/foo///"), "src/foo");
+        // root `/` は残す
+        assert_eq!(normalize_path("/"), "/");
+    }
+
+    #[test]
+    fn try_acquire_basic() {
+        let mut map = make_map();
+        let result = try_acquire(
+            &mut map,
+            "team-1",
+            "vc-alice",
+            "programmer",
+            &["src/foo.rs".to_string(), "src/bar.rs".to_string()],
+        );
+        assert_eq!(result.locked, vec!["src/foo.rs", "src/bar.rs"]);
+        assert!(result.conflicts.is_empty());
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn try_acquire_idempotent_for_same_agent() {
+        let mut map = make_map();
+        try_acquire(&mut map, "team-1", "vc-alice", "programmer", &["src/foo.rs".to_string()]);
+        let result =
+            try_acquire(&mut map, "team-1", "vc-alice", "programmer", &["src/foo.rs".to_string()]);
+        assert_eq!(result.locked, vec!["src/foo.rs"]);
+        assert!(result.conflicts.is_empty());
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn try_acquire_conflict_partitions_acquired_and_conflicts() {
+        let mut map = make_map();
+        // alice が foo.rs を握る
+        try_acquire(&mut map, "team-1", "vc-alice", "programmer", &["src/foo.rs".to_string()]);
+        // bob が [foo.rs, bar.rs] を取りに来る → foo は conflict、bar は acquire
+        let result = try_acquire(
+            &mut map,
+            "team-1",
+            "vc-bob",
+            "reviewer",
+            &["src/foo.rs".to_string(), "src/bar.rs".to_string()],
+        );
+        assert_eq!(result.locked, vec!["src/bar.rs"]);
+        assert_eq!(result.conflicts.len(), 1);
+        assert_eq!(result.conflicts[0].path, "src/foo.rs");
+        assert_eq!(result.conflicts[0].holder_agent_id, "vc-alice");
+        assert!(result.has_conflicts());
+    }
+
+    #[test]
+    fn try_acquire_normalizes_paths() {
+        let mut map = make_map();
+        // 同一 path を異なる表記で渡す → 1 件として扱われる
+        try_acquire(
+            &mut map,
+            "team-1",
+            "vc-alice",
+            "programmer",
+            &[r"src\foo.rs".to_string(), "./src/foo.rs".to_string(), "src//foo.rs".to_string()],
+        );
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn try_acquire_skips_empty_paths() {
+        let mut map = make_map();
+        let result = try_acquire(
+            &mut map,
+            "team-1",
+            "vc-alice",
+            "programmer",
+            &["".to_string(), "  ".to_string(), "src/foo.rs".to_string()],
+        );
+        assert_eq!(result.locked, vec!["src/foo.rs"]);
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn try_acquire_team_scoped() {
+        let mut map = make_map();
+        // 同一 path でも team が違えば独立に取得できる
+        try_acquire(&mut map, "team-1", "vc-alice", "programmer", &["src/foo.rs".to_string()]);
+        let result =
+            try_acquire(&mut map, "team-2", "vc-bob", "programmer", &["src/foo.rs".to_string()]);
+        assert_eq!(result.locked, vec!["src/foo.rs"]);
+        assert!(result.conflicts.is_empty());
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn release_returns_only_self_owned_paths() {
+        let mut map = make_map();
+        try_acquire(
+            &mut map,
+            "team-1",
+            "vc-alice",
+            "programmer",
+            &["src/foo.rs".to_string(), "src/bar.rs".to_string()],
+        );
+        try_acquire(&mut map, "team-1", "vc-bob", "reviewer", &["src/baz.rs".to_string()]);
+        // alice が [foo.rs (自分), baz.rs (bob)] を解放しようとしても baz.rs は無視
+        let result = release(
+            &mut map,
+            "team-1",
+            "vc-alice",
+            &["src/foo.rs".to_string(), "src/baz.rs".to_string()],
+        );
+        assert_eq!(result.unlocked, vec!["src/foo.rs"]);
+        assert_eq!(map.len(), 2); // bar (alice) + baz (bob) が残る
+    }
+
+    #[test]
+    fn release_normalizes_paths() {
+        let mut map = make_map();
+        try_acquire(&mut map, "team-1", "vc-alice", "programmer", &["src/foo.rs".to_string()]);
+        let result =
+            release(&mut map, "team-1", "vc-alice", &[r"src\foo.rs".to_string()]);
+        assert_eq!(result.unlocked, vec!["src/foo.rs"]);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn release_all_for_agent_clears_only_self() {
+        let mut map = make_map();
+        try_acquire(
+            &mut map,
+            "team-1",
+            "vc-alice",
+            "programmer",
+            &["src/foo.rs".to_string(), "src/bar.rs".to_string()],
+        );
+        try_acquire(&mut map, "team-1", "vc-bob", "reviewer", &["src/baz.rs".to_string()]);
+        let count = release_all_for_agent(&mut map, "team-1", "vc-alice");
+        assert_eq!(count, 2);
+        assert_eq!(map.len(), 1);
+        assert!(map.values().any(|l| l.agent_id == "vc-bob"));
+    }
+
+    #[test]
+    fn release_all_for_agent_team_scoped() {
+        let mut map = make_map();
+        try_acquire(&mut map, "team-1", "vc-alice", "programmer", &["src/foo.rs".to_string()]);
+        try_acquire(&mut map, "team-2", "vc-alice", "programmer", &["src/bar.rs".to_string()]);
+        // team-1 の alice の lock だけ解放する (team-2 のは残る)
+        let count = release_all_for_agent(&mut map, "team-1", "vc-alice");
+        assert_eq!(count, 1);
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn peek_returns_holders_for_other_agents() {
+        let mut map = make_map();
+        try_acquire(&mut map, "team-1", "vc-alice", "programmer", &["src/foo.rs".to_string()]);
+        // bob が peek (alice の lock を見る、自分宛は除外)
+        let conflicts = peek(
+            &map,
+            "team-1",
+            Some("vc-bob"),
+            &["src/foo.rs".to_string(), "src/bar.rs".to_string()],
+        );
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].holder_agent_id, "vc-alice");
+    }
+
+    #[test]
+    fn peek_excludes_self_when_filter_set() {
+        let mut map = make_map();
+        try_acquire(&mut map, "team-1", "vc-alice", "programmer", &["src/foo.rs".to_string()]);
+        // alice が peek (自分の lock は conflict ではないので除外される)
+        let conflicts = peek(
+            &map,
+            "team-1",
+            Some("vc-alice"),
+            &["src/foo.rs".to_string()],
+        );
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn peek_includes_all_when_filter_none() {
+        let mut map = make_map();
+        try_acquire(&mut map, "team-1", "vc-alice", "programmer", &["src/foo.rs".to_string()]);
+        // filter=None → 自分も他人もなく全 holder を返す
+        let conflicts = peek(&map, "team-1", None, &["src/foo.rs".to_string()]);
+        assert_eq!(conflicts.len(), 1);
+    }
+
+    #[test]
+    fn list_for_team_returns_only_team_locks() {
+        let mut map = make_map();
+        try_acquire(&mut map, "team-1", "vc-alice", "programmer", &["src/foo.rs".to_string()]);
+        try_acquire(&mut map, "team-2", "vc-bob", "reviewer", &["src/bar.rs".to_string()]);
+        let team1_locks = list_for_team(&map, "team-1");
+        assert_eq!(team1_locks.len(), 1);
+        assert_eq!(team1_locks[0].path, "src/foo.rs");
+    }
+}

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -10,6 +10,8 @@
 
 pub mod bridge;
 pub mod error;
+// Issue #526: vibe-team の advisory file locks (worker のファイル編集衝突を warn する)。
+pub mod file_locks;
 pub mod inject;
 pub mod protocol;
 // Issue #517: 動的ロール同士の責務境界 lint (recruit / assign_task で warning 発火)。

--- a/src-tauri/src/team_hub/protocol/mod.rs
+++ b/src-tauri/src/team_hub/protocol/mod.rs
@@ -36,8 +36,8 @@ use schema::tool_defs;
 use serde_json::{json, Value};
 use tools::{
     team_ack_handoff, team_assign_task, team_create_leader, team_diagnostics, team_dismiss,
-    team_get_tasks, team_info, team_list_role_profiles, team_read, team_recruit, team_send,
-    team_status, team_switch_leader, team_update_task,
+    team_get_tasks, team_info, team_list_role_profiles, team_lock_files, team_read, team_recruit,
+    team_send, team_status, team_switch_leader, team_unlock_files, team_update_task,
 };
 
 pub async fn handle(hub: &TeamHub, ctx: &CallContext, req: &Value) -> Option<Value> {
@@ -140,6 +140,9 @@ async fn dispatch_tool(
         "team_dismiss" => team_dismiss(hub, ctx, args).await,
         "team_list_role_profiles" => team_list_role_profiles(hub, ctx).await,
         "team_diagnostics" => team_diagnostics(hub, ctx).await,
+        // Issue #526: vibe-team の advisory file lock。
+        "team_lock_files" => team_lock_files(hub, ctx, args).await,
+        "team_unlock_files" => team_unlock_files(hub, ctx, args).await,
         other => Err(format!("Unknown tool: {other}")),
     }
 }

--- a/src-tauri/src/team_hub/protocol/schema.rs
+++ b/src-tauri/src/team_hub/protocol/schema.rs
@@ -62,7 +62,9 @@ pub(super) fn tool_defs() -> Value {
             "description":
                 "Assign a task to a role. Optionally pass `target_paths: string[]` declaring the files this task plans to edit; \
                  the Hub then peeks the advisory file lock table and returns any active holders in `lockConflicts`. \
-                 Lock conflicts do NOT block the assignment (advisory) — the Leader / assignee should reconcile manually.",
+                 Lock conflicts do NOT block the assignment (advisory) — the Leader / assignee should reconcile manually. \
+                 Returns `{ success: true, taskId: number, assignedAt: string, boundaryWarnings: string[], boundaryWarningMessage: string|null, lockConflicts: LockConflict[] }`. \
+                 `LockConflict` shape: `{ path, holderAgentId, holderRole, acquiredAt }`.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -235,7 +237,7 @@ pub(super) fn tool_defs() -> Value {
             "name": "team_lock_files",
             "description":
                 "Acquire an advisory lock on one or more file paths within this team. Call this BEFORE editing files \
-                 (Edit / Write / MultiEdit) so other team members can detect conflicts. Returns `{ locked: string[], conflicts: LockConflict[] }` \
+                 (Edit / Write / MultiEdit) so other team members can detect conflicts. Returns `{ success: true, locked: string[], conflicts: LockConflict[] }` \
                  with **partial success** semantics: paths already held by another agent are returned in `conflicts` and the rest in `locked`. \
                  Locks are in-memory and cleared on Hub restart or `team_dismiss`. Re-locking your own paths is idempotent.",
             "inputSchema": {
@@ -253,7 +255,7 @@ pub(super) fn tool_defs() -> Value {
         {
             "name": "team_unlock_files",
             "description":
-                "Release advisory locks previously acquired by this agent. Returns `{ unlocked: string[] }` listing only paths the caller actually held; paths held by other agents are silently skipped. Always call this AFTER your edits finish, including the failure path.",
+                "Release advisory locks previously acquired by this agent. Returns `{ success: true, unlocked: string[] }` listing only paths the caller actually held; paths held by other agents are silently skipped. Always call this AFTER your edits finish, including the failure path.",
             "inputSchema": {
                 "type": "object",
                 "properties": {

--- a/src-tauri/src/team_hub/protocol/schema.rs
+++ b/src-tauri/src/team_hub/protocol/schema.rs
@@ -59,12 +59,20 @@ pub(super) fn tool_defs() -> Value {
         },
         {
             "name": "team_assign_task",
-            "description": "Assign a task to a role.",
+            "description":
+                "Assign a task to a role. Optionally pass `target_paths: string[]` declaring the files this task plans to edit; \
+                 the Hub then peeks the advisory file lock table and returns any active holders in `lockConflicts`. \
+                 Lock conflicts do NOT block the assignment (advisory) — the Leader / assignee should reconcile manually.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "assignee": { "type": "string" },
-                    "description": { "type": "string" }
+                    "description": { "type": "string" },
+                    "target_paths": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional: file paths this task is expected to edit. Used to surface advisory file-lock conflicts in the response."
+                    }
                 },
                 "required": ["assignee", "description"]
             }
@@ -222,6 +230,41 @@ pub(super) fn tool_defs() -> Value {
                 "List all available role profiles (id, label, permissions). Includes both built-in (leader / hr) \
                  and any dynamic roles previously created with team_recruit.",
             "inputSchema": { "type": "object", "properties": {} }
+        },
+        {
+            "name": "team_lock_files",
+            "description":
+                "Acquire an advisory lock on one or more file paths within this team. Call this BEFORE editing files \
+                 (Edit / Write / MultiEdit) so other team members can detect conflicts. Returns `{ locked: string[], conflicts: LockConflict[] }` \
+                 with **partial success** semantics: paths already held by another agent are returned in `conflicts` and the rest in `locked`. \
+                 Locks are in-memory and cleared on Hub restart or `team_dismiss`. Re-locking your own paths is idempotent.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "paths": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Repository-relative or absolute paths to lock. Limit: 64 entries per call, 4 KiB per path."
+                    }
+                },
+                "required": ["paths"]
+            }
+        },
+        {
+            "name": "team_unlock_files",
+            "description":
+                "Release advisory locks previously acquired by this agent. Returns `{ unlocked: string[] }` listing only paths the caller actually held; paths held by other agents are silently skipped. Always call this AFTER your edits finish, including the failure path.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "paths": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Paths to release. Same limits as team_lock_files (64 / 4 KiB)."
+                    }
+                },
+                "required": ["paths"]
+            }
         }
     ])
 }

--- a/src-tauri/src/team_hub/protocol/tools/assign_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/assign_task.rs
@@ -41,6 +41,19 @@ pub async fn team_assign_task(
         }
         .into_err_string());
     }
+    // Issue #526: `target_paths: string[]` (任意) — このタスクで触る予定のファイル / dir 宣言。
+    // Hub は assign_task 時点で同 path を別 agent が握っていないか peek し、
+    // `lockConflicts` を response に乗せる (advisory: 拒否はしない、Leader が判断)。
+    let target_paths: Vec<String> = args
+        .get("target_paths")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| s.to_string())
+                .collect()
+        })
+        .unwrap_or_default();
     // 旧実装は assignee を一切検証せずに task を作成していた。
     // Claude (LLM) が "Programmer" / "プログラマー" / 存在しない role 名を渡すと、
     // task は作成されるが team_send 通知はゼロ宛先で no-op になり、
@@ -199,6 +212,46 @@ pub async fn team_assign_task(
     let boundary_warning_strs = boundary_report.finding_strings();
     let boundary_warning_message =
         boundary_report.warn_message("task boundary warnings (continuing assign)");
+
+    // Issue #526: target_paths 宣言があれば、現在 hub に登録されている file lock と照合し、
+    // 既に他 agent が握っている path があれば `lockConflicts` として response に同梱する。
+    // `team:role-lint-warning` と並列に `team:file-lock-conflict` event も emit して
+    // Canvas UI の toast 経路に乗せる (advisory: 拒否はしない)。
+    let lock_conflicts = if !target_paths.is_empty() {
+        // assignee 自身が握る path は当然衝突ではないので filter で除外。
+        let assignee_aid_filter = if resolved.len() == 1 {
+            Some(resolved[0].0.as_str())
+        } else {
+            // 複数名宛て (同 role 複数 / "all") の場合は誰の lock かを単純に決められないので
+            // フィルタ無し (= 全 holder を返す。Leader が boundaryWarnings 同様に解釈)。
+            None
+        };
+        hub.peek_file_locks(&ctx.team_id, assignee_aid_filter, &target_paths)
+            .await
+    } else {
+        Vec::new()
+    };
+    if !lock_conflicts.is_empty() {
+        let app = hub.app_handle.lock().await.clone();
+        if let Some(app) = &app {
+            let summary = lock_conflicts
+                .iter()
+                .map(|c| format!("{} held by {} ({})", c.path, c.holder_agent_id, c.holder_role))
+                .collect::<Vec<_>>()
+                .join("; ");
+            let payload = json!({
+                "teamId": ctx.team_id,
+                "source": "assign",
+                "taskId": task_id,
+                "assignee": assignee,
+                "message": format!("タスク #{} の file lock 競合: {}", task_id, summary),
+                "conflicts": lock_conflicts,
+            });
+            if let Err(e) = app.emit("team:file-lock-conflict", payload) {
+                tracing::warn!("emit team:file-lock-conflict failed: {e}");
+            }
+        }
+    }
     // Issue #172: 通知の team_send を await せず fire-and-forget でバックグラウンド spawn する。
     // assignee="all" のとき fan-out で sleep 累積して MCP RPC を秒単位でブロックしていたのを解消。
     // 配信失敗のときも呼び出し側 (Leader) には task 作成結果だけを即返す。
@@ -244,6 +297,7 @@ pub async fn team_assign_task(
         "assignedAt": assigned_at,
         "boundaryWarnings": boundary_warning_strs,
         "boundaryWarningMessage": boundary_warning_message,
+        "lockConflicts": lock_conflicts,
     }))
 }
 

--- a/src-tauri/src/team_hub/protocol/tools/dismiss.rs
+++ b/src-tauri/src/team_hub/protocol/tools/dismiss.rs
@@ -66,11 +66,23 @@ pub async fn team_dismiss(
     // dismiss された pending が孤立し、try_register_pending_recruit の人数 / singleton
     // 判定にゴミとして残り続けていた (renderer 反映の冪等性が壊れる)。
     hub.cancel_pending_recruit(&agent_id).await;
+    // Issue #526: dismiss された worker が握っていた advisory file lock を漏れなく解放する。
+    // 解放しないと「dismiss 済の worker が無限に lock を保持し続けて誰もファイル編集できない」
+    // 状態になりうる。dismiss が成立した時点で lock も自動失効と扱う。
+    let released_lock_count = hub
+        .release_all_file_locks_for_agent(&ctx.team_id, &agent_id)
+        .await;
+    if released_lock_count > 0 {
+        tracing::debug!(
+            "[team_dismiss] released {released_lock_count} file lock(s) held by '{agent_id}'"
+        );
+    }
     let dismissed_at = Utc::now().to_rfc3339();
     Ok(json!({
         "success": true,
         "agentId": agent_id,
         "dismissedAt": dismissed_at,
         "lastSeenAt": last_seen_at,
+        "releasedFileLocks": released_lock_count,
     }))
 }

--- a/src-tauri/src/team_hub/protocol/tools/file_lock.rs
+++ b/src-tauri/src/team_hub/protocol/tools/file_lock.rs
@@ -1,0 +1,150 @@
+//! tools: `team_lock_files` / `team_unlock_files` — vibe-team の advisory file lock。Issue #526。
+//!
+//! `worker` が `Edit` / `Write` 等で同じファイルを silent overwrite するのを防ぐため、
+//! 編集前に `team_lock_files(paths=[...])` で予約、編集後に `team_unlock_files(paths=[...])`
+//! で解放する協調的 lock。**advisory** = 取得しなくても hard fail しないが、Leader / 他の
+//! worker は `team_assign_task(target_paths=[...])` で peek した結果を見て調整する。
+//!
+//! response:
+//! - `team_lock_files` → `{ locked: string[], conflicts: LockConflict[] }` (partial success)
+//! - `team_unlock_files` → `{ unlocked: string[] }`
+//!
+//! 権限: 全 team member が呼べる (`team_send` / `team_read` 同様、追加権限は不要)。
+//! ただし `paths` は最大 64 件 / 1 件あたり 4 KiB に制限する (DoS 抑止)。
+
+use crate::team_hub::{CallContext, TeamHub};
+use serde_json::{json, Value};
+
+use super::error::ToolError;
+
+/// 1 リクエストで指定できる path 数の上限 (DoS 抑止)。
+const MAX_LOCK_PATHS_PER_CALL: usize = 64;
+/// 1 path あたりの最大バイト長 (異常な巨大 path を弾く)。
+const MAX_LOCK_PATH_LEN: usize = 4 * 1024;
+
+fn parse_paths_arg(args: &Value, code_prefix: &str) -> Result<Vec<String>, String> {
+    let arr = args.get("paths").and_then(|v| v.as_array()).ok_or_else(|| {
+        ToolError::invalid_args(code_prefix, "`paths` must be a non-empty string array")
+            .into_err_string()
+    })?;
+    if arr.is_empty() {
+        return Err(ToolError::invalid_args(code_prefix, "`paths` must be a non-empty string array")
+            .into_err_string());
+    }
+    if arr.len() > MAX_LOCK_PATHS_PER_CALL {
+        return Err(ToolError::invalid_args(
+            code_prefix,
+            format!(
+                "too many paths: {} (limit {})",
+                arr.len(),
+                MAX_LOCK_PATHS_PER_CALL
+            ),
+        )
+        .into_err_string());
+    }
+    let mut out = Vec::with_capacity(arr.len());
+    for v in arr {
+        let s = v.as_str().ok_or_else(|| {
+            ToolError::invalid_args(code_prefix, "`paths` must be an array of strings")
+                .into_err_string()
+        })?;
+        if s.len() > MAX_LOCK_PATH_LEN {
+            return Err(ToolError::invalid_args(
+                code_prefix,
+                format!(
+                    "path too long: {} bytes (limit {})",
+                    s.len(),
+                    MAX_LOCK_PATH_LEN
+                ),
+            )
+            .into_err_string());
+        }
+        out.push(s.to_string());
+    }
+    Ok(out)
+}
+
+/// `team_lock_files`: paths を advisory に lock する。partial success (一部 conflict でも残りは locked)。
+pub async fn team_lock_files(
+    hub: &TeamHub,
+    ctx: &CallContext,
+    args: &Value,
+) -> Result<Value, String> {
+    let paths = parse_paths_arg(args, "lock_files")?;
+    let result = hub
+        .try_acquire_file_locks(&ctx.team_id, &ctx.agent_id, &ctx.role, &paths)
+        .await;
+    Ok(json!({
+        "success": true,
+        "locked": result.locked,
+        "conflicts": result.conflicts,
+    }))
+}
+
+/// `team_unlock_files`: 自分が保持する paths のロックを解放。他 agent の lock は silent skip。
+pub async fn team_unlock_files(
+    hub: &TeamHub,
+    ctx: &CallContext,
+    args: &Value,
+) -> Result<Value, String> {
+    let paths = parse_paths_arg(args, "unlock_files")?;
+    let result = hub
+        .release_file_locks(&ctx.team_id, &ctx.agent_id, &paths)
+        .await;
+    Ok(json!({
+        "success": true,
+        "unlocked": result.unlocked,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_paths_rejects_missing_paths() {
+        let args = json!({});
+        let err = parse_paths_arg(&args, "lock_files").unwrap_err();
+        assert!(err.contains("lock_files_invalid_args"));
+        assert!(err.contains("non-empty string array"));
+    }
+
+    #[test]
+    fn parse_paths_rejects_empty_array() {
+        let args = json!({ "paths": [] });
+        let err = parse_paths_arg(&args, "lock_files").unwrap_err();
+        assert!(err.contains("non-empty string array"));
+    }
+
+    #[test]
+    fn parse_paths_rejects_non_string_element() {
+        let args = json!({ "paths": ["ok.rs", 42, "ok2.rs"] });
+        let err = parse_paths_arg(&args, "lock_files").unwrap_err();
+        assert!(err.contains("array of strings"));
+    }
+
+    #[test]
+    fn parse_paths_accepts_normal_input() {
+        let args = json!({ "paths": ["src/foo.rs", "src/bar.rs"] });
+        let parsed = parse_paths_arg(&args, "lock_files").unwrap();
+        assert_eq!(parsed, vec!["src/foo.rs", "src/bar.rs"]);
+    }
+
+    #[test]
+    fn parse_paths_rejects_too_many() {
+        let huge: Vec<String> = (0..(MAX_LOCK_PATHS_PER_CALL + 1))
+            .map(|i| format!("p{i}"))
+            .collect();
+        let args = json!({ "paths": huge });
+        let err = parse_paths_arg(&args, "lock_files").unwrap_err();
+        assert!(err.contains("too many paths"));
+    }
+
+    #[test]
+    fn parse_paths_rejects_too_long_path() {
+        let big = "a".repeat(MAX_LOCK_PATH_LEN + 1);
+        let args = json!({ "paths": [big] });
+        let err = parse_paths_arg(&args, "lock_files").unwrap_err();
+        assert!(err.contains("path too long"));
+    }
+}

--- a/src-tauri/src/team_hub/protocol/tools/mod.rs
+++ b/src-tauri/src/team_hub/protocol/tools/mod.rs
@@ -11,6 +11,8 @@ mod create_leader;
 mod diagnostics;
 mod dismiss;
 pub(super) mod error;
+// Issue #526: vibe-team の advisory file lock (team_lock_files / team_unlock_files)。
+mod file_lock;
 mod get_tasks;
 mod info;
 mod list_role_profiles;
@@ -26,6 +28,7 @@ pub use assign_task::team_assign_task;
 pub use create_leader::team_create_leader;
 pub use diagnostics::team_diagnostics;
 pub use dismiss::team_dismiss;
+pub use file_lock::{team_lock_files, team_unlock_files};
 pub use get_tasks::team_get_tasks;
 pub use info::team_info;
 pub use list_role_profiles::team_list_role_profiles;

--- a/src-tauri/src/team_hub/state.rs
+++ b/src-tauri/src/team_hub/state.rs
@@ -49,6 +49,12 @@ pub(crate) struct HubState {
     /// `team_diagnostics` MCP ツールが leader/hr の権限ガード越しに返す。
     /// in-memory only (プロセス再起動でリセット、計画の受け入れ基準で明記済み)。
     pub(crate) member_diagnostics: HashMap<String, MemberDiagnostics>,
+    /// Issue #526: vibe-team の advisory file lock 表 (team_id × normalized_path → FileLock)。
+    /// `team_lock_files` で取得、`team_unlock_files` で解放、`team_assign_task` の
+    /// `target_paths` 引数で peek (競合検知)。in-memory only (Hub 再起動で全 clear)、
+    /// TTL は設けない (本 issue では out-of-scope)。`team_dismiss` 時には対象 agent_id の
+    /// 全 lock を `release_all_for_agent` で一括解放する想定。
+    pub(crate) file_locks: HashMap<(String, String), crate::team_hub::file_locks::FileLock>,
 }
 
 /// Issue #342 Phase 3 (3.1): `team_diagnostics` で返す診断 timestamp / counter。
@@ -398,9 +404,67 @@ impl TeamHub {
                 role_profile_summary: Vec::new(),
                 dynamic_roles: HashMap::new(),
                 member_diagnostics: HashMap::new(),
+                file_locks: HashMap::new(),
             })),
             app_handle: Arc::new(Mutex::new(None)),
         }
+    }
+
+    // ===== Issue #526: file lock helpers (TeamHub method 経由で HubState の file_locks を操作) =====
+
+    /// `paths` を team_id × agent_id でロック取得試行する。partial success (一部 conflict でも残りは locked)。
+    pub async fn try_acquire_file_locks(
+        &self,
+        team_id: &str,
+        agent_id: &str,
+        role: &str,
+        paths: &[String],
+    ) -> crate::team_hub::file_locks::LockResult {
+        let mut s = self.state.lock().await;
+        crate::team_hub::file_locks::try_acquire(&mut s.file_locks, team_id, agent_id, role, paths)
+    }
+
+    /// `paths` のうち自分が保持するロックを解放する。
+    pub async fn release_file_locks(
+        &self,
+        team_id: &str,
+        agent_id: &str,
+        paths: &[String],
+    ) -> crate::team_hub::file_locks::UnlockResult {
+        let mut s = self.state.lock().await;
+        crate::team_hub::file_locks::release(&mut s.file_locks, team_id, agent_id, paths)
+    }
+
+    /// 指定 agent が team 内で保持する全 lock を解放する。`team_dismiss` 時に呼ぶ想定。
+    pub async fn release_all_file_locks_for_agent(
+        &self,
+        team_id: &str,
+        agent_id: &str,
+    ) -> u32 {
+        let mut s = self.state.lock().await;
+        crate::team_hub::file_locks::release_all_for_agent(&mut s.file_locks, team_id, agent_id)
+    }
+
+    /// `paths` の現在の lock 保持者一覧 (assign_task の競合検知用、agent_id_filter で自分宛除外可)。
+    pub async fn peek_file_locks(
+        &self,
+        team_id: &str,
+        agent_id_filter: Option<&str>,
+        paths: &[String],
+    ) -> Vec<crate::team_hub::file_locks::LockConflict> {
+        let s = self.state.lock().await;
+        crate::team_hub::file_locks::peek(&s.file_locks, team_id, agent_id_filter, paths)
+    }
+
+    /// team 内の全 lock 一覧 (将来の team_diagnostics 拡張 / UI 表示用)。
+    /// 現在は MCP API 経由の caller が居ないので `#[allow(dead_code)]`。
+    #[allow(dead_code)]
+    pub async fn list_file_locks_for_team(
+        &self,
+        team_id: &str,
+    ) -> Vec<crate::team_hub::file_locks::FileLock> {
+        let s = self.state.lock().await;
+        crate::team_hub::file_locks::list_for_team(&s.file_locks, team_id)
     }
 
     /// 動的ロールを team_id スコープで登録。既存があれば上書き。


### PR DESCRIPTION
## Summary
- Issue #526: 複数 worker が同じファイルを silent overwrite する衝突を防ぐ。
- 協調的 (advisory) な in-memory file lock 表を Hub 内に持ち、worker は `team_lock_files` / `team_unlock_files` で取得・解放、Leader / HR は `team_assign_task(target_paths=[...])` で peek して competition を検知する。
- **WARN のみ** (DENY しない)。lock 取得失敗でも hard fail せず、`team:file-lock-conflict` event を emit して Canvas UI に warning toast を出す。
- partial success / Hub 再起動で clear / `team_dismiss` で一括解放、TTL なし。

## API
| MCP tool | 入力 | 出力 |
|---|---|---|
| `team_lock_files` | `{ paths: string[] }` (≤ 64 / 4 KiB ea.) | `{ success, locked, conflicts: LockConflict[] }` (partial success) |
| `team_unlock_files` | `{ paths: string[] }` | `{ success, unlocked }` (自分以外の lock は silent skip) |
| `team_assign_task` | 既存 + `target_paths?: string[]` | 既存 + `lockConflicts: LockConflict[]` |
| `team_dismiss` | 既存 | 既存 + `releasedFileLocks: number` (自動解放数) |

`Leader が「この task はこの file 群に閉じている」と宣言する用途で target_paths を assign 時に渡すと、Hub が現在の lock holder を peek して、target 以外が握る path を lockConflicts として返す。advisory なので assign は通る。`

## 変更点 (10 files / 903 insertions, 6 deletions)
| 種類 | ファイル | 内容 |
|---|---|---|
| 新規 | `src-tauri/src/team_hub/file_locks.rs` | 純粋関数群 + 19 unit tests (normalize / try_acquire / release / release_all / peek / list / partial success / idempotency / team scoping) |
| 新規 | `src-tauri/src/team_hub/protocol/tools/file_lock.rs` | MCP tools + 6 unit tests (path 引数 validation: 64 path / 4 KiB / 型) |
| 変更 | `src-tauri/src/team_hub/mod.rs` | `pub mod file_locks;` 追加 (1 行) |
| 変更 | `src-tauri/src/team_hub/protocol/mod.rs` | dispatch 2 件追加 |
| 変更 | `src-tauri/src/team_hub/protocol/schema.rs` | tool 定義 2 件 + assign_task の `target_paths` 引数追加 |
| 変更 | `src-tauri/src/team_hub/protocol/tools/mod.rs` | mod 1 件 + use 2 件 |
| 変更 | `src-tauri/src/team_hub/protocol/tools/assign_task.rs` | `target_paths` 受け取り + `peek_file_locks` + `lockConflicts` 同梱 + event emit |
| 変更 | `src-tauri/src/team_hub/protocol/tools/dismiss.rs` | `release_all_file_locks_for_agent` 呼び出し + `releasedFileLocks` response 同梱 |
| 変更 | `src-tauri/src/team_hub/state.rs` | `HubState.file_locks` フィールド + 5 async method |
| 変更 | `.claude/skills/vibe-team/SKILL.md` | 新規 H2 `## ファイル編集の advisory lock (Rust 側 file_locks)` (Lifetime / MCP tools / target_paths peek / path 正規化 / worker 運用 4 ステップ) |

## skill_integrator pre-PR proofread (APPROVED)
5 観点 + lifetime 整合まで全て review 済 (`#540 (#517)` で確立した pre-PR proofread フローの 2 周目):
- (1) 命名整合 ✓ — `team_lock_files` / `team_unlock_files` で SKILL.md / Rust struct / fn 統一
- (2) response shape ✓ — `{ locked, conflicts }` / `{ unlocked }` が camelCase serialize 含めて一致
- (3) partial success の明示 ✓ — Hub 側は automatic rollback しない設計まで明記
- (4) TTL / 解放忘れ ✓ — in-memory only / Hub 再起動で clear / TTL なし / dismiss で一括解放
- (5) lifetime 整合 ✓ — `dismiss.rs` の `cancel_pending_recruit` 直後で `release_all_file_locks_for_agent`、`releasedFileLocks` response 同梱で漏れ無し

## 衝突回避
- **#513 (rust_team_hub_ops 進行中)**: `team_hub/mod.rs` は #513 が触らない方針確定なので `pub mod file_locks;` append は衝突 0。`dynamic_role.rs` / `recruit.rs` は本 PR で無改変。
- **#537 (skill_integrator 並行進行中)**: SKILL.md は別 H2 位置で完全分離 (`## Worktree 隔離` は `## 統合フェーズ` ↔ `## 名前空間` 間、私の `## ファイル編集の advisory lock` は `## 動的ロール責務境界 lint` ↔ `## 利用できるツール一覧` 間)。`role-profiles-builtin.ts` は本 PR で無改変。

## Test plan
- [x] `cargo test team_hub::file_locks` (19/19 pass)
- [x] `cargo test team_hub` (119/119 pass — 既存 test 影響なし)
- [x] `npm run typecheck` pass
- [x] `cargo check --lib` clean

## 関連
- Closes #526
- Refs #517 (boundaryWarnings と並列の lockConflicts response field 設計)
- Refs #507 (5 軸 / 採用前チェック invariant 不変)