### PR TITLE
fix(pty): resolve Windows CLI commands before spawn

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -4,7 +4,7 @@
 // terminal:data:{id} / terminal:exit:{id} イベントを emit する。
 
 mod codex_instructions;
-mod command_validation;
+pub(crate) mod command_validation;
 mod paste_image;
 
 use crate::pty::{spawn_session, SpawnOptions, UserWriteOutcome};

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -8,12 +8,17 @@ use crate::pty::scrollback::{
     scrollback_to_string, Scrollback, WriteBudget, MAX_TERMINAL_WRITE_BYTES_PER_CALL,
     MAX_TERMINAL_WRITE_BYTES_PER_SEC, TERMINAL_WRITE_WINDOW,
 };
+use crate::{commands::terminal::command_validation, util::log_redact::redact_home};
 use anyhow::{anyhow, Result};
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use serde::Serialize;
 use std::collections::HashMap;
+#[cfg(windows)]
+use std::collections::HashSet;
 use std::io::{Read, Write};
 use std::path::Path;
+#[cfg(windows)]
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
@@ -279,6 +284,251 @@ fn should_inherit_env(key: &str) -> bool {
     )
 }
 
+#[derive(Debug, Clone)]
+struct PreparedSpawnCommand {
+    requested_command: String,
+    resolved_command: String,
+    program: String,
+    args: Vec<String>,
+    path_entries: usize,
+    pathext_present: bool,
+}
+
+fn prepare_spawn_command(opts: &SpawnOptions) -> Result<PreparedSpawnCommand> {
+    let (command, args) = command_validation::normalize_terminal_command(
+        Some(opts.command.clone()),
+        Some(opts.args.clone()),
+    );
+    if !command_validation::is_allowed_terminal_command(&command) {
+        return Err(anyhow!(
+            "command is not allowed at spawn boundary: {command}"
+        ));
+    }
+    if let Some(reason) = command_validation::reject_immediate_exec_args(&command, &args) {
+        return Err(anyhow!("{reason}"));
+    }
+    resolve_spawn_command(&command, args, &opts.env)
+}
+
+fn env_value(env: &HashMap<String, String>, key: &str) -> Option<String> {
+    env.iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(key))
+        .map(|(_, v)| v.clone())
+        .or_else(|| std::env::var(key).ok())
+        .filter(|v| !v.trim().is_empty())
+}
+
+#[cfg(not(windows))]
+fn count_path_entries(path: Option<&str>) -> usize {
+    path.map(std::env::split_paths)
+        .map(|paths| paths.count())
+        .unwrap_or(0)
+}
+
+#[cfg(not(windows))]
+fn resolve_spawn_command(
+    command: &str,
+    args: Vec<String>,
+    env: &HashMap<String, String>,
+) -> Result<PreparedSpawnCommand> {
+    let resolved_command = which::which(command)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| command.to_string());
+    Ok(PreparedSpawnCommand {
+        requested_command: command.to_string(),
+        resolved_command: resolved_command.clone(),
+        program: resolved_command,
+        args,
+        path_entries: count_path_entries(env_value(env, "PATH").as_deref()),
+        pathext_present: false,
+    })
+}
+
+#[cfg(windows)]
+fn resolve_spawn_command(
+    command: &str,
+    args: Vec<String>,
+    env: &HashMap<String, String>,
+) -> Result<PreparedSpawnCommand> {
+    resolve_windows_spawn_command(command, args, env)
+}
+
+#[cfg(windows)]
+fn resolve_windows_spawn_command(
+    command: &str,
+    args: Vec<String>,
+    env: &HashMap<String, String>,
+) -> Result<PreparedSpawnCommand> {
+    let pathext_raw = env_value(env, "PATHEXT");
+    let pathext = windows_pathext(pathext_raw.as_deref());
+    let search_dirs = windows_search_dirs(env);
+    let resolved = resolve_windows_command_path(command, &search_dirs, &pathext)?;
+    let mut spawn_args = args;
+    let program = if is_windows_cmd_script(&resolved) {
+        let mut wrapped = Vec::with_capacity(spawn_args.len() + 2);
+        wrapped.push("/C".to_string());
+        wrapped.push(resolved.to_string_lossy().into_owned());
+        wrapped.append(&mut spawn_args);
+        spawn_args = wrapped;
+        env_value(env, "COMSPEC").unwrap_or_else(|| "cmd.exe".to_string())
+    } else {
+        resolved.to_string_lossy().into_owned()
+    };
+
+    Ok(PreparedSpawnCommand {
+        requested_command: command.to_string(),
+        resolved_command: resolved.to_string_lossy().into_owned(),
+        program,
+        args: spawn_args,
+        path_entries: search_dirs.len(),
+        pathext_present: pathext_raw.is_some(),
+    })
+}
+
+#[cfg(windows)]
+fn windows_pathext(raw: Option<&str>) -> Vec<String> {
+    let values = raw
+        .map(|s| {
+            s.split(';')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| {
+                    let ext = if s.starts_with('.') {
+                        s.to_string()
+                    } else {
+                        format!(".{s}")
+                    };
+                    ext.to_ascii_lowercase()
+                })
+                .collect::<Vec<_>>()
+        })
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| {
+            [".com", ".exe", ".bat", ".cmd"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        });
+
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for ext in values {
+        if seen.insert(ext.clone()) {
+            out.push(ext);
+        }
+    }
+    out
+}
+
+#[cfg(windows)]
+fn windows_search_dirs(env: &HashMap<String, String>) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    let mut seen = HashSet::new();
+    let mut push_dir = |path: PathBuf| {
+        let key = path.to_string_lossy().to_ascii_lowercase();
+        if !key.trim().is_empty() && seen.insert(key) {
+            dirs.push(path);
+        }
+    };
+
+    if let Some(path) = env.iter().find(|(k, _)| k.eq_ignore_ascii_case("PATH")) {
+        for dir in std::env::split_paths(path.1) {
+            push_dir(dir);
+        }
+    }
+    if let Ok(path) = std::env::var("PATH") {
+        for dir in std::env::split_paths(&path) {
+            push_dir(dir);
+        }
+    }
+
+    if let Some(appdata) = env_value(env, "APPDATA") {
+        push_dir(PathBuf::from(appdata).join("npm"));
+    }
+    if let Some(userprofile) = env_value(env, "USERPROFILE") {
+        push_dir(PathBuf::from(userprofile).join(".local").join("bin"));
+    }
+    if let Some(localappdata) = env_value(env, "LOCALAPPDATA") {
+        let base = PathBuf::from(localappdata);
+        push_dir(base.join("Microsoft").join("WindowsApps"));
+        push_dir(base.join("OpenAI").join("Codex").join("bin"));
+    }
+
+    dirs
+}
+
+#[cfg(windows)]
+fn command_has_path_separator(command: &str) -> bool {
+    command.contains('\\') || command.contains('/')
+}
+
+#[cfg(windows)]
+fn command_has_extension(command: &str) -> bool {
+    Path::new(command).extension().is_some()
+}
+
+#[cfg(windows)]
+fn candidate_paths(base: &Path, pathext: &[String]) -> Vec<PathBuf> {
+    if base.extension().is_some() {
+        return vec![base.to_path_buf()];
+    }
+    let mut out = vec![base.to_path_buf()];
+    for ext in pathext {
+        out.push(PathBuf::from(format!("{}{}", base.to_string_lossy(), ext)));
+    }
+    out
+}
+
+#[cfg(windows)]
+fn resolve_windows_command_path(
+    command: &str,
+    search_dirs: &[PathBuf],
+    pathext: &[String],
+) -> Result<PathBuf> {
+    let direct_path = PathBuf::from(command);
+    if direct_path.is_absolute() || command_has_path_separator(command) {
+        for candidate in candidate_paths(&direct_path, pathext) {
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+        }
+        return Err(anyhow!(
+            "command executable was not found: {}",
+            redact_home(command)
+        ));
+    }
+
+    if command_has_extension(command) {
+        if let Ok(found) = which::which(command) {
+            return Ok(found);
+        }
+    } else if let Ok(found) = which::which(command) {
+        return Ok(found);
+    }
+
+    for dir in search_dirs {
+        for candidate in candidate_paths(&dir.join(command), pathext) {
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+        }
+    }
+
+    Err(anyhow!(
+        "command executable was not found: {} (searched {} PATH entries)",
+        command,
+        search_dirs.len()
+    ))
+}
+
+#[cfg(windows)]
+fn is_windows_cmd_script(path: &Path) -> bool {
+    path.extension()
+        .and_then(|s| s.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat"))
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod env_strip_tests {
     use super::should_inherit_env;
@@ -313,12 +563,126 @@ mod env_strip_tests {
     }
 }
 
+#[cfg(all(test, windows))]
+mod spawn_command_resolution_tests {
+    use super::*;
+
+    fn base_spawn_options(command: String, args: Vec<String>) -> SpawnOptions {
+        SpawnOptions {
+            command,
+            args,
+            cwd: ".".to_string(),
+            is_codex: false,
+            cols: 80,
+            rows: 24,
+            env: HashMap::new(),
+            agent_id: None,
+            session_key: None,
+            team_id: None,
+            role: None,
+        }
+    }
+
+    #[test]
+    fn resolves_cmd_from_opts_env_path_and_wraps_with_cmd_exe() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cli = tmp.path().join("fakeagent.cmd");
+        std::fs::write(&cli, "@echo off\r\n").unwrap();
+        let mut env = HashMap::new();
+        env.insert(
+            "PATH".to_string(),
+            tmp.path().to_string_lossy().into_owned(),
+        );
+
+        let prepared =
+            resolve_windows_spawn_command("fakeagent", vec!["--version".to_string()], &env)
+                .unwrap();
+
+        assert_eq!(
+            Path::new(&prepared.program)
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(str::to_ascii_lowercase)
+                .as_deref(),
+            Some("cmd.exe")
+        );
+        assert_eq!(prepared.args[0], "/C");
+        assert_eq!(PathBuf::from(&prepared.args[1]), cli);
+        assert_eq!(prepared.args[2], "--version");
+        assert_eq!(PathBuf::from(prepared.resolved_command), cli);
+    }
+
+    #[test]
+    fn resolves_exe_without_cmd_wrapper() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cli = tmp.path().join("fakeagent.exe");
+        std::fs::write(&cli, "").unwrap();
+        let mut env = HashMap::new();
+        env.insert(
+            "PATH".to_string(),
+            tmp.path().to_string_lossy().into_owned(),
+        );
+
+        let prepared =
+            resolve_windows_spawn_command("fakeagent", vec!["--help".to_string()], &env).unwrap();
+
+        assert_eq!(PathBuf::from(&prepared.program), cli);
+        assert_eq!(prepared.args, vec!["--help"]);
+    }
+
+    #[test]
+    fn normalizes_inline_command_again_at_spawn_boundary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cli = tmp.path().join("codex.exe");
+        std::fs::write(&cli, "").unwrap();
+        let command = format!(
+            r#""{}" --dangerously-bypass-approvals-and-sandbox"#,
+            cli.display()
+        );
+        let mut opts = base_spawn_options(
+            command,
+            vec![
+                "--config".to_string(),
+                "disable_paste_burst=true".to_string(),
+            ],
+        );
+
+        let prepared = prepare_spawn_command(&opts).unwrap();
+
+        assert_eq!(PathBuf::from(&prepared.program), cli);
+        assert_eq!(
+            prepared.args,
+            vec![
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--config",
+                "disable_paste_burst=true",
+            ]
+        );
+
+        opts.command = "cmd /c echo unsafe".to_string();
+        opts.args.clear();
+        let err = prepare_spawn_command(&opts).unwrap_err().to_string();
+        assert!(err.contains("cmd immediate-exec flags"));
+    }
+}
+
 pub fn spawn_session(
     app: AppHandle,
     id: String,
     opts: SpawnOptions,
     registry: std::sync::Arc<crate::pty::SessionRegistry>,
 ) -> Result<SessionHandle> {
+    let prepared_command = prepare_spawn_command(&opts)?;
+    tracing::info!(
+        "[pty] spawn command requested={} resolved={} launcher={} args.len={} path_entries={} pathext_present={}",
+        redact_home(&prepared_command.requested_command),
+        redact_home(&prepared_command.resolved_command),
+        redact_home(&prepared_command.program),
+        prepared_command.args.len(),
+        prepared_command.path_entries,
+        prepared_command.pathext_present
+    );
+
     let pty_system = native_pty_system();
     let pair = pty_system.openpty(PtySize {
         rows: opts.rows.max(5),
@@ -327,13 +691,8 @@ pub fn spawn_session(
         pixel_height: 0,
     })?;
 
-    // Windows: PATHEXT 経由で .cmd / .bat / .exe を解決する。
-    // 旧 node-pty は内部で同等処理をしていたため、claude → claude.cmd の自動解決が必要。
-    let resolved_command = which::which(&opts.command)
-        .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| opts.command.clone());
-    let mut cmd = CommandBuilder::new(&resolved_command);
-    for a in &opts.args {
+    let mut cmd = CommandBuilder::new(&prepared_command.program);
+    for a in &prepared_command.args {
         cmd.arg(a);
     }
     cmd.cwd(&opts.cwd);

--- a/tasks/issue-556/plan.md
+++ b/tasks/issue-556/plan.md
@@ -1,0 +1,66 @@
+# Issue #556 - CLI resolver hotfix plan
+
+## 計画
+
+- 対象 Issue は #556 の 1 件だけにする。
+- 原因は `terminal_create` 入口の inline flags 分離だけではなく、PTY spawn 直前の Windows CLI 解決不足として扱う。
+- `SpawnOptions.command` と `SpawnOptions.args` は spawn 境界でも再正規化する。
+- 再正規化後に allowlist と immediate-exec 拒否を再実行する。
+- Windows では、設定済み絶対パス、`which`、`opts.env["PATH"]`、親プロセス `PATH`、代表的なユーザー CLI 配置を順に探索する。
+- `.cmd` / `.bat` を解決した場合は、`CommandBuilder::new("cmd.exe")` と `args=["/C", resolved_path, ...original_args]` で起動する。
+- 解決不能時は silent bare fallback を避け、home-redacted な診断ログ付きで明示エラーにする。
+- INFO ログには `requested`, `resolved`, `args.len`, `path_entries`, `pathext_present` 相当だけを出す。system prompt や args 本文は出さない。
+- 変更は `src-tauri/src/pty/session.rs` を中心にし、必要なら `command_validation` helper の公開範囲だけ調整する。
+
+## Next Steps
+
+- ユーザー確認後、`fix/issue-556-cli-resolver` ブランチを作成する。
+- Issue #556 のラベルを `planned` から `implementing` へ移す。
+- `tasks/batch-pipeline-state.json` に #556 単独バッチの状態を記録する。
+- 実装後、次の検証を実行する。
+  - `cargo test --manifest-path src-tauri\Cargo.toml command_normalization_tests --lib`
+  - `cargo test --manifest-path src-tauri\Cargo.toml spawn_command_resolution_tests --lib`
+  - `cargo check --manifest-path src-tauri\Cargo.toml`
+  - `cargo test --manifest-path src-tauri\Cargo.toml --lib`
+  - `npm run typecheck`
+  - `npm run test`
+  - `npm run build:vite`
+  - `git diff --check`
+
+## 調査メモ
+
+- `src-tauri/src/commands/terminal.rs` は `normalize_terminal_command()` を入口で呼び、allowlist と immediate-exec 拒否を実行している。
+- `src-tauri/src/pty/session.rs` は spawn 直前で `which::which(&opts.command)` に失敗すると `opts.command` の bare fallback に戻している。
+- Issue #556 の追加コメントでは、Explorer / Start Menu 起動時の PATH 差、`.cmd` / `.bat` 直接 spawn の `error 193` リスク、silent fallback の調査しづらさが指摘されている。
+- `tasks/lessons.md` にも、Windows の生 `CreateProcessW` は PATHEXT 解決をしないため、拡張子付き解決と `.cmd` 対応が必要だと記録されている。
+
+## 進捗
+
+- `terminal_create` 入口だけでなく、`spawn_session` 境界でも command / args を再正規化するようにした。
+- spawn 境界でも allowlist と immediate-exec 拒否を再実行するようにした。
+- Windows CLI resolver を追加し、`PATH`、`PATHEXT`、代表的なユーザー CLI 配置を探索するようにした。
+- `.cmd` / `.bat` は `cmd.exe /C` で包んで起動するようにした。
+- resolver 結果を切り分けやすい INFO ログを追加した。args 本文はログに出していない。
+
+## 検証結果
+
+- `cargo test --manifest-path src-tauri\Cargo.toml command_normalization_tests --lib`: PASS (7 tests)
+- `cargo test --manifest-path src-tauri\Cargo.toml spawn_command_resolution_tests --lib`: PASS (3 tests)
+- `cargo check --manifest-path src-tauri\Cargo.toml`: PASS（既存 warning のみ）
+- `cargo test --manifest-path src-tauri\Cargo.toml --lib`: PASS (293 tests / 既存 warning のみ)
+- `npm run typecheck`: PASS
+- `npm run test`: PASS (45 files / 288 tests、既存 jsdom warning のみ)
+- `npm run build:vite`: PASS
+- `git diff --check`: PASS
+
+## Next Tasks
+
+- PR #557 の CodeRabbit / CI の結果を確認する。
+- PR merge 後、release / packaged app 側で Codex と Claude Code の起動を確認する。
+- 起動確認後、Issue #556 を close する。
+
+## 投稿結果
+
+- PR: https://github.com/yusei531642/vibe-editor/pull/557
+- Issue comment: https://github.com/yusei531642/vibe-editor/issues/556#issuecomment-4403888408
+- Issue label: `implemented`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1580,3 +1580,53 @@ Plan: `tasks/release-v1.4.12.md`
 
 - [x] PR #554: https://github.com/yusei531642/vibe-editor/pull/554
 - [x] Issue #553: Bot merge 後に close、`implemented` ラベルへ更新
+
+## Issue Autopilot Batch - Issue #556 CLI resolver hotfix (2026-05-08 / Codex)
+
+計画: `tasks/issue-556/plan.md`
+
+### 計画
+
+- [x] `planned` 付き open Issue を確認し、今回の対象を #556 の単独バッチに限定する。
+- [x] Issue #556 の本文、実装計画コメント、追加調査メモ、Claude Code セカンドオピニオンを確認する。
+- [x] `AGENTS.md` / `CLAUDE.md` / `vibe-editor` skill / `tasks/lessons.md` を確認する。
+- [x] `terminal_create` 入口の command 正規化と `spawn_session` 直前の Windows CLI 解決を確認する。
+- [x] ユーザー確認後、`fix/issue-556-cli-resolver` ブランチを作成する。
+- [x] Issue #556 のラベルを `planned` から `implementing` へ移す。
+- [x] spawn 境界で command / args を再正規化し、allowlist と immediate-exec 拒否を再実行する。
+- [x] Windows CLI resolver を追加し、`.cmd` / `.bat` は `cmd.exe /C` で起動する。
+- [x] resolver と spawn 境界の Rust 回帰テストを追加する。
+- [x] Rust targeted test、`cargo check`、全 Rust lib test、`npm run typecheck`、`npm run test`、`npm run build:vite`、`git diff --check` を通す。
+- [x] PR を作成し、Issue コメントへ検証結果を記録する: https://github.com/yusei531642/vibe-editor/pull/557
+
+### Next Steps
+
+- [x] 実装開始の承認を受ける。
+- [x] `fix/issue-556-cli-resolver` を切る。
+- [x] `tasks/batch-pipeline-state.json` を #556 単独バッチとして初期化する。
+- [x] #556 の Phase A を完了し、PR 作成後に CodeRabbit / CI を確認する。
+
+### 進捗
+
+- [x] `src-tauri/src/commands/terminal.rs` の `command_validation` を spawn 側から再利用できるよう `pub(crate)` 化。
+- [x] `src-tauri/src/pty/session.rs` に spawn 境界の `prepare_spawn_command()` を追加。
+- [x] Windows resolver で `PATH`、`PATHEXT`、`%APPDATA%\npm`、`%USERPROFILE%\.local\bin`、`%LOCALAPPDATA%\Microsoft\WindowsApps`、`%LOCALAPPDATA%\OpenAI\Codex\bin` を探索。
+- [x] `.cmd` / `.bat` 解決時は `cmd.exe /C <resolved script> ...args` に変換。
+- [x] INFO ログに requested / resolved / launcher / args.len / path_entries / pathext_present を出し、args 本文は出さない。
+
+### 検証結果
+
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml command_normalization_tests --lib`: PASS (7 tests)
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml spawn_command_resolution_tests --lib`: PASS (3 tests)
+- [x] `cargo check --manifest-path src-tauri\Cargo.toml`: PASS（既存 warning: `LockResult::has_conflicts` / `TemplateReport::{warnings,warn_message}`）
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml --lib`: PASS (293 tests / 既存 warning: `unused variable: home`)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (45 files / 288 tests、jsdom の Tauri `listen()` cleanup warning は既存)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
+
+### 投稿結果
+
+- [x] PR: https://github.com/yusei531642/vibe-editor/pull/557
+- [x] Issue comment: https://github.com/yusei531642/vibe-editor/issues/556#issuecomment-4403888408
+- [x] Issue #556: `implementing` -> `implemented`。Issue close は PR merge 後。


### PR DESCRIPTION
## Summary
- PTY spawn 境界でも command / args を再正規化し、allowlist と immediate-exec 拒否を再実行
- Windows CLI resolver を追加し、PATH / PATHEXT / 代表的なユーザー CLI 配置から実行ファイルを探索
- `.cmd` / `.bat` 解決時は `cmd.exe /C` で起動し、CreateProcessW の直接実行失敗を避ける
- resolver の回帰テストと #556 の作業記録を追加

Closes #556

## Test plan
- [x] `cargo test --manifest-path src-tauri\Cargo.toml command_normalization_tests --lib` (7 tests)
- [x] `cargo test --manifest-path src-tauri\Cargo.toml spawn_command_resolution_tests --lib` (3 tests)
- [x] `cargo check --manifest-path src-tauri\Cargo.toml` (既存 warning のみ)
- [x] `cargo test --manifest-path src-tauri\Cargo.toml --lib` (293 tests / 既存 warning のみ)
- [x] `npm run typecheck`
- [x] `npm run test` (45 files / 288 tests、既存 jsdom warning のみ)
- [x] `npm run build:vite`
- [x] `git diff --check`