### PR TITLE
test(terminal): cover claude inline command args

### DIFF
--- a/src-tauri/src/commands/terminal/command_validation.rs
+++ b/src-tauri/src/commands/terminal/command_validation.rs
@@ -322,6 +322,28 @@ mod command_normalization_tests {
     }
 
     #[test]
+    fn splits_claude_inline_command_args_with_system_prompt() {
+        let prompt = "あなたはチーム「Leader」のLeader。\n最初の指示が来るまで待機する。";
+        let (command, args) = normalize_terminal_command(
+            Some(format!(
+                r#"claude --dangerously-skip-permissions --chrome --append-system-prompt "{prompt}""#
+            )),
+            None,
+        );
+
+        assert_eq!(command, "claude");
+        assert_eq!(
+            args,
+            vec![
+                "--dangerously-skip-permissions",
+                "--chrome",
+                "--append-system-prompt",
+                prompt,
+            ]
+        );
+    }
+
+    #[test]
     fn strips_quotes_around_windows_executable_path() {
         let (command, args) = normalize_terminal_command(
             Some(r#""C:\Program Files\Codex\codex.exe" --foo "bar baz""#.to_string()),

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1558,3 +1558,19 @@ Plan: `tasks/release-v1.4.12.md`
 - [x] Issue #550: Bot merge 後に close、`implemented` ラベルへ更新
 - [x] Release `v1.5.2`: https://github.com/yusei531642/vibe-editor/releases/tag/v1.5.2
 - [x] `latest.json`: `version` が `1.5.2` を返すことを確認
+
+## Issue #553 - Claude Code inline command args regression test (2026-05-08 / Codex)
+
+### 計画
+
+- [x] ユーザー環境のインストール済み `vibe-editor.exe` が `1.5.1` であることを確認する。
+- [x] 現行 `main` の `normalize_terminal_command()` が Claude / Codex 共通で使われることを確認する。
+- [x] Claude Code の `--dangerously-skip-permissions --chrome --append-system-prompt` 実例を回帰テストに追加する。
+- [x] Rust targeted test と diff check を通す。
+- [ ] PR を作成し、Bot merge を確認する。
+
+### 検証結果
+
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml claude_inline_command_args --lib`: PASS (1 test)
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml command_normalization_tests --lib`: PASS (7 tests)
+- [x] `git diff --check`: PASS


### PR DESCRIPTION
## 概要
- Claude Code の `claude --dangerously-skip-permissions --chrome --append-system-prompt "..."` 実例を `normalize_terminal_command()` の回帰テストに追加しました。
- PR #551 の修正は Claude / Codex 共通で効きますが、Codex だけに見えるテスト名だったため、Claude 側の同根エラーも明示的に固定します。
- ユーザー環境のインストール済み `vibe-editor.exe` は `1.5.1` と確認済みで、`v1.5.2` に更新すれば本症状は解消されます。

Closes #553

## 検証
- [x] `cargo test --manifest-path src-tauri\Cargo.toml claude_inline_command_args --lib` (1 test)
- [x] `cargo test --manifest-path src-tauri\Cargo.toml command_normalization_tests --lib` (7 tests)
- [x] `git diff --check`