### PR TITLE
chore(pty): #579 spawn 所要時間を tracing ログで可視化

### DIFF
--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -751,6 +751,215 @@ mod spawn_command_resolution_tests {
     }
 }
 
+#[cfg(test)]
+mod spawn_metrics_tests {
+    //! Issue #579: PTY spawn の所要時間ログ周りのユニットテスト。
+    //!
+    //! 実 PTY を立てる E2E は CI が遅いため避け、ヘルパ関数の単体挙動と
+    //! 自前の captured-writer subscriber で `[pty] spawn ok` / `[pty] spawn failed`
+    //! の出力を確認する軽量テストに留める。`tracing-test` を使わないのは、
+    //! こちらの subscriber は `target: "pty"` を自分の crate filter で弾かない
+    //! (test ローカルに `with_default` で全 target を拾う) ため。
+
+    use super::*;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::MakeWriter;
+
+    fn fixture(resolved: &str, requested: &str) -> PreparedSpawnCommand {
+        PreparedSpawnCommand {
+            requested_command: requested.to_string(),
+            resolved_command: resolved.to_string(),
+            program: resolved.to_string(),
+            args: vec![],
+            path_entries: 0,
+            pathext_present: false,
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct CapturedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CapturedWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CapturedWriter {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn capture<F: FnOnce()>(f: F) -> String {
+        let writer = CapturedWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer.clone())
+            .with_max_level(tracing::Level::TRACE)
+            .with_target(true)
+            .with_ansi(false)
+            .finish();
+        tracing::subscriber::with_default(subscriber, f);
+        let buf = writer.0.lock().unwrap().clone();
+        String::from_utf8(buf).unwrap_or_default()
+    }
+
+    #[test]
+    fn engine_label_picks_codex_when_flag_set() {
+        assert_eq!(engine_label(true), "codex");
+        assert_eq!(engine_label(false), "claude");
+    }
+
+    #[test]
+    fn platform_label_returns_known_value() {
+        let p = platform_label();
+        assert!(matches!(p, "windows" | "macos" | "linux" | "other"));
+    }
+
+    #[test]
+    fn build_cmd_label_strips_windows_path() {
+        let prepared = fixture(r"C:\Users\foo\AppData\Roaming\npm\claude.cmd", "claude");
+        assert_eq!(build_cmd_label(&prepared), "claude.cmd");
+    }
+
+    #[test]
+    fn build_cmd_label_strips_unix_path() {
+        let prepared = fixture("/usr/local/bin/codex", "codex");
+        assert_eq!(build_cmd_label(&prepared), "codex");
+    }
+
+    #[test]
+    fn build_cmd_label_falls_back_to_requested_when_resolved_empty() {
+        let prepared = fixture("", "claude");
+        assert_eq!(build_cmd_label(&prepared), "claude");
+    }
+
+    #[test]
+    fn log_spawn_outcome_emits_info_on_success() {
+        let logs = capture(|| {
+            log_spawn_outcome("claude.cmd", "claude", "windows", 123, None);
+        });
+        // tracing-subscriber の既定 formatter は文字列フィールドを quote しないので
+        // `engine=claude` のように key=value (no quotes) で照合する。集計用 grep の
+        // 想定もこの形 (`Select-String 'engine=claude'`)。
+        assert!(
+            logs.contains("[pty] spawn ok"),
+            "expected `[pty] spawn ok` in logs but got: {logs}"
+        );
+        assert!(logs.contains("elapsed_ms=123"), "logs: {logs}");
+        assert!(logs.contains("engine=claude"), "logs: {logs}");
+        assert!(logs.contains("platform=windows"), "logs: {logs}");
+        assert!(logs.contains("command=claude.cmd"), "logs: {logs}");
+        // target=pty が prefix 部分に出る (`INFO pty:` のような行になる)
+        assert!(logs.contains("pty:"), "expected `pty:` target prefix: {logs}");
+        // INFO レベルで出ていること (failed は warn)
+        assert!(logs.contains("INFO"), "logs: {logs}");
+        assert!(
+            !logs.contains("[pty] spawn failed"),
+            "success path emitted failure log: {logs}"
+        );
+    }
+
+    #[test]
+    fn log_spawn_outcome_emits_warn_on_failure() {
+        let logs = capture(|| {
+            log_spawn_outcome(
+                "codex.cmd",
+                "codex",
+                "windows",
+                456,
+                Some("executable not found"),
+            );
+        });
+        assert!(
+            logs.contains("[pty] spawn failed"),
+            "expected `[pty] spawn failed` in logs but got: {logs}"
+        );
+        assert!(logs.contains("elapsed_ms=456"), "logs: {logs}");
+        assert!(logs.contains("engine=codex"), "logs: {logs}");
+        assert!(
+            logs.contains("error=executable not found"),
+            "logs: {logs}"
+        );
+        // WARN レベルで出ていること
+        assert!(logs.contains("WARN"), "logs: {logs}");
+    }
+}
+
+/// Issue #579: spawn ログ用に「漏洩しない短い command ラベル」を作る。
+///
+/// resolved_command はフルパス (例: `C:\Users\foo\AppData\Roaming\npm\claude.cmd`) を
+/// 持ちうるので、basename だけ取り出してさらに `redact_home` を通す。`Path::file_name`
+/// は Unix 上で Windows 区切り `\` を解釈しないため、cross-platform に動かすには
+/// 両方の区切りで rsplit する。
+fn build_cmd_label(prepared: &PreparedSpawnCommand) -> String {
+    let basename = prepared
+        .resolved_command
+        .rsplit(|c: char| c == '/' || c == '\\')
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(prepared.requested_command.as_str())
+        .to_string();
+    redact_home(&basename)
+}
+
+fn engine_label(is_codex: bool) -> &'static str {
+    if is_codex {
+        "codex"
+    } else {
+        "claude"
+    }
+}
+
+fn platform_label() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "windows"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else {
+        "other"
+    }
+}
+
+/// Issue #579: PTY spawn の所要時間 + 結果を tracing で記録する。
+/// 集計は `target=pty` + メッセージ `[pty] spawn ok` / `[pty] spawn failed` で grep する想定。
+/// 詳細は `tasks/issue-579/notes.md` を参照。
+fn log_spawn_outcome(
+    cmd_label: &str,
+    engine: &str,
+    platform: &str,
+    elapsed_ms: u64,
+    error: Option<&str>,
+) {
+    match error {
+        None => tracing::info!(
+            target: "pty",
+            command = %cmd_label,
+            engine = %engine,
+            platform = %platform,
+            elapsed_ms = elapsed_ms,
+            "[pty] spawn ok"
+        ),
+        Some(err) => tracing::warn!(
+            target: "pty",
+            command = %cmd_label,
+            engine = %engine,
+            platform = %platform,
+            elapsed_ms = elapsed_ms,
+            error = %err,
+            "[pty] spawn failed"
+        ),
+    }
+}
+
 pub fn spawn_session(
     app: AppHandle,
     id: String,
@@ -793,7 +1002,26 @@ pub fn spawn_session(
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
 
-    let mut child = pair.slave.spawn_command(cmd)?;
+    // Issue #579: PTY spawn 所要時間を計測してログに出す。
+    // Windows ConPTY + cmd.exe + npm shim 経由の起動コストの p50/p95 を取るのが目的。
+    // 失敗パスでも elapsed_ms を残すため `?` ではなく match で分岐する。
+    let cmd_label = build_cmd_label(&prepared_command);
+    let engine = engine_label(opts.is_codex);
+    let platform = platform_label();
+    let started = Instant::now();
+    let spawn_result = pair.slave.spawn_command(cmd);
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    let mut child = match spawn_result {
+        Ok(child) => {
+            log_spawn_outcome(&cmd_label, engine, platform, elapsed_ms, None);
+            child
+        }
+        Err(err) => {
+            let err_string = err.to_string();
+            log_spawn_outcome(&cmd_label, engine, platform, elapsed_ms, Some(&err_string));
+            return Err(err.into());
+        }
+    };
     drop(pair.slave);
 
     let killer = child.clone_killer();

--- a/tasks/issue-579/notes.md
+++ b/tasks/issue-579/notes.md
@@ -1,0 +1,127 @@
+# Issue #579 — PTY spawn 所要時間メトリクス: 観測ノート
+
+このドキュメントは Issue #579 で導入した PTY spawn 計測ログ (`[pty] spawn ok` / `[pty] spawn failed`) の **集計手順** と、観測値から **次 issue を起票するかの判定基準** を記録するためのもの。
+
+## 出力フォーマット
+
+`src-tauri/src/pty/session.rs::log_spawn_outcome` から `tracing::info!` / `tracing::warn!` で出る。`target` は `pty`、構造化フィールドは以下:
+
+| field        | 例                       | 説明                                                  |
+|--------------|--------------------------|-------------------------------------------------------|
+| `command`    | `claude.cmd`             | basename + extension (フルパスは漏らさない)。`redact_home` 通過済み |
+| `engine`     | `claude` / `codex`       | `SpawnOptions::is_codex` から判定                      |
+| `platform`   | `windows` / `macos` / `linux` | `cfg!(target_os = ...)` で判定                  |
+| `elapsed_ms` | `1234`                   | `Instant::now()` から `pair.slave.spawn_command(cmd)` 完了までの ms |
+| `error`      | `executable not found`   | 失敗時のみ。spawn_command の `anyhow::Error` の Display |
+
+成功/失敗で別メッセージ:
+
+- 成功: `info!("[pty] spawn ok")`
+- 失敗: `warn!("[pty] spawn failed")`
+
+ログは vibe-editor の標準ロガー (`tracing-subscriber` + `tracing-appender`) で `~/.vibe-editor/logs/vibe-editor.log` に書き出される (Issue #326)。
+
+## 集計方法 (Windows / PowerShell)
+
+vibe-editor を起動 → claude / codex を 5 回ずつ recruit → アプリを閉じて以下を実行:
+
+```powershell
+# ログファイルパス
+$log = Join-Path $env:USERPROFILE ".vibe-editor\logs\vibe-editor.log"
+
+# spawn ok 行から elapsed_ms を抽出
+$elapsed = Select-String -Path $log -Pattern '\[pty\] spawn ok' |
+    ForEach-Object {
+        if ($_.Line -match 'elapsed_ms=(\d+)') { [int]$Matches[1] }
+    }
+
+# 件数 / 中央値 / p95
+$n = $elapsed.Count
+$sorted = $elapsed | Sort-Object
+"count: $n"
+"p50  : $($sorted[[int][math]::Floor($n * 0.5)]) ms"
+"p95  : $($sorted[[int][math]::Floor($n * 0.95)]) ms"
+"max  : $(($sorted | Select-Object -Last 1)) ms"
+```
+
+engine / platform 別に分ける場合:
+
+```powershell
+# 注意: tracing-subscriber の既定 formatter は文字列フィールドを quote せず
+# `engine=claude` `platform=windows` のような key=value で出すため、正規表現も unquoted で書く。
+Select-String -Path $log -Pattern '\[pty\] spawn ok' |
+    ForEach-Object {
+        $line = $_.Line
+        $engine   = if ($line -match 'engine=(\w+)')   { $Matches[1] } else { '?' }
+        $platform = if ($line -match 'platform=(\w+)') { $Matches[1] } else { '?' }
+        $ms       = if ($line -match 'elapsed_ms=(\d+)') { [int]$Matches[1] } else { 0 }
+        [pscustomobject]@{ engine = $engine; platform = $platform; ms = $ms }
+    } |
+    Group-Object engine, platform |
+    ForEach-Object {
+        $vals = ($_.Group.ms | Sort-Object)
+        $n = $vals.Count
+        [pscustomobject]@{
+            bucket = $_.Name
+            count  = $n
+            p50_ms = $vals[[int][math]::Floor($n * 0.5)]
+            p95_ms = $vals[[int][math]::Floor($n * 0.95)]
+        }
+    }
+```
+
+## 集計方法 (macOS / Linux)
+
+```bash
+LOG="$HOME/.vibe-editor/logs/vibe-editor.log"
+grep '\[pty\] spawn ok' "$LOG" \
+    | grep -oE 'elapsed_ms=[0-9]+' \
+    | cut -d= -f2 \
+    | sort -n \
+    | awk '{
+        a[NR]=$1
+      } END {
+        n=NR
+        printf "count: %d\np50  : %d ms\np95  : %d ms\nmax  : %d ms\n", \
+            n, a[int(n*0.5)+1], a[int(n*0.95)+1], a[n]
+      }'
+```
+
+## 失敗パスの確認
+
+存在しないコマンドを spawn したときに `[pty] spawn failed` が出ることを確認する:
+
+```powershell
+Select-String -Path $log -Pattern '\[pty\] spawn failed'
+```
+
+`elapsed_ms` と `error` フィールドが両方記録されているか目視チェック。`prepare_spawn_command` の段階で弾かれる (allowlist 違反等) のは `[pty] spawn failed` には来ないので、portable-pty の `spawn_command` 自体が失敗したケースだけが集まる。
+
+## 次 issue を起票する判定基準
+
+Issue #574 の handshake timeout は **30 秒**。中央値がこの **10% = 3 秒 (3000 ms)** を超えるなら、PTY spawn の最適化を別 issue で起票する。具体的には以下のいずれかで起票:
+
+| 条件                                       | 起票内容                                    |
+|--------------------------------------------|---------------------------------------------|
+| Windows の `engine=claude` で p50 ≥ 3000ms | claude shim 解決の最適化 issue              |
+| Windows の `engine=codex` で p50 ≥ 3000ms  | codex shim 解決の最適化 issue               |
+| 任意プラットフォームで p95 ≥ 10000ms       | PTY pool / lazy spawn 検討 issue            |
+| 失敗率 (failed / (ok+failed)) > 5%         | spawn 信頼性 issue (root cause 別途調査)    |
+
+### 判定材料の最低サンプル数
+
+- 1 platform × 1 engine あたり最低 **20 サンプル**。それ未満なら判定保留。
+- 集計期間は **約 1 週間**を目安にする (週次でしか計測しないなら 2 週間)。
+
+### 起票時に転記する数字
+
+- `count` / `p50` / `p95` / `max`
+- engine × platform の bucket
+- 集計期間 (例: 2026-05-08 〜 2026-05-15)
+
+## 関連
+
+- 親 Issue: #574 (Phase 1) — Canvas モードでの recruit 5s ack timeout
+- 本 Issue: #579 (Phase 2 follow-up) — 観測ログのみ
+- 関連 PR: #557 / #561 / #565 / #571 / #573 (PTY shim 解決系)
+- 計測コード: `src-tauri/src/pty/session.rs::log_spawn_outcome`


### PR DESCRIPTION
## Summary
- `pty::session::spawn_session` の `pair.slave.spawn_command(...)` を `Instant::now()` で挟み、成功/失敗の両分岐で elapsed_ms を tracing ログに残す。Windows ConPTY + cmd.exe shim の起動コストの p50/p95 を grep で計測できるようにする。
- 成功時 `info!("[pty] spawn ok")`、失敗時 `warn!("[pty] spawn failed")`、`target=pty` の構造化フィールド (`command` / `engine` / `platform` / `elapsed_ms` / `error`) を付与。`command` は basename + ext のみ + `redact_home` でフルパス漏洩を防ぐ。
- `tasks/issue-579/notes.md` に PowerShell / awk の集計レシピと「中央値が handshake timeout 30s の 10% (3s) を超えたら最適化 issue を起票する」判定基準を記載。本 PR は観測ログのみで最適化施策 (PTY pool / lazy spawn / shim キャッシュ) は別 issue 化する。

Closes #579
Refs #574

## Test plan
- [x] `cargo test -p vibe-editor pty::session` — 15 件 (新規 7 件含む) すべてパス
- [x] `cargo build` — 通過 (warnings は既存の team_hub 由来のみ)
- [ ] 実機で `npm run dev` → claude / codex を 5 回ずつ recruit → `~/.vibe-editor/logs/vibe-editor.log` に `[pty] spawn ok` が記録され、`elapsed_ms=` がパース可能であることを確認 (集計用 grep は notes.md 参照)
- [ ] 失敗パスの確認: 存在しないコマンドを spawn → `[pty] spawn failed` が `elapsed_ms` + `error` 付きで残ることを目視確認

## 変更ファイル
- `src-tauri/src/pty/session.rs` — 計測ロジック + ヘルパ関数 (`build_cmd_label` / `engine_label` / `platform_label` / `log_spawn_outcome`) + 単体テストモジュール `spawn_metrics_tests`
- `tasks/issue-579/notes.md` — 集計レシピ + 次 issue 起票条件