### PR TITLE
chore(release): v1.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-editor",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-editor",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/geist-mono": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5218,7 +5218,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.5.4"
+version = "1.5.5"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",

--- a/tasks/release-v1.5.5.md
+++ b/tasks/release-v1.5.5.md
@@ -1,0 +1,42 @@
+# Release v1.5.5
+
+## 計画
+
+- PR #565 の IDE 初期表示 hidden terminal 修正を含むパッチとして `v1.5.5` を作成する。
+- `main` は PR #565 merge commit `f28e078` まで同期済み。
+- version files を `1.5.5` に更新する。
+- release PR を作成し、CI と reviewer bot の承認を待つ。
+- PR merge 後に local `main` を同期する。
+- `v1.5.5` annotated tag を merge commit に作成して push する。
+- `release.yml` の build を監視する。
+- draft release の assets と `latest.json` を確認し、publish する。
+
+## Next Steps
+
+- [x] `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` を `1.5.5` に更新する。
+- [x] `src-tauri/Cargo.lock` を `1.5.5` に同期する。
+- [x] `npm run typecheck`、`npm run build:vite`、`cargo check` を実行する。
+- [ ] release PR を作成する。
+- [ ] release workflow を監視し、draft release を publish する。
+
+## 進捗
+
+- [x] `main` が PR #565 merge commit `f28e078` を含むことを確認。
+- [x] `chore/release-v1.5.5` ブランチを作成。
+- [x] `package.json` / `package-lock.json` を `1.5.5` に更新。
+- [x] `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` / `src-tauri/tauri.conf.json` を `1.5.5` に更新。
+- [x] ローカル品質ゲートを通過。
+
+## 検証結果
+
+- [x] `npm run typecheck`: PASS
+- [x] `npm run build:vite`: PASS
+- [x] `C:\Users\zooyo\.cargo\bin\cargo.exe check --manifest-path src-tauri\Cargo.toml`: PASS（既存 warning: `LockResult::has_conflicts` / `TemplateReport::{warnings,warn_message}`）
+- [x] `git diff --check`: PASS
+
+## Next Tasks
+
+- release PR を作成し、CI と reviewer bot を確認する。
+- PR merge 後に `main` を同期し、`v1.5.5` tag を push する。
+- release workflow を監視し、draft release の assets と `latest.json` を確認する。
+- draft release を publish する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1804,3 +1804,31 @@ Plan: `tasks/issue-564-plan.md`
 - [x] `npm run build:vite`: PASS
 - [x] `git diff --check`: PASS
 - [x] Tauri dev 起動確認: isolated dev identifier / port 5174 で起動後 10 秒、`terminal_create` / `spawn command requested` / `[起動エラー]` なし。
+
+## Release v1.5.5 (2026-05-08 / Codex)
+
+Plan: `tasks/release-v1.5.5.md`
+
+### 計画
+
+- [x] PR #565 の IDE 初期表示 hidden terminal 修正が `main` に入っていることを確認する。
+- [x] `chore/release-v1.5.5` ブランチを作成する。
+- [x] npm / Rust / Tauri の version を `1.5.5` に更新する。
+- [x] 品質ゲートを通す。
+- [ ] release PR を作成し、CI / reviewer bot を確認する。
+- [ ] PR merge 後に `v1.5.5` tag を pushする。
+- [ ] release workflow を監視し、draft release の assets と `latest.json` を確認する。
+- [ ] draft release を publish する。
+
+### Next Steps
+
+- [x] `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` / `src-tauri/tauri.conf.json` を `1.5.5` に更新する。
+- [x] `npm run typecheck`、`npm run build:vite`、`cargo check` を実行する。
+- [ ] release PR を作成し、CI と reviewer bot を確認する。
+
+### 検証結果
+
+- [x] `npm run typecheck`: PASS
+- [x] `npm run build:vite`: PASS
+- [x] `C:\Users\zooyo\.cargo\bin\cargo.exe check --manifest-path src-tauri\Cargo.toml`: PASS（既存 warning: `LockResult::has_conflicts` / `TemplateReport::{warnings,warn_message}`）
+- [x] `git diff --check`: PASS


### PR DESCRIPTION
## Summary
- Bump app/package/Tauri/Rust version to `1.5.5`.
- Add release tracking for `v1.5.5`.
- This patch release includes #565, which stops hidden terminal startup on the IDE initial screen.

## Verification
- `npm run typecheck`
- `npm run build:vite`
- `C:\Users\zooyo\.cargo\bin\cargo.exe check --manifest-path src-tauri\Cargo.toml`
- `git diff --check`