### PR TITLE
fix(pty): prefer Windows cmd shims over shell shims

### DIFF
--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -472,10 +472,11 @@ fn candidate_paths(base: &Path, pathext: &[String]) -> Vec<PathBuf> {
     if base.extension().is_some() {
         return vec![base.to_path_buf()];
     }
-    let mut out = vec![base.to_path_buf()];
+    let mut out = Vec::with_capacity(pathext.len() + 1);
     for ext in pathext {
         out.push(PathBuf::from(format!("{}{}", base.to_string_lossy(), ext)));
     }
+    out.push(base.to_path_buf());
     out
 }
 
@@ -502,8 +503,6 @@ fn resolve_windows_command_path(
         if let Ok(found) = which::which(command) {
             return Ok(found);
         }
-    } else if let Ok(found) = which::which(command) {
-        return Ok(found);
     }
 
     for dir in search_dirs {
@@ -628,6 +627,41 @@ mod spawn_command_resolution_tests {
 
         assert_eq!(PathBuf::from(&prepared.program), cli);
         assert_eq!(prepared.args, vec!["--help"]);
+    }
+
+    #[test]
+    fn prefers_cmd_over_extensionless_npm_shell_shim() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shell_shim = tmp.path().join("codex");
+        let cmd_shim = tmp.path().join("codex.cmd");
+        std::fs::write(
+            &shell_shim,
+            "#!/bin/sh\nexec node \"$basedir/node_modules/.bin/codex\"\n",
+        )
+        .unwrap();
+        std::fs::write(&cmd_shim, "@echo off\r\n").unwrap();
+        let mut env = HashMap::new();
+        env.insert(
+            "PATH".to_string(),
+            tmp.path().to_string_lossy().into_owned(),
+        );
+        env.insert("PATHEXT".to_string(), ".COM;.EXE;.BAT;.CMD".to_string());
+
+        let prepared =
+            resolve_windows_spawn_command("codex", vec!["--version".to_string()], &env).unwrap();
+
+        assert_eq!(PathBuf::from(&prepared.resolved_command), cmd_shim);
+        assert_eq!(
+            Path::new(&prepared.program)
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(str::to_ascii_lowercase)
+                .as_deref(),
+            Some("cmd.exe")
+        );
+        assert_eq!(prepared.args[0], "/C");
+        assert_eq!(PathBuf::from(&prepared.args[1]), cmd_shim);
+        assert_eq!(prepared.args[2], "--version");
     }
 
     #[test]

--- a/tasks/issue-560-plan.md
+++ b/tasks/issue-560-plan.md
@@ -1,0 +1,41 @@
+# Issue #560 - Windows npm shim resolution
+
+## 計画
+
+- v1.5.3 のログから、resolver が `~/AppData/Roaming/npm/codex` / `claude` の拡張子なし shell shim を選ぶ症状を確認する。
+- `src-tauri/src/pty/session.rs` の Windows resolver で、bare command の候補順を PATHEXT 優先へ変える。
+- `.cmd` / `.bat` を選んだ場合は既存どおり `cmd.exe /C` で起動する。
+- 同じディレクトリに `codex` と `codex.cmd` があるケースを回帰テストに追加する。
+- targeted Rust test、`cargo check`、Rust lib test、frontend check、build、diff check を通す。
+
+## Next Steps
+
+- [x] `candidate_paths()` の候補順を修正する。
+- [x] `spawn_command_resolution_tests` に npm shell shim 再現ケースを追加する。
+- [ ] Issue #560 用 PR を作成し、CI と reviewer bot を確認する。
+
+## 進捗
+
+- [x] Windows の bare command 解決では `which::which(command)` を避け、アプリ側の探索順で PATHEXT 候補を優先する。
+- [x] `codex` と `codex.cmd` が同じディレクトリにある場合、`.cmd` を選び `cmd.exe /C` で起動する。
+- [x] `tasks/lessons.md` に npm extensionless shim の再発防止を追記した。
+
+## 検証結果
+
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml spawn_command_resolution_tests --lib`: PASS (4 tests)
+- [x] `cargo check --manifest-path src-tauri\Cargo.toml`: PASS
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml --lib`: PASS (294 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (45 files / 288 tests)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
+
+## Next Tasks
+
+- [x] `cargo check --manifest-path src-tauri\Cargo.toml`
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml --lib`
+- [x] `npm run typecheck`
+- [x] `npm run test`
+- [x] `npm run build:vite`
+- [x] `git diff --check`
+- [ ] PR を作成し、CI と reviewer bot を確認する。

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -49,6 +49,13 @@ if let Some(window) = app.get_webview_window("main") {
 - `which::which("claude")` で事前に絶対パス + 拡張子付きに変換してから spawn する
 - エラー: `os error 193` (`%1 は有効な Win32 アプリケーションではありません`)
 
+### npm の拡張子なし shim を Windows で直接 spawn しない
+- Windows npm は `codex` / `claude` の拡張子なし shell shim と `.cmd` shim を同じディレクトリに作る。
+- 拡張子なし shim は `#!/bin/sh` のテキストなので、`CreateProcessW` に直接渡すと `os error 193` になる。
+- Windows の bare command resolver は `which` に任せきらず、PATHEXT 候補（`.com`, `.exe`, `.bat`, `.cmd`）を拡張子なし候補より先に見る。
+- `.cmd` / `.bat` を選んだ場合は `cmd.exe /C <shim> ...args` で起動する。
+- 回帰テストでは、同じ一時ディレクトリに `codex` と `codex.cmd` を置き、`.cmd` が選ばれることを必ず確認する。
+
 ## PTY / ConPTY
 
 ### Windows ConPTY の EOF 挙動

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1671,3 +1671,39 @@ Plan: `tasks/release-v1.5.3.md`
 - [x] PR #558: https://github.com/yusei531642/vibe-editor/pull/558
 - [x] Release: https://github.com/yusei531642/vibe-editor/releases/tag/v1.5.3
 - [x] Assets: Windows `.exe`、macOS `.dmg` / `.app.tar.gz`、Linux `.AppImage` / `.deb` / `.rpm`、SBOM、signatures、`latest.json`
+
+## Issue #560 Windows npm shim resolver hotfix (2026-05-08 / Codex)
+
+Plan: `tasks/issue-560-plan.md`
+
+### 計画
+
+- [x] v1.5.3 の実ログで `os error 193` を確認する。
+- [x] resolver が `~/AppData/Roaming/npm/codex` / `claude` の拡張子なし shell shim を選んでいることを確認する。
+- [x] 同じディレクトリに `.cmd` shim が存在することを確認する。
+- [x] Windows resolver の候補順を PATHEXT 優先へ変える。
+- [x] npm shell shim 再現テストを追加する。
+- [x] targeted Rust test と主要品質ゲートを通す。
+- [ ] PR を作成し、CI / reviewer bot を確認する。
+
+### Next Steps
+
+- [x] `src-tauri/src/pty/session.rs` を最小修正する。
+- [x] `tasks/lessons.md` に再発防止を追記する。
+- [ ] Issue #560 に検証結果をコメントする。
+
+### 進捗
+
+- [x] `candidate_paths()` を PATHEXT 候補優先、拡張子なし候補を最後に変更。
+- [x] Windows bare command では `which::which(command)` を使わず、アプリ側の探索順で解決するよう変更。
+- [x] `prefers_cmd_over_extensionless_npm_shell_shim` を追加。
+
+### 検証結果
+
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml spawn_command_resolution_tests --lib`: PASS (4 tests)
+- [x] `cargo check --manifest-path src-tauri\Cargo.toml`: PASS（既存 warning: `LockResult::has_conflicts` / `TemplateReport::{warnings,warn_message}`）
+- [x] `cargo test --manifest-path src-tauri\Cargo.toml --lib`: PASS (294 tests / 既存 warning: `unused variable: home`)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (45 files / 288 tests、jsdom の Tauri `listen()` cleanup warning は既存)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS


### PR DESCRIPTION
## Summary
- Fix Windows CLI resolution so PATHEXT candidates are preferred over extensionless npm shell shims.
- Avoid `which::which("codex")` / `which::which("claude")` returning `~/AppData/Roaming/npm/<name>` shell shims for bare commands.
- Add a regression test for a directory containing both `codex` and `codex.cmd`.
- Record the RCA and prevention note in tasks docs.

Closes #560

## Root cause
v1.5.3 did run the resolver, but it resolved `codex` / `claude` to extensionless npm shell shims. Those files start with `#!/bin/sh` and are not Win32 executables, so `CreateProcessW` returned `os error 193`. The resolver must prefer `.cmd` / `.exe` candidates before extensionless files on Windows.

## Test plan
- cargo test --manifest-path src-tauri\Cargo.toml spawn_command_resolution_tests --lib
- cargo check --manifest-path src-tauri\Cargo.toml
- cargo test --manifest-path src-tauri\Cargo.toml --lib
- npm run typecheck
- npm run test
- npm run build:vite
- git diff --check