### PR TITLE
fix(canvas): #595 EditorCard dirty 内容を ×/Clear で破棄する前に確認

### DIFF
--- a/src/renderer/src/components/canvas/cards/EditorCard.tsx
+++ b/src/renderer/src/components/canvas/cards/EditorCard.tsx
@@ -3,12 +3,18 @@
  *
  * payload: { projectRoot, relPath }
  * 自前で files.read/write を呼び、dirty 管理 + Ctrl+S 保存。
+ *
+ * Issue #595: dirty な編集内容が × ボタンや Clear で確認なく失われる data-loss
+ * バグを塞ぐため、mount 時に editor-card-dirty-registry へ snapshot provider
+ * を登録する。これにより `useConfirmRemoveCard` / Canvas Clear が削除前に
+ * dirty card 一覧を覗いて confirm dialog を出せる。
  */
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import { CardFrame } from '../CardFrame';
 import { EditorView } from '../../EditorView';
 import { detectLanguage } from '../../../lib/language';
+import { registerEditorCardDirty } from '../../../lib/editor-card-dirty-registry';
 
 interface EditorPayload {
   projectRoot: string;
@@ -64,6 +70,18 @@ function EditorCardImpl({ id, data }: NodeProps): JSX.Element {
   }, [projectRoot, relPath, isImage]);
 
   const dirty = content !== original;
+
+  // Issue #595: dirty 状態を Canvas モード共通の registry へ snapshot 経由で公開する。
+  // ref を介すことで content/dirty が変わるたびに register を作り直さずに済み、
+  // useConfirmRemoveCard / Canvas Clear の削除直前 lookup でも常に最新値を返せる。
+  // relPath は「空 EditorCard」(payload.relPath = '') もあり得るので、空文字なら
+  // title (= 'エディタ' / 'Editor') にフォールバックして confirm dialog で空白行が
+  // 出ないようにする (`??` だと空文字を素通ししてしまうので `||` を使う)。
+  const dirtySnapshotRef = useRef({ relPath: relPath || '', isDirty: false });
+  dirtySnapshotRef.current = { relPath: relPath || title || '', isDirty: dirty };
+  useEffect(() => {
+    return registerEditorCardDirty(id, () => dirtySnapshotRef.current);
+  }, [id]);
 
   const onSave = useCallback(async () => {
     if (!dirty) return;

--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -62,6 +62,7 @@ import {
 import { placeBatchAwayFromNodes } from '../lib/canvas-placement';
 import { useCanvasTeamRestore } from '../lib/hooks/use-canvas-team-restore';
 import { useCanvasAutoSave } from '../lib/hooks/use-canvas-auto-save';
+import { getDirtyEditorCardSnapshots } from '../lib/editor-card-dirty-registry';
 
 type Tab = 'preset' | 'recent';
 
@@ -507,7 +508,19 @@ export function CanvasLayout(): JSX.Element {
             type="button"
             className="canvas-btn canvas-btn--ghost"
             onClick={() => {
-              if (window.confirm(t('canvas.clearConfirm'))) clear();
+              // Issue #595: dirty な EditorCard が残っていればファイル名一覧を提示して
+              // 単一 confirm で確認する。dirty が無いときは既存の「全部消す?」だけ。
+              const dirty = getDirtyEditorCardSnapshots();
+              if (dirty.length === 0) {
+                if (window.confirm(t('canvas.clearConfirm'))) clear();
+                return;
+              }
+              const paths = dirty.map((d) => `• ${d.relPath}`).join('\n');
+              const message = t('canvas.clearConfirmWithDirtyEditors', {
+                count: dirty.length,
+                paths
+              });
+              if (window.confirm(message)) clear();
             }}
             title={t('canvas.clear.tooltip')}
             aria-label={t('canvas.clear.tooltip')}

--- a/src/renderer/src/lib/__tests__/editor-card-dirty-registry.test.ts
+++ b/src/renderer/src/lib/__tests__/editor-card-dirty-registry.test.ts
@@ -1,0 +1,73 @@
+/**
+ * editor-card-dirty-registry の単体テスト (Issue #595)。
+ *
+ * - register / unregister の lifecycle
+ * - 同 id の上書き
+ * - getDirtyEditorCardSnapshots(undefined) と (ids) の両ルートで dirty のみ拾うこと
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  __resetEditorCardDirtyRegistry,
+  getDirtyEditorCardSnapshots,
+  getEditorCardDirtySnapshot,
+  registerEditorCardDirty
+} from '../editor-card-dirty-registry';
+
+afterEach(() => {
+  __resetEditorCardDirtyRegistry();
+});
+
+describe('editor-card-dirty-registry', () => {
+  it('register / unregister の lifecycle', () => {
+    const unreg = registerEditorCardDirty('e1', () => ({ relPath: 'a.ts', isDirty: true }));
+    expect(getEditorCardDirtySnapshot('e1')).toEqual({ relPath: 'a.ts', isDirty: true });
+    unreg();
+    expect(getEditorCardDirtySnapshot('e1')).toBeNull();
+  });
+
+  it('snapshot は呼び出し時点で評価される (closure 経由で最新値を返す)', () => {
+    let dirty = false;
+    registerEditorCardDirty('e1', () => ({ relPath: 'a.ts', isDirty: dirty }));
+    expect(getEditorCardDirtySnapshot('e1')).toEqual({ relPath: 'a.ts', isDirty: false });
+    dirty = true;
+    expect(getEditorCardDirtySnapshot('e1')).toEqual({ relPath: 'a.ts', isDirty: true });
+  });
+
+  it('同 id を再 register すると後発が勝ち、cleanup は古い provider を削除しない', () => {
+    const unreg1 = registerEditorCardDirty('e1', () => ({ relPath: 'old.ts', isDirty: true }));
+    registerEditorCardDirty('e1', () => ({ relPath: 'new.ts', isDirty: true }));
+    expect(getEditorCardDirtySnapshot('e1')?.relPath).toBe('new.ts');
+    // 旧 unreg は新しい provider を巻き込まない
+    unreg1();
+    expect(getEditorCardDirtySnapshot('e1')?.relPath).toBe('new.ts');
+  });
+
+  it('getDirtyEditorCardSnapshots(undefined) は登録順で dirty のみ返す', () => {
+    registerEditorCardDirty('e1', () => ({ relPath: 'a.ts', isDirty: true }));
+    registerEditorCardDirty('e2', () => ({ relPath: 'b.ts', isDirty: false }));
+    registerEditorCardDirty('e3', () => ({ relPath: 'c.ts', isDirty: true }));
+    expect(getDirtyEditorCardSnapshots()).toEqual([
+      { id: 'e1', relPath: 'a.ts' },
+      { id: 'e3', relPath: 'c.ts' }
+    ]);
+  });
+
+  it('getDirtyEditorCardSnapshots(ids) は ids の順序を尊重し、未登録 id は無視する', () => {
+    registerEditorCardDirty('e1', () => ({ relPath: 'a.ts', isDirty: true }));
+    registerEditorCardDirty('e2', () => ({ relPath: 'b.ts', isDirty: true }));
+    registerEditorCardDirty('e3', () => ({ relPath: 'c.ts', isDirty: false }));
+    const out = getDirtyEditorCardSnapshots(['unknown', 'e2', 'e1', 'e3']);
+    expect(out).toEqual([
+      { id: 'e2', relPath: 'b.ts' },
+      { id: 'e1', relPath: 'a.ts' }
+    ]);
+  });
+
+  it('Set<string> も Iterable として受け付ける', () => {
+    registerEditorCardDirty('e1', () => ({ relPath: 'a.ts', isDirty: true }));
+    registerEditorCardDirty('e2', () => ({ relPath: 'b.ts', isDirty: false }));
+    const ids = new Set(['e1', 'e2']);
+    const out = getDirtyEditorCardSnapshots(ids);
+    expect(out).toEqual([{ id: 'e1', relPath: 'a.ts' }]);
+  });
+});

--- a/src/renderer/src/lib/__tests__/use-confirm-remove-card.test.tsx
+++ b/src/renderer/src/lib/__tests__/use-confirm-remove-card.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * useConfirmRemoveCard の confirm 経路テスト (Issue #595)。
+ *
+ * - dirty な EditorCard が居る場合は window.confirm が呼ばれ、cancel すると removeCard が走らない
+ * - 確認 OK の場合は removeCard が走る
+ * - dirty 無しなら追加 confirm を出さずにそのまま removeCard する
+ * - team cascade で dirty editor が巻き込まれる場合も confirm が出る
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { useConfirmRemoveCard } from '../use-confirm-remove-card';
+import { useCanvasStore } from '../../stores/canvas';
+import {
+  __resetEditorCardDirtyRegistry,
+  registerEditorCardDirty
+} from '../editor-card-dirty-registry';
+import { SettingsProvider } from '../settings-context';
+import { ToastProvider } from '../toast-context';
+import { DEFAULT_SETTINGS } from '../../../../types/shared';
+
+type TestWindow = Window &
+  typeof globalThis & {
+    api?: unknown;
+  };
+
+function installApiStub(): void {
+  (window as TestWindow).api = {
+    settings: {
+      load: vi.fn(async () => DEFAULT_SETTINGS),
+      save: vi.fn(async () => undefined)
+    },
+    app: {
+      setProjectRoot: vi.fn(async () => undefined),
+      setZoomLevel: vi.fn(async () => undefined)
+    }
+  };
+}
+
+function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <SettingsProvider>
+      <ToastProvider>{children}</ToastProvider>
+    </SettingsProvider>
+  );
+}
+
+function setupCanvas(
+  nodes: { id: string; type: string; payload?: Record<string, unknown> }[]
+): void {
+  useCanvasStore.setState({
+    nodes: nodes.map((n) => ({
+      id: n.id,
+      type: n.type,
+      position: { x: 0, y: 0 },
+      data: { cardType: n.type as never, title: n.id, payload: n.payload }
+    })) as never,
+    edges: [],
+    teamLocks: {}
+  } as never);
+}
+
+describe('useConfirmRemoveCard (Issue #595)', () => {
+  let originalApi: unknown;
+  let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    originalApi = (window as TestWindow).api;
+    installApiStub();
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    __resetEditorCardDirtyRegistry();
+    useCanvasStore.setState({ nodes: [], edges: [], teamLocks: {} } as never);
+  });
+
+  afterEach(() => {
+    if (originalApi === undefined) {
+      delete (window as TestWindow).api;
+    } else {
+      (window as TestWindow).api = originalApi;
+    }
+    __resetEditorCardDirtyRegistry();
+    useCanvasStore.setState({ nodes: [], edges: [], teamLocks: {} } as never);
+    confirmSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('単一 dirty EditorCard を × で閉じようとすると confirm が出る', () => {
+    setupCanvas([{ id: 'editor-1', type: 'editor' }]);
+    registerEditorCardDirty('editor-1', () => ({ relPath: 'src/foo.ts', isDirty: true }));
+    confirmSpy.mockReturnValue(true);
+
+    const { result } = renderHook(() => useConfirmRemoveCard(), { wrapper: Wrapper });
+    result.current('editor-1');
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(confirmSpy.mock.calls[0][0]).toContain('src/foo.ts');
+    expect(useCanvasStore.getState().nodes).toEqual([]);
+  });
+
+  it('dirty EditorCard で confirm cancel すると removeCard は呼ばれず content が残る', () => {
+    setupCanvas([{ id: 'editor-1', type: 'editor' }]);
+    registerEditorCardDirty('editor-1', () => ({ relPath: 'src/foo.ts', isDirty: true }));
+    confirmSpy.mockReturnValue(false);
+
+    const { result } = renderHook(() => useConfirmRemoveCard(), { wrapper: Wrapper });
+    result.current('editor-1');
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(useCanvasStore.getState().nodes).toHaveLength(1);
+  });
+
+  it('dirty で無い EditorCard は追加 confirm を出さずに即削除する', () => {
+    setupCanvas([{ id: 'editor-1', type: 'editor' }]);
+    registerEditorCardDirty('editor-1', () => ({ relPath: 'src/foo.ts', isDirty: false }));
+
+    const { result } = renderHook(() => useConfirmRemoveCard(), { wrapper: Wrapper });
+    result.current('editor-1');
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(useCanvasStore.getState().nodes).toEqual([]);
+  });
+
+  it('team cascade で dirty EditorCard が巻き込まれるなら editor confirm まで通る', () => {
+    setupCanvas([
+      { id: 'leader-1', type: 'agent', payload: { teamId: 'team-x', teamName: 'Alpha' } },
+      { id: 'worker-1', type: 'agent', payload: { teamId: 'team-x' } },
+      { id: 'editor-1', type: 'editor', payload: { teamId: 'team-x' } }
+    ]);
+    registerEditorCardDirty('editor-1', () => ({ relPath: 'src/foo.ts', isDirty: true }));
+    confirmSpy.mockReturnValue(true);
+
+    const { result } = renderHook(() => useConfirmRemoveCard(), { wrapper: Wrapper });
+    result.current('leader-1');
+
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    expect(confirmSpy.mock.calls[0][0]).toMatch(/Alpha|3/);
+    expect(confirmSpy.mock.calls[1][0]).toContain('src/foo.ts');
+    expect(useCanvasStore.getState().nodes).toEqual([]);
+  });
+
+  it('team cascade で 1 回目をキャンセルすれば editor confirm まで進まず何も削除されない', () => {
+    setupCanvas([
+      { id: 'leader-1', type: 'agent', payload: { teamId: 'team-x' } },
+      { id: 'worker-1', type: 'agent', payload: { teamId: 'team-x' } },
+      { id: 'editor-1', type: 'editor', payload: { teamId: 'team-x' } }
+    ]);
+    registerEditorCardDirty('editor-1', () => ({ relPath: 'src/foo.ts', isDirty: true }));
+    confirmSpy.mockReturnValue(false);
+
+    const { result } = renderHook(() => useConfirmRemoveCard(), { wrapper: Wrapper });
+    result.current('leader-1');
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(useCanvasStore.getState().nodes).toHaveLength(3);
+  });
+});

--- a/src/renderer/src/lib/editor-card-dirty-registry.ts
+++ b/src/renderer/src/lib/editor-card-dirty-registry.ts
@@ -1,0 +1,86 @@
+/**
+ * Issue #595: Canvas EditorCard の dirty 状態を一元管理する advisory registry。
+ *
+ * EditorCard.tsx は `content` / `original` をコンポーネントローカル `useState` で
+ * 保持するため、× ボタン (`CardFrame` → `useConfirmRemoveCard`) や Canvas Clear
+ * (`CanvasLayout`) からは EditorCard を unmount させずに dirty 内容を覗けない。
+ * 各 EditorCard が mount 時に「自分の最新 dirty snapshot を返す closure」を
+ * このモジュール scope の Map に register することで、削除/Clear 経路から
+ * 同期的に「未保存の編集が残っている card 一覧」を取得して confirm dialog を
+ * 出せるようにする。
+ *
+ * 設計メモ:
+ *  - subscribers は zustand / React Context ではなく単なる module Map にする。
+ *    confirm を出す側はあくまで window.confirm を一発叩きたいだけで、再描画は不要。
+ *  - provider は **closure** にして、register 時点の content 値ではなく
+ *    呼び出し時点の最新 ref を読み取る (`dirtySnapshotRef.current`)。
+ *    これにより EditorCard の content が変わっても再 register せずに済み、
+ *    `dirty` が頻繁に変わるたびに registry を作り直す churn を避けられる。
+ *  - `__resetEditorCardDirtyRegistry` は test 用 (vitest 各 test 間の汚染防止)。
+ */
+
+export interface EditorCardDirtySnapshot {
+  /** 表示用ファイル名。relPath が空のときも何か返す (caller 側でフォールバック表示する) */
+  relPath: string;
+  /** content !== original なら true */
+  isDirty: boolean;
+}
+
+type SnapshotProvider = () => EditorCardDirtySnapshot;
+
+const providers = new Map<string, SnapshotProvider>();
+
+/**
+ * EditorCard が mount 時に呼ぶ。返り値は unregister 用の cleanup 関数。
+ * 同 id で既に他 provider が register 済みの場合は新しい provider で上書きする
+ * (React の二重マウントなど)。unregister は「自分が登録した provider」と一致する
+ * ときだけ削除し、後発の register を巻き込まないようにする。
+ */
+export function registerEditorCardDirty(
+  id: string,
+  provider: SnapshotProvider
+): () => void {
+  providers.set(id, provider);
+  return () => {
+    if (providers.get(id) === provider) {
+      providers.delete(id);
+    }
+  };
+}
+
+export function getEditorCardDirtySnapshot(id: string): EditorCardDirtySnapshot | null {
+  const p = providers.get(id);
+  return p ? p() : null;
+}
+
+/**
+ * dirty な editor card の id + relPath 一覧を返す。
+ * `ids` 指定時は指定範囲のみ、省略時は全 register 済み card から拾う。
+ *
+ * 順序は呼び出し時の `ids` の順 (省略時は Map insertion order)。confirm dialog で
+ * 「先に開いたファイルから順に表示」したいので Map の挿入順を尊重する。
+ */
+export function getDirtyEditorCardSnapshots(
+  ids?: Iterable<string>
+): { id: string; relPath: string }[] {
+  const out: { id: string; relPath: string }[] = [];
+  if (ids === undefined) {
+    for (const [id, provider] of providers) {
+      const snap = provider();
+      if (snap.isDirty) out.push({ id, relPath: snap.relPath });
+    }
+    return out;
+  }
+  for (const id of ids) {
+    const provider = providers.get(id);
+    if (!provider) continue;
+    const snap = provider();
+    if (snap.isDirty) out.push({ id, relPath: snap.relPath });
+  }
+  return out;
+}
+
+/** test-only: registry を空にする。本体コードからは呼ばない。 */
+export function __resetEditorCardDirtyRegistry(): void {
+  providers.clear();
+}

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -178,6 +178,11 @@ const ja: Dict = {
   'editor.discardSingle': '未保存の変更があります。このファイルを閉じますか？\n\n{path}',
   'editor.discardMultiple': '未保存の変更があります。このまま切り替えると {count} 個のファイルの変更が失われます。続行しますか？',
   'editor.restartConfirm': '未保存の変更があります。このままアプリを再起動すると変更が失われます。続行しますか？',
+  // Issue #595: Canvas 上の EditorCard を × / Clear で閉じる際に未保存編集を確認するダイアログ。
+  'editor.confirmDiscardChanges':
+    '未保存の編集が残っています。このカードを閉じると編集内容は失われます。続行しますか？\n\n{path}',
+  'editor.confirmDiscardChangesPlural':
+    '未保存の編集が {count} 件残っています。これらのカードを閉じると編集内容はすべて失われます。続行しますか？\n\n{paths}',
 
   // ---------- Welcome ----------
   'welcome.subtitle': 'vibe coding with Claude Code',
@@ -260,6 +265,9 @@ const ja: Dict = {
   'canvas.clear': 'クリア',
   'canvas.clear.tooltip': 'クリア — Canvas 上のカードをすべて削除',
   'canvas.clearConfirm': 'Canvas 上のカードをすべて削除しますか？',
+  // Issue #595: Clear 実行時に dirty な EditorCard が居ればファイル名一覧と件数を表示する。
+  'canvas.clearConfirmWithDirtyEditors':
+    'Canvas 上のカードをすべて削除します。未保存の編集が {count} 件あり、これらは破棄されます。続行しますか？\n\n{paths}',
   'canvas.switchToIde': 'IDE モードに戻る',
   'canvas.switchToIde.tooltip': 'IDE — エディタとターミナル中心の IDE モードへ切替',
   'canvas.modeToggle': 'Canvas モードに切り替え',
@@ -819,6 +827,11 @@ const en: Dict = {
   'editor.discardSingle': 'This file has unsaved changes. Close it anyway?\n\n{path}',
   'editor.discardMultiple': 'There are unsaved changes. Switching now will discard {count} file(s). Continue?',
   'editor.restartConfirm': 'There are unsaved changes. Restarting the app will discard them. Continue?',
+  // Issue #595: Confirmation shown when closing a Canvas EditorCard with unsaved edits via × / Clear.
+  'editor.confirmDiscardChanges':
+    'This card has unsaved changes that will be lost if you close it. Continue?\n\n{path}',
+  'editor.confirmDiscardChangesPlural':
+    '{count} cards have unsaved changes that will be lost if you close them. Continue?\n\n{paths}',
 
   // ---------- Welcome ----------
   'welcome.subtitle': 'vibe coding with Claude Code',
@@ -901,6 +914,9 @@ const en: Dict = {
   'canvas.clear': 'Clear',
   'canvas.clear.tooltip': 'Clear — Remove every card from the canvas',
   'canvas.clearConfirm': 'Clear every card on the canvas?',
+  // Issue #595: Shown when Clear is invoked while one or more EditorCards have unsaved edits.
+  'canvas.clearConfirmWithDirtyEditors':
+    'Clearing the canvas will discard {count} unsaved edit(s). Continue?\n\n{paths}',
   'canvas.switchToIde': 'Switch to IDE mode',
   'canvas.switchToIde.tooltip': 'IDE — Return to the editor + terminal IDE mode',
   'canvas.modeToggle': 'Switch to Canvas mode',

--- a/src/renderer/src/lib/use-confirm-remove-card.ts
+++ b/src/renderer/src/lib/use-confirm-remove-card.ts
@@ -6,10 +6,15 @@
  *   (canvas.ts:122-)。Leader 1 枚閉じたつもりが HR / 動的ワーカー全員消える事故を防ぐため、
  *   ユーザー操作 (× / 右クリック / Delete) からの呼び出しは必ずこのラッパー経由にする。
  *   採用リスナー (use-recruit-listener) など内部処理は store.removeCard を直接使ってよい。
+ *
+ * Issue #595: EditorCard の未保存編集が × / Clear で confirm 無く飛ぶ data-loss を塞ぐため、
+ *   削除対象 (cascadeTeam で広がる ids も含めて) の中に dirty editor が居れば追加 confirm
+ *   を出す。dirty 検出は editor-card-dirty-registry が一元管理する。
  */
 import { useCallback } from 'react';
 import { useCanvasStore } from '../stores/canvas';
 import { useT } from './i18n';
+import { getDirtyEditorCardSnapshots } from './editor-card-dirty-registry';
 
 export function useConfirmRemoveCard(): (id: string) => void {
   const t = useT();
@@ -18,24 +23,40 @@ export function useConfirmRemoveCard(): (id: string) => void {
       const state = useCanvasStore.getState();
       const target = state.nodes.find((n) => n.id === id);
       const teamId = (target?.data?.payload as { teamId?: string } | undefined)?.teamId;
+      // store.removeCard と同じ「cascadeTeam=true」の動きで削除対象 id 集合を作る。
+      // editor dirty チェックはこの集合全体に対して行う。
+      const idsToRemove = new Set<string>([id]);
       if (teamId) {
-        const teamMembers = state.nodes.filter((n) => {
+        for (const n of state.nodes) {
           const tid = (n.data?.payload as { teamId?: string } | undefined)?.teamId;
-          return tid === teamId;
-        });
-        if (teamMembers.length > 1) {
-          // チーム名は payload.teamName / data.title から拾う (どちらかが入っていれば良い)。
-          const teamName =
-            (target?.data?.payload as { teamName?: string } | undefined)?.teamName ??
-            teamId;
-          const ok = window.confirm(
-            t('agentCard.confirmCloseTeam', {
-              count: teamMembers.length,
-              name: teamName
-            })
-          );
-          if (!ok) return;
+          if (tid === teamId) idsToRemove.add(n.id);
         }
+      }
+      // ---- 1) チーム cascade confirm (既存仕様) ----
+      if (teamId && idsToRemove.size > 1) {
+        const teamName =
+          (target?.data?.payload as { teamName?: string } | undefined)?.teamName ?? teamId;
+        const ok = window.confirm(
+          t('agentCard.confirmCloseTeam', {
+            count: idsToRemove.size,
+            name: teamName
+          })
+        );
+        if (!ok) return;
+      }
+      // ---- 2) editor dirty confirm (Issue #595) ----
+      const dirty = getDirtyEditorCardSnapshots(idsToRemove);
+      if (dirty.length === 1) {
+        const ok = window.confirm(
+          t('editor.confirmDiscardChanges', { path: dirty[0].relPath })
+        );
+        if (!ok) return;
+      } else if (dirty.length > 1) {
+        const paths = dirty.map((d) => `• ${d.relPath}`).join('\n');
+        const ok = window.confirm(
+          t('editor.confirmDiscardChangesPlural', { count: dirty.length, paths })
+        );
+        if (!ok) return;
       }
       state.removeCard(id);
     },


### PR DESCRIPTION
## Summary
- Canvas モードの EditorCard は `content` / `original` をローカル `useState` で持っており、× ボタン・Clear のいずれの経路でも dirty 検査が無く未保存編集が confirm 無しで失われる data-loss を起こしていた (Tier S-2 / CRITICAL)。
- `editor-card-dirty-registry` を導入し、EditorCard が mount 時に「最新の dirty snapshot を返す closure」を register することで、削除/Clear path から同期的に dirty 一覧を覗けるようにした。
- `useConfirmRemoveCard` は cascadeTeam の集合に dirty editor が含まれれば追加 confirm を出し、`CanvasLayout` の Clear はファイル名一覧と件数を 1 ダイアログに集約する。
- i18n (ja/en) に `editor.confirmDiscardChanges` / `editor.confirmDiscardChangesPlural` / `canvas.clearConfirmWithDirtyEditors` を追加。
- 単体テスト 11 件 (registry lifecycle 6 件 + useConfirmRemoveCard 5 件) を追加。

## なぜこの設計か
- EditorCard を unmount せずに dirty 内容を覗く必要があるため、grouping は React state ではなく **module-scope の `Map<id, () => snapshot>`** にした (zustand を使うと selector subscribe が無駄に発火する)。
- snapshot は **closure + `useRef`** で読むので、content / dirty が変動しても register を作り直す必要がなく、`useEffect(() => register(...), [id])` で id 不変なら mount 時に 1 度だけ register される。
- `useConfirmRemoveCard` 内で `removeCard` と同じ cascadeTeam 集合を計算してから dirty 検査することで、Leader 1 枚の × でチーム内 EditorCard が巻き込まれるケースもカバー。

## 関連 Issue
Closes #595

## Test plan
- [x] `npm run typecheck` pass
- [x] `npx vitest run` pass (53 files / 331 tests)
- [x] vite 本番ビルド (`npx vite build`) が成功
- [x] 新規ユニットテスト (registry lifecycle / useConfirmRemoveCard confirm path) で「dirty → ×/Clear → cancel で content 残る・OK で削除」「team cascade 経路」「dirty 無しで追加 confirm 無し」をカバー
- [ ] (実機) Canvas → Editor → 入力 → × / Clear で confirm が出ること、Cancel で content が残ること