### PR TITLE
docs(tasks): record v1.5.5 release

### DIFF
--- a/tasks/release-v1.5.5.md
+++ b/tasks/release-v1.5.5.md
@@ -16,8 +16,8 @@
 - [x] `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` を `1.5.5` に更新する。
 - [x] `src-tauri/Cargo.lock` を `1.5.5` に同期する。
 - [x] `npm run typecheck`、`npm run build:vite`、`cargo check` を実行する。
-- [ ] release PR を作成する。
-- [ ] release workflow を監視し、draft release を publish する。
+- [x] release PR を作成する。
+- [x] release workflow を監視し、draft release を publish する。
 
 ## 進捗
 
@@ -26,6 +26,12 @@
 - [x] `package.json` / `package-lock.json` を `1.5.5` に更新。
 - [x] `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` / `src-tauri/tauri.conf.json` を `1.5.5` に更新。
 - [x] ローカル品質ゲートを通過。
+- [x] Release PR #566 を作成し、CI と reviewer bot approval を確認。
+- [x] PR #566 の bot merge 後に `main` を同期。
+- [x] `v1.5.5` annotated tag を push。
+- [x] Release workflow run `25546233461` を監視し、全 matrix build の成功を確認。
+- [x] Draft release の assets と `latest.json` を確認。
+- [x] Draft release を publish。
 
 ## 検証結果
 
@@ -33,10 +39,20 @@
 - [x] `npm run build:vite`: PASS
 - [x] `C:\Users\zooyo\.cargo\bin\cargo.exe check --manifest-path src-tauri\Cargo.toml`: PASS（既存 warning: `LockResult::has_conflicts` / `TemplateReport::{warnings,warn_message}`）
 - [x] `git diff --check`: PASS
+- [x] GitHub Actions `ci / verify`: PASS (run `25545970791`)
+- [x] Release workflow: PASS (run `25546233461`)
+- [x] `latest.json`: `version` が `1.5.5`、platforms が `darwin-aarch64` / `linux-x86_64` / `windows-x86_64`
 
 ## Next Tasks
 
-- release PR を作成し、CI と reviewer bot を確認する。
-- PR merge 後に `main` を同期し、`v1.5.5` tag を push する。
-- release workflow を監視し、draft release の assets と `latest.json` を確認する。
-- draft release を publish する。
+- [x] release PR を作成し、CI と reviewer bot を確認する。
+- [x] PR merge 後に `main` を同期し、`v1.5.5` tag を push する。
+- [x] release workflow を監視し、draft release の assets と `latest.json` を確認する。
+- [x] draft release を publish する。
+
+## 完了結果
+
+- [x] PR #566: https://github.com/yusei531642/vibe-editor/pull/566
+- [x] Release: https://github.com/yusei531642/vibe-editor/releases/tag/v1.5.5
+- [x] Assets: Windows `.exe`、macOS `.dmg` / `.app.tar.gz`、Linux `.AppImage` / `.deb` / `.rpm`、SBOM、signatures、`latest.json`
+- [x] Published at: 2026-05-08T08:55:50Z

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1815,16 +1815,16 @@ Plan: `tasks/release-v1.5.5.md`
 - [x] `chore/release-v1.5.5` ブランチを作成する。
 - [x] npm / Rust / Tauri の version を `1.5.5` に更新する。
 - [x] 品質ゲートを通す。
-- [ ] release PR を作成し、CI / reviewer bot を確認する。
-- [ ] PR merge 後に `v1.5.5` tag を pushする。
-- [ ] release workflow を監視し、draft release の assets と `latest.json` を確認する。
-- [ ] draft release を publish する。
+- [x] release PR を作成し、CI / reviewer bot を確認する。
+- [x] PR merge 後に `v1.5.5` tag を pushする。
+- [x] release workflow を監視し、draft release の assets と `latest.json` を確認する。
+- [x] draft release を publish する。
 
 ### Next Steps
 
 - [x] `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` / `src-tauri/tauri.conf.json` を `1.5.5` に更新する。
 - [x] `npm run typecheck`、`npm run build:vite`、`cargo check` を実行する。
-- [ ] release PR を作成し、CI と reviewer bot を確認する。
+- [x] release PR を作成し、CI と reviewer bot を確認する。
 
 ### 検証結果
 
@@ -1832,3 +1832,13 @@ Plan: `tasks/release-v1.5.5.md`
 - [x] `npm run build:vite`: PASS
 - [x] `C:\Users\zooyo\.cargo\bin\cargo.exe check --manifest-path src-tauri\Cargo.toml`: PASS（既存 warning: `LockResult::has_conflicts` / `TemplateReport::{warnings,warn_message}`）
 - [x] `git diff --check`: PASS
+- [x] GitHub Actions `ci / verify`: PASS (run `25545970791`)
+- [x] Release workflow: PASS (run `25546233461`)
+- [x] `latest.json`: `version` が `1.5.5`、platforms が `darwin-aarch64` / `linux-x86_64` / `windows-x86_64`
+
+### 完了結果
+
+- [x] PR #566: https://github.com/yusei531642/vibe-editor/pull/566
+- [x] Release: https://github.com/yusei531642/vibe-editor/releases/tag/v1.5.5
+- [x] Assets: Windows `.exe`、macOS `.dmg` / `.app.tar.gz`、Linux `.AppImage` / `.deb` / `.rpm`、SBOM、signatures、`latest.json`
+- [x] Published at: 2026-05-08T08:55:50Z


### PR DESCRIPTION
## Summary
- Record the completed v1.5.5 release in task docs.
- Capture PR, workflow, release URL, assets, and publish timestamp.

## Verification
- `git diff --check`