### PR TITLE
docs(tasks): record v1.5.4 release

### DIFF
--- a/tasks/issue-560-plan.md
+++ b/tasks/issue-560-plan.md
@@ -12,13 +12,16 @@
 
 - [x] `candidate_paths()` の候補順を修正する。
 - [x] `spawn_command_resolution_tests` に npm shell shim 再現ケースを追加する。
-- [ ] Issue #560 用 PR を作成し、CI と reviewer bot を確認する。
+- [x] Issue #560 用 PR を作成し、CI と reviewer bot を確認する。
 
 ## 進捗
 
 - [x] Windows の bare command 解決では `which::which(command)` を避け、アプリ側の探索順で PATHEXT 候補を優先する。
 - [x] `codex` と `codex.cmd` が同じディレクトリにある場合、`.cmd` を選び `cmd.exe /C` で起動する。
 - [x] `tasks/lessons.md` に npm extensionless shim の再発防止を追記した。
+- [x] PR #561 を作成し、CI と `vibe-editor-reviewer` approval を確認した。
+- [x] PR #561 の bot merge 後に `main` を同期した。
+- [x] ローカル dev 版を起動し、Claude / Codex の実起動ログで修正を確認した。
 
 ## 検証結果
 
@@ -29,6 +32,9 @@
 - [x] `npm run test`: PASS (45 files / 288 tests)
 - [x] `npm run build:vite`: PASS
 - [x] `git diff --check`: PASS
+- [x] GitHub Actions `ci / verify`: PASS (run `25541771313`)
+- [x] Local dev verification: `target\debug\vibe-editor.exe` 起動、Claude は `~/.local/bin/claude.exe`、Codex は `~/AppData/Roaming/npm/codex.cmd` + `cmd.exe` に解決。
+- [x] Local dev verification: dev app start line 34472 以降に `CreateProcessW` / `os error 193` は出ていない。
 
 ## Next Tasks
 
@@ -38,4 +44,12 @@
 - [x] `npm run test`
 - [x] `npm run build:vite`
 - [x] `git diff --check`
-- [ ] PR を作成し、CI と reviewer bot を確認する。
+- [x] PR を作成し、CI と reviewer bot を確認する。
+
+## 完了結果
+
+- [x] Issue #560: https://github.com/yusei531642/vibe-editor/issues/560
+- [x] PR #561: https://github.com/yusei531642/vibe-editor/pull/561
+- [x] Merge commit: `02947f5aefa1a2a456d1b89ece869f525fb4ce39`
+- [x] Issue comment: https://github.com/yusei531642/vibe-editor/issues/560#issuecomment-4404243505
+- [x] Follow-up release: https://github.com/yusei531642/vibe-editor/releases/tag/v1.5.4

--- a/tasks/release-v1.5.4.md
+++ b/tasks/release-v1.5.4.md
@@ -1,0 +1,63 @@
+# Release v1.5.4
+
+## 計画
+
+- `v1.5.3` の Windows CLI 起動不具合を修正した PR #561 を含むパッチとして `v1.5.4` を作成する。
+- `main` は PR #561 merge commit `02947f5` まで同期済み。
+- ローカル dev 版で Claude / Codex の起動ログを確認してから release PR に進む。
+- version files を `1.5.4` に更新する。
+- release PR を作成し、CI と reviewer bot の承認を待つ。
+- PR merge 後に local `main` を同期する。
+- `v1.5.4` annotated tag を merge commit に作成して push する。
+- `release.yml` の build を監視する。
+- draft release の assets と `latest.json` を確認し、publish する。
+
+## Next Steps
+
+- [x] ローカル dev 版で Claude / Codex 起動ログを確認する。
+- [x] `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` を `1.5.4` に更新する。
+- [x] `src-tauri/Cargo.lock` を `1.5.4` に同期する。
+- [x] `npm run typecheck`、`npm run build:vite`、`cargo check` を実行する。
+- [x] release PR を作成する。
+- [x] release workflow を監視し、draft release を publish する。
+
+## 進捗
+
+- [x] `main` が PR #561 merge commit `02947f5` を含むことを確認。
+- [x] 5173 が別プロジェクトで使用中のため、Tauri dev override で 5174 を使って dev 起動。
+- [x] dev 版で Claude / Codex terminal restore を発火し、実起動ログを確認。
+- [x] `chore/release-v1.5.4` ブランチを作成。
+- [x] `package.json` / `package-lock.json` を `1.5.4` に更新。
+- [x] `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` / `src-tauri/tauri.conf.json` を `1.5.4` に更新。
+- [x] Release PR #562 を作成し、CI と reviewer bot approval を確認。
+- [x] PR #562 の bot merge 後に `main` を同期。
+- [x] `v1.5.4` annotated tag を push。
+- [x] Release workflow run `25542885051` を監視し、全 matrix build の成功を確認。
+- [x] Draft release の assets と `latest.json` を確認。
+- [x] Draft release を publish。
+
+## 検証結果
+
+- [x] Local dev verification: Claude は `~/.local/bin/claude.exe` に解決。
+- [x] Local dev verification: Codex は `~/AppData/Roaming/npm/codex.cmd` に解決し、launcher は `C:\WINDOWS\system32\cmd.exe`。
+- [x] Local dev verification: dev app start line 34472 以降に `CreateProcessW` / `os error 193` は出ていない。
+- [x] `npm run typecheck`: PASS
+- [x] `npm run build:vite`: PASS
+- [x] `C:\Users\zooyo\.cargo\bin\cargo.exe check --manifest-path src-tauri\Cargo.toml`: PASS
+- [x] GitHub Actions `ci / verify`: PASS (run `25542614930`)
+- [x] Release workflow: PASS (run `25542885051`)
+- [x] `latest.json`: `version` が `1.5.4`、platforms が `darwin-aarch64` / `linux-x86_64` / `windows-x86_64`
+
+## Next Tasks
+
+- [x] release PR を作成し、CI と reviewer bot を確認する。
+- [x] PR merge 後に `main` を同期し、`v1.5.4` tag を push する。
+- [x] release workflow を監視し、draft release の assets と `latest.json` を確認する。
+- [x] draft release を publish する。
+
+## 完了結果
+
+- [x] PR #562: https://github.com/yusei531642/vibe-editor/pull/562
+- [x] Release: https://github.com/yusei531642/vibe-editor/releases/tag/v1.5.4
+- [x] Assets: Windows `.exe`、macOS `.dmg` / `.app.tar.gz`、Linux `.AppImage` / `.deb` / `.rpm`、SBOM、signatures、`latest.json`
+- [x] Published at: 2026-05-08T07:37:39Z

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1684,19 +1684,22 @@ Plan: `tasks/issue-560-plan.md`
 - [x] Windows resolver の候補順を PATHEXT 優先へ変える。
 - [x] npm shell shim 再現テストを追加する。
 - [x] targeted Rust test と主要品質ゲートを通す。
-- [ ] PR を作成し、CI / reviewer bot を確認する。
+- [x] PR を作成し、CI / reviewer bot を確認する。
 
 ### Next Steps
 
 - [x] `src-tauri/src/pty/session.rs` を最小修正する。
 - [x] `tasks/lessons.md` に再発防止を追記する。
-- [ ] Issue #560 に検証結果をコメントする。
+- [x] Issue #560 に検証結果をコメントする。
 
 ### 進捗
 
 - [x] `candidate_paths()` を PATHEXT 候補優先、拡張子なし候補を最後に変更。
 - [x] Windows bare command では `which::which(command)` を使わず、アプリ側の探索順で解決するよう変更。
 - [x] `prefers_cmd_over_extensionless_npm_shell_shim` を追加。
+- [x] PR #561 を作成し、CI と reviewer bot approval を確認。
+- [x] PR #561 の bot merge 後に `main` を同期。
+- [x] ローカル dev 版で Claude / Codex の実起動ログを確認。
 
 ### 検証結果
 
@@ -1707,3 +1710,55 @@ Plan: `tasks/issue-560-plan.md`
 - [x] `npm run test`: PASS (45 files / 288 tests、jsdom の Tauri `listen()` cleanup warning は既存)
 - [x] `npm run build:vite`: PASS
 - [x] `git diff --check`: PASS
+- [x] GitHub Actions `ci / verify`: PASS (run `25541771313`)
+- [x] Local dev verification: Claude は `~/.local/bin/claude.exe`、Codex は `~/AppData/Roaming/npm/codex.cmd` + `cmd.exe` に解決。
+- [x] Local dev verification: dev app start line 34472 以降に `CreateProcessW` / `os error 193` は出ていない。
+
+### 完了結果
+
+- [x] Issue #560: https://github.com/yusei531642/vibe-editor/issues/560
+- [x] PR #561: https://github.com/yusei531642/vibe-editor/pull/561
+- [x] Issue comment: https://github.com/yusei531642/vibe-editor/issues/560#issuecomment-4404243505
+- [x] Follow-up release: https://github.com/yusei531642/vibe-editor/releases/tag/v1.5.4
+
+## Release v1.5.4 (2026-05-08 / Codex)
+
+Plan: `tasks/release-v1.5.4.md`
+
+### 計画
+
+- [x] PR #561 の Windows CLI shim resolver fix が `main` に入っていることを確認する。
+- [x] ローカル dev 版で Claude / Codex の起動ログを確認する。
+- [x] `chore/release-v1.5.4` ブランチを作成する。
+- [x] npm / Rust / Tauri の version を `1.5.4` に更新する。
+- [x] 品質ゲートを通す。
+- [x] release PR を作成し、CI / reviewer bot を確認する。
+- [x] PR merge 後に `v1.5.4` tag を push する。
+- [x] release workflow を監視し、draft release の assets と `latest.json` を確認する。
+- [x] draft release を publish する。
+
+### Next Steps
+
+- [x] dev 起動で `CreateProcessW` / `os error 193` が再発しないことを確認する。
+- [x] `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` / `src-tauri/tauri.conf.json` を `1.5.4` に更新する。
+- [x] `npm run typecheck`、`npm run build:vite`、`cargo check` を実行する。
+- [x] release PR を作成し、CI と reviewer bot を確認する。
+
+### 検証結果
+
+- [x] Local dev verification: Claude は `~/.local/bin/claude.exe` に解決。
+- [x] Local dev verification: Codex は `~/AppData/Roaming/npm/codex.cmd` に解決し、launcher は `C:\WINDOWS\system32\cmd.exe`。
+- [x] Local dev verification: dev app start line 34472 以降に `CreateProcessW` / `os error 193` は出ていない。
+- [x] `npm run typecheck`: PASS
+- [x] `npm run build:vite`: PASS
+- [x] `C:\Users\zooyo\.cargo\bin\cargo.exe check --manifest-path src-tauri\Cargo.toml`: PASS
+- [x] GitHub Actions `ci / verify`: PASS (run `25542614930`)
+- [x] Release workflow: PASS (run `25542885051`)
+- [x] `latest.json`: `version` が `1.5.4`、platforms が `darwin-aarch64` / `linux-x86_64` / `windows-x86_64`
+
+### 完了結果
+
+- [x] PR #562: https://github.com/yusei531642/vibe-editor/pull/562
+- [x] Release: https://github.com/yusei531642/vibe-editor/releases/tag/v1.5.4
+- [x] Assets: Windows `.exe`、macOS `.dmg` / `.app.tar.gz`、Linux `.AppImage` / `.deb` / `.rpm`、SBOM、signatures、`latest.json`
+- [x] Published at: 2026-05-08T07:37:39Z


### PR DESCRIPTION
## Summary
- Record the completed Issue #560 hotfix verification and v1.5.4 release flow.
- Add the v1.5.4 release task log with local dev verification and release workflow evidence.

## Verification
- git diff --check