### PR TITLE
fix(terminal): normalize inline command args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-editor",
-  "version": "1.4.12",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-editor",
-      "version": "1.4.12",
+      "version": "1.5.2",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/geist-mono": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5218,7 +5218,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.5.1"
+version = "1.5.2"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -78,12 +78,8 @@ pub struct SavePastedImageResult {
     pub error: Option<String>,
 }
 
-/// 旧 resolveCommand 相当の最小実装。Phase 1 では「未指定なら 'claude'」だけ。
 fn resolve_command(command: Option<String>, args: Option<Vec<String>>) -> (String, Vec<String>) {
-    let cmd = command
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "claude".to_string());
-    (cmd, args.unwrap_or_default())
+    command_validation::normalize_terminal_command(command, args)
 }
 
 /// Codex の system prompt を、PTY (TUI) に直接「最初の入力」として注入する fallback 経路。

--- a/src-tauri/src/commands/terminal/command_validation.rs
+++ b/src-tauri/src/commands/terminal/command_validation.rs
@@ -24,6 +24,67 @@ pub fn command_basename(command: &str) -> String {
         .to_string()
 }
 
+fn split_command_line(input: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut chars = input.trim().chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' | '\'' => {
+                if quote == Some(ch) {
+                    quote = None;
+                } else if quote.is_none() {
+                    quote = Some(ch);
+                } else {
+                    current.push(ch);
+                }
+            }
+            '\\' => {
+                let next = chars.peek().copied();
+                if quote.is_some() && next == quote {
+                    current.push(chars.next().unwrap_or(ch));
+                } else if quote.is_none() && matches!(next, Some('"') | Some('\'')) {
+                    current.push(chars.next().unwrap_or(ch));
+                } else {
+                    current.push(ch);
+                }
+            }
+            c if c.is_whitespace() && quote.is_none() => {
+                if !current.is_empty() {
+                    parts.push(std::mem::take(&mut current));
+                }
+            }
+            c => current.push(c),
+        }
+    }
+
+    if !current.is_empty() {
+        parts.push(current);
+    }
+    parts
+}
+
+pub fn normalize_terminal_command(
+    command: Option<String>,
+    args: Option<Vec<String>>,
+) -> (String, Vec<String>) {
+    let mut existing_args = args.unwrap_or_default();
+    let raw = command
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("claude");
+    let mut parts = split_command_line(raw);
+    if parts.is_empty() {
+        return ("claude".to_string(), existing_args);
+    }
+    let cmd = parts.remove(0);
+    parts.append(&mut existing_args);
+    (cmd, parts)
+}
+
 pub fn configured_terminal_commands() -> HashSet<String> {
     let mut out = HashSet::new();
     let path = crate::util::config_paths::settings_path();
@@ -36,6 +97,9 @@ pub fn configured_terminal_commands() -> HashSet<String> {
     let mut push = |raw: Option<&str>| {
         if let Some(cmd) = raw.map(str::trim).filter(|s| !s.is_empty()) {
             out.insert(cmd.to_ascii_lowercase());
+            if let Some(program) = split_command_line(cmd).first() {
+                out.insert(program.to_ascii_lowercase());
+            }
         }
     };
     push(value.get("claudeCommand").and_then(|v| v.as_str()));
@@ -213,5 +277,93 @@ mod codex_command_tests {
         assert!(!is_codex_command("claude"));
         assert!(!is_codex_command("bash"));
         assert!(!is_codex_command(""));
+    }
+}
+
+#[cfg(test)]
+mod command_normalization_tests {
+    use super::{normalize_terminal_command, reject_immediate_exec_args, split_command_line};
+
+    #[test]
+    fn splits_inline_codex_flags_from_command_field() {
+        let (command, args) = normalize_terminal_command(
+            Some("codex --dangerously-bypass-approvals-and-sandbox".to_string()),
+            None,
+        );
+
+        assert_eq!(command, "codex");
+        assert_eq!(args, vec!["--dangerously-bypass-approvals-and-sandbox"]);
+    }
+
+    #[test]
+    fn inline_args_are_prepended_before_existing_args() {
+        let (command, args) = normalize_terminal_command(
+            Some("codex --dangerously-bypass-approvals-and-sandbox".to_string()),
+            Some(vec![
+                "-c".to_string(),
+                "disable_paste_burst=true".to_string(),
+                "--config".to_string(),
+                r"model_instructions_file=C:\Users\zooyo\.vibe-editor\codex-instructions\instr.md"
+                    .to_string(),
+            ]),
+        );
+
+        assert_eq!(command, "codex");
+        assert_eq!(
+            args,
+            vec![
+                "--dangerously-bypass-approvals-and-sandbox",
+                "-c",
+                "disable_paste_burst=true",
+                "--config",
+                r"model_instructions_file=C:\Users\zooyo\.vibe-editor\codex-instructions\instr.md",
+            ]
+        );
+    }
+
+    #[test]
+    fn strips_quotes_around_windows_executable_path() {
+        let (command, args) = normalize_terminal_command(
+            Some(r#""C:\Program Files\Codex\codex.exe" --foo "bar baz""#.to_string()),
+            None,
+        );
+
+        assert_eq!(command, r"C:\Program Files\Codex\codex.exe");
+        assert_eq!(args, vec!["--foo", "bar baz"]);
+    }
+
+    #[test]
+    fn defaults_to_claude_when_command_is_blank() {
+        let (command, args) =
+            normalize_terminal_command(Some("   ".to_string()), Some(vec!["--resume".into()]));
+
+        assert_eq!(command, "claude");
+        assert_eq!(args, vec!["--resume"]);
+    }
+
+    #[test]
+    fn split_preserves_windows_backslashes() {
+        assert_eq!(
+            split_command_line(
+                r#"codex --config model_instructions_file=C:\Users\zooyo\.vibe-editor\instr.md"#
+            ),
+            vec![
+                "codex",
+                "--config",
+                r"model_instructions_file=C:\Users\zooyo\.vibe-editor\instr.md",
+            ]
+        );
+    }
+
+    #[test]
+    fn immediate_exec_rejection_runs_after_normalization() {
+        let (command, args) =
+            normalize_terminal_command(Some("cmd /c echo unsafe".to_string()), None);
+
+        assert_eq!(command, "cmd");
+        assert_eq!(
+            reject_immediate_exec_args(&command, &args),
+            Some("cmd immediate-exec flags (/c /k) are blocked")
+        );
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1522,3 +1522,30 @@ Plan: `tasks/release-v1.4.12.md`
 - [x] #523: https://github.com/yusei531642/vibe-editor/issues/523#issuecomment-4402921223
 - [x] #527: https://github.com/yusei531642/vibe-editor/issues/527#issuecomment-4402921222
 - [x] #515 / #523 / #527: `implementing` -> `implemented`。Issue close は PR #549 merge 後。
+
+## Hotfix - Issue #550 Codex command args normalization (2026-05-08 / Codex)
+
+### 計画
+
+- [x] Windows 起動エラーを Issue #550 として作成する。
+- [x] `fix/issue-550-codex-command-args` ブランチを作成する。
+- [x] Rust 側で `command` 欄に混ざった flags を起動前に `args` へ分離する。
+- [x] `cmd /c` などの即時実行拒否が、分離後の args にも効くことをテストする。
+- [x] Rust test / cargo check / diff check を通す。
+- [ ] PR を作成し、Bot merge 後に `v1.5.2` をリリースする。
+
+### Next Steps
+
+- [x] `src-tauri/src/commands/terminal/command_validation.rs` に command 正規化 helper と unit test を追加する。
+- [x] `terminal_create` の入口で正規化 helper を使う。
+- [x] 検証結果を Issue / PR / 本ファイルへ記録する。
+
+### 検証結果
+
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml command_normalization_tests --lib`: PASS (6 tests)
+- [x] `cargo check --manifest-path src-tauri\Cargo.toml`: PASS (既存 warning: `LockResult::has_conflicts` / `TemplateReport::{warnings,warn_message}`)
+- [x] `npm run typecheck`: PASS
+- [x] `git diff --check`: PASS
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml --lib`: PASS (289 tests / 既存 warning: `unused variable: home`)
+- [x] `npm run test`: PASS (45 files / 288 tests、jsdom の Tauri `listen()` cleanup warning は既存)
+- [x] `npm run build:vite`: PASS


### PR DESCRIPTION
## 概要
- Windows で `codex --dangerously-bypass-approvals-and-sandbox` のような引数付き command 設定を起動すると、文字列全体を実行ファイル名として `CreateProcessW` に渡して失敗する問題を修正しました。
- `command` 欄を起動前に shell 風に分割し、先頭 token を executable、残りを `args` の先頭へ移します。
- 分割後の args に対して、既存の `cmd /c` / `powershell -Command` などの即時実行拒否を維持します。
- hotfix release 用に `v1.5.2` へバージョンを更新しました。

Closes #550

## 検証
- [x] `cargo test --manifest-path src-tauri\Cargo.toml command_normalization_tests --lib` (6 tests)
- [x] `cargo check --manifest-path src-tauri\Cargo.toml` (既存 warning のみ)
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] `cargo test --manifest-path src-tauri\Cargo.toml --lib` (289 tests)
- [x] `npm run test` (45 files / 288 tests、jsdom の Tauri listen cleanup warning は既存)
- [x] `npm run build:vite`