### PR TITLE
feat(canvas): #578 Canvas 非表示中の recruit を可視化時に Toast で警告

### DIFF
--- a/src-tauri/src/commands/team_state.rs
+++ b/src-tauri/src/commands/team_state.rs
@@ -390,6 +390,32 @@ pub async fn team_state_read(
     load_orchestration_state(&project_root, &team_id).await
 }
 
+/// Issue #578: Canvas (= Tauri webview) が非表示の間に `team:recruit-request` が走った
+/// 観測点を tracing ログに 1 行残すだけの軽量 endpoint。renderer 側 `useRecruitListener`
+/// が hidden 経過時間 >= 5000ms (env `VIBE_TEAM_RECRUIT_HIDDEN_THRESHOLD_MS` で調整可能)
+/// の条件を満たした recruit に対してのみ呼ぶ。短時間 hidden で info ログを汚染しない設計。
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecruitObservedWhileHiddenArgs {
+    pub team_id: String,
+    pub agent_id: String,
+    pub hidden_for_ms: u64,
+}
+
+#[tauri::command]
+pub async fn recruit_observed_while_hidden(
+    args: RecruitObservedWhileHiddenArgs,
+) -> Result<(), String> {
+    tracing::info!(
+        target: "teamhub",
+        team_id = %args.team_id,
+        agent_id = %args.agent_id,
+        hidden_for_ms = args.hidden_for_ms,
+        "[teamhub] recruit observed while canvas hidden"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,6 +130,8 @@ pub fn run() {
             commands::team_history::team_history_save_batch,
             commands::team_history::team_history_delete,
             commands::team_state::team_state_read,
+            // ---- recruit observability (Issue #578) ----
+            commands::team_state::recruit_observed_while_hidden,
             // ---- team diagnostics read (Issue #510) ----
             commands::team_diagnostics::team_diagnostics_read,
             // ---- team inject retry (Issue #511) ----

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -39,6 +39,7 @@ import { OnboardingWizard } from './components/OnboardingWizard';
 import { ContextMenu, type ContextMenuItem } from './components/ContextMenu';
 import { MenuBar, MenuItem, MenuDivider, MenuSection } from './components/shell/MenuBar';
 import { useRecruitListener } from './lib/use-recruit-listener';
+import { useCanvasVisibility } from './lib/use-canvas-visibility';
 import { useWindowFrameInsets } from './lib/use-window-frame-insets';
 import { ClaudeNotFound } from './components/ClaudeNotFound';
 import { getStatusMascotState } from './lib/status-mascot';
@@ -618,6 +619,9 @@ export function App(): JSX.Element {
     }
   }, [hasGitRepo, sidebarView]);
   const activityFeed = useActivityFeed();
+  // Issue #578: Canvas (Tauri webview) の可視状態を観測する singleton listener を mount。
+  // useRecruitListener が hidden 中の recruit を集計するために使う。
+  useCanvasVisibility();
   // Phase 6: vibe-canvas:recruit/dismiss イベントを listen して canvas store に反映
   useRecruitListener();
   const activityOpen = useUiStore((s) => s.activityOpen);

--- a/src/renderer/src/lib/__tests__/use-canvas-visibility.test.ts
+++ b/src/renderer/src/lib/__tests__/use-canvas-visibility.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Issue #578: `useCanvasVisibility` の挙動を固定する。
+ *
+ * 検証範囲:
+ *   - `document.visibilityState` の変化が `isCanvasVisibleNow()` に反映される
+ *   - `getHiddenSinceMs()` が hidden 開始時刻を保持し visible 復帰で null に戻る
+ *   - `subscribeOnVisible` が hidden→visible 遷移時のみ発火する (edge trigger)
+ *   - 連続して visible のまま `subscribeOnVisible` を発火させない
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __resetCanvasVisibilityForTests,
+  getHiddenSinceMs,
+  isCanvasVisibleNow,
+  subscribeOnVisible
+} from '../use-canvas-visibility';
+
+function setVisibilityState(value: 'visible' | 'hidden'): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => value
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+function fireFocus(): void {
+  window.dispatchEvent(new Event('focus'));
+}
+
+function fireBlur(): void {
+  window.dispatchEvent(new Event('blur'));
+}
+
+describe('useCanvasVisibility', () => {
+  beforeEach(() => {
+    __resetCanvasVisibilityForTests();
+    setVisibilityState('visible');
+    // jsdom では document.hasFocus は true を返す。明示してテスト外要因を排除。
+    Object.defineProperty(document, 'hasFocus', {
+      configurable: true,
+      value: () => true
+    });
+  });
+
+  afterEach(() => {
+    __resetCanvasVisibilityForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('visible 時は isCanvasVisibleNow=true、hiddenSinceMs=null', () => {
+    expect(isCanvasVisibleNow()).toBe(true);
+    expect(getHiddenSinceMs()).toBeNull();
+  });
+
+  it('hidden 遷移で hiddenSinceMs に Date.now() を記録し isCanvasVisibleNow=false になる', () => {
+    isCanvasVisibleNow(); // ensureInit
+    const before = Date.now();
+    setVisibilityState('hidden');
+    expect(isCanvasVisibleNow()).toBe(false);
+    const since = getHiddenSinceMs();
+    expect(since).not.toBeNull();
+    expect(since!).toBeGreaterThanOrEqual(before);
+  });
+
+  it('window blur でも hidden になる (Tauri webview がフォーカス外)', () => {
+    isCanvasVisibleNow();
+    fireBlur();
+    expect(isCanvasVisibleNow()).toBe(false);
+    expect(getHiddenSinceMs()).not.toBeNull();
+  });
+
+  it('visible に戻ると hiddenSinceMs=null に復帰する', () => {
+    isCanvasVisibleNow();
+    setVisibilityState('hidden');
+    expect(getHiddenSinceMs()).not.toBeNull();
+    setVisibilityState('visible');
+    expect(isCanvasVisibleNow()).toBe(true);
+    expect(getHiddenSinceMs()).toBeNull();
+  });
+
+  it('subscribeOnVisible は hidden→visible 遷移時のみ発火する (edge trigger)', () => {
+    const cb = vi.fn();
+    const unsub = subscribeOnVisible(cb);
+
+    // visible のまま focus/blur が来ても発火しない
+    fireFocus();
+    expect(cb).not.toHaveBeenCalled();
+
+    setVisibilityState('hidden');
+    expect(cb).not.toHaveBeenCalled(); // hidden 遷移では発火しない
+
+    setVisibilityState('visible');
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // 連続して visible のまま focus が来ても再発火しない
+    fireFocus();
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // 再度 hidden → visible で再発火
+    setVisibilityState('hidden');
+    setVisibilityState('visible');
+    expect(cb).toHaveBeenCalledTimes(2);
+
+    unsub();
+    setVisibilityState('hidden');
+    setVisibilityState('visible');
+    expect(cb).toHaveBeenCalledTimes(2); // unsub 後は発火しない
+  });
+
+  it('複数 subscriber が独立して発火する', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    subscribeOnVisible(a);
+    subscribeOnVisible(b);
+
+    setVisibilityState('hidden');
+    setVisibilityState('visible');
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/src/lib/__tests__/use-recruit-listener-hidden.test.tsx
+++ b/src/renderer/src/lib/__tests__/use-recruit-listener-hidden.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * Issue #578: hidden 中に複数件の `team:recruit-request` を受けても、
+ * 可視化遷移時に 1 回だけ Toast が表示されることを固定する。
+ *
+ * - `@tauri-apps/api/event.listen` をモックして手動で payload を発火する
+ * - `useCanvasStore` / `useRoleProfiles` / `recruit-ack` / `tauri-api` の team-state IPC を
+ *   stub し、recruit handler の async 経路 (requester not found) は早期 return させる。
+ * - visibility は singleton state を直接 toggle して観測する。
+ */
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock
+} from 'vitest';
+import type { ReactNode } from 'react';
+
+import { ToastProvider } from '../toast-context';
+
+// ----- Mocks -----
+
+const mocks = vi.hoisted(() => ({
+  listeners: new Map<string, (event: { payload: unknown }) => void>(),
+  recruitObserved: vi.fn().mockResolvedValue(undefined),
+  ackRecruit: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(
+    async (event: string, cb: (e: { payload: unknown }) => void) => {
+      mocks.listeners.set(event, cb);
+      return () => mocks.listeners.delete(event);
+    }
+  )
+}));
+
+vi.mock('../subscribe-event', () => ({
+  // ToastProvider が `team:role-lint-warning` 等を購読しに来るが、テストでは無視。
+  subscribeEvent: vi.fn(() => () => {})
+}));
+
+vi.mock('../recruit-ack', () => ({
+  ackRecruit: (...args: unknown[]) => mocks.ackRecruit(...args)
+}));
+
+vi.mock('../tauri-api', () => ({
+  api: {
+    teamState: {
+      recruitObservedWhileHidden: (...args: unknown[]) =>
+        mocks.recruitObserved(...args)
+    }
+  }
+}));
+
+// canvas store: requester がいない状態で固定 → recruit handler の async 経路は
+// `requester_not_found` で早期 return する。Toast 集計に必要な hidden カウントは
+// その前段で行われるため、テストの観測点は変わらない。
+vi.mock('../../stores/canvas', () => ({
+  useCanvasStore: Object.assign(
+    () => ({ nodes: [] }),
+    {
+      getState: () => ({
+        nodes: [],
+        addCard: vi.fn(),
+        notifyRecruit: vi.fn()
+      })
+    }
+  )
+}));
+
+vi.mock('../role-profiles-context', () => ({
+  useRoleProfiles: () => ({ registerDynamicRole: vi.fn() })
+}));
+
+// 最小 i18n: 表示用にキー + パラメータ値を結合して返し、テストで count を文字列照合できるようにする。
+vi.mock('../i18n', () => ({
+  useT:
+    () =>
+    (key: string, params?: Record<string, string | number>): string => {
+      if (!params) return key;
+      const tail = Object.entries(params)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(' ');
+      return `${key}|${tail}`;
+    }
+}));
+
+// 上のモックがすべて hoist された後で対象 hook を import する。
+import { useRecruitListener } from '../use-recruit-listener';
+import { __resetCanvasVisibilityForTests } from '../use-canvas-visibility';
+
+function Harness({ children }: { children?: ReactNode }): JSX.Element {
+  useRecruitListener();
+  return <>{children}</>;
+}
+
+function setVisibility(value: 'visible' | 'hidden'): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => value
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+function emitRecruit(newAgentId: string): void {
+  const cb = mocks.listeners.get('team:recruit-request');
+  if (!cb) throw new Error('team:recruit-request listener not registered yet');
+  cb({
+    payload: {
+      teamId: 'team-1',
+      requesterAgentId: 'requester-x',
+      requesterRole: 'leader',
+      newAgentId,
+      roleProfileId: 'worker',
+      engine: 'claude'
+    }
+  });
+}
+
+describe('useRecruitListener — hidden recruit aggregation (Issue #578)', () => {
+  beforeEach(() => {
+    __resetCanvasVisibilityForTests();
+    mocks.listeners.clear();
+    mocks.recruitObserved.mockClear();
+    mocks.ackRecruit.mockClear();
+    setVisibility('visible');
+    Object.defineProperty(document, 'hasFocus', {
+      configurable: true,
+      value: () => true
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    __resetCanvasVisibilityForTests();
+    vi.clearAllMocks();
+  });
+
+  it('hidden 中に 3 件の recruit が来ても、可視化時に Toast は 1 回だけ表示される', async () => {
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>
+    );
+
+    await waitFor(() => {
+      expect(mocks.listeners.get('team:recruit-request')).toBeTruthy();
+    });
+
+    // Canvas を hidden にしてから recruit を 3 件発火
+    act(() => setVisibility('hidden'));
+    await act(async () => {
+      emitRecruit('agent-a');
+      emitRecruit('agent-b');
+      emitRecruit('agent-c');
+    });
+
+    // hidden 中は Toast は表示されない
+    expect(document.querySelectorAll('.toast--warning').length).toBe(0);
+
+    // 可視化遷移で 1 件だけ警告 Toast が出る (mock i18n は `key|count=N` 形式)
+    act(() => setVisibility('visible'));
+    await waitFor(() => {
+      const warnings = document.querySelectorAll('.toast--warning');
+      expect(warnings.length).toBe(1);
+      expect(warnings[0].textContent).toContain('count=3');
+    });
+
+    // 同じ visible のまま再度 visibilitychange を撒いても増えない (edge trigger)
+    act(() => setVisibility('visible'));
+    expect(document.querySelectorAll('.toast--warning').length).toBe(1);
+  });
+
+  it('visible 中の recruit は Toast を出さない (Canvas を見ているのでユーザに気付きが要らない)', async () => {
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>
+    );
+    await waitFor(() => expect(mocks.listeners.get('team:recruit-request')).toBeTruthy());
+
+    await act(async () => {
+      emitRecruit('agent-a');
+      emitRecruit('agent-b');
+    });
+
+    expect(document.querySelectorAll('.toast--warning').length).toBe(0);
+  });
+
+  it('hidden 経過時間が threshold 未満なら recruit_observed_while_hidden IPC を呼ばない', async () => {
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>
+    );
+    await waitFor(() => expect(mocks.listeners.get('team:recruit-request')).toBeTruthy());
+
+    act(() => setVisibility('hidden'));
+    await act(async () => emitRecruit('agent-a'));
+
+    // hidden になった直後 (= 0ms 経過) なので IPC は呼ばれない
+    expect(mocks.recruitObserved).not.toHaveBeenCalled();
+  });
+
+  it('hidden 経過時間が threshold 以上なら recruit_observed_while_hidden IPC を呼ぶ', async () => {
+    // Date.now() だけスタブする (vi.useFakeTimers は waitFor の内部 setTimeout を止めて
+    // テストが timeout するため使わない)。
+    let mockNow = 1_700_000_000_000;
+    const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => mockNow);
+    try {
+      render(
+        <ToastProvider>
+          <Harness />
+        </ToastProvider>
+      );
+      await waitFor(() =>
+        expect(mocks.listeners.get('team:recruit-request')).toBeTruthy()
+      );
+
+      act(() => setVisibility('hidden')); // hiddenSinceMs = 1_700_000_000_000
+      mockNow += 6000;                   // threshold 5000ms を超える経過時間
+      await act(async () => emitRecruit('agent-a'));
+
+      expect(mocks.recruitObserved).toHaveBeenCalledTimes(1);
+      const arg = (mocks.recruitObserved as Mock).mock.calls[0]![0] as {
+        teamId: string;
+        agentId: string;
+        hiddenForMs: number;
+      };
+      expect(arg.teamId).toBe('team-1');
+      expect(arg.agentId).toBe('agent-a');
+      expect(arg.hiddenForMs).toBeGreaterThanOrEqual(5000);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+  });
+});

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -486,6 +486,9 @@ const ja: Dict = {
   'toast.terminalNotReady': 'ターミナルが起動していません',
   'toast.settings.saveFailed': '設定の保存に失敗しました: {error}',
   'toast.settings.projectRootFailed': 'プロジェクトルートの反映に失敗しました: {error}',
+  // Issue #578: Canvas 非表示中に recruit が走った件数を可視化時に警告する
+  'toast.recruitWhileHidden':
+    'Canvas を非表示の間にメンバー採用が {count} 件走りました。失敗していたら再実行してください',
 
   // ---------- Terminal (pasteエラー等) ----------
   'terminal.pasteImageFailed': '画像保存失敗',
@@ -1126,6 +1129,9 @@ const en: Dict = {
   'toast.terminalNotReady': 'Terminal is not ready',
   'toast.settings.saveFailed': 'Failed to save settings: {error}',
   'toast.settings.projectRootFailed': 'Failed to apply project root: {error}',
+  // Issue #578: Warn when recruits ran while canvas was hidden
+  'toast.recruitWhileHidden':
+    '{count} recruit(s) ran while Canvas was hidden. Re-run any that may have failed',
 
   // ---------- Status ----------
   // ---------- Terminal (paste errors) ----------

--- a/src/renderer/src/lib/tauri-api/team-state.ts
+++ b/src/renderer/src/lib/tauri-api/team-state.ts
@@ -9,10 +9,20 @@
 // wrapper は read のみ用意する (write は agent が `team_assign_task` 等を MCP で叩く)。
 
 import { invoke } from '@tauri-apps/api/core';
-import type { TeamOrchestrationState } from '../../../../types/shared';
+import type {
+  RecruitObservedWhileHiddenArgs,
+  TeamOrchestrationState
+} from '../../../../types/shared';
 
 export const teamState = {
   /** 永続化されたチームの orchestration state を読み出す。未保存なら null。 */
   read: (projectRoot: string, teamId: string): Promise<TeamOrchestrationState | null> =>
-    invoke('team_state_read', { projectRoot, teamId })
+    invoke('team_state_read', { projectRoot, teamId }),
+
+  /**
+   * Issue #578: Canvas (Tauri webview) が非表示の間に `team:recruit-request` が走った
+   * 観測点を Hub 側ログに残す。renderer 側で hidden 経過時間 >= 5000ms を満たす場合のみ呼ぶ。
+   */
+  recruitObservedWhileHidden: (args: RecruitObservedWhileHiddenArgs): Promise<void> =>
+    invoke('recruit_observed_while_hidden', { args })
 };

--- a/src/renderer/src/lib/use-canvas-visibility.ts
+++ b/src/renderer/src/lib/use-canvas-visibility.ts
@@ -1,0 +1,217 @@
+/**
+ * useCanvasVisibility — Canvas (= Tauri webview) の可視状態を統合的に観測する hook。
+ *
+ * 「可視」とは:
+ *   - `document.visibilityState === 'visible'` (タブ / window がブラウザ的に visible)
+ *   - **かつ** Tauri Window がフォーカスされている (= ユーザの一次注意がここにある)
+ *
+ * 両方満たしたときに `isCanvasVisible = true`、片方でも欠けたら `false`。
+ *
+ * Issue #578: Canvas 非表示中に `team:recruit-request` が走ると、ユーザは採用結果を
+ * 視認できないまま終わるため、可視化遷移時にまとめて通知する基盤として使う。
+ *
+ * 設計:
+ *   - 状態と subscriber 集合は **モジュールレベル singleton**。複数 hook 呼び出しでも
+ *     `document` / `window` / Tauri `onFocusChanged` のリスナーは 1 セットだけ。
+ *   - hook は `useState` を介して reactive な `isCanvasVisible` を返すので、UI 更新にも使える。
+ *   - hidden 経過時間を取得する `getHiddenSinceMs()` を別関数で公開 (recruit IPC のしきい値判定用)。
+ *   - `subscribeOnVisible(cb)` は **hidden → visible 遷移時のみ** cb を発火させる。
+ *     既に visible のときに subscribe しても発火しない (= edge trigger)。
+ *
+ * テスト:
+ *   - vitest 環境では Tauri runtime が無いので `getCurrentWindow()` の動的 import が
+ *     reject されることがある。それは silently 無視し、`document.visibilitychange` /
+ *     `window.focus`|`blur` だけで動かす。
+ *   - `__resetCanvasVisibilityForTests()` で singleton state を初期化できる。
+ */
+import { useEffect, useState } from 'react';
+
+interface CanvasVisibilityState {
+  /** document.visibilityState !== 'hidden' */
+  documentVisible: boolean;
+  /** Tauri Window / browser window がフォーカスを持っている */
+  windowFocused: boolean;
+  /** hidden に転じた瞬間の Date.now()。visible なら null */
+  hiddenSinceMs: number | null;
+}
+
+const state: CanvasVisibilityState = {
+  documentVisible: true,
+  windowFocused: true,
+  hiddenSinceMs: null
+};
+
+const subscribers = new Set<() => void>();
+
+let initialized = false;
+let unlistenDoc: (() => void) | null = null;
+let unlistenFocus: (() => void) | null = null;
+let unlistenBlur: (() => void) | null = null;
+let unlistenTauriFocus: (() => void) | null = null;
+
+function isVisibleNowInternal(): boolean {
+  return state.documentVisible && state.windowFocused;
+}
+
+function notify(): void {
+  // copy to avoid mutation while iterating
+  for (const cb of [...subscribers]) {
+    try {
+      cb();
+    } catch (err) {
+      console.error('[canvas-visibility] subscriber threw', err);
+    }
+  }
+}
+
+function applyTransition(): void {
+  const visibleNow = isVisibleNowInternal();
+  const wasHidden = state.hiddenSinceMs !== null;
+  if (visibleNow && wasHidden) {
+    // hidden → visible
+    state.hiddenSinceMs = null;
+    notify();
+  } else if (!visibleNow && !wasHidden) {
+    // visible → hidden
+    state.hiddenSinceMs = Date.now();
+    notify();
+  }
+}
+
+function ensureInit(): void {
+  if (initialized) return;
+  initialized = true;
+
+  if (typeof document !== 'undefined') {
+    state.documentVisible = document.visibilityState !== 'hidden';
+  }
+  if (typeof document !== 'undefined' && typeof document.hasFocus === 'function') {
+    state.windowFocused = document.hasFocus();
+  }
+  state.hiddenSinceMs = isVisibleNowInternal() ? null : Date.now();
+
+  if (typeof document !== 'undefined') {
+    const onVisibilityChange = (): void => {
+      state.documentVisible = document.visibilityState !== 'hidden';
+      applyTransition();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    unlistenDoc = () => document.removeEventListener('visibilitychange', onVisibilityChange);
+  }
+
+  if (typeof window !== 'undefined') {
+    const onFocus = (): void => {
+      state.windowFocused = true;
+      applyTransition();
+    };
+    const onBlur = (): void => {
+      state.windowFocused = false;
+      applyTransition();
+    };
+    window.addEventListener('focus', onFocus);
+    window.addEventListener('blur', onBlur);
+    unlistenFocus = () => window.removeEventListener('focus', onFocus);
+    unlistenBlur = () => window.removeEventListener('blur', onBlur);
+  }
+
+  // Tauri Window の onFocusChanged を best-effort で購読する。
+  // 通常は window.focus/blur で十分だが、フレームレス + カスタム title bar 環境では
+  // OS 側 focus 変化が webview event に乗らない場合があるため重ね掛けする。
+  void (async () => {
+    try {
+      const mod = await import('@tauri-apps/api/window');
+      const win = mod.getCurrentWindow();
+      const off = await win.onFocusChanged((event) => {
+        state.windowFocused = event.payload;
+        applyTransition();
+      });
+      unlistenTauriFocus = off;
+    } catch {
+      // Tauri runtime が無い (vitest / pure browser) — silently 諦める。
+    }
+  })();
+}
+
+/**
+ * 現在 Canvas が可視か。hidden→visible 遷移時の callback を escape したいときに同期で参照する。
+ * recruit listener など hook 外でも呼べるように export している。
+ */
+export function isCanvasVisibleNow(): boolean {
+  ensureInit();
+  return isVisibleNowInternal();
+}
+
+/**
+ * hidden 状態が始まった時点の `Date.now()`。visible なら `null`。
+ * IPC `recruit_observed_while_hidden` のしきい値判定 (5000ms) で使う。
+ */
+export function getHiddenSinceMs(): number | null {
+  ensureInit();
+  return state.hiddenSinceMs;
+}
+
+/**
+ * **hidden → visible 遷移時のみ** cb を発火する subscriber を登録する。
+ * 戻り値の関数で解除。subscribe 時点で visible でも cb は発火しない (edge trigger)。
+ */
+export function subscribeOnVisible(cb: () => void): () => void {
+  ensureInit();
+  const wrapped = (): void => {
+    if (isVisibleNowInternal()) cb();
+  };
+  subscribers.add(wrapped);
+  return () => {
+    subscribers.delete(wrapped);
+  };
+}
+
+export interface CanvasVisibilityHook {
+  /** 現在 Canvas が可視か (reactive)。 */
+  isCanvasVisible: boolean;
+  /** hidden→visible 遷移時のみ呼ばれる subscriber を登録する。 */
+  subscribeOnVisible(cb: () => void): () => void;
+}
+
+/**
+ * React 側で `isCanvasVisible` を reactive に参照したいときに使う hook。
+ * 内部の listener セットは singleton なので複数箇所で呼んでも multiplicative にはならない。
+ */
+export function useCanvasVisibility(): CanvasVisibilityHook {
+  ensureInit();
+  const [isCanvasVisible, setIsCanvasVisible] = useState<boolean>(() =>
+    isVisibleNowInternal()
+  );
+  useEffect(() => {
+    const update = (): void => setIsCanvasVisible(isVisibleNowInternal());
+    subscribers.add(update);
+    // mount 直後に singleton state とズレている可能性に備えて 1 度同期する
+    update();
+    return () => {
+      subscribers.delete(update);
+    };
+  }, []);
+  return {
+    isCanvasVisible,
+    subscribeOnVisible
+  };
+}
+
+/**
+ * vitest 用: singleton 状態を初期化してリスナーも全部外す。
+ * test ファイル間で漏れた DOM listener が後続テストを壊さないようにする。
+ */
+export function __resetCanvasVisibilityForTests(): void {
+  unlistenDoc?.();
+  unlistenFocus?.();
+  unlistenBlur?.();
+  unlistenTauriFocus?.();
+  unlistenDoc = null;
+  unlistenFocus = null;
+  unlistenBlur = null;
+  unlistenTauriFocus = null;
+  initialized = false;
+  subscribers.clear();
+  state.documentVisible = true;
+  state.windowFocused = true;
+  state.hiddenSinceMs = null;
+}

--- a/src/renderer/src/lib/use-recruit-listener.ts
+++ b/src/renderer/src/lib/use-recruit-listener.ts
@@ -6,8 +6,14 @@
  * の 3 イベントを受け、canvas store にカードを追加 / 削除する。
  *
  * App.tsx で 1 度だけ mount される想定。
+ *
+ * Issue #578: Canvas が非表示中 (`document.visibilityState === 'hidden'` または
+ * Tauri Window がフォーカス外) に `team:recruit-request` を受けた場合は、件数を
+ * ローカル ref に積み、可視化遷移時に Toast Context で 1 回まとめて警告する。
+ * hidden 経過時間が 5000ms 以上 (env `VIBE_TEAM_RECRUIT_HIDDEN_THRESHOLD_MS` で調整可能)
+ * の場合のみ Hub に観測 IPC `recruit_observed_while_hidden` を投げる。
  */
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { useCanvasStore } from '../stores/canvas';
 import type { Node } from '@xyflow/react';
@@ -16,6 +22,30 @@ import { useRoleProfiles } from './role-profiles-context';
 import { ackRecruit } from './recruit-ack';
 import { findRecruitPosition } from './canvas-recruit-position';
 import type { WaitPolicy } from '../../../types/shared';
+import { useToast } from './toast-context';
+import { useT } from './i18n';
+import {
+  getHiddenSinceMs,
+  isCanvasVisibleNow,
+  subscribeOnVisible
+} from './use-canvas-visibility';
+import { api } from './tauri-api';
+
+const DEFAULT_HIDDEN_THRESHOLD_MS = 5000;
+
+function resolveHiddenThresholdMs(): number {
+  // Vite は VITE_ プレフィックス付き env のみ renderer に注入する。
+  // 実運用では `VIBE_TEAM_RECRUIT_HIDDEN_THRESHOLD_MS=10000 npm run dev` で起動するか、
+  // Vite の define で `VITE_VIBE_TEAM_RECRUIT_HIDDEN_THRESHOLD_MS` として供給する。
+  const raw = (import.meta as unknown as {
+    env?: Record<string, string | undefined>;
+  }).env?.VITE_VIBE_TEAM_RECRUIT_HIDDEN_THRESHOLD_MS;
+  if (raw) {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  return DEFAULT_HIDDEN_THRESHOLD_MS;
+}
 
 interface RecruitRequestPayload {
   teamId: string;
@@ -85,6 +115,35 @@ function mergeCustomInstructions(
 export function useRecruitListener(): void {
   // 動的ロールを RoleProfilesContext に投入するためのフック関数
   const { registerDynamicRole } = useRoleProfiles();
+  const { showToast } = useToast();
+  const t = useT();
+
+  // Issue #578: hidden 中に積んだ recruit を可視化遷移で flush するため、
+  // showToast / t は ref 経由で listen() callback から最新参照する。listen 登録は
+  // mount 時 1 回だけで再登録しない (recruit handler の他処理と整合)。
+  const showToastRef = useRef(showToast);
+  showToastRef.current = showToast;
+  const tRef = useRef(t);
+  tRef.current = t;
+
+  // hidden 中に観測した recruit の件数 + 最古の hidden 起点。可視化時に flush。
+  const pendingHiddenRef = useRef<{ count: number; firstObservedAt: number | null }>({
+    count: 0,
+    firstObservedAt: null
+  });
+
+  useEffect(() => {
+    return subscribeOnVisible(() => {
+      const pending = pendingHiddenRef.current;
+      if (pending.count === 0) return;
+      const count = pending.count;
+      pendingHiddenRef.current = { count: 0, firstObservedAt: null };
+      showToastRef.current(tRef.current('toast.recruitWhileHidden', { count }), {
+        tone: 'warning',
+        duration: 8000
+      });
+    });
+  }, []);
 
   useEffect(() => {
     const unlistens: UnlistenFn[] = [];
@@ -93,6 +152,27 @@ export function useRecruitListener(): void {
     void listen<RecruitRequestPayload>('team:recruit-request', (e) => {
       if (cancelled) return;
       const p = e.payload;
+      // Issue #578: Canvas が非表示中の recruit は件数を積み、可視化時にまとめて警告する。
+      // hidden 経過時間が threshold 以上なら Hub にも観測 IPC を投げる (短時間 hidden で
+      // info ログを汚染しない)。可視カード追加処理 (下の async ブロック) はそのまま続行する。
+      if (!isCanvasVisibleNow()) {
+        const pending = pendingHiddenRef.current;
+        pending.count += 1;
+        if (pending.firstObservedAt === null) pending.firstObservedAt = Date.now();
+        const hiddenSince = getHiddenSinceMs();
+        const hiddenForMs = hiddenSince === null ? 0 : Date.now() - hiddenSince;
+        if (hiddenForMs >= resolveHiddenThresholdMs()) {
+          void api.teamState
+            .recruitObservedWhileHidden({
+              teamId: p.teamId,
+              agentId: p.newAgentId,
+              hiddenForMs
+            })
+            .catch((err) => {
+              console.warn('[recruit] recruit_observed_while_hidden IPC failed', err);
+            });
+        }
+      }
       void (async () => {
         // Issue #342 Phase 1: requester 探索は 2 段階で行う。
         //   1. agentId 完全一致で 1 回走査 (旧挙動)。

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1085,6 +1085,24 @@ export interface TeamDiagnosticsMemberRow {
   stalenessThresholdMs: number;
 }
 
+// ---------- Canvas Visibility Observation (Issue #578) ----------
+
+/**
+ * Issue #578: Canvas が非表示中 (`document.visibilityState === 'hidden'` または
+ * Tauri Window がフォーカス外) に `team:recruit-request` が走った観測を Hub 側へ
+ * 通知するための IPC 引数。`hiddenForMs >= 5000` の場合のみ renderer から呼ばれる。
+ *
+ * Rust 側は `tracing::info!` でサーバログに 1 行残すだけの軽量 endpoint。
+ * Leader / 開発者がログ集計で「非アクティブ中採用の頻度」を見るための観測点。
+ */
+export interface RecruitObservedWhileHiddenArgs {
+  teamId: string;
+  /** 採用された新規 agent_id (recruit-request payload の newAgentId)。 */
+  agentId: string;
+  /** Canvas が hidden だった経過時間 (ms)。 */
+  hiddenForMs: number;
+}
+
 // ---------- Window Effects (Issue #260) ----------
 
 /**


### PR DESCRIPTION
## Summary
- `useCanvasVisibility` hook を新設し、`document.visibilityState` と Tauri Window のフォーカスを統合した singleton state machine で Canvas の可視状態を観測する。
- `useRecruitListener` を改修し、Canvas 非表示中の `team:recruit-request` を件数 + 最古起点で集計、可視化遷移 (hidden → visible) で warning Toast を 1 回だけ表示する (失敗した採用に気付ける動線)。
- 観測 IPC `recruit_observed_while_hidden` (`team_state.rs` に追記) を追加し、hidden 経過時間 >= 5000ms の場合のみ Hub 側 `tracing::info!` にログを残す。閾値は env `VITE_VIBE_TEAM_RECRUIT_HIDDEN_THRESHOLD_MS` で調整可。
- 5 点同期: `shared.ts` (`RecruitObservedWhileHiddenArgs`) / `commands/team_state.rs` (struct + handler) / `lib.rs` `invoke_handler!` / `tauri-api/team-state.ts` wrapper / 既に登録済 `commands/mod.rs` のすべてが揃っていることを確認済み。
- 単体テスト 2 ファイル (`use-canvas-visibility.test.ts` / `use-recruit-listener-hidden.test.tsx`) を追加し、Toast 1 回通知 + threshold 判定 + edge trigger を固定。

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (317/317 passed)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `npm run build` (release exe / NSIS bundle 生成成功。updater 署名は CI 専用なので local では skip)
- [ ] 手動確認: Canvas を別 window に隠す → recruit 6 件 → 戻ったときに件数入り Toast 1 回出る

Closes #578
Refs #574