### PR TITLE
fix: #587 #588 #589 recruit / terminal follow-up 3 件をまとめて修正

### DIFF
--- a/src-tauri/src/team_hub/protocol/consts.rs
+++ b/src-tauri/src/team_hub/protocol/consts.rs
@@ -27,9 +27,20 @@ pub(crate) const RECRUIT_MAX_CONCURRENCY: usize = 8;
 ///
 /// Issue #574: Windows + WebView 環境で同時 6 件 recruit 等のとき 5s では addCard 完了前に
 /// cancel が走る事故が報告されたため 5s → 15s に拡大。実行時値は環境変数
-/// `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS` (有効範囲は 1 以上の u64 秒) で上書き可能。
-/// 参照は `protocol/tools/recruit.rs` の `recruit_ack_timeout()` ヘルパ経由。
+/// `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS` (有効範囲は `1..=RECRUIT_ACK_TIMEOUT_MAX_SECS` 秒)
+/// で上書き可能。参照は `protocol/tools/recruit.rs` の `recruit_ack_timeout()` ヘルパ経由。
 pub(crate) const RECRUIT_ACK_TIMEOUT: Duration = Duration::from_secs(15);
+/// Issue #587: `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS` で受け付ける ack timeout 秒数の上限。
+///
+/// 上限なしのままだと `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS=999999999` 等で ack 待ちが
+/// 事実上永久になり、`recruit_ack` が来るまで pending が永続化 → 後続 recruit semaphore も
+/// 塞がれて team が事実上 lock される事故が起きうる (`VIBE_TEAM_RECRUIT_GRACE_MS` /
+/// `VIBE_TEAM_RECRUIT_CONCURRENCY` は既にクランプ済みで非対称)。
+///
+/// 600 秒 (= 10 分) は「Windows + WebView で同時 6 件 recruit したとき addCard 完了まで
+/// 観測上 ~30s 程度 (#574)」を 1 桁オーダーで上回り、かつ「user が UI で待つ限界」を
+/// 大きく超えない中間値として採用する。
+pub(crate) const RECRUIT_ACK_TIMEOUT_MAX_SECS: u64 = 600;
 /// 動的ロール instructions の最大長。Leader が暴走して巨大プロンプトを投げてくるのを抑える。
 pub(crate) const MAX_DYNAMIC_INSTRUCTIONS_LEN: usize = 16 * 1024; // 16 KiB
 /// 動的ロール label / description の最大長

--- a/src-tauri/src/team_hub/protocol/tools/recruit.rs
+++ b/src-tauri/src/team_hub/protocol/tools/recruit.rs
@@ -9,6 +9,7 @@ use tauri::Emitter;
 use uuid::Uuid;
 
 use super::super::consts::RECRUIT_ACK_TIMEOUT;
+use super::super::consts::RECRUIT_ACK_TIMEOUT_MAX_SECS;
 use super::super::consts::RECRUIT_TIMEOUT;
 use super::super::dynamic_role::{validate_and_register_dynamic_role, DynamicRoleOutcome};
 use super::super::instruction_lint::{lint_all, LintReport};
@@ -19,20 +20,43 @@ use crate::team_hub::role_lint::{compute_role_overlap, RoleSnapshot};
 
 const DEFAULT_WAIT_POLICY: &str = "strict";
 
-/// Issue #574: `RECRUIT_ACK_TIMEOUT` の実行時値を env override 込みで返す。
+/// Issue #574 / #587: `RECRUIT_ACK_TIMEOUT` の実行時値を env override 込みで返す。
 ///
-/// `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS` を u64 秒として読み出し、`>= 1` の値が
-/// パースできればその Duration を返す。未設定 / パース失敗 / 0 のときは
-/// `RECRUIT_ACK_TIMEOUT` (= 15s) を返す。
+/// `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS` を u64 秒として読み出し、
+/// `1..=RECRUIT_ACK_TIMEOUT_MAX_SECS` の範囲に収まっていればその Duration を返す。
+/// 未設定 / parse 失敗 / 0 / 上限超過のときは `RECRUIT_ACK_TIMEOUT` (= 15s) を返す。
+///
+/// 範囲外の値が渡された場合は `tracing::warn!` で notice する
+/// (= 「env を設定したのに反映されない」相談時に運用が即座に気付けるようにする)。
 ///
 /// `team_recruit` / `team_create_leader` の双方から参照される共通入口。
 pub(super) fn recruit_ack_timeout() -> Duration {
-    std::env::var("VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS")
-        .ok()
-        .and_then(|raw| raw.trim().parse::<u64>().ok())
-        .filter(|&secs| secs > 0)
-        .map(Duration::from_secs)
-        .unwrap_or(RECRUIT_ACK_TIMEOUT)
+    let Ok(raw) = std::env::var("VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS") else {
+        return RECRUIT_ACK_TIMEOUT;
+    };
+    let trimmed = raw.trim();
+    let parsed = match trimmed.parse::<u64>() {
+        Ok(v) => v,
+        Err(_) => {
+            tracing::warn!(
+                "[teamhub] VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS={trimmed:?} could not be parsed as u64; \
+                 falling back to default {default}s",
+                default = RECRUIT_ACK_TIMEOUT.as_secs(),
+            );
+            return RECRUIT_ACK_TIMEOUT;
+        }
+    };
+    if (1..=RECRUIT_ACK_TIMEOUT_MAX_SECS).contains(&parsed) {
+        Duration::from_secs(parsed)
+    } else {
+        tracing::warn!(
+            "[teamhub] VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS={parsed} is out of range \
+             (must be 1..={max}); falling back to default {default}s",
+            max = RECRUIT_ACK_TIMEOUT_MAX_SECS,
+            default = RECRUIT_ACK_TIMEOUT.as_secs(),
+        );
+        RECRUIT_ACK_TIMEOUT
+    }
 }
 
 fn parse_wait_policy(args: &Value) -> Result<String, String> {
@@ -539,8 +563,29 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_wait_policy, DEFAULT_WAIT_POLICY};
+    use super::{
+        parse_wait_policy, recruit_ack_timeout, DEFAULT_WAIT_POLICY, RECRUIT_ACK_TIMEOUT,
+        RECRUIT_ACK_TIMEOUT_MAX_SECS,
+    };
     use serde_json::json;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    /// `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS` はプロセス global な env var なので、
+    /// 境界値テストを並列に走らせると set / unset が交差して flaky になる。
+    /// テスト間で直列化するための Mutex。`std::env::set_var` の unsafe 化に巻き込まれない
+    /// よう、テスト中は guard を必ず保持する。
+    static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+    fn with_env<F: FnOnce()>(value: Option<&str>, f: F) {
+        let _g = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        match value {
+            Some(v) => std::env::set_var("VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS", v),
+            None => std::env::remove_var("VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS"),
+        }
+        f();
+        std::env::remove_var("VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS");
+    }
 
     #[test]
     fn parse_wait_policy_defaults_to_strict() {
@@ -564,5 +609,65 @@ mod tests {
 
         assert!(err.contains("recruit_invalid_wait_policy"));
         assert!(err.contains("strict, standard, or proactive"));
+    }
+
+    /// Issue #587: `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS=0` は default にフォールバック。
+    #[test]
+    fn ack_timeout_zero_falls_back_to_default() {
+        with_env(Some("0"), || {
+            assert_eq!(recruit_ack_timeout(), RECRUIT_ACK_TIMEOUT);
+        });
+    }
+
+    /// Issue #587: 下限 1 はそのまま採用される。
+    #[test]
+    fn ack_timeout_lower_bound_one_is_accepted() {
+        with_env(Some("1"), || {
+            assert_eq!(recruit_ack_timeout(), Duration::from_secs(1));
+        });
+    }
+
+    /// Issue #587: 上限 600 はそのまま採用される。
+    #[test]
+    fn ack_timeout_upper_bound_is_accepted() {
+        with_env(Some("600"), || {
+            assert_eq!(
+                recruit_ack_timeout(),
+                Duration::from_secs(RECRUIT_ACK_TIMEOUT_MAX_SECS)
+            );
+        });
+    }
+
+    /// Issue #587: 上限 + 1 (= 601) は範囲外なので default にフォールバック。
+    #[test]
+    fn ack_timeout_just_above_upper_bound_falls_back_to_default() {
+        with_env(Some("601"), || {
+            assert_eq!(recruit_ack_timeout(), RECRUIT_ACK_TIMEOUT);
+        });
+    }
+
+    /// Issue #587: 巨大値 (= 約 31 年) も範囲外なので default にフォールバック。
+    /// クランプを忘れると pending が事実上永久に残る事故になるため、明示的に確認する。
+    #[test]
+    fn ack_timeout_extreme_value_falls_back_to_default() {
+        with_env(Some("999999999"), || {
+            assert_eq!(recruit_ack_timeout(), RECRUIT_ACK_TIMEOUT);
+        });
+    }
+
+    /// Issue #587: 未設定なら default。
+    #[test]
+    fn ack_timeout_unset_returns_default() {
+        with_env(None, || {
+            assert_eq!(recruit_ack_timeout(), RECRUIT_ACK_TIMEOUT);
+        });
+    }
+
+    /// Issue #587: parse 失敗 (非 u64 文字列) も default にフォールバック。
+    #[test]
+    fn ack_timeout_garbage_value_falls_back_to_default() {
+        with_env(Some("not-a-number"), || {
+            assert_eq!(recruit_ack_timeout(), RECRUIT_ACK_TIMEOUT);
+        });
     }
 }

--- a/src-tauri/src/team_hub/state.rs
+++ b/src-tauri/src/team_hub/state.rs
@@ -959,12 +959,34 @@ impl TeamHub {
     ) -> Result<OwnedSemaphorePermit, String> {
         // semaphore の lookup / 挿入だけ HubState lock 内で済ませ、その後の `acquire_owned`
         // はロック外で行う (acquire 側で他の HubState 操作と競合しないように)。
+        //
+        // Issue #589: lazy init で 1 回だけ tracing log を出す。env を変えたのに反映されない
+        // 相談時に、起動ログから実際の permit 数を確認できるようにする。
+        // - 範囲内 env override → info "source=env"
+        // - env 未設定 (= default 採用) → info "source=default"
+        // - env 設定済みだが parse 失敗 / 範囲外で default にフォールバック → warn "source=fallback"
         let semaphore = {
             let mut s = self.state.lock().await;
-            s.recruit_semaphores
-                .entry(team_id.to_string())
-                .or_insert_with(|| Arc::new(Semaphore::new(recruit_concurrency_from_env())))
-                .clone()
+            if let Some(existing) = s.recruit_semaphores.get(team_id) {
+                existing.clone()
+            } else {
+                let (permits, source) = recruit_concurrency_from_env_with_source();
+                if matches!(source, RecruitConcurrencySource::InvalidEnvFallback) {
+                    tracing::warn!(
+                        "[teamhub] recruit semaphore initialized: team={team_id} permits={permits} source={source}",
+                        source = source.label(),
+                    );
+                } else {
+                    tracing::info!(
+                        "[teamhub] recruit semaphore initialized: team={team_id} permits={permits} source={source}",
+                        source = source.label(),
+                    );
+                }
+                let sem = Arc::new(Semaphore::new(permits));
+                s.recruit_semaphores
+                    .insert(team_id.to_string(), sem.clone());
+                sem
+            }
         };
         let timeout = crate::team_hub::protocol::consts::RECRUIT_TIMEOUT;
         match tokio::time::timeout(timeout, semaphore.acquire_owned()).await {
@@ -1461,19 +1483,58 @@ impl TeamHub {
     }
 }
 
-/// Issue #576: `VIBE_TEAM_RECRUIT_CONCURRENCY` 環境変数を読んで permit 数を決める。
-/// `1..=RECRUIT_MAX_CONCURRENCY` の範囲外、parse 失敗、未設定はいずれも
-/// `RECRUIT_DEFAULT_CONCURRENCY` にフォールバック。
+/// Issue #589: `recruit_concurrency_from_env_with_source` の戻り値。permit 数の選択経路を
+/// 区別して、lazy init 時のログレベル (info / warn) を切り替えるために使う。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecruitConcurrencySource {
+    /// `VIBE_TEAM_RECRUIT_CONCURRENCY` が `1..=RECRUIT_MAX_CONCURRENCY` の範囲内で設定済み。
+    Env,
+    /// `VIBE_TEAM_RECRUIT_CONCURRENCY` が未設定 (= 通常運用)。
+    Default,
+    /// `VIBE_TEAM_RECRUIT_CONCURRENCY` は設定されているが parse 失敗 / 範囲外で
+    /// `RECRUIT_DEFAULT_CONCURRENCY` にフォールバックした (= 設定ミスの可能性)。
+    InvalidEnvFallback,
+}
+
+impl RecruitConcurrencySource {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Env => "env",
+            Self::Default => "default",
+            Self::InvalidEnvFallback => "fallback",
+        }
+    }
+}
+
+/// Issue #576 / #589: `VIBE_TEAM_RECRUIT_CONCURRENCY` 環境変数を読んで permit 数を決め、
+/// その決定経路 (env override / default / 範囲外 fallback) も併せて返す。
 ///
-/// `acquire_recruit_permit` の lazy 初期化時に 1 度だけ呼ばれる想定なので、env を読む
-/// オーバーヘッドは無視できる。
-fn recruit_concurrency_from_env() -> usize {
+/// `1..=RECRUIT_MAX_CONCURRENCY` の範囲外・parse 失敗は `RECRUIT_DEFAULT_CONCURRENCY` に
+/// フォールバックし、`InvalidEnvFallback` を返す。未設定は `Default`、範囲内 override は
+/// `Env`。lazy init log の info / warn 分岐にこの source を使う (Issue #589)。
+///
+/// `acquire_recruit_permit` の lazy 初期化時に team_id ごとに 1 度だけ呼ばれる想定なので、
+/// env を読むオーバーヘッドは無視できる。
+fn recruit_concurrency_from_env_with_source() -> (usize, RecruitConcurrencySource) {
     use crate::team_hub::protocol::consts::{RECRUIT_DEFAULT_CONCURRENCY, RECRUIT_MAX_CONCURRENCY};
-    std::env::var("VIBE_TEAM_RECRUIT_CONCURRENCY")
-        .ok()
-        .and_then(|raw| raw.trim().parse::<usize>().ok())
-        .filter(|&n| (1..=RECRUIT_MAX_CONCURRENCY).contains(&n))
-        .unwrap_or(RECRUIT_DEFAULT_CONCURRENCY)
+    match std::env::var("VIBE_TEAM_RECRUIT_CONCURRENCY") {
+        Err(_) => (RECRUIT_DEFAULT_CONCURRENCY, RecruitConcurrencySource::Default),
+        Ok(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return (RECRUIT_DEFAULT_CONCURRENCY, RecruitConcurrencySource::Default);
+            }
+            match trimmed.parse::<usize>() {
+                Ok(n) if (1..=RECRUIT_MAX_CONCURRENCY).contains(&n) => {
+                    (n, RecruitConcurrencySource::Env)
+                }
+                _ => (
+                    RECRUIT_DEFAULT_CONCURRENCY,
+                    RecruitConcurrencySource::InvalidEnvFallback,
+                ),
+            }
+        }
+    }
 }
 
 /// Issue #577: timeout 後に遅着 ack を rescue する grace window。
@@ -1852,5 +1913,207 @@ mod recruit_semaphore_tests {
 
         drop(permit_y);
         drop(permit_x);
+    }
+}
+
+/// Issue #589: `acquire_recruit_permit` の lazy init 時に出力する tracing ログのテスト。
+///
+/// `tracing::subscriber::with_default` は thread-local で subscriber を差し替えるため、
+/// `current_thread` runtime で `block_on` した async コードからも捕捉できる。env を触る
+/// テストはプロセス global な VIBE_TEAM_RECRUIT_CONCURRENCY を共有するので Mutex で直列化。
+#[cfg(test)]
+mod recruit_semaphore_log_tests {
+    use super::TeamHub;
+    use crate::pty::SessionRegistry;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::MakeWriter;
+
+    static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+    fn make_hub() -> TeamHub {
+        TeamHub::new(Arc::new(SessionRegistry::new()))
+    }
+
+    #[derive(Clone, Default)]
+    struct CapturedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CapturedWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CapturedWriter {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn capture<F: FnOnce()>(f: F) -> String {
+        let writer = CapturedWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer.clone())
+            .with_max_level(tracing::Level::TRACE)
+            .with_target(false)
+            .with_ansi(false)
+            .finish();
+        tracing::subscriber::with_default(subscriber, f);
+        let buf = writer.0.lock().unwrap().clone();
+        String::from_utf8(buf).unwrap_or_default()
+    }
+
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current_thread runtime")
+            .block_on(future)
+    }
+
+    /// 初回の `acquire_recruit_permit` で 1 回だけ `recruit semaphore initialized` が
+    /// 出力され、2 回目以降の acquire では再出力されない (lazy init 1 回限り)。
+    #[test]
+    fn lazy_init_log_emitted_only_once_per_team() {
+        let _g = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("VIBE_TEAM_RECRUIT_CONCURRENCY");
+
+        let logs = capture(|| {
+            block_on(async {
+                let hub = make_hub();
+                let p1 = hub
+                    .acquire_recruit_permit("team-init-once")
+                    .await
+                    .expect("first acquire should succeed");
+                drop(p1);
+                let p2 = hub
+                    .acquire_recruit_permit("team-init-once")
+                    .await
+                    .expect("second acquire should succeed");
+                drop(p2);
+            });
+        });
+
+        let init_count = logs.matches("recruit semaphore initialized").count();
+        assert_eq!(
+            init_count, 1,
+            "expected exactly 1 init log across 2 acquires; got: {logs}",
+        );
+        assert!(
+            logs.contains("team=team-init-once"),
+            "init log should include team_id; got: {logs}",
+        );
+        assert!(
+            logs.contains("source=default"),
+            "unset env should be logged as source=default; got: {logs}",
+        );
+        assert!(
+            logs.contains("INFO"),
+            "default source should be info-level; got: {logs}",
+        );
+    }
+
+    /// 範囲内 env override (`VIBE_TEAM_RECRUIT_CONCURRENCY=4`) は info で `source=env`。
+    #[test]
+    fn lazy_init_log_with_valid_env_uses_info_and_marks_env() {
+        let _g = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("VIBE_TEAM_RECRUIT_CONCURRENCY", "4");
+
+        let logs = capture(|| {
+            block_on(async {
+                let hub = make_hub();
+                let p = hub
+                    .acquire_recruit_permit("team-init-env")
+                    .await
+                    .expect("acquire should succeed");
+                drop(p);
+            });
+        });
+
+        std::env::remove_var("VIBE_TEAM_RECRUIT_CONCURRENCY");
+
+        assert!(
+            logs.contains("recruit semaphore initialized"),
+            "expected init log; got: {logs}",
+        );
+        assert!(
+            logs.contains("source=env"),
+            "in-range env should be logged as source=env; got: {logs}",
+        );
+        assert!(
+            logs.contains("permits=4"),
+            "permits should reflect env value; got: {logs}",
+        );
+        assert!(
+            logs.contains("INFO"),
+            "valid env should be info-level; got: {logs}",
+        );
+    }
+
+    /// 範囲外 env (= `VIBE_TEAM_RECRUIT_CONCURRENCY=999`) は warn で `source=fallback`。
+    #[test]
+    fn lazy_init_log_with_invalid_env_uses_warn_and_marks_fallback() {
+        let _g = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("VIBE_TEAM_RECRUIT_CONCURRENCY", "999");
+
+        let logs = capture(|| {
+            block_on(async {
+                let hub = make_hub();
+                let p = hub
+                    .acquire_recruit_permit("team-init-bad")
+                    .await
+                    .expect("acquire should still succeed (default fallback)");
+                drop(p);
+            });
+        });
+
+        std::env::remove_var("VIBE_TEAM_RECRUIT_CONCURRENCY");
+
+        assert!(
+            logs.contains("recruit semaphore initialized"),
+            "expected init log; got: {logs}",
+        );
+        assert!(
+            logs.contains("source=fallback"),
+            "out-of-range env should be logged as source=fallback; got: {logs}",
+        );
+        assert!(
+            logs.contains("WARN"),
+            "out-of-range env should be warn-level; got: {logs}",
+        );
+    }
+
+    /// parse 失敗 (= `VIBE_TEAM_RECRUIT_CONCURRENCY=not-a-number`) も warn + fallback。
+    #[test]
+    fn lazy_init_log_with_unparseable_env_uses_warn_and_marks_fallback() {
+        let _g = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("VIBE_TEAM_RECRUIT_CONCURRENCY", "not-a-number");
+
+        let logs = capture(|| {
+            block_on(async {
+                let hub = make_hub();
+                let p = hub
+                    .acquire_recruit_permit("team-init-garbage")
+                    .await
+                    .expect("acquire should still succeed (default fallback)");
+                drop(p);
+            });
+        });
+
+        std::env::remove_var("VIBE_TEAM_RECRUIT_CONCURRENCY");
+
+        assert!(
+            logs.contains("source=fallback"),
+            "unparseable env should be logged as source=fallback; got: {logs}",
+        );
+        assert!(
+            logs.contains("WARN"),
+            "unparseable env should be warn-level; got: {logs}",
+        );
     }
 }

--- a/src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx
@@ -1,7 +1,12 @@
 import { act, cleanup, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useTerminalTabs, type UseTerminalTabsOptions } from '../use-terminal-tabs';
+import {
+  MAX_TERMINALS,
+  TERMINAL_WARN_THRESHOLD,
+  useTerminalTabs,
+  type UseTerminalTabsOptions
+} from '../use-terminal-tabs';
 
 function options(overrides: Partial<UseTerminalTabsOptions> = {}): UseTerminalTabsOptions {
   return {
@@ -73,5 +78,83 @@ describe('useTerminalTabs', () => {
 
     expect(result.current.terminalTabs).toHaveLength(0);
     expect(result.current.activeTerminalTabId).toBe(0);
+  });
+
+  // ---- Issue #588: addTerminalTab の同期連打レース ----
+
+  it('caps terminal count at MAX_TERMINALS even when invoked synchronously beyond the limit (#588)', () => {
+    const showToast = vi.fn();
+    const { result } = renderHook(() => useTerminalTabs(options({ showToast })));
+
+    const initialNextId = result.current.nextTerminalIdRef.current;
+
+    // 同期 (= 1 つの act 内で連続 invoke) で MAX_TERMINALS + 5 回 addTerminalTab() を呼ぶ。
+    // 旧実装では updater 外で id ref が無条件 increment され、accepted フラグが
+    // batching 下で false のままになる race があった。修正後は updater 内で reject 判定 →
+    // id 採番 → tab 追加までが原子的に走るため、確実に MAX_TERMINALS で頭打ちになる。
+    act(() => {
+      for (let i = 0; i < MAX_TERMINALS + 5; i++) {
+        result.current.addTerminalTab({ agent: 'claude' });
+      }
+    });
+
+    expect(result.current.terminalTabs).toHaveLength(MAX_TERMINALS);
+
+    // 上限到達トーストが少なくとも 1 回は呼ばれていること。
+    const upperLimitCalls = showToast.mock.calls.filter(([msg]) =>
+      String(msg).includes(`ターミナル上限（${MAX_TERMINALS}）`)
+    );
+    expect(upperLimitCalls.length).toBeGreaterThanOrEqual(1);
+
+    // 閾値接近トーストが (TERMINAL_WARN_THRESHOLD 到達タイミングで) 1 回は呼ばれていること。
+    const thresholdCalls = showToast.mock.calls.filter(([msg]) =>
+      String(msg).includes(`ターミナル数が ${TERMINAL_WARN_THRESHOLD}`)
+    );
+    expect(thresholdCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not consume nextTerminalIdRef on rejected adds (#588)', () => {
+    const { result } = renderHook(() => useTerminalTabs(options({ showToast: vi.fn() })));
+
+    const startNextId = result.current.nextTerminalIdRef.current;
+
+    act(() => {
+      for (let i = 0; i < MAX_TERMINALS + 5; i++) {
+        result.current.addTerminalTab({ agent: 'claude' });
+      }
+    });
+
+    // 30 タブだけ確定。id ref は accepted 数 (= MAX_TERMINALS) しか進まない。
+    // 旧実装では reject 分も含めた MAX_TERMINALS + 5 (= 35) 進んでいた。
+    expect(result.current.terminalTabs).toHaveLength(MAX_TERMINALS);
+    expect(result.current.nextTerminalIdRef.current).toBe(startNextId + MAX_TERMINALS);
+
+    // タブ id が連番になっていることも確認 (= reject 分が穴あきにならない)。
+    const ids = result.current.terminalTabs.map((t) => t.id);
+    expect(ids).toEqual(
+      Array.from({ length: MAX_TERMINALS }, (_, i) => startNextId + i)
+    );
+  });
+
+  it('after the limit is reached, closing one tab allows adding exactly one more (#588)', () => {
+    const { result } = renderHook(() => useTerminalTabs(options({ showToast: vi.fn() })));
+
+    act(() => {
+      for (let i = 0; i < MAX_TERMINALS; i++) {
+        result.current.addTerminalTab({ agent: 'claude' });
+      }
+    });
+    expect(result.current.terminalTabs).toHaveLength(MAX_TERMINALS);
+
+    const firstId = result.current.terminalTabs[0]!.id;
+    act(() => {
+      result.current.closeTerminalTab(firstId);
+    });
+    expect(result.current.terminalTabs).toHaveLength(MAX_TERMINALS - 1);
+
+    act(() => {
+      result.current.addTerminalTab({ agent: 'claude' });
+    });
+    expect(result.current.terminalTabs).toHaveLength(MAX_TERMINALS);
   });
 });

--- a/src/renderer/src/lib/hooks/use-terminal-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs.ts
@@ -204,10 +204,30 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
 
   const addTerminalTab = useCallback(
     (addOpts?: AddTerminalTabOptions): number | null => {
-      const id = nextTerminalIdRef.current++;
+      // Issue #588: 旧実装は updater 外で `nextTerminalIdRef.current++` と
+      // `let accepted = false` を行い、updater 内で `accepted = true` をセットしていた。
+      // React 18 の自動 batching 下では setState の updater は同期実行されないことがあり、
+      // 同期で N 回連打した場合に
+      //   (a) `accepted` が false のまま return null されて `setActiveTerminalTabId` がスキップ、
+      //   (b) reject 分まで `nextTerminalIdRef.current` が無駄消費される
+      // という race が起きていた。
+      //
+      // 修正: id 採番と active 切替を updater 内に閉じ込め、reject 時は (return prev で) 純粋に
+      // 何も起こらない設計に変える。これで updater が直列に走ってもタブ数は MAX_TERMINALS で
+      // 確実に頭打ちになり、id ref も accepted 数しか進まない。`setActiveTerminalTabId` を
+      // updater 内から呼ぶのは「同コンポーネント内の setState を queue する」だけなので
+      // strict mode の二重実行下でも同じ id を再代入するだけで idempotent。
       const agentType = addOpts?.agent ?? 'claude';
-      let accepted = false;
+      let assignedId: number | null = null;
       setTerminalTabs((prev) => {
+        if (prev.length >= MAX_TERMINALS) {
+          optsRef.current.showToast(`ターミナル上限（${MAX_TERMINALS}）に達しました`, {
+            tone: 'warning'
+          });
+          return prev;
+        }
+        const id = nextTerminalIdRef.current++;
+        assignedId = id;
         // ラベル自動生成: チームロール or 連番
         let label: string;
         if (addOpts?.role) {
@@ -235,12 +255,6 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
           label,
           customLabel: addOpts?.customLabel ?? null
         };
-        if (prev.length >= MAX_TERMINALS) {
-          optsRef.current.showToast(`ターミナル上限（${MAX_TERMINALS}）に達しました`, {
-            tone: 'warning'
-          });
-          return prev;
-        }
         // 閾値を超えそうなら軽く警告
         if (prev.length + 1 === TERMINAL_WARN_THRESHOLD) {
           optsRef.current.showToast(
@@ -248,12 +262,12 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
             { tone: 'info' }
           );
         }
-        accepted = true;
+        // 新タブを active に切り替える。reject パスは return prev で先に抜けているので、
+        // ここに到達する = タブ追加が確定している。
+        setActiveTerminalTabId(id);
         return [...prev, tab];
       });
-      if (!accepted) return null;
-      setActiveTerminalTabId(id);
-      return id;
+      return assignedId;
     },
     []
   );


### PR DESCRIPTION
## Summary

#577 (PR #584) の audit follow-up 3 件を 1 PR にバンドル (1 commit/issue) で修正。

- **#587 [Rust]** `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS` に上限バリデーション (1..=600s) を追加。
  - 触る: \`src-tauri/src/team_hub/protocol/consts.rs\` (新定数 \`RECRUIT_ACK_TIMEOUT_MAX_SECS=600\`),
    \`src-tauri/src/team_hub/protocol/tools/recruit.rs\` (\`recruit_ack_timeout()\` クランプ + warn ログ)
  - 範囲外 / parse 失敗は default (15s) にフォールバックし \`tracing::warn!\` で notice。
  - 上限なしのままだと \`VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS=999999999\` 等で ack 待ちが
    事実上永久になり、recruit semaphore が塞がれて team が事実上 lock される事故を防ぐ。

- **#588 [TS/React]** \`addTerminalTab\` の同期連打レースを修正。
  - 触る: \`src/renderer/src/lib/hooks/use-terminal-tabs.ts\`,
    \`src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx\`
  - 旧実装は updater 外で \`nextTerminalIdRef.current++\` を行い、\`accepted\` フラグを
    updater 内でセットしていたが、React 18 の自動 batching 下では updater が同期実行
    されないことがあり MAX_TERMINALS チェックがすり抜けるリスクがあった。
  - 修正: id 採番 / \`setActiveTerminalTabId\` を updater 内に閉じ込め、reject パスは
    冒頭で \`return prev\` する設計に変更。タブ数は MAX_TERMINALS で確実に頭打ちになり、
    id ref も accepted 数しか進まない。

- **#589 [Rust]** recruit semaphore の lazy init 時に permit 数を tracing で出力。
  - 触る: \`src-tauri/src/team_hub/state.rs\` (\`acquire_recruit_permit\` の lazy init に
    log 追加 + \`recruit_concurrency_from_env_with_source\` への refactor)
  - team_id ごとに 1 回だけ
    \`[teamhub] recruit semaphore initialized: team=<id> permits=<N> source=<env|default|fallback>\`
    を出す。env を変えたのに反映されない相談時に、起動ログから実際の permit 数を確認可能。
  - \`source=fallback\` (= parse 失敗 / 範囲外で default に戻った設定ミス疑い) は warn level、
    それ以外は info level。

## Test plan

- [x] \`cargo test --manifest-path src-tauri/Cargo.toml\` — 334 tests passed (新規 14 件含む)
- [x] \`npm run typecheck\` — エラー 0
- [x] \`npx vitest run\` — 51 files / 320 tests passed (新規 3 件含む)
- [x] \`cargo check --tests\` — warning 数は main と同一 (新規 warning なし)
- [x] #587: 境界値テスト (0 / 1 / 600 / 601 / 999999999 / 未設定 / parse 失敗) で default fallback / 採用を確認
- [x] #588: MAX_TERMINALS+5 回 sync 連打でタブ数が 30 で止まる + id ref 無駄消費なし + 連番 id を確認
- [x] #589: lazy init 初回のみログ 1 行 / 範囲内 env で source=env+info / 範囲外 env で source=fallback+warn を確認

Closes #587
Closes #588
Closes #589