### PR TITLE
fix(canvas): #569 拡大した Leader と recruit 子カードが重ならないよう size-aware 配置

### DIFF
--- a/src/renderer/src/lib/__tests__/canvas-recruit-position.test.ts
+++ b/src/renderer/src/lib/__tests__/canvas-recruit-position.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import type { Node } from '@xyflow/react';
+import { findRecruitPosition } from '../canvas-recruit-position';
+import type { CardData } from '../../stores/canvas';
+import { NODE_H, NODE_W } from '../../stores/canvas';
+
+/** 既定サイズ NODE_W × NODE_H 用テストノード factory */
+function defaultNode(
+  id: string,
+  x: number,
+  y: number,
+  extra: Partial<Node<CardData>> = {}
+): Node<CardData> {
+  return {
+    id,
+    type: 'agent',
+    position: { x, y },
+    data: { cardType: 'agent', title: id },
+    style: { width: NODE_W, height: NODE_H },
+    ...extra
+  };
+}
+
+/** 拡大サイズ用テストノード factory */
+function resizedNode(
+  id: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number
+): Node<CardData> {
+  return {
+    id,
+    type: 'agent',
+    position: { x, y },
+    data: { cardType: 'agent', title: id },
+    style: { width, height }
+  };
+}
+
+/** rect 同士の overlap 判定 (canvas-placement.ts の overlaps と同じ意味) */
+function rect(x: number, y: number, w: number, h: number): {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+} {
+  return { left: x, top: y, right: x + w, bottom: y + h };
+}
+
+function overlaps(
+  a: { left: number; top: number; right: number; bottom: number },
+  b: { left: number; top: number; right: number; bottom: number }
+): boolean {
+  return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+}
+
+const stableScreen = () => 1920;
+
+describe('findRecruitPosition', () => {
+  describe('既定サイズ requester (regression)', () => {
+    it('メンバー 0 名: 旧挙動どおり右側に配置 (cx + radius - NODE_W/2, cy - NODE_H/2)', () => {
+      const requester = defaultNode('leader', 0, 0);
+      const pos = findRecruitPosition(requester, [requester], { getScreenSize: stableScreen });
+
+      // requesterOuter = NODE_W/2, childOuter = NODE_W/2, margin = 60
+      // baseRadius = NODE_W + 60
+      const radius = NODE_W + 60;
+      const cx = NODE_W / 2;
+      const cy = NODE_H / 2;
+      expect(pos.x).toBeCloseTo(cx + radius - NODE_W / 2, 6);
+      expect(pos.y).toBeCloseTo(cy - NODE_H / 2, 6);
+    });
+
+    it('メンバー 1 名: 1 人目と反対側に配置されて overlap しない', () => {
+      const leader = defaultNode('leader', 0, 0);
+      const first = defaultNode('first', NODE_W + 60, 0);
+      const pos = findRecruitPosition(leader, [leader, first], { getScreenSize: stableScreen });
+
+      const reqRect = rect(0, 0, NODE_W, NODE_H);
+      const childRect = rect(pos.x, pos.y, NODE_W, NODE_H);
+      const firstRect = rect(NODE_W + 60, 0, NODE_W, NODE_H);
+      expect(overlaps(reqRect, childRect)).toBe(false);
+      expect(overlaps(firstRect, childRect)).toBe(false);
+    });
+
+    it('メンバー 6 名以上: requester の右側 2 列グリッドに展開', () => {
+      const leader = defaultNode('leader', 100, 200);
+      const others = Array.from({ length: 5 }, (_, i) =>
+        defaultNode(`m${i}`, i * 100, i * 100)
+      );
+      const pos = findRecruitPosition(leader, [leader, ...others], {
+        getScreenSize: stableScreen
+      });
+
+      // newIdx = others.length = 5 (メンバーのうち leader 以外 = 5 名), col = 1, row = 2
+      // 既定サイズ requester なので rW=NODE_W, x = leader.x + NODE_W + 32 + (NODE_W + 32) * 1
+      const expectedX = 100 + NODE_W + 32 + (NODE_W + 32) * 1;
+      const expectedY = 200 + (NODE_H + 32) * 2;
+      expect(pos.x).toBe(expectedX);
+      expect(pos.y).toBe(expectedY);
+    });
+  });
+
+  describe('拡大 requester (Issue #569)', () => {
+    it('メンバー 0 名: 拡大 requester でも overlap しない', () => {
+      const leader = resizedNode('leader', 0, 0, 1200, 800);
+      const pos = findRecruitPosition(leader, [leader], { getScreenSize: stableScreen });
+
+      const reqRect = rect(0, 0, 1200, 800);
+      const childRect = rect(pos.x, pos.y, NODE_W, NODE_H);
+      expect(overlaps(reqRect, childRect)).toBe(false);
+      // 子の左端が requester の右端より外側にある
+      expect(pos.x).toBeGreaterThanOrEqual(1200);
+    });
+
+    it('メンバー 1 名: 拡大 requester / 既存メンバーの両方と overlap しない', () => {
+      const leader = resizedNode('leader', 0, 0, 1200, 800);
+      const first = defaultNode('first', 1500, 100);
+      const pos = findRecruitPosition(leader, [leader, first], { getScreenSize: stableScreen });
+
+      const reqRect = rect(0, 0, 1200, 800);
+      const childRect = rect(pos.x, pos.y, NODE_W, NODE_H);
+      const firstRect = rect(1500, 100, NODE_W, NODE_H);
+      expect(overlaps(reqRect, childRect)).toBe(false);
+      expect(overlaps(firstRect, childRect)).toBe(false);
+    });
+
+    it('メンバー 6 名以上 (grid): 1 列目の x 起点が requester の右端 + GRID_COL_GAP', () => {
+      const leader = resizedNode('leader', 100, 200, 1200, 800);
+      const others = Array.from({ length: 5 }, (_, i) =>
+        defaultNode(`m${i}`, 5000 + i * 100, 5000 + i * 100)
+      );
+      const pos = findRecruitPosition(leader, [leader, ...others], {
+        getScreenSize: stableScreen
+      });
+
+      // newIdx=5 → col=1, row=2
+      // 起点 x = leader.x + rW + 32 + (NODE_W + 32) * 1
+      const expectedX = 100 + 1200 + 32 + (NODE_W + 32) * 1;
+      const expectedY = 200 + (NODE_H + 32) * 2;
+      expect(pos.x).toBe(expectedX);
+      expect(pos.y).toBe(expectedY);
+    });
+
+    it('縦長 requester でも overlap しない (rH > NODE_H)', () => {
+      const leader = resizedNode('leader', 0, 0, NODE_W, 1500);
+      const pos = findRecruitPosition(leader, [leader], { getScreenSize: stableScreen });
+
+      const reqRect = rect(0, 0, NODE_W, 1500);
+      const childRect = rect(pos.x, pos.y, NODE_W, NODE_H);
+      expect(overlaps(reqRect, childRect)).toBe(false);
+    });
+  });
+
+  describe('screen-size cap', () => {
+    it('小画面でも overlap 回避を優先 (baseRadius を effectiveCap で下回らない)', () => {
+      const leader = resizedNode('leader', 0, 0, 1200, 800);
+      // 極端な小画面: cap = max(NODE_W, 200 * 0.45) = NODE_W (760) になる
+      // しかし baseRadius = max(1200,800)/2 + max(NODE_W,NODE_H)/2 + 60
+      //                 = 600 + 380 + 60 = 1040 > cap なので effectiveCap = baseRadius
+      const pos = findRecruitPosition(leader, [leader], { getScreenSize: () => 200 });
+
+      const reqRect = rect(0, 0, 1200, 800);
+      const childRect = rect(pos.x, pos.y, NODE_W, NODE_H);
+      expect(overlaps(reqRect, childRect)).toBe(false);
+    });
+  });
+});

--- a/src/renderer/src/lib/canvas-placement.ts
+++ b/src/renderer/src/lib/canvas-placement.ts
@@ -60,13 +60,16 @@ function pointOrNull(position: Partial<CanvasPoint> | undefined): CanvasPoint | 
   return x === null || y === null ? null : { x, y };
 }
 
-function nodeRect(
+/**
+ * 任意の Canvas ノードから「実際に描画されている幅/高さ」を取り出す。
+ * 優先順位は `style.width` → `measured.width` → `node.width` → fallback。
+ * NodeResizer で拡大されたカードを基準に配置計算したい用途で使う (Issue #569)。
+ */
+export function getNodeSize(
   node: CanvasPlacementNode,
   fallbackWidth: number,
   fallbackHeight: number
-): Rect | null {
-  const position = pointOrNull(node.position);
-  if (!position) return null;
+): { width: number; height: number } {
   const width = positiveDimension(
     node.style?.width ?? node.measured?.width ?? node.width,
     fallbackWidth
@@ -75,6 +78,17 @@ function nodeRect(
     node.style?.height ?? node.measured?.height ?? node.height,
     fallbackHeight
   );
+  return { width, height };
+}
+
+function nodeRect(
+  node: CanvasPlacementNode,
+  fallbackWidth: number,
+  fallbackHeight: number
+): Rect | null {
+  const position = pointOrNull(node.position);
+  if (!position) return null;
+  const { width, height } = getNodeSize(node, fallbackWidth, fallbackHeight);
   return {
     left: position.x,
     top: position.y,

--- a/src/renderer/src/lib/canvas-recruit-position.ts
+++ b/src/renderer/src/lib/canvas-recruit-position.ts
@@ -1,0 +1,137 @@
+/**
+ * Recruit (team_recruit) で新メンバーカードを配置する位置を計算する pure module。
+ *
+ * Issue #259: 6 名以上は同心円配置を諦め、requester の右側 2 列グリッドに展開する。
+ * Issue #569: requester (Leader / HR) が NodeResizer で拡大されている場合でも、
+ *   center / radius / grid 起点を「requester の実サイズ」で計算することで新メンバーが
+ *   requester の bounding box にめり込まないようにする。子カード自身のサイズは
+ *   `addCard` 側で常に NODE_W × NODE_H 固定なので、ここでは requester サイズだけを
+ *   動的に扱う (= Leader を拡大しても子は Leader と同じ大きさにしない、を維持)。
+ *
+ * `use-recruit-listener.ts` から `useEffect` 経由でしか呼ばれないが、tauri / react
+ * 依存を持たない pure 関数として切り出すことで vitest から直接 unit test できる。
+ * (`canvas-recruit-focus.ts` と同じ分離パターン。)
+ */
+import type { Node } from '@xyflow/react';
+import type { CardData } from '../stores/canvas';
+import { NODE_H, NODE_W } from '../stores/canvas';
+import { getNodeSize } from './canvas-placement';
+
+/**
+ * Issue #259: 同心円配置のマージン。
+ *  - 0-3 名: 60 (狭めに、1080p でも fitView せず収まる)
+ *  - 4-5 名: 80 (PR #257 と同じ既存挙動を維持)
+ */
+function recruitMargin(memberCount: number): number {
+  return memberCount <= 3 ? 60 : 80;
+}
+
+/**
+ * Issue #259: 6 名以上 (Leader 含む newMemberCount >= 6) は同心円配置を諦め、
+ * requester の右側 2 列グリッドに展開する。
+ */
+const GRID_PLACEMENT_THRESHOLD = 6;
+const GRID_COLS = 2;
+const GRID_COL_GAP = 32;
+const GRID_ROW_GAP = 32;
+
+/**
+ * `window.innerWidth/innerHeight` から radius のキャップを計算する。
+ * テストから注入できるよう関数化。
+ */
+function defaultScreenSize(): number {
+  if (typeof window === 'undefined') return Math.max(1920, 1080);
+  return Math.max(window.innerWidth || 1920, window.innerHeight || 1080);
+}
+
+export interface FindRecruitPositionOptions {
+  /** screen-size cap 計算用。テストから注入する。 */
+  getScreenSize?: () => number;
+}
+
+/** requester の周囲で空いている角度を見つけて配置位置を返す。
+ *  既存メンバーの方角をスキャンし、最も空いている角度をピック。
+ *
+ *  Issue #569: requester (Leader / HR) が NodeResizer で拡大されている場合でも、
+ *  `style.width/height` を読んで center / radius / grid の起点を実サイズベースに
+ *  計算する。新メンバー側のカードサイズは固定 (NODE_W × NODE_H) のままなので、
+ *  Leader を拡大しても子は同サイズにならない。
+ */
+export function findRecruitPosition(
+  requester: Node<CardData>,
+  team: Node<CardData>[],
+  options: FindRecruitPositionOptions = {}
+): { x: number; y: number } {
+  const others = team.filter((n) => n.id !== requester.id);
+  const newMemberCount = others.length + 1;
+  const { width: rW, height: rH } = getNodeSize(requester, NODE_W, NODE_H);
+
+  // Issue #259 / #569: 6 名以上は requester の右側 2 列グリッドに展開。
+  // 1 列目の起点を「requester の右端 + GRID_COL_GAP」にすることで、
+  // 拡大された requester でも overlap しない。
+  if (newMemberCount >= GRID_PLACEMENT_THRESHOLD) {
+    const newIdx = others.length; // 0-based new index = 既存 others 数
+    const col = newIdx % GRID_COLS;
+    const row = Math.floor(newIdx / GRID_COLS);
+    return {
+      x: requester.position.x + rW + GRID_COL_GAP + (NODE_W + GRID_COL_GAP) * col,
+      y: requester.position.y + (NODE_H + GRID_ROW_GAP) * row
+    };
+  }
+
+  // 通常: 同心円配置 (size-aware 半径)
+  const cx = requester.position.x + rW / 2;
+  const cy = requester.position.y + rH / 2;
+  // requester の外接半径 + 子カードの外接半径 + マージン。
+  // これにより requester の bounding box の外側に子の中心が来ることが保証される。
+  // 旧挙動 (NODE_W + 60 / NODE_W + 80) は requester=NODE_W×NODE_H のときの
+  // requesterOuter + childOuter ≒ NODE_W のケースに一致する設計。
+  const requesterOuter = Math.max(rW, rH) / 2;
+  const childOuter = Math.max(NODE_W, NODE_H) / 2;
+  const margin = recruitMargin(newMemberCount);
+  const baseRadius = requesterOuter + childOuter + margin;
+  // 既存の screen-size cap (極端な小画面で radius が暴れないようにするガード) は維持。
+  // ただし overlap 回避を優先するので、cap は baseRadius を必ず下回らせない
+  // (= effectiveCap は baseRadius を絶対下限として clamp する)。
+  const screenSize = (options.getScreenSize ?? defaultScreenSize)();
+  const cap = Math.max(NODE_W, screenSize * 0.45);
+  const effectiveCap = Math.max(cap, baseRadius);
+  const radius = Math.min(baseRadius, effectiveCap);
+
+  if (others.length === 0) {
+    // 子カードの中心を (cx + radius, cy) に置きたいので、左上座標は子の半サイズ分戻す。
+    return {
+      x: cx + radius - NODE_W / 2,
+      y: cy - NODE_H / 2
+    };
+  }
+  // 既存メンバーの角度を集計 (他メンバーは既定サイズ前提で OK)
+  const usedAngles = others.map((n) => {
+    const ox = n.position.x + NODE_W / 2;
+    const oy = n.position.y + NODE_H / 2;
+    return Math.atan2(oy - cy, ox - cx);
+  });
+  // 12 等分のスロットを試して、最も近い既存メンバーから角度的に最も離れた slot を選ぶ
+  const SLOTS = 12;
+  let bestAngle = 0;
+  let bestDist = -1;
+  for (let i = 0; i < SLOTS; i++) {
+    const a = (i / SLOTS) * Math.PI * 2 - Math.PI / 2; // 上から時計回り
+    const minDistToUsed = usedAngles.reduce((min, u) => {
+      const d = Math.min(
+        Math.abs(a - u),
+        Math.abs(a - u + Math.PI * 2),
+        Math.abs(a - u - Math.PI * 2)
+      );
+      return Math.min(min, d);
+    }, Number.POSITIVE_INFINITY);
+    if (minDistToUsed > bestDist) {
+      bestDist = minDistToUsed;
+      bestAngle = a;
+    }
+  }
+  return {
+    x: cx + Math.cos(bestAngle) * radius - NODE_W / 2,
+    y: cy + Math.sin(bestAngle) * radius - NODE_H / 2
+  };
+}

--- a/src/renderer/src/lib/use-recruit-listener.ts
+++ b/src/renderer/src/lib/use-recruit-listener.ts
@@ -9,11 +9,12 @@
  */
 import { useEffect } from 'react';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-import { useCanvasStore, NODE_W, NODE_H } from '../stores/canvas';
+import { useCanvasStore } from '../stores/canvas';
 import type { Node } from '@xyflow/react';
 import type { CardData } from '../stores/canvas';
 import { useRoleProfiles } from './role-profiles-context';
 import { ackRecruit } from './recruit-ack';
+import { findRecruitPosition } from './canvas-recruit-position';
 import type { WaitPolicy } from '../../../types/shared';
 
 interface RecruitRequestPayload {
@@ -45,36 +46,6 @@ interface RecruitCancelledPayload {
   newAgentId: string;
   reason: string;
 }
-
-// NODE_W / NODE_H は stores/canvas.ts の共有定数を import (Issue #253 で 640x400 に拡張)
-
-/**
- * Issue #259: 同心円配置の半径を「メンバー数 + 画面サイズ」両方に応じた可変値にする。
- *  - 0-3 名: NODE_W + 60 (狭めに、1080p でも fitView せず収まる)
- *  - 4-5 名: NODE_W + 80 (PR #257 と同じ既存挙動を維持)
- *  - 6+ 名: 同心円ではなくグリッド配置に切替えるため radius は使われない
- *  - clamp: 画面サイズの 45% を上限として極端な小画面で半径が画面外を超えないようにする
- *           (NODE_W 未満には絶対しない)
- */
-function computeRecruitRadius(memberCount: number): number {
-  const base = memberCount <= 3 ? NODE_W + 60 : NODE_W + 80;
-  const screenSize = Math.max(
-    typeof window !== 'undefined' ? window.innerWidth : 1920,
-    typeof window !== 'undefined' ? window.innerHeight : 1080
-  );
-  const cap = Math.max(NODE_W, screenSize * 0.45);
-  return Math.min(base, cap);
-}
-
-/**
- * Issue #259: 6 名以上 (Leader 含む newMemberCount >= 6) は同心円配置を諦め、
- * requester の右側 2 列グリッドに展開する。論理幅が小画面 viewport を超えても
- * Canvas 側 fitView の zoom 下限ガードと組み合わせて UX を保つ。
- */
-const GRID_PLACEMENT_THRESHOLD = 6;
-const GRID_COLS = 2;
-const GRID_COL_GAP = 32;
-const GRID_ROW_GAP = 32;
 
 function waitPolicyInstructions(policy: WaitPolicy | undefined): string {
   const resolved = policy ?? 'strict';
@@ -109,64 +80,6 @@ function mergeCustomInstructions(
   waitPolicy: WaitPolicy | undefined
 ): string {
   return [raw?.trim(), waitPolicyInstructions(waitPolicy)].filter(Boolean).join('\n\n');
-}
-
-/** requester の周囲で空いている角度を見つけて配置位置を返す。
- *  既存メンバーの方角をスキャンし、最も空いている角度をピック。 */
-function findRecruitPosition(
-  requester: Node<CardData>,
-  team: Node<CardData>[]
-): { x: number; y: number } {
-  const others = team.filter((n) => n.id !== requester.id);
-  const newMemberCount = others.length + 1;
-
-  // Issue #259: 6 名以上は requester の右側 2 列グリッドに展開
-  if (newMemberCount >= GRID_PLACEMENT_THRESHOLD) {
-    const newIdx = others.length; // 0-based new index = 既存 others 数
-    const col = newIdx % GRID_COLS;
-    const row = Math.floor(newIdx / GRID_COLS);
-    return {
-      x: requester.position.x + (NODE_W + GRID_COL_GAP) * (col + 1),
-      y: requester.position.y + (NODE_H + GRID_ROW_GAP) * row
-    };
-  }
-
-  // 通常: 同心円配置 (可変半径)
-  const radius = computeRecruitRadius(newMemberCount);
-  const cx = requester.position.x + NODE_W / 2;
-  const cy = requester.position.y + NODE_H / 2;
-  if (others.length === 0) {
-    return { x: requester.position.x + radius, y: requester.position.y };
-  }
-  // 既存メンバーの角度を集計
-  const usedAngles = others.map((n) => {
-    const ox = n.position.x + NODE_W / 2;
-    const oy = n.position.y + NODE_H / 2;
-    return Math.atan2(oy - cy, ox - cx);
-  });
-  // 12 等分のスロットを試して、最も近い既存メンバーから角度的に最も離れた slot を選ぶ
-  const SLOTS = 12;
-  let bestAngle = 0;
-  let bestDist = -1;
-  for (let i = 0; i < SLOTS; i++) {
-    const a = (i / SLOTS) * Math.PI * 2 - Math.PI / 2; // 上から時計回り
-    const minDistToUsed = usedAngles.reduce((min, u) => {
-      const d = Math.min(
-        Math.abs(a - u),
-        Math.abs(a - u + Math.PI * 2),
-        Math.abs(a - u - Math.PI * 2)
-      );
-      return Math.min(min, d);
-    }, Number.POSITIVE_INFINITY);
-    if (minDistToUsed > bestDist) {
-      bestDist = minDistToUsed;
-      bestAngle = a;
-    }
-  }
-  return {
-    x: cx + Math.cos(bestAngle) * radius - NODE_W / 2,
-    y: cy + Math.sin(bestAngle) * radius - NODE_H / 2
-  };
 }
 
 export function useRecruitListener(): void {


### PR DESCRIPTION
## Summary
- `findRecruitPosition` を `requester.style.width/height` 基準の size-aware 計算に変更し、Leader / HR を NodeResizer で拡大した状態で `team_recruit` しても新メンバーが requester の bounding box にめり込まないようにする
- 同心円配置の半径を「requester 外接半径 + 子外接半径 + マージン (60/80)」で算出し、grid 配置 (>=6 名) の 1 列目起点を「requester 右端 + GRID_COL_GAP」に変更
- 子カードのサイズは `addCard` 既定 (`NODE_W × NODE_H`) のまま変更せず、Leader 拡大時に同サイズにならないことを維持
- pure module `canvas-recruit-position.ts` に切り出して unit test 可能にし、regression + 拡大 + 小画面 cap で 8 ケースを追加

Closes #569

## 変更ファイル
- `src/renderer/src/lib/canvas-placement.ts` — `getNodeSize` を named export 追加
- `src/renderer/src/lib/canvas-recruit-position.ts` (新規) — pure な `findRecruitPosition`
- `src/renderer/src/lib/use-recruit-listener.ts` — 配置計算を新モジュールに委譲し、未使用となった旧ロジックを削除
- `src/renderer/src/lib/__tests__/canvas-recruit-position.test.ts` (新規) — 単体テスト 8 件

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm test` 305 件 pass (新規 8 件含む)
- [ ] 実機 (`npm run dev`) で:
  - [ ] Canvas で Leader を 1.5〜2 倍 (例 1200×800) に NodeResizer で拡大
  - [ ] `team_recruit` で 1〜5 名採用 → 全員 Leader と overlap せずに配置される
  - [ ] 6 名目以降を採用 → 右側 2 列グリッドが Leader 右端 + 32px から始まる
  - [ ] 採用された子カードのサイズが既定 (760×460) のまま (Leader と同サイズになっていない)
  - [ ] Leader を既定サイズに戻して再採用 → 旧挙動と同じ円形配置 (regression)