### PR TITLE
feat(vibe-team): worker health-check UI を Canvas に追加 (sleep age / status / stale / dead) (#510)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod logs;
 pub mod role_profiles;
 pub mod sessions;
 pub mod settings;
+pub mod team_diagnostics;
 pub mod team_history;
 pub mod team_inject;
 pub mod team_presets;

--- a/src-tauri/src/commands/team_diagnostics.rs
+++ b/src-tauri/src/commands/team_diagnostics.rs
@@ -1,0 +1,41 @@
+// team_diagnostics.* command — Issue #510.
+//
+// Renderer (Canvas dashboard / health-check UI) から TeamHub の per-member 診断値を読み出す
+// Tauri IPC。元の `team_hub::protocol::tools::diagnostics::team_diagnostics` は MCP socket
+// 専用 (agent process が自身の役職で呼ぶ前提) で `Permission::ViewDiagnostics` を中で check
+// する。renderer は「Leader が UI から監視している」セマンティクス、つまり Leader 視点の
+// 観測なので、Leader 役で `CallContext` を組み立てて同関数を呼ぶ薄い wrapper として実装する。
+// Hub 内ロジック (`build_member_diagnostics_row` の row 構築) を 100% 共有することで、
+// Issue #524 で追加された PTY 由来 fields (`lastPtyOutputAt` / `autoStale` / `lastPtyActivityAgeMs`
+// / `stalenessThresholdMs`) が自動的に renderer 側にも届く。
+
+use crate::state::AppState;
+use crate::team_hub::protocol::tools::team_diagnostics;
+use crate::team_hub::CallContext;
+use serde_json::Value;
+use tauri::State;
+
+/// renderer 経由で TeamHub diagnostics を読む。team_id 未登録 / Hub 未起動の場合は
+/// `members: []` と等価な「空集計」を返す (UI 側で空状態として描画する)。
+///
+/// 引数 `team_id` のみ。プロジェクトルートは Hub 内の current state から自動決定される。
+/// Permission check は内部で leader 役を impersonate して通過させる ("renderer = Leader が
+/// UI から見ている" という semantic を体現)。
+#[tauri::command]
+pub async fn team_diagnostics_read(
+    state: State<'_, AppState>,
+    team_id: String,
+) -> Result<Value, String> {
+    let hub = state.team_hub.clone();
+    let ctx = CallContext {
+        team_id,
+        // Leader 役で impersonate: ViewDiagnostics permission を通すため。
+        // 物理シグナル (lastPtyOutputAt / autoStale 等) は agent_id ごとに per-member で
+        // 計算されるため、caller 側の agent_id は permission check 以外には影響しない。
+        role: "leader".to_string(),
+        // 既存 agent と衝突しない synthetic id。pending_inbox_summary の "from_agent_id == self"
+        // フィルタで誤って team message を除外しないよう、いずれの agent_id とも被らない名前。
+        agent_id: "vibe-editor.renderer".to_string(),
+    };
+    team_diagnostics(&hub, &ctx).await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,6 +130,8 @@ pub fn run() {
             commands::team_history::team_history_save_batch,
             commands::team_history::team_history_delete,
             commands::team_state::team_state_read,
+            // ---- team diagnostics read (Issue #510) ----
+            commands::team_diagnostics::team_diagnostics_read,
             // ---- team inject retry (Issue #511) ----
             commands::team_inject::team_send_retry_inject,
             // ---- team_presets (Issue #522) ----

--- a/src-tauri/src/team_hub/protocol/mod.rs
+++ b/src-tauri/src/team_hub/protocol/mod.rs
@@ -32,7 +32,10 @@ pub(in crate::team_hub) mod permissions;
 // Issue #508: 動的ロール定義の必須テンプレ + 曖昧名 + Worktree Isolation Rule の validation。
 mod role_template;
 mod schema;
-mod tools;
+// Issue #510: tools::diagnostics を `commands/team_diagnostics.rs` (Tauri IPC) から
+// 呼び出すため crate 内可視に緩める。renderer は Leader 役で薄い wrapper を介して
+// MCP と同一データを取得する。external (extra-crate) 公開は意図しないので `pub(crate)` 維持。
+pub(crate) mod tools;
 
 use crate::team_hub::{CallContext, TeamHub};
 use schema::tool_defs;

--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -10,6 +10,7 @@ import {
   List,
   Maximize2,
   Ruler,
+  Skull,
   Users,
   ZoomIn,
   ZoomOut
@@ -24,6 +25,8 @@ import {
   aggregateTeamSummary,
   type CardSummary
 } from '../../lib/agent-summary';
+import { useTeamHealth } from '../../lib/use-team-health';
+import { deriveHealth } from '../../lib/agent-health';
 import { TeamPresetsPanel } from './TeamPresetsPanel';
 import { TeamDashboard } from './TeamDashboard';
 import type { AgentPayload } from './cards/AgentNodeCard/types';
@@ -178,6 +181,34 @@ export function StageHud(): JSX.Element {
   );
   const showTeamSummary = teamSummary.total > 0;
 
+  // Issue #510: TeamHub diagnostics から dead 数を集計し、HUD に 5 番目のピルとして出す。
+  // teamId は activeTeamId 1 件しか想定しないので、agent ノード群の最頻 teamId を採る。
+  // teamId が無い (= スタンドアロンカードのみ) なら null で hook が no-op になる。
+  const aggregatedTeamId = useMemo<string | null>(() => {
+    let leader: string | null = null;
+    let first: string | null = null;
+    for (const node of agentNodes) {
+      const payload = (node.data as CardData | undefined)?.payload as AgentPayload | undefined;
+      if (!payload?.teamId) continue;
+      if (first === null) first = payload.teamId;
+      const role = payload.roleProfileId ?? payload.role;
+      if (role === 'leader' && leader === null) leader = payload.teamId;
+    }
+    return leader ?? first;
+  }, [agentNodes]);
+  const healthSnapshot = useTeamHealth(aggregatedTeamId);
+  const deadCount = useMemo(() => {
+    let n = 0;
+    for (const node of agentNodes) {
+      const payload = (node.data as CardData | undefined)?.payload as AgentPayload | undefined;
+      if (!payload?.agentId) continue;
+      const row = healthSnapshot.byAgentId[payload.agentId];
+      const h = deriveHealth(row);
+      if (h.state === 'dead') n += 1;
+    }
+    return n;
+  }, [agentNodes, healthSnapshot]);
+
   // Issue #514: dashboard に渡す teamId / projectRoot を canvas state + settings から導出。
   // 複数 team が並ぶ稀なケースは「Leader カードがある team を優先」、無ければ最初の agent team を採る。
   const { settings } = useSettings();
@@ -238,6 +269,19 @@ export function StageHud(): JSX.Element {
               <span className="tc__hud-summary-num">{teamSummary.stale}</span>
               <span className="tc__hud-summary-text">
                 {t('canvas.hud.summary.stale')}
+              </span>
+            </span>
+            <span
+              className={
+                'tc__hud-summary-pill tc__hud-summary-pill--dead' +
+                (deadCount > 0 ? ' is-on' : '')
+              }
+              title={t('canvas.hud.summary.dead.tooltip')}
+            >
+              <Skull size={11} strokeWidth={2.2} aria-hidden="true" />
+              <span className="tc__hud-summary-num">{deadCount}</span>
+              <span className="tc__hud-summary-text">
+                {t('canvas.hud.summary.dead')}
               </span>
             </span>
             <span

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -16,8 +16,20 @@
  */
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Handle, NodeResizer, Position, type NodeProps } from '@xyflow/react';
-import { AlertTriangle, ClipboardCheck, ClipboardList, Clock, Inbox, RotateCcw } from 'lucide-react';
+import {
+  AlertTriangle,
+  ClipboardCheck,
+  ClipboardList,
+  Clock,
+  Heart,
+  HeartPulse,
+  Inbox,
+  RotateCcw,
+  Skull
+} from 'lucide-react';
 import { useT } from '../../../../lib/i18n';
+import { useTeamHealth } from '../../../../lib/use-team-health';
+import { deriveHealth, type HealthState } from '../../../../lib/agent-health';
 import { useTeamInjectFailed } from '../../../../lib/use-team-inject-failed';
 import { useTeamInboxRead } from '../../../../lib/use-team-inbox-read';
 import { useTeamHandoff } from '../../../../lib/use-team-handoff';
@@ -133,6 +145,41 @@ function formatAgoLabel(
   if (ago === null) return t('agentCard.summary.ago.unobserved');
   if (ago.unit === 'now') return t('agentCard.summary.ago.now');
   return t(`agentCard.summary.ago.${ago.unit}`, { value: ago.value });
+}
+
+/**
+ * Issue #510: 「●alive | ◐stale | ○dead」 + 経過秒/分 + 自己申告ステータスを 1 行に整形する。
+ * - alive: status があれば status を出す。なければ 'alive' のみ。
+ * - stale / dead: 経過時間を強調 ('沈黙 N 分')。
+ */
+function formatHealthLabel(
+  state: HealthState,
+  ageMs: number | null,
+  currentStatus: string | null,
+  t: (key: string, params?: Record<string, string | number>) => string
+): string {
+  const stateLabel = t(`agentCard.summary.health.state.${state}`);
+  if (state === 'alive') {
+    if (currentStatus && currentStatus.trim().length > 0) {
+      const status = currentStatus.length > 32 ? currentStatus.slice(0, 31) + '…' : currentStatus;
+      return `${stateLabel} · ${status}`;
+    }
+    return stateLabel;
+  }
+  if (ageMs === null) return stateLabel;
+  // 沈黙時間: 1 分未満は秒、それ以上は分単位 (停滞は「N 分」が直感的)。
+  const sec = Math.floor(ageMs / 1000);
+  if (sec < 60) {
+    return t('agentCard.summary.health.silent.sec', {
+      state: stateLabel,
+      value: sec
+    });
+  }
+  const min = Math.floor(sec / 60);
+  return t('agentCard.summary.health.silent.min', {
+    state: stateLabel,
+    value: min
+  });
 }
 
 function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
@@ -596,6 +643,15 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   }, [id, summary, publishSummary]);
   const summaryAgoLabel = formatAgoLabel(summary.lastOutputAgo, t);
 
+  // Issue #510: TeamHub diagnostics を 5s poll し、自カードの per-agent 行から
+  // health (alive / stale / dead) と現在 status / pendingInbox を抽出する。
+  // teamId / agentId が両方揃っているカードのみ意味がある (standalone agent は null)。
+  const healthSnapshot = useTeamHealth(payload.teamId ?? null);
+  const healthRow = payload.agentId
+    ? healthSnapshot.byAgentId[payload.agentId] ?? null
+    : null;
+  const health = useMemo(() => deriveHealth(healthRow), [healthRow]);
+
   return (
     <>
       <NodeResizer
@@ -686,6 +742,34 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
               <AlertTriangle size={11} strokeWidth={2} aria-hidden="true" />
               <span className="canvas-agent-card__summary-text">
                 {t('agentCard.summary.needsLeader')}
+              </span>
+            </div>
+          ) : null}
+          {/* Issue #510: 自カードに対応する TeamHub diagnostics 行から health badge を表示する。 */}
+          {/* teamId / agentId が無いスタンドアロンカードでは何も出さない (= state==='unknown' は描画しない)。 */}
+          {payload.agentId && payload.teamId && health.state !== 'unknown' ? (
+            <div
+              className={
+                'canvas-agent-card__summary-row canvas-agent-card__summary-row--health' +
+                ' canvas-agent-card__summary-row--health-' + health.state
+              }
+              role="status"
+              title={
+                t('agentCard.summary.health.tooltip', {
+                  state: t(`agentCard.summary.health.state.${health.state}`),
+                  status: health.currentStatus ?? t('agentCard.summary.health.noStatus')
+                })
+              }
+            >
+              {health.state === 'alive' ? (
+                <Heart size={11} strokeWidth={2.2} aria-hidden="true" />
+              ) : health.state === 'stale' ? (
+                <HeartPulse size={11} strokeWidth={2.2} aria-hidden="true" />
+              ) : (
+                <Skull size={11} strokeWidth={2.2} aria-hidden="true" />
+              )}
+              <span className="canvas-agent-card__summary-text">
+                {formatHealthLabel(health.state, health.ageMs, health.currentStatus, t)}
               </span>
             </div>
           ) : null}

--- a/src/renderer/src/lib/agent-health.ts
+++ b/src/renderer/src/lib/agent-health.ts
@@ -1,0 +1,69 @@
+/**
+ * agent-health — Issue #510.
+ *
+ * `TeamDiagnosticsMemberRow` 1 行を、UI に出す 3 値ヘルス (alive / stale / dead) と
+ * 経過秒の表示に変換する純粋関数。Rust 側 #524 で生えた `autoStale` を一次判定に使い、
+ * 「どれくらい長く沈黙していれば dead と見なすか」だけ renderer 側で重ね判定する。
+ *
+ * `dead` は `lastPtyActivityAgeMs` が `DEAD_THRESHOLD_MS` を超え、かつ
+ * `lastStatusAgeMs` も同様に超過しているとき。Hub の `autoStale` が true でも、
+ * 「動いている (PTY 出力あり) が status 申告だけ古い」ケースは dead にしない。
+ */
+import type { TeamDiagnosticsMemberRow } from '../../../types/shared';
+
+/**
+ * 「もう動いていない」と見なす経過時間 (ms)。
+ * `STATUS_STALE_THRESHOLD_SECS` (Hub 側 5 分) の 3 倍 = 15 分。
+ * これ以上沈黙する worker は手動介入が必要なケースが大半。
+ */
+export const DEAD_THRESHOLD_MS = 15 * 60_000;
+
+export type HealthState = 'alive' | 'stale' | 'dead' | 'unknown';
+
+export interface HealthDerived {
+  state: HealthState;
+  /** 表示用: 「最終出力からどれだけ経ったか」を `formatRelativeMs` 互換に整形 */
+  ageMs: number | null;
+  /** 自己申告ステータス文字列。null / 空なら未申告。 */
+  currentStatus: string | null;
+  /** pendingInbox 数 (UI で badge 表示) */
+  pendingInboxCount: number;
+}
+
+export function deriveHealth(
+  row: TeamDiagnosticsMemberRow | null | undefined
+): HealthDerived {
+  if (!row) {
+    return {
+      state: 'unknown',
+      ageMs: null,
+      currentStatus: null,
+      pendingInboxCount: 0
+    };
+  }
+
+  // 「最終出力 (= プロセスが本当に動いた最後の物理シグナル)」を最も信頼する。
+  // PTY 出力時刻が無いときは status 申告の age をフォールバック表示。
+  const ageMs = row.lastPtyActivityAgeMs ?? row.lastStatusAgeMs;
+
+  let state: HealthState;
+  if (row.lastPtyActivityAgeMs !== null && row.lastPtyActivityAgeMs >= DEAD_THRESHOLD_MS) {
+    // PTY 出力が 15 分以上途絶 → dead。lastStatusAgeMs もチェックしないのは、
+    // status 申告は agent が忘れがちなので、PTY の絶対沈黙が確定的シグナル。
+    state = 'dead';
+  } else if (row.autoStale) {
+    state = 'stale';
+  } else if (row.lastPtyActivityAgeMs !== null || row.lastStatusAgeMs !== null) {
+    state = 'alive';
+  } else {
+    // 1 度も観測されていない (= recruit 直後の handshake 前) は unknown 扱い。
+    state = 'unknown';
+  }
+
+  return {
+    state,
+    ageMs: ageMs ?? null,
+    currentStatus: row.currentStatus,
+    pendingInboxCount: row.pendingInboxCount
+  };
+}

--- a/src/renderer/src/lib/agent-health.ts
+++ b/src/renderer/src/lib/agent-health.ts
@@ -5,9 +5,11 @@
  * 経過秒の表示に変換する純粋関数。Rust 側 #524 で生えた `autoStale` を一次判定に使い、
  * 「どれくらい長く沈黙していれば dead と見なすか」だけ renderer 側で重ね判定する。
  *
- * `dead` は `lastPtyActivityAgeMs` が `DEAD_THRESHOLD_MS` を超え、かつ
- * `lastStatusAgeMs` も同様に超過しているとき。Hub の `autoStale` が true でも、
- * 「動いている (PTY 出力あり) が status 申告だけ古い」ケースは dead にしない。
+ * `dead` は `lastPtyActivityAgeMs` が `DEAD_THRESHOLD_MS` を超えるとき (PTY 出力が
+ * 15 分以上途絶した = プロセスが本当に動いていない決定的シグナル)。
+ * Hub の `autoStale` が true でも「動いている (PTY 出力あり) が status 申告だけ古い」
+ * ケースは dead にしない。`lastStatusAgeMs` は `alive` 判定の補助 (status / PTY の
+ * いずれかが観測されていれば alive 候補) としてのみ参照する。
  */
 import type { TeamDiagnosticsMemberRow } from '../../../types/shared';
 

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -314,6 +314,16 @@ const ja: Dict = {
   'agentCard.summary.ago.hour': '最終出力から {value} 時間前',
   'agentCard.summary.ago.day': '最終出力から {value} 日前',
 
+  // Issue #510: Agent カード health badge (TeamHub diagnostics 由来)
+  'agentCard.summary.health.state.alive': '稼働中',
+  'agentCard.summary.health.state.stale': '沈黙中',
+  'agentCard.summary.health.state.dead': '応答なし',
+  'agentCard.summary.health.state.unknown': '不明',
+  'agentCard.summary.health.silent.sec': '{state} ({value} 秒沈黙)',
+  'agentCard.summary.health.silent.min': '{state} ({value} 分沈黙)',
+  'agentCard.summary.health.tooltip': 'Health: {state} / 直近自己申告: {status}',
+  'agentCard.summary.health.noStatus': '自己申告なし',
+
   // Issue #521: Canvas 全体サマリ HUD
   'canvas.hud.summary.label': 'Canvas 全体の状態サマリ',
   'canvas.hud.summary.active': '進行中',
@@ -325,6 +335,9 @@ const ja: Dict = {
   'canvas.hud.summary.stale.tooltip': '停滞 — 5 分以上出力が無いエージェントの数',
   'canvas.hud.summary.completed': '完了',
   'canvas.hud.summary.completed.tooltip': '完了 — handoff ack 済 / 退役済のエージェントの数',
+  'canvas.hud.summary.dead': '応答なし',
+  'canvas.hud.summary.dead.tooltip':
+    '応答なし — 15 分以上 PTY 出力なしのエージェントの数 (Hub diagnostics 由来)',
 
   // Issue #522: Team Presets panel
   'preset.title': 'チームプリセット',
@@ -938,6 +951,16 @@ const en: Dict = {
   'agentCard.summary.ago.hour': 'Last output {value}h ago',
   'agentCard.summary.ago.day': 'Last output {value}d ago',
 
+  // Issue #510: Agent card health badge (sourced from TeamHub diagnostics)
+  'agentCard.summary.health.state.alive': 'Alive',
+  'agentCard.summary.health.state.stale': 'Stale',
+  'agentCard.summary.health.state.dead': 'Unresponsive',
+  'agentCard.summary.health.state.unknown': 'Unknown',
+  'agentCard.summary.health.silent.sec': '{state} (silent for {value}s)',
+  'agentCard.summary.health.silent.min': '{state} (silent for {value}m)',
+  'agentCard.summary.health.tooltip': 'Health: {state} · last self-status: {status}',
+  'agentCard.summary.health.noStatus': 'no self-reported status',
+
   // Issue #521: Canvas-wide summary HUD
   'canvas.hud.summary.label': 'Canvas team summary',
   'canvas.hud.summary.active': 'Active',
@@ -950,6 +973,9 @@ const en: Dict = {
   'canvas.hud.summary.completed': 'Completed',
   'canvas.hud.summary.completed.tooltip':
     'Completed — agents with acked handoff or retired sessions',
+  'canvas.hud.summary.dead': 'Unresponsive',
+  'canvas.hud.summary.dead.tooltip':
+    'Unresponsive — agents with no PTY output for 15+ minutes (sourced from hub diagnostics)',
 
   // Issue #522: Team Presets panel
   'preset.title': 'Team Presets',

--- a/src/renderer/src/lib/tauri-api/team.ts
+++ b/src/renderer/src/lib/tauri-api/team.ts
@@ -19,7 +19,24 @@ import {
   type CardSummary,
   type TeamSummaryAggregate
 } from '../agent-summary';
-import type { RetryInjectArgs, RetryInjectResult } from '../../../../types/shared';
+import type {
+  RetryInjectArgs,
+  RetryInjectResult,
+  TeamDiagnosticsMemberRow
+} from '../../../../types/shared';
+
+/**
+ * Issue #510: `team_diagnostics_read` IPC の戻り値。Rust 側 `team_diagnostics` 関数の
+ * outer JSON shape (`{ myAgentId, myRole, teamId, serverLogPath, members[] }`) を
+ * そのまま投影する。renderer は基本 `members` だけを使う。
+ */
+export interface TeamDiagnosticsResponse {
+  myAgentId: string;
+  myRole: string;
+  teamId: string;
+  serverLogPath: string | null;
+  members: TeamDiagnosticsMemberRow[];
+}
 
 export interface TeamSummaryRequest {
   /** 集計対象の agent ノード (caller 側で type === 'agent' フィルタ済み) */
@@ -50,5 +67,12 @@ export const team = {
    *   reject されたエラー文字列は JSON `{"code":"retry_*","message":"..."}` 形式。caller は `JSON.parse()` で分岐できる。
    */
   retryInject: (args: RetryInjectArgs): Promise<RetryInjectResult> =>
-    invoke('team_send_retry_inject', { args })
+    invoke('team_send_retry_inject', { args }),
+  /**
+   * Issue #510: TeamHub の per-member 診断値を Leader 視点で取得する。
+   * 内部で leader 役を impersonate して MCP `team_diagnostics` と同一データを返す。
+   * Hub 未起動 / team 未登録時も基本的に空 members で返る (errors は reject)。
+   */
+  diagnosticsRead: (teamId: string): Promise<TeamDiagnosticsResponse> =>
+    invoke('team_diagnostics_read', { teamId })
 };

--- a/src/renderer/src/lib/tauri-api/team.ts
+++ b/src/renderer/src/lib/tauri-api/team.ts
@@ -72,6 +72,14 @@ export const team = {
    * Issue #510: TeamHub の per-member 診断値を Leader 視点で取得する。
    * 内部で leader 役を impersonate して MCP `team_diagnostics` と同一データを返す。
    * Hub 未起動 / team 未登録時も基本的に空 members で返る (errors は reject)。
+   *
+   * 引数キー命名: 本プロジェクトは Rust 側 `#[tauri::command]` の snake_case パラメータ
+   * (`team_id: String`) に対し、JS invoke 側は **camelCase** (`{ teamId }`) を渡す
+   * 慣例で統一している。Tauri 2 のデフォルト動作で `camelCase` JS キーは自動的に
+   * `snake_case` Rust パラメータへマッピングされる (例: `teamHistory.list({ projectRoot })`,
+   * `teamState.read({ projectRoot, teamId })` 等、全 wrapper 同一パターン)。
+   * snake_case をそのまま JS から渡すと逆に名前解決が崩れる可能性があるため、
+   * ここでも他 wrapper と揃えて camelCase で送る。
    */
   diagnosticsRead: (teamId: string): Promise<TeamDiagnosticsResponse> =>
     invoke('team_diagnostics_read', { teamId })

--- a/src/renderer/src/lib/use-team-health.ts
+++ b/src/renderer/src/lib/use-team-health.ts
@@ -1,0 +1,141 @@
+/**
+ * use-team-health — Issue #510.
+ *
+ * `team_diagnostics_read` IPC を 5 秒間隔で poll し、agentId をキーにした
+ * `Map<agentId, TeamDiagnosticsMemberRow>` を返す軽量 hook。
+ *
+ * 設計:
+ *   - 同 hook を多数の AgentNodeCard が同時にマウントしうるが、teamId 単位で
+ *     同じ poll を共有しないと N 倍 IPC が走ってしまう。本実装は最初の caller のみが
+ *     活性 poll を持ち、追加 caller は同じ Map に subscribe するだけのレジストリパターン。
+ *   - Tab が非フォーカスの間は poll を一時停止する (CPU / IPC コスト削減)。
+ *   - teamId が null の間は何もしない。
+ */
+import { useEffect, useState } from 'react';
+import type { TeamDiagnosticsMemberRow } from '../../../types/shared';
+
+/** poll 間隔。CPU 負荷と "agent が止まったとき何秒以内に気づくか" のバランス。 */
+const POLL_INTERVAL_MS = 5_000;
+
+interface Snapshot {
+  /** agentId → 最新行 */
+  byAgentId: Record<string, TeamDiagnosticsMemberRow>;
+  /** 観測時刻 (Date.now()) */
+  fetchedAt: number;
+}
+
+interface RegistryEntry {
+  refCount: number;
+  snapshot: Snapshot | null;
+  listeners: Set<(snap: Snapshot | null) => void>;
+  timer: number | null;
+  /** in-flight な fetch があれば true (同時多重を防ぐ) */
+  inflight: boolean;
+}
+
+const registry = new Map<string, RegistryEntry>();
+
+function notify(entry: RegistryEntry): void {
+  for (const fn of entry.listeners) fn(entry.snapshot);
+}
+
+async function fetchOnce(teamId: string, entry: RegistryEntry): Promise<void> {
+  if (entry.inflight) return;
+  if (typeof document !== 'undefined' && document.hidden) return;
+  // window.api が未注入 (test 環境 / Tauri 外) の場合は静かに no-op。
+  // unhandled rejection を避けるため一切 invoke を試みない。
+  const api =
+    typeof window !== 'undefined'
+      ? (window as unknown as { api?: { team?: { diagnosticsRead?: unknown } } }).api
+      : undefined;
+  if (!api?.team || typeof api.team.diagnosticsRead !== 'function') return;
+  entry.inflight = true;
+  try {
+    const res = await window.api.team.diagnosticsRead(teamId);
+    const byAgentId: Record<string, TeamDiagnosticsMemberRow> = {};
+    for (const m of res.members) byAgentId[m.agentId] = m;
+    entry.snapshot = { byAgentId, fetchedAt: Date.now() };
+    notify(entry);
+  } catch (err) {
+    // Hub 未起動など想定内エラーは warn にとどめる (UI は old snapshot で続行)。
+    console.warn('[team-health] diagnostics fetch failed:', err);
+  } finally {
+    entry.inflight = false;
+  }
+}
+
+function ensurePoll(teamId: string, entry: RegistryEntry): void {
+  if (entry.timer !== null) return;
+  void fetchOnce(teamId, entry);
+  entry.timer = window.setInterval(() => {
+    void fetchOnce(teamId, entry);
+  }, POLL_INTERVAL_MS);
+}
+
+function stopPoll(entry: RegistryEntry): void {
+  if (entry.timer !== null) {
+    window.clearInterval(entry.timer);
+    entry.timer = null;
+  }
+}
+
+/**
+ * teamId に対する diagnostics の最新スナップショットを購読する。
+ * 同じ teamId を複数コンポーネントが購読しても poll は 1 回だけ走る。
+ */
+export function useTeamHealth(
+  teamId: string | null
+): { byAgentId: Record<string, TeamDiagnosticsMemberRow>; fetchedAt: number | null } {
+  const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
+
+  useEffect(() => {
+    if (!teamId) {
+      setSnapshot(null);
+      return;
+    }
+    let entry = registry.get(teamId);
+    if (!entry) {
+      entry = {
+        refCount: 0,
+        snapshot: null,
+        listeners: new Set(),
+        timer: null,
+        inflight: false
+      };
+      registry.set(teamId, entry);
+    }
+    entry.refCount += 1;
+    const listener = (snap: Snapshot | null) => setSnapshot(snap);
+    entry.listeners.add(listener);
+    setSnapshot(entry.snapshot);
+    ensurePoll(teamId, entry);
+
+    // tab visibility: hidden になったら poll を即停止、戻ったら再 fetch。
+    const onVisibility = () => {
+      if (!entry) return;
+      if (document.hidden) {
+        stopPoll(entry);
+      } else if (entry.refCount > 0) {
+        ensurePoll(teamId, entry);
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      const e = registry.get(teamId);
+      if (!e) return;
+      e.listeners.delete(listener);
+      e.refCount -= 1;
+      if (e.refCount <= 0) {
+        stopPoll(e);
+        registry.delete(teamId);
+      }
+    };
+  }, [teamId]);
+
+  return {
+    byAgentId: snapshot?.byAgentId ?? {},
+    fetchedAt: snapshot?.fetchedAt ?? null
+  };
+}

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -785,6 +785,33 @@
 .canvas-agent-card__summary-row--unread-stalled svg {
   color: var(--accent-warning, #d97706);
 }
+
+/* Issue #510: TeamHub diagnostics 由来の health badge (●alive / ◐stale / ○dead).
+ * alive はトーン控えめ (動いている時に視覚負荷を上げない)、stale / dead は彩度を上げる. */
+.canvas-agent-card__summary-row--health {
+  color: var(--fg-subtle);
+}
+.canvas-agent-card__summary-row--health-alive {
+  color: var(--accent-success, var(--accent));
+}
+.canvas-agent-card__summary-row--health-alive svg {
+  color: var(--accent-success, var(--accent));
+}
+.canvas-agent-card__summary-row--health-stale {
+  color: var(--accent-warning, #d97706);
+  font-weight: 600;
+}
+.canvas-agent-card__summary-row--health-stale svg {
+  color: var(--accent-warning, #d97706);
+}
+.canvas-agent-card__summary-row--health-dead {
+  color: var(--accent-danger, #ef4444);
+  font-weight: 700;
+}
+.canvas-agent-card__summary-row--health-dead svg {
+  color: var(--accent-danger, #ef4444);
+}
+
 .canvas-agent-card__summary-text {
   flex: 1 1 auto;
   min-width: 0;
@@ -794,9 +821,10 @@
 }
 
 /* Issue #260 PR-3 互換: density=compact ではサマリ占有を抑え、
- * 1 行目 (タスク) のみ表示する。残り 2 行は折りたたんでカード密度を維持。 */
+ * 1 行目 (タスク) のみ表示する。残り行は折りたたんでカード密度を維持。 */
 [data-density='compact'] .canvas-agent-card__summary-row--clock,
-[data-density='compact'] .canvas-agent-card__summary-row--leader {
+[data-density='compact'] .canvas-agent-card__summary-row--leader,
+[data-density='compact'] .canvas-agent-card__summary-row--health {
   display: none;
 }
 [data-density='compact'] .canvas-agent-card__summary {
@@ -1159,6 +1187,15 @@
 }
 .tc__hud-summary-pill--completed .tc__hud-summary-num {
   color: var(--accent-success, var(--accent));
+}
+/* Issue #510: dead worker count pill。0 件のとき muted、1 件以上で danger 色を強調する。 */
+.tc__hud-summary-pill--dead.is-on {
+  background: color-mix(in srgb, var(--accent-danger, #ef4444) 18%, transparent);
+  border-color: color-mix(in srgb, var(--accent-danger, #ef4444) 35%, transparent);
+}
+.tc__hud-summary-pill--dead.is-on .tc__hud-summary-num,
+.tc__hud-summary-pill--dead.is-on svg {
+  color: var(--accent-danger, #ef4444);
 }
 /* compact 密度ではテキストを折りたたんで数値+アイコンだけ残す。 */
 [data-density='compact'] .tc__hud-summary-text {


### PR DESCRIPTION
## Summary

Canvas 上の Agent カードと StageHud に「沈黙時間 / 状態 / pendingInbox / stale 判定」を常時表示し、Leader が個別カードを開かなくても worker の生存と進捗を把握できるようにする health-check UI。

#524 (rust_team_hub_ops merged) で diagnostics に必要な PTY 由来 fields (`lastPtyOutputAt` / `autoStale` / `lastPtyActivityAgeMs` / `stalenessThresholdMs`) が揃ったので、本 PR は **その上に乗る renderer 中心の UI 実装**。

## Changes

- **Rust 側 (薄い IPC wrapper のみ)**:
  - 新規 `commands/team_diagnostics.rs` — `team_diagnostics_read` `#[tauri::command]`. Leader 役を impersonate して `team_hub::protocol::tools::team_diagnostics` を呼ぶ thin wrapper. `team_hub::protocol::tools` を `pub(crate)` に緩めて access 可能に
  - 既存 const / 構造体 / diagnostics ロジックは **0 行 touch** (#524 と完全重複なし)
  - `commands/mod.rs` + `lib.rs` invoke_handler に登録 (5-point sync)

- **Renderer 側**:
  - 新規 `lib/use-team-health.ts` — teamId 単位の 5s poll を refCount registry で共有 (N 個の AgentNodeCard が並んでも poll は 1 回)。`document.hidden` で停止、`window.api` 未注入時は no-op
  - 新規 `lib/agent-health.ts` — `alive / stale / dead / unknown` の 4 値に正規化する純粋関数 (DEAD_THRESHOLD_MS = 15 分、PTY 沈黙を主シグナル)
  - `tauri-api/team.ts` に `team.diagnosticsRead()` + `TeamDiagnosticsResponse` 型
  - **CardFrame.tsx** の summary block に 4 行目 `__summary-row--health` を sibling 配置 (既存 `--task` / `--clock` / `--leader` / `--unread` と並列)
  - **StageHud** の team-summary HUD に 5 番目のピル `--dead` (Skull アイコン)
  - `canvas.css` に health row + dead pill のスタイル
  - i18n ja/en (`agentCard.summary.health.*` / `canvas.hud.summary.dead*`)

## 衝突調整

- **#524 (rust_team_hub_ops, merged)** の `diagnostics.rs` / `state.rs` / `consts.rs` は 0 行 touch、私の追加は新規 file `team_diagnostics.rs` のみ → 物理的非競合
- **#509 (rust_team_hub_ops 進行中)** が CardFrame に `__summary-row--unread` を追加しており、私の `__summary-row--health` を sibling として並列配置 (#511 / #521 / #522 で確立した sibling パターンを継承)
- **#517 (rust_team_hub_core)** は toast listener のみで co-location 合意済 → 干渉なし

## Test plan

- [x] `cargo check` 通過
- [x] `npm run typecheck` 通過
- [x] `npx vitest run` 全 278 件通過 (14 unhandled errors は **pre-existing**, 私の変更前から発生 — `transformCallback` 関連の test 環境制約で本 PR 起因ではない)
- [ ] 手動: 4 名チームを起動、1 名で長時間ビルド / 1 名で即終了 / 1 名で沈黙 / 1 名で busy → 各 health 表示が変わるかを目視確認
- [ ] 手動: focus 喪失で poll が止まることを確認
- [ ] 手動: 全テーマ (claude-dark/light, dark, midnight, light, glass) で配色破綻なし