### PR TITLE
fix(teamhub): #574 recruit_ack の timeout 拡大と観測強化

### DIFF
--- a/src-tauri/src/team_hub/protocol/consts.rs
+++ b/src-tauri/src/team_hub/protocol/consts.rs
@@ -9,9 +9,14 @@
 use std::time::Duration;
 
 pub(crate) const RECRUIT_TIMEOUT: Duration = Duration::from_secs(30);
-/// Issue #342 Phase 1: renderer 側 `app_recruit_ack` invoke 受領を待つ短期タイムアウト。
-/// 「addCard / spawn 開始の受領通知」だけを待つので 5s で十分 (handshake 完了までは待たない)。
-pub(crate) const RECRUIT_ACK_TIMEOUT: Duration = Duration::from_secs(5);
+/// Issue #342 Phase 1: renderer 側 `app_recruit_ack` invoke 受領を待つ短期タイムアウトの
+/// デフォルト値。「addCard / spawn 開始の受領通知」を待つ (handshake 完了までは待たない)。
+///
+/// Issue #574: Windows + WebView 環境で同時 6 件 recruit 等のとき 5s では addCard 完了前に
+/// cancel が走る事故が報告されたため 5s → 15s に拡大。実行時値は環境変数
+/// `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS` (有効範囲は 1 以上の u64 秒) で上書き可能。
+/// 参照は `protocol/tools/recruit.rs` の `recruit_ack_timeout()` ヘルパ経由。
+pub(crate) const RECRUIT_ACK_TIMEOUT: Duration = Duration::from_secs(15);
 /// 動的ロール instructions の最大長。Leader が暴走して巨大プロンプトを投げてくるのを抑える。
 pub(crate) const MAX_DYNAMIC_INSTRUCTIONS_LEN: usize = 16 * 1024; // 16 KiB
 /// 動的ロール label / description の最大長

--- a/src-tauri/src/team_hub/protocol/tools/create_leader.rs
+++ b/src-tauri/src/team_hub/protocol/tools/create_leader.rs
@@ -14,9 +14,10 @@ use std::time::Instant;
 use tauri::Emitter;
 use uuid::Uuid;
 
-use super::super::consts::{RECRUIT_ACK_TIMEOUT, RECRUIT_TIMEOUT};
+use super::super::consts::RECRUIT_TIMEOUT;
 use super::super::permissions::{check_permission, Permission};
 use super::error::RecruitError;
+use super::recruit::recruit_ack_timeout;
 
 /// `team_create_leader` — 引き継ぎ用に同 teamId へ追加の leader カードを spawn する。
 ///
@@ -140,8 +141,17 @@ pub async fn team_create_leader(
     }
 
     // ack 待機 (renderer が `team:recruit-request` を受領 → addCard 開始)
-    match tokio::time::timeout(RECRUIT_ACK_TIMEOUT, ack_rx).await {
-        Ok(Ok(ack)) if ack.ok => {}
+    // Issue #574: timeout 値は `recruit_ack_timeout()` (env override 込み、default 15s)。
+    let ack_timeout = recruit_ack_timeout();
+    match tokio::time::timeout(ack_timeout, ack_rx).await {
+        Ok(Ok(ack)) if ack.ok => {
+            let elapsed_ms = started.elapsed().as_millis() as u64;
+            tracing::info!(
+                "[teamhub] recruit_ack received agent_id={new_agent_id} \
+                 team_id={team_id} elapsed_ms={elapsed_ms}",
+                team_id = ctx.team_id,
+            );
+        }
         Ok(Ok(ack)) => {
             hub.cancel_pending_recruit(&new_agent_id).await;
             let phase_str = ack
@@ -185,6 +195,12 @@ pub async fn team_create_leader(
             .into_err_string());
         }
         Err(_) => {
+            let elapsed_ms = started.elapsed().as_millis() as u64;
+            tracing::info!(
+                "[teamhub] recruit_ack timed_out agent_id={new_agent_id} \
+                 team_id={team_id} elapsed_ms={elapsed_ms}",
+                team_id = ctx.team_id,
+            );
             hub.cancel_pending_recruit(&new_agent_id).await;
             if let Some(app) = &app {
                 let _ = app.emit(
@@ -196,10 +212,10 @@ pub async fn team_create_leader(
                 code: "create_leader_ack_timeout".into(),
                 message: format!(
                     "renderer did not ack recruit-request within {}s",
-                    RECRUIT_ACK_TIMEOUT.as_secs()
+                    ack_timeout.as_secs()
                 ),
                 phase: Some("ack".into()),
-                elapsed_ms: Some(started.elapsed().as_millis() as u64),
+                elapsed_ms: Some(elapsed_ms),
             }
             .into_err_string());
         }

--- a/src-tauri/src/team_hub/protocol/tools/recruit.rs
+++ b/src-tauri/src/team_hub/protocol/tools/recruit.rs
@@ -4,7 +4,7 @@
 
 use crate::team_hub::{CallContext, DynamicRole, TeamHub};
 use serde_json::{json, Value};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tauri::Emitter;
 use uuid::Uuid;
 
@@ -18,6 +18,22 @@ use super::error::RecruitError;
 use crate::team_hub::role_lint::{compute_role_overlap, RoleSnapshot};
 
 const DEFAULT_WAIT_POLICY: &str = "strict";
+
+/// Issue #574: `RECRUIT_ACK_TIMEOUT` の実行時値を env override 込みで返す。
+///
+/// `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS` を u64 秒として読み出し、`>= 1` の値が
+/// パースできればその Duration を返す。未設定 / パース失敗 / 0 のときは
+/// `RECRUIT_ACK_TIMEOUT` (= 15s) を返す。
+///
+/// `team_recruit` / `team_create_leader` の双方から参照される共通入口。
+pub(super) fn recruit_ack_timeout() -> Duration {
+    std::env::var("VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|&secs| secs > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(RECRUIT_ACK_TIMEOUT)
+}
 
 fn parse_wait_policy(args: &Value) -> Result<String, String> {
     let raw = args
@@ -329,13 +345,21 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
     let disable_ack = std::env::var("VIBE_TEAM_DISABLE_RECRUIT_ACK").as_deref() == Ok("1");
 
     if !disable_ack {
-        // Issue #342 Phase 1: ack 短期待機 (5s)。renderer が `team:recruit-request` を受領して
+        // Issue #342 Phase 1: ack 短期待機。renderer が `team:recruit-request` を受領して
         // addCard / spawn を開始した時点で `app_recruit_ack(ok=true)` が来る。
         // ack 失敗 / timeout なら handshake を待たずに即座に構造化エラーを返す。
-        match tokio::time::timeout(RECRUIT_ACK_TIMEOUT, ack_rx).await {
+        // Issue #574: timeout 値は `recruit_ack_timeout()` (env override 込み、default 15s)。
+        let ack_timeout = recruit_ack_timeout();
+        match tokio::time::timeout(ack_timeout, ack_rx).await {
             Ok(Ok(ack)) if ack.ok => {
                 // ack 受領 OK。続けて handshake 待機へ。
                 // ※ ack=true は受領通知のみ。MCP 成功判定は依然 handshake 経由のみ。
+                let elapsed_ms = started.elapsed().as_millis() as u64;
+                tracing::info!(
+                    "[teamhub] recruit_ack received agent_id={new_agent_id} \
+                     team_id={team_id} elapsed_ms={elapsed_ms}",
+                    team_id = ctx.team_id,
+                );
             }
             Ok(Ok(ack)) => {
                 // renderer から ack(ok=false) が来た = 起動失敗を即時通知された
@@ -379,7 +403,13 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
                 .into_err_string());
             }
             Err(_) => {
-                // ack timeout (5s)。renderer が `team:recruit-request` を受け取れていない可能性。
+                // ack timeout。renderer が `team:recruit-request` を受け取れていない可能性。
+                let elapsed_ms = started.elapsed().as_millis() as u64;
+                tracing::info!(
+                    "[teamhub] recruit_ack timed_out agent_id={new_agent_id} \
+                     team_id={team_id} elapsed_ms={elapsed_ms}",
+                    team_id = ctx.team_id,
+                );
                 hub.cancel_pending_recruit(&new_agent_id).await;
                 if let Some(app) = &app {
                     let _ = app.emit(
@@ -391,11 +421,11 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
                     "recruit_ack_timeout",
                     format!(
                         "renderer did not ack recruit-request within {}s",
-                        RECRUIT_ACK_TIMEOUT.as_secs()
+                        ack_timeout.as_secs()
                     ),
                 )
                 .with_phase("ack")
-                .with_elapsed_ms(started.elapsed().as_millis() as u64)
+                .with_elapsed_ms(elapsed_ms)
                 .into_err_string());
             }
         }

--- a/src-tauri/src/team_hub/state.rs
+++ b/src-tauri/src/team_hub/state.rs
@@ -894,8 +894,13 @@ impl TeamHub {
     ) -> Result<(), AckError> {
         let mut s = self.state.lock().await;
         let Some(pending) = s.pending_recruits.get_mut(agent_id) else {
-            tracing::warn!(
-                "[teamhub] recruit_ack ignored: no pending recruit for agent={agent_id}"
+            // Issue #574: ack_timeout 後の遅着 ack は設計上の正常現象 (cancel_pending_recruit が
+            // pending を完全削除した後で renderer が ack invoke を届けるパス) なので、
+            // warn → info に降格してアラート noise を減らす。agent_id / team_id / reason は
+            // 構造化キーで出して grep / 集計しやすくする。
+            tracing::info!(
+                "[teamhub] recruit_ack ignored agent_id={agent_id} team_id={expected_team_id} \
+                 reason=no_pending_recruit"
             );
             return Err(AckError::NotFound);
         };


### PR DESCRIPTION
## Summary
- `RECRUIT_ACK_TIMEOUT` を 5s → 15s に拡大し、`VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS` (u64 秒, 1 以上) で実行時上書き可能化。Windows + WebView で同時 6 件 recruit / canvas 非アクティブ時に「recruit_ack ignored: no pending recruit」が頻発する事故を緩和する Phase 1 (即効・低リスク) 修正。
- `team_recruit` / `team_create_leader` の ack 経路に `tracing::info!("[teamhub] recruit_ack received|timed_out agent_id=... team_id=... elapsed_ms=...")` を追加。emit→ack の片道時間を観測できるようにし、Phase 2 (直列化 / 遅着 ack 救済) の要否を数値で判断するための足場を作る。
- `state.rs::resolve_recruit_ack` の「no pending recruit」ブランチを `tracing::warn!` → `tracing::info!` に降格。`agent_id` / `team_id` / `reason=no_pending_recruit` を構造化キーで出力。timeout 後の遅着 ack は設計上の正常現象なのでアラート noise を減らす意図。`team_id mismatch` / `already acked` の warn は異常系として維持。

Phase 2 (semaphore による直列化 / 遅着 ack の grace 救済 / canvas 非アクティブ検出 / Windows PTY spawn 計測) は本 PR のスコープ外。

## Test plan
- [x] `cargo test -p vibe-editor team_hub` (179 件 PASS / 既存テスト全通過)
- [x] `cargo build` 通過確認 (warning は本変更と無関係な既存 dead_code のみ)
- [x] env 未設定時のデフォルトが 15s に拡大されていること (consts.rs の値で検証)
- [x] `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS=2` 等の有効値で上書きされること (helper の単純な fold 経路)
- [x] 無効値 (非数値 / 空 / 0) でデフォルトにフォールバックすること (helper の `filter`/`ok` 経路)
- [x] renderer / IPC 契約への変更なし — 既存挙動への影響は ack timeout 値の拡大のみ

Closes #574