### PR TITLE
chore(release): bump version to 1.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-editor",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-editor",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/geist-mono": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5218,7 +5218,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.5.2"
+version = "1.5.3"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",

--- a/tasks/release-v1.5.3.md
+++ b/tasks/release-v1.5.3.md
@@ -1,0 +1,42 @@
+# Release v1.5.3
+
+## 計画
+
+- 最新公開リリース `v1.5.2` の次パッチとして `v1.5.3` を作成する。
+- `main` は Issue #556 修正 PR #557 merge commit `0292dbd` まで同期済み。
+- version files を `1.5.3` に更新する。
+- release PR を作成し、CI と reviewer bot の承認を待つ。
+- PR merge 後に local `main` を同期する。
+- `v1.5.3` annotated tag を merge commit に作成して push する。
+- `release.yml` の build を監視する。
+- draft release の assets と `latest.json` を確認し、publish する。
+
+## Next Steps
+
+- `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` を `1.5.3` に更新する。
+- `src-tauri/Cargo.lock` を cargo で同期する。
+- `cargo check --manifest-path src-tauri\Cargo.toml`、`npm run typecheck`、`npm run test`、`npm run build:vite`、`git diff --check` を実行する。
+- release PR を作成する。
+
+## 進捗
+
+- [x] `chore/release-v1.5.3` ブランチを作成。
+- [x] `package.json` / `package-lock.json` を `1.5.3` に更新。
+- [x] `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` / `src-tauri/tauri.conf.json` を `1.5.3` に更新。
+- [x] 品質ゲートを実行。
+
+## 検証結果
+
+- [x] `cargo check --manifest-path src-tauri\Cargo.toml`: PASS
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml --lib`: PASS (293 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (45 files / 288 tests)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
+
+## Next Tasks
+
+- [ ] release PR を作成し、CI と reviewer bot を確認する。
+- [ ] PR merge 後に `main` を同期し、`v1.5.3` tag を push する。
+- [ ] release workflow を監視し、draft release の assets と `latest.json` を確認する。
+- [ ] draft release を publish する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1630,3 +1630,35 @@ Plan: `tasks/release-v1.4.12.md`
 - [x] PR: https://github.com/yusei531642/vibe-editor/pull/557
 - [x] Issue comment: https://github.com/yusei531642/vibe-editor/issues/556#issuecomment-4403888408
 - [x] Issue #556: `implementing` -> `implemented`。Issue close は PR merge 後。
+
+## Release v1.5.3 (2026-05-08 / Codex)
+
+Plan: `tasks/release-v1.5.3.md`
+
+### 計画
+
+- [x] 最新公開リリースが `v1.5.2` であることを確認する。
+- [x] `main` が PR #557 merge commit `0292dbd` まで同期済みであることを確認する。
+- [x] `chore/release-v1.5.3` ブランチを作成する。
+- [x] npm / Rust / Tauri の version を `1.5.3` に更新する。
+- [x] `Cargo.lock` を同期する。
+- [x] 品質ゲートを通す。
+- [ ] release PR を作成し、CI / reviewer bot を確認する。
+- [ ] PR merge 後に `v1.5.3` tag を push する。
+- [ ] release workflow を監視し、draft release の assets と `latest.json` を確認する。
+- [ ] draft release を publish する。
+
+### Next Steps
+
+- [x] `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` を `1.5.3` に更新する。
+- [x] `cargo check --manifest-path src-tauri\Cargo.toml` で `Cargo.lock` を同期する。
+- [x] `npm run typecheck`、`npm run test`、`npm run build:vite`、`git diff --check` を実行する。
+
+### 検証結果
+
+- [x] `cargo check --manifest-path src-tauri\Cargo.toml`: PASS
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml --lib`: PASS (293 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (45 files / 288 tests)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS


### PR DESCRIPTION
## Summary
- Bump app/package versions from 1.5.2 to 1.5.3.
- Sync npm lockfile, Cargo lockfile, and Tauri config for the v1.5.3 release.
- Add release tracking notes for v1.5.3.

## Test plan
- cargo check --manifest-path src-tauri\Cargo.toml
- cargo test --manifest-path src-tauri\Cargo.toml --lib
- npm run typecheck
- npm run test
- npm run build:vite
- git diff --check

## Release notes
- Prepares the v1.5.3 patch release after PR #557 / Issue #556.