### PR TITLE
fix: stop hidden terminal startup in IDE

### DIFF
--- a/src/renderer/src/components/TerminalView.tsx
+++ b/src/renderer/src/components/TerminalView.tsx
@@ -47,7 +47,7 @@ interface TerminalViewProps {
   env?: Record<string, string>;
   /** TeamHub 用のチーム識別子 */
   teamId?: string;
-  /** 現在このペインが表示されているか（非表示時は fit をスキップ） */
+  /** 現在このペインが表示されているか（非表示時は PTY spawn / fit をスキップ） */
   visible: boolean;
   /** 起動後に自動送信するメッセージ（配列なら順番に送信） */
   initialMessage?: string | string[];
@@ -233,6 +233,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       cwd,
       fallbackCwd,
       command,
+      spawnEnabled: visible,
       // Issue #271: HMR remount 時に同じ PTY へ再 bind するための論理キー。
       sessionKey,
       termRef,

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/TerminalOverlay.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/TerminalOverlay.tsx
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { TerminalView, type TerminalViewHandle } from '../../../TerminalView';
 import { useSettings } from '../../../../lib/settings-context';
 import { useCanvasStore } from '../../../../stores/canvas';
+import { useUiStore } from '../../../../stores/ui';
 import { useCanvasTerminalFit } from '../../../../lib/use-canvas-terminal-fit';
 import { useXtermScrollToBottomOnResize } from '../../../../lib/use-xterm-scroll-on-resize';
 import { useRecruitSpawnAck } from '../../../../lib/use-terminal-spawn';
@@ -85,6 +86,7 @@ export function TerminalOverlay({
   const { settings } = useSettings();
   const setCardTitle = useCanvasStore((s) => s.setCardTitle);
   const setCardPayload = useCanvasStore((s) => s.setCardPayload);
+  const isCanvasActive = useUiStore((s) => s.viewMode === 'canvas');
   // Issue #261: NodeResizer でカードを縮めたあと再度広げたとき、内部 `.xterm-viewport`
   // の scrollTop が中途半端な位置で残って「末尾が見えない」状態になることがある。
   // `.canvas-agent-card__term` 自体のサイズ変化を ResizeObserver で監視し、
@@ -201,7 +203,9 @@ export function TerminalOverlay({
         // 潰れないようガード (`?? args` だと `[]` でも truthy 扱いで args が無視される)。
         args={payload.args && payload.args.length > 0 ? payload.args : args}
         codexInstructions={codexInstructions}
-        visible={true}
+        // Issue #564: IDE 初期表示では Canvas 側 AgentNode を非表示保持するだけなので、
+        // 裏で Leader/Codex の PTY を起動しない。
+        visible={isCanvasActive}
         teamId={payload.teamId}
         agentId={payload.agentId}
         role={roleProfileId}

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/__tests__/TerminalOverlay.test.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/__tests__/TerminalOverlay.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+const terminalViewProps = vi.hoisted(() => [] as Array<{ visible?: boolean }>);
+
+vi.mock('../../../../TerminalView', () => ({
+  TerminalView: (props: { visible?: boolean }) => {
+    terminalViewProps.push(props);
+    return <div data-testid="agent-terminal-view-stub" data-visible={String(props.visible)} />;
+  }
+}));
+
+import { TerminalOverlay } from '../TerminalOverlay';
+import { SettingsProvider } from '../../../../../lib/settings-context';
+import { useUiStore } from '../../../../../stores/ui';
+import { DEFAULT_SETTINGS } from '../../../../../../../types/shared';
+
+type TestWindow = Window &
+  typeof globalThis & {
+    api?: unknown;
+  };
+
+function installApi(): void {
+  (window as TestWindow).api = {
+    settings: {
+      load: vi.fn(async () => DEFAULT_SETTINGS),
+      save: vi.fn(async () => undefined)
+    },
+    app: {
+      setProjectRoot: vi.fn(async () => undefined),
+      setZoomLevel: vi.fn(async () => undefined)
+    }
+  };
+}
+
+function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+  return <SettingsProvider>{children}</SettingsProvider>;
+}
+
+function renderOverlay() {
+  return render(
+    <Wrapper>
+      <TerminalOverlay
+        cardId="agent-node-1"
+        termRef={{ current: null }}
+        payload={{ agentId: 'agent-1', teamId: 'team-1' }}
+        title="Leader"
+        roleProfileId="leader"
+        cwd="/tmp/work"
+        command="claude"
+        args={['--print']}
+        onStatus={vi.fn()}
+        onActivity={vi.fn()}
+      />
+    </Wrapper>
+  );
+}
+
+describe('TerminalOverlay visibility gate', () => {
+  let originalApi: unknown;
+
+  beforeEach(() => {
+    originalApi = (window as TestWindow).api;
+    installApi();
+    terminalViewProps.length = 0;
+    useUiStore.setState({ viewMode: 'ide' });
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (originalApi === undefined) {
+      delete (window as TestWindow).api;
+    } else {
+      (window as TestWindow).api = originalApi;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('IDE モードでは AgentNode の TerminalView を非表示扱いにする', async () => {
+    useUiStore.setState({ viewMode: 'ide' });
+    renderOverlay();
+    expect(await screen.findByTestId('agent-terminal-view-stub')).toHaveAttribute(
+      'data-visible',
+      'false'
+    );
+    expect(terminalViewProps.at(-1)?.visible).toBe(false);
+  });
+
+  it('Canvas モードでは AgentNode の TerminalView を表示扱いにする', async () => {
+    useUiStore.setState({ viewMode: 'canvas' });
+    renderOverlay();
+    expect(await screen.findByTestId('agent-terminal-view-stub')).toHaveAttribute(
+      'data-visible',
+      'true'
+    );
+    expect(terminalViewProps.at(-1)?.visible).toBe(true);
+  });
+});

--- a/src/renderer/src/components/canvas/cards/TerminalCard.tsx
+++ b/src/renderer/src/components/canvas/cards/TerminalCard.tsx
@@ -11,6 +11,7 @@ import { CardFrame } from '../CardFrame';
 import { TerminalView, type TerminalViewHandle } from '../../TerminalView';
 import { useSettings } from '../../../lib/settings-context';
 import { useCanvasStore, NODE_MIN_W, NODE_MIN_H } from '../../../stores/canvas';
+import { useUiStore } from '../../../stores/ui';
 import { useCanvasTerminalFit } from '../../../lib/use-canvas-terminal-fit';
 import { useXtermScrollToBottomOnResize } from '../../../lib/use-xterm-scroll-on-resize';
 
@@ -41,6 +42,7 @@ function TerminalCardImpl({ id, data }: NodeProps): JSX.Element {
   const title = (data?.title as string) ?? 'Terminal';
   const [, setStatus] = useState<string>('');
   const setCardPayload = useCanvasStore((s) => s.setCardPayload);
+  const isCanvasActive = useUiStore((s) => s.viewMode === 'canvas');
   // Issue #253: Canvas zoom 下でも論理 px ベースで cols/rows を確定させる
   const fit = useCanvasTerminalFit(settings);
 
@@ -101,7 +103,9 @@ function TerminalCardImpl({ id, data }: NodeProps): JSX.Element {
             fallbackCwd={cwd}
             command={command}
             args={args}
-            visible={true}
+            // Issue #564: IDE モードでは CanvasLayout が非表示のまま mount される。
+            // その状態で PTY を起動しないよう、Canvas 表示中だけ TerminalView を起動可能にする。
+            visible={isCanvasActive}
             teamId={payload.teamId}
             agentId={payload.agentId}
             role={payload.role}

--- a/src/renderer/src/components/canvas/cards/__tests__/TerminalCard.test.tsx
+++ b/src/renderer/src/components/canvas/cards/__tests__/TerminalCard.test.tsx
@@ -12,6 +12,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 
+const terminalViewProps = vi.hoisted(() => [] as Array<{ visible?: boolean }>);
+
 vi.mock('@xyflow/react', () => ({
   Handle: () => null,
   NodeResizer: () => null,
@@ -20,12 +22,16 @@ vi.mock('@xyflow/react', () => ({
 }));
 
 vi.mock('../../../TerminalView', () => ({
-  TerminalView: () => <div data-testid="terminal-view-stub" />
+  TerminalView: (props: { visible?: boolean }) => {
+    terminalViewProps.push(props);
+    return <div data-testid="terminal-view-stub" data-visible={String(props.visible)} />;
+  }
 }));
 
 import TerminalCard from '../TerminalCard';
 import { SettingsProvider } from '../../../../lib/settings-context';
 import { ToastProvider } from '../../../../lib/toast-context';
+import { useUiStore } from '../../../../stores/ui';
 import { DEFAULT_SETTINGS } from '../../../../../../types/shared';
 
 type TestWindow = Window &
@@ -84,6 +90,8 @@ describe('TerminalCard (smoke)', () => {
   beforeEach(() => {
     originalApi = (window as TestWindow).api;
     installApi();
+    terminalViewProps.length = 0;
+    useUiStore.setState({ viewMode: 'ide' });
   });
 
   afterEach(() => {
@@ -100,5 +108,19 @@ describe('TerminalCard (smoke)', () => {
     renderCard();
     expect(await screen.findByText('Terminal A')).toBeInTheDocument();
     expect(screen.getByTestId('terminal-view-stub')).toBeInTheDocument();
+  });
+
+  it('IDE モードでは TerminalView を非表示扱いにして PTY 起動を抑止する', async () => {
+    useUiStore.setState({ viewMode: 'ide' });
+    renderCard();
+    expect(await screen.findByTestId('terminal-view-stub')).toHaveAttribute('data-visible', 'false');
+    expect(terminalViewProps.at(-1)?.visible).toBe(false);
+  });
+
+  it('Canvas モードでは TerminalView を表示扱いにする', async () => {
+    useUiStore.setState({ viewMode: 'canvas' });
+    renderCard();
+    expect(await screen.findByTestId('terminal-view-stub')).toHaveAttribute('data-visible', 'true');
+    expect(terminalViewProps.at(-1)?.visible).toBe(true);
   });
 });

--- a/src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx
@@ -1,0 +1,77 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useTerminalTabs, type UseTerminalTabsOptions } from '../use-terminal-tabs';
+
+function options(overrides: Partial<UseTerminalTabsOptions> = {}): UseTerminalTabsOptions {
+  return {
+    viewMode: 'ide',
+    claudeReady: true,
+    projectRoot: 'C:\\Users\\zooyo',
+    showToast: vi.fn(),
+    closeTeam: vi.fn(),
+    ...overrides
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('useTerminalTabs', () => {
+  it('does not auto-create a terminal on the IDE initial screen', async () => {
+    const { result } = renderHook(() => useTerminalTabs(options()));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.terminalTabs).toHaveLength(0);
+    expect(result.current.activeTerminalTabId).toBe(0);
+  });
+
+  it('keeps terminal creation explicit', () => {
+    const { result } = renderHook(() => useTerminalTabs(options()));
+
+    act(() => {
+      result.current.addTerminalTab({ agent: 'claude' });
+    });
+
+    expect(result.current.terminalTabs).toHaveLength(1);
+    expect(result.current.terminalTabs[0]?.label).toBe('Claude #1');
+  });
+
+  it('does not create a replacement terminal when the last tab is closed', () => {
+    const { result } = renderHook(() => useTerminalTabs(options()));
+
+    act(() => {
+      result.current.addTerminalTab({ agent: 'claude' });
+    });
+    const tabId = result.current.terminalTabs[0]?.id;
+    expect(tabId).toBeDefined();
+
+    act(() => {
+      result.current.closeTerminalTab(tabId as number);
+    });
+
+    expect(result.current.terminalTabs).toHaveLength(0);
+    expect(result.current.activeTerminalTabId).toBe(0);
+  });
+
+  it('clears terminals on project switch without auto-starting Claude', () => {
+    const { result } = renderHook(() => useTerminalTabs(options()));
+
+    act(() => {
+      result.current.addTerminalTab({ agent: 'claude' });
+    });
+    expect(result.current.terminalTabs).toHaveLength(1);
+
+    act(() => {
+      result.current.resetForProjectSwitch();
+    });
+
+    expect(result.current.terminalTabs).toHaveLength(0);
+    expect(result.current.activeTerminalTabId).toBe(0);
+  });
+});

--- a/src/renderer/src/lib/hooks/__tests__/use-xterm-bind.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-xterm-bind.test.tsx
@@ -206,4 +206,81 @@ describe('useXtermBind: spawn → unmount lifecycle', () => {
     // ptyId を持っていないので kill は呼ばれない (orphan kill 防止)。
     expect(kill).not.toHaveBeenCalled();
   });
+
+  it('spawnEnabled=false では PTY 起動を延期し、true になった時点で起動する', async () => {
+    const term = makeTerminal();
+    const fit = { fit: vi.fn() } as unknown as FitAddon;
+    const create = vi.fn(async (opts: { id?: string }) => ({
+      ok: true,
+      id: opts.id ?? 'pty-test-deferred'
+    }));
+    const kill = vi.fn(async () => undefined);
+
+    (window as TestWindow).api = {
+      terminal: {
+        onDataReady: vi.fn(async () => vi.fn()),
+        onExitReady: vi.fn(async () => vi.fn()),
+        onSessionIdReady: vi.fn(async () => vi.fn()),
+        onData: vi.fn(() => vi.fn()),
+        onExit: vi.fn(() => vi.fn()),
+        onSessionId: vi.fn(() => vi.fn()),
+        create,
+        write: vi.fn(async () => undefined),
+        resize: vi.fn(async () => undefined),
+        kill
+      }
+    };
+
+    const ptyIdRef = makeRef<string | null>(null);
+    const termRef = makeRef<Terminal | null>(term);
+    const fitRef = makeRef<FitAddon | null>(fit);
+    const snapRef = makeRef<PtySpawnSnapshot>({});
+    const callbacksRef = makeRef<PtySessionCallbacks>({});
+    const disposedRef = makeRef(false);
+    const observeChunk = vi.fn();
+
+    const { rerender, unmount } = renderHook(
+      ({ enabled }) =>
+        useXtermBind({
+          cwd: '/tmp/work',
+          command: 'claude',
+          spawnEnabled: enabled,
+          termRef,
+          fitRef,
+          snapRef,
+          callbacksRef,
+          ptyIdRef,
+          disposedRef,
+          observeChunk,
+          unscaledFit: false
+        }),
+      { initialProps: { enabled: false } }
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(create).not.toHaveBeenCalled();
+
+    await act(async () => {
+      rerender({ enabled: true });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    const spawnedId = create.mock.calls[0][0].id as string;
+    await waitFor(() => expect(ptyIdRef.current).toBe(spawnedId));
+
+    await act(async () => {
+      rerender({ enabled: false });
+      await Promise.resolve();
+    });
+    expect(kill).not.toHaveBeenCalled();
+
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+    });
+    expect(kill).toHaveBeenCalledWith(spawnedId);
+  });
 });

--- a/src/renderer/src/lib/hooks/use-terminal-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs.ts
@@ -127,7 +127,7 @@ export interface UseTerminalTabsResult {
   nextTerminalIdRef: React.MutableRefObject<number>;
 
   // ---- project switch lifecycle ----
-  /** projectSwitchedRef.current から呼ぶ。新規 Claude #1 を 1 つ自動生成して active に。 */
+  /** projectSwitchedRef.current から呼ぶ。ターミナルは自動生成せず空の初期画面に戻す。 */
   resetForProjectSwitch: () => void;
 }
 
@@ -262,24 +262,8 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
     setTerminalTabs((prev) => {
       const next = prev.filter((t) => t.id !== tabId);
       if (next.length === 0) {
-        // 最後の1個 → 新しいスタンドアロンタブを自動生成
-        const newId = nextTerminalIdRef.current++;
-        const fresh: TerminalTab = {
-          id: newId,
-          version: 1,
-          agent: 'claude',
-          role: null,
-          teamId: null,
-          agentId: `agent-${newId}`,
-          status: '',
-          exited: false,
-          resumeSessionId: null,
-          teamHistoryMemberIdx: null,
-          label: 'Claude #1',
-          customLabel: null
-        };
-        setActiveTerminalTabId(newId);
-        return [fresh];
+        setActiveTerminalTabId(0);
+        return [];
       }
       setActiveTerminalTabId((active) => {
         if (active !== tabId) return active;
@@ -325,20 +309,8 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
     restartTerminalTab(activeTerminalTabId);
   }, [activeTerminalTabId, restartTerminalTab]);
 
-  // 初回タブ作成: Claude OK かつ projectRoot 設定済みでタブなし。
-  // Canvas モードでは App は不可視の裏マウントなので、ここでターミナルを生やすと
-  // Rust 側で無駄な PTY が常駐し、IDE へ切り替えたときにも "迷子ターミナル" として現れる。
-  // → viewMode === 'ide' のときだけ自動生成する。
-  useEffect(() => {
-    if (
-      opts.claudeReady &&
-      opts.projectRoot &&
-      terminalTabs.length === 0 &&
-      opts.viewMode === 'ide'
-    ) {
-      addTerminalTab();
-    }
-  }, [opts.claudeReady, opts.projectRoot, terminalTabs.length, addTerminalTab, opts.viewMode]);
+  // Issue #564: IDE 初期画面ではターミナルを自動生成しない。
+  // ターミナル起動はユーザーの明示操作、team recruit、session resume だけに限定する。
 
   const getDnDProps = useCallback(
     (tabId: number): DnDHandlers => ({
@@ -382,24 +354,8 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
   );
 
   const resetForProjectSwitch = useCallback(() => {
-    const newId = nextTerminalIdRef.current++;
-    setTerminalTabs([
-      {
-        id: newId,
-        version: 0,
-        agent: 'claude',
-        role: null,
-        teamId: null,
-        agentId: `agent-${newId}`,
-        status: '起動中…',
-        exited: false,
-        resumeSessionId: null,
-        teamHistoryMemberIdx: null,
-        label: 'Claude #1',
-        customLabel: null
-      }
-    ]);
-    setActiveTerminalTabId(newId);
+    setTerminalTabs([]);
+    setActiveTerminalTabId(0);
   }, []);
 
   return {

--- a/src/renderer/src/lib/hooks/use-xterm-bind.ts
+++ b/src/renderer/src/lib/hooks/use-xterm-bind.ts
@@ -18,7 +18,7 @@
  * 不変式 #3 (Issue #285): 新規 spawn は client-generated id + `subscribeEventReady` で
  *   pre-subscribe してから create を呼ぶ。post-subscribe race を構造的に消す。
  */
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { MutableRefObject, RefObject } from 'react';
 import type { Terminal } from '@xterm/xterm';
 import type { FitAddon } from '@xterm/addon-fit';
@@ -73,6 +73,11 @@ export interface UseXtermBindOptions {
   fallbackCwd?: string;
   command: string;
   /**
+   * false の間は PTY spawn を延期する。Canvas を IDE モードで非表示保持するとき、
+   * mount 済みの TerminalView が裏で端末を起動しないようにするためのゲート。
+   */
+  spawnEnabled?: boolean;
+  /**
    * Issue #271: HMR remount 時に同じ PTY へ再 bind するための論理キー。
    * 親が `term:${tab.id}` / `canvas-term:${node.id}` 等の安定した文字列を
    * 渡すと、Vite HMR で本フックが unmount → remount しても terminal.kill を
@@ -111,6 +116,7 @@ export function useXtermBind(options: UseXtermBindOptions): void {
     cwd,
     fallbackCwd,
     command,
+    spawnEnabled = true,
     sessionKey,
     termRef,
     fitRef,
@@ -142,8 +148,25 @@ export function useXtermBind(options: UseXtermBindOptions): void {
   containerRefRef.current = containerRef;
   const lastScheduledRefRef = useRef(lastScheduledRef);
   lastScheduledRefRef.current = lastScheduledRef;
+  const spawnEnabledRef = useRef(spawnEnabled);
+  spawnEnabledRef.current = spawnEnabled;
+  const spawnDeferredRef = useRef(false);
+  const [deferredSpawnToken, setDeferredSpawnToken] = useState(0);
 
   useEffect(() => {
+    if (!spawnEnabled || !spawnDeferredRef.current) return;
+    spawnDeferredRef.current = false;
+    setDeferredSpawnToken((token) => token + 1);
+  }, [spawnEnabled]);
+
+  useEffect(() => {
+    if (!spawnEnabledRef.current) {
+      spawnDeferredRef.current = true;
+      disposedRef.current = true;
+      return;
+    }
+    spawnDeferredRef.current = false;
+
     const term = termRef.current;
     const fit = fitRef.current;
     if (!term) return;
@@ -371,6 +394,10 @@ export function useXtermBind(options: UseXtermBindOptions): void {
       try {
         await loadInitialMetrics();
         if (localDisposed || disposedRef.current) return;
+        if (!spawnEnabledRef.current && !ptyIdRef.current) {
+          spawnDeferredRef.current = true;
+          return;
+        }
 
         callbacksRef.current.onStatus?.(`${command} を起動中…`);
         // 不変式 #2: 初回 spawn 時点のスナップショットを使う (以後の prop 変化は無視)
@@ -432,6 +459,11 @@ export function useXtermBind(options: UseXtermBindOptions): void {
             newSpawnSessionIdCb
           );
           if (!ok) return;
+        }
+        if (!spawnEnabledRef.current && !ptyIdRef.current) {
+          unsubscribePtyListeners();
+          spawnDeferredRef.current = true;
+          return;
         }
 
         const res = await window.api.terminal.create({
@@ -711,8 +743,8 @@ export function useXtermBind(options: UseXtermBindOptions): void {
         }
       }
     };
-    // 不変式 #1: deps は [cwd, command] のみ。
+    // 不変式 #1: deps は [cwd, command, deferredSpawnToken] のみ。
     // 他の props/callbacks/refs は意図的に依存配列から除外する。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cwd, command]);
+  }, [cwd, command, deferredSpawnToken]);
 }

--- a/tasks/issue-564-plan.md
+++ b/tasks/issue-564-plan.md
@@ -1,0 +1,51 @@
+# Issue #564 - IDE initial screen must not auto-start terminals
+
+## 計画
+
+- Issue #443 との違いを整理する。#443 は初期ターミナルの表示崩れ、#564 は初期ターミナル生成そのものを止める。
+- `use-terminal-tabs.ts` の自動生成経路をすべて確認する。
+- Canvas / Team 側の TerminalView が IDE モードでも裏で mount されないか確認する。
+- IDE 初期表示で `terminalTabs.length === 0` を正とし、`addTerminalTab()` を自動実行しない。
+- 最後のタブを閉じても、代替の `Claude #1` を自動生成しない。
+- project switch reset でも `Claude #1` を自動生成しない。
+- Canvas が非表示の間は TerminalView の PTY spawn を延期する。
+- 回帰テストで IDE tabs 3 経路と Canvas hidden spawn 経路を固定する。
+- `tasks/lessons.md` に再発防止を追記する。
+
+## Next Steps
+
+- [x] Issue #564 を作成する。
+- [x] `src/renderer/src/lib/hooks/use-terminal-tabs.ts` を最小修正する。
+- [x] `use-terminal-tabs` の回帰テストを追加する。
+- [x] Canvas hidden spawn の回帰テストを追加する。
+- [x] 関連 Vitest、typecheck、build、diff check を通す。
+- [x] `npm run dev` 相当で IDE 初期表示時に `terminal_create` が出ないことを確認する。
+
+## 進捗
+
+- [x] `use-terminal-tabs.ts` に 3 つの自動生成経路があることを確認。
+  - 初期 effect: `claudeReady && projectRoot && terminalTabs.length === 0 && viewMode === 'ide'`
+  - 最後のタブ close: 空配列の代わりに `Claude #1` を生成
+  - project switch reset: `Claude #1` を生成
+- [x] ローカル dev で初回仮説が不足していることを確認。
+  - `terminal_create command=claude` と `terminal_create command=codex` が IDE 起動直後に出た。
+  - `main.tsx` は CanvasLayout を常時 mount し、IDE では `display:none` にしている。
+  - そのため保存済み Canvas / Team ノードの TerminalView が非表示で PTY を起動していた。
+- [x] `TerminalView` に `spawnEnabled` ゲートを追加し、`visible=false` では PTY spawn を延期。
+- [x] `TerminalCard` / `TerminalOverlay` は Canvas 表示中だけ `visible=true` を渡す。
+
+## 検証結果
+
+- [x] `npx vitest run src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx`: PASS
+- [x] `npx vitest run src/renderer/src/lib/hooks/__tests__/use-xterm-bind.test.tsx`: PASS
+- [x] `npx vitest run src/renderer/src/components/canvas/cards/__tests__/TerminalCard.test.tsx src/renderer/src/components/canvas/cards/AgentNodeCard/__tests__/TerminalOverlay.test.tsx`: PASS
+- [x] `npx vitest run src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx src/renderer/src/lib/hooks/__tests__/use-xterm-bind.test.tsx src/renderer/src/components/canvas/cards/__tests__/TerminalCard.test.tsx src/renderer/src/components/canvas/cards/AgentNodeCard/__tests__/TerminalOverlay.test.tsx`: PASS (12 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
+- [x] Tauri dev 起動確認: isolated dev identifier / port 5174 で起動後 10 秒、`terminal_create` / `spawn command requested` / `[起動エラー]` なし。
+- [x] 参考: 通常 dev profile では persisted `vibe-editor:ui.viewMode=canvas` のため Canvas agent が起動した。IDE 初期表示の検証条件と分けて扱う。
+
+## Next Tasks
+
+- PR URL を追記する。

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -191,6 +191,15 @@ codex exec --sandbox read-only --color never --ephemeral \
 - advisory lock を強化するときは、新しい lock engine を足す前に、既存 tool を「必ず使われる導線」へ接続する。
 - Tauri event helper を React effect から使う場合は、jsdom の `listen()` reject が未処理 rejection にならないよう helper 側で noop cleanup を返す。
 
+## Issue #564 - IDE initial terminal auto-start
+
+- IDE 初期画面では terminal tab を 0 件のまま表示する。`claudeReady && projectRoot && tabs.length === 0` のような effect で `addTerminalTab()` を呼ばない。
+- 最後の terminal tab を閉じた時や project switch reset 時も、代替の `Claude #1` を自動生成しない。
+- `CanvasLayout` は IDE モードでも非表示 mount されるため、Canvas / Team の TerminalView に `visible=true` を固定しない。
+- TerminalView は「非表示なら fit だけ止める」では不十分。`visible=false` の間は PTY spawn も延期する。
+- terminal / PTY の起動は、ユーザーの明示操作、team recruit、session resume のような明示イベントだけに限定する。
+- 再発防止テストでは「初期表示」「last-tab close」「project switch reset」「hidden Canvas / Team spawn」の 4 経路を必ず固定する。
+
 ## Issue #520 - team_send untrusted data boundary
 
 - 外部 API / ファイル / Web スクレイプ本文を agent へ渡すときは、通常の `message` 文字列に混ぜず、`data` として構造化する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1762,3 +1762,45 @@ Plan: `tasks/release-v1.5.4.md`
 - [x] Release: https://github.com/yusei531642/vibe-editor/releases/tag/v1.5.4
 - [x] Assets: Windows `.exe`、macOS `.dmg` / `.app.tar.gz`、Linux `.AppImage` / `.deb` / `.rpm`、SBOM、signatures、`latest.json`
 - [x] Published at: 2026-05-08T07:37:39Z
+
+## Issue #564 IDE initial screen must not auto-start terminals (2026-05-08 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/564
+Plan: `tasks/issue-564-plan.md`
+
+### 計画
+
+- [x] #443 との差分を整理する。#443 は初期ターミナルの表示崩れ、#564 は初期ターミナル生成そのもの。
+- [x] `use-terminal-tabs.ts` の自動生成経路を調査する。
+- [x] IDE 初期表示で `addTerminalTab()` を自動実行しない。
+- [x] 最後のタブを閉じた時に `Claude #1` を自動生成しない。
+- [x] project switch reset で `Claude #1` を自動生成しない。
+- [x] Canvas / Team 側の hidden TerminalView が IDE 初期表示で PTY を起動しないようにする。
+- [x] 回帰テストで IDE tabs 3 経路と Canvas hidden spawn 経路を固定する。
+- [x] ローカル dev で IDE 初期表示時に `terminal_create` が起きないことを確認する。
+
+### Next Steps
+
+- [x] `src/renderer/src/lib/hooks/use-terminal-tabs.ts` を最小修正する。
+- [x] `src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx` を追加する。
+- [x] Canvas hidden spawn の回帰テストを追加する。
+- [x] `tasks/lessons.md` に再発防止を追記する。
+
+### 進捗
+
+- [x] 初期 effect、last-tab close、project switch reset の 3 経路を原因候補として確認。
+- [x] ローカル dev で初回仮説が不足していることを確認。IDE 起動直後に Canvas / Team 側から `terminal_create command=claude` と `terminal_create command=codex` が出ていた。
+- [x] `TerminalView` は `visible=false` なら PTY spawn を延期する。
+- [x] `TerminalCard` / `TerminalOverlay` は `viewMode === 'canvas'` の時だけ `visible=true` を渡す。
+- [x] 通常 dev profile は persisted `viewMode=canvas` だったため Canvas agent が起動した。isolated dev identifier で IDE 初期表示を再現して検証した。
+
+### 検証結果
+
+- [x] `npx vitest run src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx`: PASS
+- [x] `npx vitest run src/renderer/src/lib/hooks/__tests__/use-xterm-bind.test.tsx`: PASS
+- [x] `npx vitest run src/renderer/src/components/canvas/cards/__tests__/TerminalCard.test.tsx src/renderer/src/components/canvas/cards/AgentNodeCard/__tests__/TerminalOverlay.test.tsx`: PASS
+- [x] `npx vitest run src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx src/renderer/src/lib/hooks/__tests__/use-xterm-bind.test.tsx src/renderer/src/components/canvas/cards/__tests__/TerminalCard.test.tsx src/renderer/src/components/canvas/cards/AgentNodeCard/__tests__/TerminalOverlay.test.tsx`: PASS (12 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
+- [x] Tauri dev 起動確認: isolated dev identifier / port 5174 で起動後 10 秒、`terminal_create` / `spawn command requested` / `[起動エラー]` なし。


### PR DESCRIPTION
## Summary
- Stop IDE initial screen from auto-creating a terminal tab.
- Keep terminal tab count at zero after last-tab close and project switch reset.
- Gate Canvas/Team TerminalView spawning so hidden Canvas nodes do not start PTYs in IDE mode.

## Verification
- `npx vitest run src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx src/renderer/src/lib/hooks/__tests__/use-xterm-bind.test.tsx src/renderer/src/components/canvas/cards/__tests__/TerminalCard.test.tsx src/renderer/src/components/canvas/cards/AgentNodeCard/__tests__/TerminalOverlay.test.tsx`
- `npm run typecheck`
- `npm run build:vite`
- `git diff --check`
- Tauri dev startup with isolated dev identifier / port 5174: no `terminal_create`, no `spawn command requested`, no `[起動エラー]` after IDE initial startup.

Closes #564