### PR TITLE
fix(pty): import PathBuf unconditionally for non-Windows builds

### DIFF
--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -16,9 +16,7 @@ use std::collections::HashMap;
 #[cfg(windows)]
 use std::collections::HashSet;
 use std::io::{Read, Write};
-use std::path::Path;
-#[cfg(windows)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};


### PR DESCRIPTION
## Summary

PR #571 introduced `resolve_terminal_command_path_for_check{,_with_env}` whose signatures use `Result<PathBuf>` regardless of target, but `use std::path::PathBuf` in `src-tauri/src/pty/session.rs` was still gated behind `#[cfg(windows)]`. As a result, the Linux / macOS CI `verify` job fails with `error[E0425]: cannot find type PathBuf in this scope` after #571 merged.

This hotfix removes the `#[cfg(windows)]` from the `PathBuf` import so all targets compile.

## Test plan

- [x] `cargo check --lib` — Finished `dev` profile (no errors)
- [x] `cargo test --lib` — 295/295 PASS on Windows
- [ ] CI `verify` (Linux) — passes after this hotfix
- [ ] vibe-editor-reviewer (bot) review pass