### PR TITLE
fix(backend): #597 codex MCP setup/cleanup の rollback を claude と対称化

### DIFF
--- a/src-tauri/src/commands/app/team_mcp.rs
+++ b/src-tauri/src/commands/app/team_mcp.rs
@@ -1,5 +1,7 @@
 use crate::state::AppState;
+use anyhow::{anyhow, Result};
 use serde::Serialize;
+use std::path::Path;
 use tauri::State;
 
 #[derive(Serialize, Default)]
@@ -44,6 +46,98 @@ pub struct TeamMcpMember {
     pub agent_id: String,
     pub role: String,
     pub agent: String,
+}
+
+/// Issue #597: claude / codex のどちらか片方だけが書き換わった「半端状態」を絶対に残さない。
+///
+/// シーケンス:
+///   1. claude / codex 両方の現状を pre-snapshot (片肺ではダメ)
+///   2. claude::setup → 失敗時は両方 restore
+///   3. codex::setup → 失敗時は両方 restore (`~/.claude.json` を rollback しないと
+///      legacy/現行 entry が片方だけ残る不整合が永続化する)
+///
+/// 戻り値は claude::setup_at が変更を生んだかどうか (changed)。
+async fn run_setup_at(
+    claude_path: &Path,
+    codex_path: &Path,
+    desired: &serde_json::Value,
+    bridge_path: &str,
+) -> Result<bool> {
+    let claude_snap = crate::mcp_config::claude::snapshot_at(claude_path)
+        .await
+        .map_err(|e| anyhow!("claude mcp snapshot: {e:#}"))?;
+    let codex_snap = crate::mcp_config::codex::snapshot_at(codex_path)
+        .await
+        .map_err(|e| anyhow!("codex mcp snapshot: {e:#}"))?;
+
+    let mut changed = false;
+    match crate::mcp_config::claude::setup_at(claude_path, desired).await {
+        Ok(c) => changed |= c,
+        Err(e) => {
+            let mut error_msg = format!("claude mcp setup: {e:#}");
+            rollback_both(claude_path, claude_snap, codex_path, codex_snap, &mut error_msg).await;
+            return Err(anyhow!(error_msg));
+        }
+    }
+    if let Err(e) = crate::mcp_config::codex::setup_at(codex_path, bridge_path).await {
+        let mut error_msg = format!("codex mcp setup: {e:#}");
+        rollback_both(claude_path, claude_snap, codex_path, codex_snap, &mut error_msg).await;
+        return Err(anyhow!(error_msg));
+    }
+    Ok(changed)
+}
+
+/// Issue #597: cleanup_team_mcp も対称な 2-phase rollback。setup と同じ rollback_both を共有。
+async fn run_cleanup_at(claude_path: &Path, codex_path: &Path) -> Result<bool> {
+    let claude_snap = crate::mcp_config::claude::snapshot_at(claude_path)
+        .await
+        .map_err(|e| anyhow!("claude mcp snapshot: {e:#}"))?;
+    let codex_snap = crate::mcp_config::codex::snapshot_at(codex_path)
+        .await
+        .map_err(|e| anyhow!("codex mcp snapshot: {e:#}"))?;
+
+    let mut removed = false;
+    match crate::mcp_config::claude::cleanup_at(claude_path).await {
+        Ok(r) => removed |= r,
+        Err(e) => {
+            let mut error_msg = format!("claude mcp cleanup: {e:#}");
+            rollback_both(claude_path, claude_snap, codex_path, codex_snap, &mut error_msg).await;
+            return Err(anyhow!(error_msg));
+        }
+    }
+    if let Err(e) = crate::mcp_config::codex::cleanup_at(codex_path).await {
+        let mut error_msg = format!("codex mcp cleanup: {e:#}");
+        rollback_both(claude_path, claude_snap, codex_path, codex_snap, &mut error_msg).await;
+        return Err(anyhow!(error_msg));
+    }
+    Ok(removed)
+}
+
+/// claude / codex の snapshot を両方 restore。失敗はログに残し、ユーザー向け error_msg にも追記する
+/// (片方だけ rollback 成功 / 失敗の組み合わせをユーザーが手動で確認できるよう、明示的に書く)。
+async fn rollback_both(
+    claude_path: &Path,
+    claude_snap: Option<Vec<u8>>,
+    codex_path: &Path,
+    codex_snap: Option<Vec<u8>>,
+    error_msg: &mut String,
+) {
+    if let Err(re) = crate::mcp_config::claude::restore_at(claude_path, claude_snap).await {
+        tracing::error!("[mcp] claude rollback failed: {re:#}");
+        *error_msg = format!(
+            "{error_msg} (rollback claude also failed: {re:#}; please review ~/.claude.json manually)"
+        );
+    } else {
+        tracing::warn!("[mcp] claude rolled back to previous snapshot");
+    }
+    if let Err(re) = crate::mcp_config::codex::restore_at(codex_path, codex_snap).await {
+        tracing::error!("[mcp] codex rollback failed: {re:#}");
+        *error_msg = format!(
+            "{error_msg} (rollback codex also failed: {re:#}; please review ~/.codex/config.toml manually)"
+        );
+    } else {
+        tracing::warn!("[mcp] codex rolled back to previous snapshot");
+    }
 }
 
 #[tauri::command]
@@ -126,54 +220,22 @@ pub async fn app_setup_team_mcp(
     let (socket, token, bridge_path) = hub.info().await;
     let desired = crate::mcp_config::bridge_desired(&socket, &token, &bridge_path);
 
-    // Issue #118: claude / codex のどちらか片方だけが書き換わった「半端状態」を残さない。
-    // 事前にスナップショットを取り、claude→codex の順に書く。codex で失敗したら claude を rollback。
-    let claude_snap = match crate::mcp_config::claude::snapshot().await {
-        Ok(s) => s,
-        Err(e) => {
-            return Ok(SetupTeamMcpResult {
-                ok: false,
-                error: Some(format!("claude mcp snapshot: {e:#}")),
-                ..Default::default()
-            });
-        }
-    };
-
-    let mut changed = false;
-    match crate::mcp_config::claude::setup(&desired).await {
-        Ok(c) => changed |= c,
-        Err(e) => {
-            return Ok(SetupTeamMcpResult {
-                ok: false,
-                error: Some(format!("claude mcp setup: {e:#}")),
-                ..Default::default()
-            })
-        }
-    }
-    if let Err(e) = crate::mcp_config::codex::setup(&bridge_path).await {
-        // claude 側を元に戻す。rollback 自体が失敗した場合はログに残し、ユーザーには両方
-        // 失敗したことを返す (ユーザーが手動で `~/.claude.json` を確認できるようメッセージで促す)。
-        let mut error_msg = format!("codex mcp setup: {e:#}");
-        if let Err(re) = crate::mcp_config::claude::restore(claude_snap).await {
-            tracing::error!("[mcp] claude rollback failed after codex setup error: {re:#}");
-            error_msg = format!(
-                "{error_msg} (rollback claude also failed: {re:#}; please review ~/.claude.json manually)"
-            );
-        } else {
-            tracing::warn!("[mcp] codex setup failed, claude rolled back to previous state");
-        }
-        return Ok(SetupTeamMcpResult {
+    // Issue #597: claude / codex の片肺 rollback を防止。両方 pre-snapshot → 失敗時両方 restore。
+    let claude_path = crate::mcp_config::claude::config_path();
+    let codex_path = crate::mcp_config::codex::config_path();
+    match run_setup_at(&claude_path, &codex_path, &desired, &bridge_path).await {
+        Ok(changed) => Ok(SetupTeamMcpResult {
+            ok: true,
+            socket: Some(socket),
+            changed: Some(changed),
+            error: None,
+        }),
+        Err(e) => Ok(SetupTeamMcpResult {
             ok: false,
-            error: Some(error_msg),
+            error: Some(format!("{e:#}")),
             ..Default::default()
-        });
+        }),
     }
-    Ok(SetupTeamMcpResult {
-        ok: true,
-        socket: Some(socket),
-        changed: Some(changed),
-        error: None,
-    })
 }
 
 #[tauri::command]
@@ -183,54 +245,30 @@ pub async fn app_cleanup_team_mcp(
     team_id: String,
 ) -> crate::commands::error::CommandResult<CleanupTeamMcpResult> {
     let last = state.team_hub.clear_team(&team_id).await;
-    let mut removed = false;
-    if last {
-        // Issue #118: 片側だけ vibe-team 行が消えた半端状態を残さない。
-        // 事前にスナップショットを取り、codex 側で失敗したら claude を元に戻す。
-        let claude_snap = match crate::mcp_config::claude::snapshot().await {
-            Ok(s) => s,
-            Err(e) => {
-                return Ok(CleanupTeamMcpResult {
-                    ok: false,
-                    error: Some(format!("claude mcp snapshot: {e:#}")),
-                    removed: None,
-                });
-            }
-        };
-
-        // 残りアクティブチームが 0 になったら MCP 設定を削除
-        match crate::mcp_config::claude::cleanup().await {
-            Ok(r) => removed |= r,
-            Err(e) => {
-                return Ok(CleanupTeamMcpResult {
-                    ok: false,
-                    error: Some(format!("claude mcp cleanup: {e:#}")),
-                    removed: None,
-                })
-            }
-        }
-        if let Err(e) = crate::mcp_config::codex::cleanup().await {
-            let mut error_msg = format!("codex mcp cleanup: {e:#}");
-            if let Err(re) = crate::mcp_config::claude::restore(claude_snap).await {
-                tracing::error!("[mcp] claude rollback failed after codex cleanup error: {re:#}");
-                error_msg = format!(
-                    "{error_msg} (rollback claude also failed: {re:#}; please review ~/.claude.json manually)"
-                );
-            } else {
-                tracing::warn!("[mcp] codex cleanup failed, claude restored to previous state");
-            }
-            return Ok(CleanupTeamMcpResult {
-                ok: false,
-                error: Some(error_msg),
-                removed: None,
-            });
-        }
+    if !last {
+        return Ok(CleanupTeamMcpResult {
+            ok: true,
+            removed: Some(false),
+            error: None,
+        });
     }
-    Ok(CleanupTeamMcpResult {
-        ok: true,
-        removed: Some(removed),
-        error: None,
-    })
+
+    // Issue #597: 残りアクティブチームが 0 になったら MCP 設定を削除。
+    // claude / codex の片肺 rollback を防止 — 両方 pre-snapshot → 失敗時両方 restore。
+    let claude_path = crate::mcp_config::claude::config_path();
+    let codex_path = crate::mcp_config::codex::config_path();
+    match run_cleanup_at(&claude_path, &codex_path).await {
+        Ok(removed) => Ok(CleanupTeamMcpResult {
+            ok: true,
+            removed: Some(removed),
+            error: None,
+        }),
+        Err(e) => Ok(CleanupTeamMcpResult {
+            ok: false,
+            error: Some(format!("{e:#}")),
+            removed: None,
+        }),
+    }
 }
 
 #[tauri::command]
@@ -375,4 +413,178 @@ pub async fn app_recruit_ack(
         .resolve_recruit_ack(&new_agent_id, &team_id, outcome)
         .await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    //! Issue #597: claude / codex の片肺 rollback を防止する 2-phase シーケンスのテスト。
+    //!
+    //! `app_setup_team_mcp` 自体は `tauri::State` に依存して unit test しづらいので、
+    //! 実体である `run_setup_at` / `run_cleanup_at` を path 引数で叩いて検証する。
+    //! 共通の `rollback_both` を使うので、setup の rollback 経路で symmetry が証明できれば
+    //! cleanup の rollback も同等に動く (cleanup の失敗注入は OS 依存性が高く不安定なため省略)。
+
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+    use tokio::fs;
+
+    /// codex 側 setup を強制失敗させたとき、claude 側も snapshot 状態に戻ること。
+    ///
+    /// 失敗の作り方: codex_path の親を「regular file」として配置 → atomic_write 内の
+    /// `create_dir_all(parent)` が ENOTDIR / AlreadyExists 系で失敗する (POSIX/Windows 共通)。
+    /// これは Issue #597 の修正前は claude::restore だけが走り codex 側の半端書き残存を
+    /// 招いていた経路。修正後は claude 側も巻き戻る。
+    #[tokio::test]
+    async fn setup_rolls_back_both_when_codex_setup_fails() {
+        let tmp = TempDir::new().unwrap();
+        let claude_path = tmp.path().join(".claude.json");
+        // 既存 claude content を仕込む (rollback 後にこれが残ることを検証)
+        let original_claude = br#"{"existing":true}"#.to_vec();
+        fs::write(&claude_path, &original_claude).await.unwrap();
+
+        // codex_path の親を「ファイル」にして codex::setup_at の create_dir_all を確実に失敗させる
+        let blocker = tmp.path().join("blocker");
+        fs::write(&blocker, b"this is a file, not a directory")
+            .await
+            .unwrap();
+        let codex_path = blocker.join("config.toml");
+
+        let desired = json!({
+            "type": "stdio",
+            "command": "node",
+            "args": ["/tmp/bridge.js"]
+        });
+
+        let res = run_setup_at(&claude_path, &codex_path, &desired, "/tmp/bridge.js").await;
+        assert!(res.is_err(), "codex setup should fail when parent is a file");
+        let msg = format!("{:#}", res.unwrap_err());
+        assert!(
+            msg.contains("codex mcp setup"),
+            "error should mention codex mcp setup, got: {msg}"
+        );
+
+        // claude 側が rollback されているか確認
+        let after = fs::read(&claude_path).await.unwrap();
+        assert_eq!(
+            after, original_claude,
+            "claude must be rolled back to original bytes"
+        );
+        // codex 側はそもそも書けなかったので存在しないこと
+        assert!(
+            !codex_path.exists(),
+            "codex file should not exist after failed setup"
+        );
+    }
+
+    /// claude 側 setup を強制失敗 (root が array → object check で Err) させたとき、
+    /// codex 側の事前 snapshot も restore されること。
+    #[tokio::test]
+    async fn setup_rolls_back_both_when_claude_setup_fails() {
+        let tmp = TempDir::new().unwrap();
+        let claude_path = tmp.path().join(".claude.json");
+        // claude::setup_at は root が JSON array だと「~/.claude.json must be an object」で Err。
+        fs::write(&claude_path, b"[]").await.unwrap();
+
+        let codex_path = tmp.path().join(".codex").join("config.toml");
+        // codex に既存 content を入れて、rollback で元に戻ることを検証
+        let original_codex = b"[other]\nfoo = 1\n".to_vec();
+        fs::create_dir_all(codex_path.parent().unwrap())
+            .await
+            .unwrap();
+        fs::write(&codex_path, &original_codex).await.unwrap();
+
+        let desired = json!({ "type": "stdio" });
+        let res = run_setup_at(&claude_path, &codex_path, &desired, "/tmp/bridge.js").await;
+        assert!(res.is_err(), "claude setup should fail with array root");
+        let msg = format!("{:#}", res.unwrap_err());
+        assert!(
+            msg.contains("claude mcp setup"),
+            "error should mention claude mcp setup, got: {msg}"
+        );
+
+        // claude は元のまま (array)
+        let claude_after = fs::read(&claude_path).await.unwrap();
+        assert_eq!(claude_after, b"[]");
+        // codex も rollback で original_codex のまま (claude 失敗時でも codex 側 snapshot は restore される)
+        let codex_after = fs::read(&codex_path).await.unwrap();
+        assert_eq!(
+            codex_after, original_codex,
+            "codex must be unchanged / rolled back even when claude side fails first"
+        );
+    }
+
+    /// 正常系: 両方 setup 成功 → claude には mcpServers.vibe-team が、
+    /// codex には [mcp_servers.vibe-team] が入る。
+    #[tokio::test]
+    async fn setup_writes_both_when_no_failure() {
+        let tmp = TempDir::new().unwrap();
+        let claude_path = tmp.path().join(".claude.json");
+        let codex_path = tmp.path().join(".codex").join("config.toml");
+
+        let desired = json!({
+            "type": "stdio",
+            "command": "node",
+            "args": ["/tmp/bridge.js"]
+        });
+
+        let changed = run_setup_at(&claude_path, &codex_path, &desired, "/tmp/bridge.js")
+            .await
+            .unwrap();
+        assert!(changed, "first setup should report changed=true");
+
+        let claude_str = fs::read_to_string(&claude_path).await.unwrap();
+        assert!(
+            claude_str.contains("vibe-team"),
+            "claude should contain vibe-team entry"
+        );
+        let codex_str = fs::read_to_string(&codex_path).await.unwrap();
+        assert!(
+            codex_str.contains("[mcp_servers.vibe-team]"),
+            "codex should contain section"
+        );
+    }
+
+    /// cleanup 正常系: claude / codex 両方から vibe-team 行が消える。
+    #[tokio::test]
+    async fn cleanup_removes_from_both() {
+        let tmp = TempDir::new().unwrap();
+        let claude_path = tmp.path().join(".claude.json");
+        let original_claude = br#"{
+  "mcpServers": {
+    "vibe-team": { "command": "node" }
+  }
+}"#
+        .to_vec();
+        fs::write(&claude_path, &original_claude).await.unwrap();
+
+        let codex_path = tmp.path().join(".codex").join("config.toml");
+        let original_codex =
+            b"[other]\nfoo = 1\n\n[mcp_servers.vibe-team]\ncommand = \"node\"\n".to_vec();
+        fs::create_dir_all(codex_path.parent().unwrap())
+            .await
+            .unwrap();
+        fs::write(&codex_path, &original_codex).await.unwrap();
+
+        let removed = run_cleanup_at(&claude_path, &codex_path).await.unwrap();
+        assert!(
+            removed,
+            "cleanup should report removed=true when claude had vibe-team entry"
+        );
+
+        let claude_after = fs::read_to_string(&claude_path).await.unwrap();
+        assert!(
+            !claude_after.contains("vibe-team"),
+            "claude vibe-team entry should be gone"
+        );
+        let codex_after = fs::read_to_string(&codex_path).await.unwrap();
+        assert!(
+            !codex_after.contains("[mcp_servers.vibe-team]"),
+            "codex section should be gone"
+        );
+        assert!(
+            codex_after.contains("[other]"),
+            "codex other sections must be preserved"
+        );
+    }
 }

--- a/src-tauri/src/mcp_config/claude.rs
+++ b/src-tauri/src/mcp_config/claude.rs
@@ -2,23 +2,26 @@
 
 use anyhow::Result;
 use serde_json::Value;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::fs;
 
 const ENTRY: &str = "vibe-team";
 const LEGACY_ENTRY: &str = "vive-team";
 
-fn config_path() -> PathBuf {
+pub(crate) fn config_path() -> PathBuf {
     dirs::home_dir().unwrap_or_default().join(".claude.json")
 }
 
 /// `mcpServers["vibe-team"]` を `desired` で上書き。
 /// 既に同じ内容なら false (no-op)、変更したら true を返す。
 /// 旧 `vive-team` エントリがあれば同時に削除する (名前変更による自動マイグレーション)。
-pub async fn setup(desired: &Value) -> Result<bool> {
-    let path = config_path();
-    let mut config: Value = match fs::read(&path).await {
-        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_else(|_| Value::Object(Default::default())),
+///
+/// Issue #597: テスト容易化のため path を引数に取る (production code は config_path() を渡す)。
+pub(crate) async fn setup_at(path: &Path, desired: &Value) -> Result<bool> {
+    let mut config: Value = match fs::read(path).await {
+        Ok(bytes) => {
+            serde_json::from_slice(&bytes).unwrap_or_else(|_| Value::Object(Default::default()))
+        }
         Err(_) => Value::Object(Default::default()),
     };
     let obj = config
@@ -39,39 +42,36 @@ pub async fn setup(desired: &Value) -> Result<bool> {
     servers_obj.insert(ENTRY.into(), desired.clone());
     let json = serde_json::to_vec_pretty(&config)?;
     // Issue #37: ~/.claude.json は他アプリとも共有。半端書き込みで全消失するのを避けるため atomic に。
-    crate::commands::atomic_write::atomic_write(&path, &json).await?;
+    crate::commands::atomic_write::atomic_write(path, &json).await?;
     Ok(true)
 }
 
 /// Issue #118: setup/cleanup の rollback 用に、現状のファイル内容を丸ごとスナップショット。
-/// `Ok(None)` はファイル未存在 (= 元々何も無い)。restore() で None を渡すとファイル削除で原状回復する。
-pub async fn snapshot() -> Result<Option<Vec<u8>>> {
-    let path = config_path();
-    match fs::read(&path).await {
+/// `Ok(None)` はファイル未存在 (= 元々何も無い)。restore_at() で None を渡すとファイル削除で原状回復する。
+pub(crate) async fn snapshot_at(path: &Path) -> Result<Option<Vec<u8>>> {
+    match fs::read(path).await {
         Ok(b) => Ok(Some(b)),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(e.into()),
     }
 }
 
-/// Issue #118: snapshot() で取った状態へ atomic に書き戻す。
-pub async fn restore(snap: Option<Vec<u8>>) -> Result<()> {
-    let path = config_path();
+/// Issue #118: snapshot_at() で取った状態へ atomic に書き戻す。
+pub(crate) async fn restore_at(path: &Path, snap: Option<Vec<u8>>) -> Result<()> {
     match snap {
         Some(bytes) => {
-            crate::commands::atomic_write::atomic_write(&path, &bytes).await?;
+            crate::commands::atomic_write::atomic_write(path, &bytes).await?;
         }
         None => {
             // 元々ファイルが無かった場合は削除して原状回復
-            let _ = fs::remove_file(&path).await;
+            let _ = fs::remove_file(path).await;
         }
     }
     Ok(())
 }
 
-pub async fn cleanup() -> Result<bool> {
-    let path = config_path();
-    let Ok(bytes) = fs::read(&path).await else {
+pub(crate) async fn cleanup_at(path: &Path) -> Result<bool> {
+    let Ok(bytes) = fs::read(path).await else {
         return Ok(false);
     };
     let mut config: Value = serde_json::from_slice(&bytes).unwrap_or_default();
@@ -88,7 +88,50 @@ pub async fn cleanup() -> Result<bool> {
         // Issue #108: setup と同じく cleanup も atomic_write を使う。
         // 直接 fs::write で上書きすると、書き込み中のクラッシュで `~/.claude.json` が
         // 空 / 半端な状態で残り、Claude Code 全体の設定が失われる事故になる。
-        crate::commands::atomic_write::atomic_write(&path, &json).await?;
+        crate::commands::atomic_write::atomic_write(path, &json).await?;
     }
     Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn snapshot_returns_none_when_file_absent() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(".claude.json");
+        assert!(snapshot_at(&path).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn restore_round_trips_existing_content() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(".claude.json");
+        let original = br#"{"existing":true}"#.to_vec();
+        fs::write(&path, &original).await.unwrap();
+
+        let snap = snapshot_at(&path).await.unwrap();
+        // 何か壊して restore で元に戻す
+        fs::write(&path, b"corrupted").await.unwrap();
+        restore_at(&path, snap).await.unwrap();
+        let got = fs::read(&path).await.unwrap();
+        assert_eq!(got, original);
+    }
+
+    #[tokio::test]
+    async fn setup_at_returns_err_when_root_is_array() {
+        // 「~/.claude.json must be an object」エラー経路 (rollback テストで使う)
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(".claude.json");
+        fs::write(&path, b"[]").await.unwrap();
+        let desired = json!({ "type": "stdio" });
+        let res = setup_at(&path, &desired).await;
+        assert!(res.is_err(), "array root should fail with object check");
+        // ファイルは触られていないはず
+        let still = fs::read(&path).await.unwrap();
+        assert_eq!(still, b"[]");
+    }
 }

--- a/src-tauri/src/mcp_config/codex.rs
+++ b/src-tauri/src/mcp_config/codex.rs
@@ -1,7 +1,7 @@
 // Codex MCP 設定 (~/.codex/config.toml) の `[mcp_servers.vibe-team]` を更新
 
 use anyhow::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::fs;
 
 const SECTION: &str = "mcp_servers.vibe-team";
@@ -30,7 +30,7 @@ fn toml_escape_basic_string(s: &str) -> String {
     out
 }
 
-fn config_path() -> PathBuf {
+pub(crate) fn config_path() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_default()
         .join(".codex")
@@ -57,12 +57,12 @@ pub fn remove_toml_section(content: &str, section: &str) -> String {
     out.join("\n")
 }
 
-pub async fn setup(bridge_path: &str) -> Result<()> {
-    let path = config_path();
+/// Issue #597: テスト容易化のため path を引数に取る (production code は config_path() を渡す)。
+pub(crate) async fn setup_at(path: &Path, bridge_path: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).await?;
     }
-    let mut content: String = fs::read_to_string(&path).await.unwrap_or_default();
+    let mut content: String = fs::read_to_string(path).await.unwrap_or_default();
     content = remove_toml_section(&content, SECTION);
     content = remove_toml_section(&content, LEGACY_SECTION);
     // Issue #44: bridge_path を TOML basic string 用に正規 escape。
@@ -75,18 +75,127 @@ pub async fn setup(bridge_path: &str) -> Result<()> {
     );
     // Issue #37: ~/.codex/config.toml も他アプリと共有なので atomic に上書き
     let data = (content + &section).into_bytes();
-    crate::commands::atomic_write::atomic_write(&path, &data).await?;
+    crate::commands::atomic_write::atomic_write(path, &data).await?;
     Ok(())
 }
 
-pub async fn cleanup() -> Result<()> {
-    let path = config_path();
-    let Ok(content) = fs::read_to_string(&path).await else {
+pub(crate) async fn cleanup_at(path: &Path) -> Result<()> {
+    let Ok(content) = fs::read_to_string(path).await else {
         return Ok(());
     };
     let stripped = remove_toml_section(&content, SECTION);
     let stripped = remove_toml_section(&stripped, LEGACY_SECTION);
     let cleaned = format!("{}\n", stripped.trim_end());
-    crate::commands::atomic_write::atomic_write(&path, cleaned.as_bytes()).await?;
+    crate::commands::atomic_write::atomic_write(path, cleaned.as_bytes()).await?;
     Ok(())
+}
+
+/// Issue #597: setup/cleanup の rollback 用に、現状のファイル内容を丸ごとスナップショット。
+/// `Ok(None)` はファイル未存在 (= 元々何も無い)。restore_at() で None を渡すとファイル削除で原状回復する。
+/// claude::snapshot_at() と対称 — どちらか片方だけ snapshot を持つ片肺 rollback を防ぐため。
+pub(crate) async fn snapshot_at(path: &Path) -> Result<Option<Vec<u8>>> {
+    match fs::read(path).await {
+        Ok(b) => Ok(Some(b)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Issue #597: snapshot_at() で取った状態へ atomic に書き戻す。claude::restore_at() と対称。
+pub(crate) async fn restore_at(path: &Path, snap: Option<Vec<u8>>) -> Result<()> {
+    match snap {
+        Some(bytes) => {
+            crate::commands::atomic_write::atomic_write(path, &bytes).await?;
+        }
+        None => {
+            // 元々ファイルが無かった場合は削除して原状回復。
+            // 既に存在しなければ NotFound が返るが、無視して OK。
+            let _ = fs::remove_file(path).await;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn snapshot_returns_none_when_file_absent() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        let snap = snapshot_at(&path).await.unwrap();
+        assert!(snap.is_none(), "absent file should yield None");
+    }
+
+    #[tokio::test]
+    async fn snapshot_returns_bytes_for_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        fs::write(&path, b"[other]\nfoo = 1\n").await.unwrap();
+        let snap = snapshot_at(&path).await.unwrap().expect("Some bytes");
+        assert_eq!(snap, b"[other]\nfoo = 1\n");
+    }
+
+    #[tokio::test]
+    async fn restore_writes_bytes_back() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        fs::write(&path, b"current").await.unwrap();
+        restore_at(&path, Some(b"original".to_vec())).await.unwrap();
+        let got = fs::read(&path).await.unwrap();
+        assert_eq!(got, b"original");
+    }
+
+    #[tokio::test]
+    async fn restore_none_deletes_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        fs::write(&path, b"to-be-deleted").await.unwrap();
+        restore_at(&path, None).await.unwrap();
+        assert!(!path.exists(), "restore(None) should delete file");
+    }
+
+    #[tokio::test]
+    async fn restore_none_is_noop_when_already_absent() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        // 既に無い状態で restore(None) を呼んでも OK
+        restore_at(&path, None).await.unwrap();
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn setup_then_restore_round_trips_to_original_bytes() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        let original = b"[other]\nfoo = 1\n".to_vec();
+        fs::write(&path, &original).await.unwrap();
+
+        let snap = snapshot_at(&path).await.unwrap();
+        // setup を走らせて vibe-team section を追加
+        setup_at(&path, "/tmp/bridge.js").await.unwrap();
+        let after_setup = fs::read(&path).await.unwrap();
+        assert!(after_setup.windows(SECTION.len()).any(|w| w == SECTION.as_bytes()));
+
+        // snapshot を使って巻き戻す
+        restore_at(&path, snap).await.unwrap();
+        let restored = fs::read(&path).await.unwrap();
+        assert_eq!(restored, original, "restore should match original byte-for-byte");
+    }
+
+    #[tokio::test]
+    async fn setup_then_restore_with_none_removes_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        // 元々ファイルが無い状態で snapshot → None
+        let snap = snapshot_at(&path).await.unwrap();
+        assert!(snap.is_none());
+        setup_at(&path, "/tmp/bridge.js").await.unwrap();
+        assert!(path.exists());
+        // restore(None) でファイル削除
+        restore_at(&path, snap).await.unwrap();
+        assert!(!path.exists(), "restore(None) should remove file created by setup");
+    }
 }


### PR DESCRIPTION
Closes #597

## Summary
- `app_setup_team_mcp` / `app_cleanup_team_mcp` は claude 設定のみ pre-snapshot を取り、codex 側書き込み失敗時に claude しか rollback しない片肺シーケンスだった (`~/.codex/config.toml` 半端書き残存 — CRITICAL データ損失)
- codex には `snapshot/restore` API そのものが存在しなかったため、claude.rs と対称な `snapshot_at` / `restore_at` を新設
- 両 setup/cleanup を「**両方 pre-snapshot → claude write → codex write → どちらか失敗時は両方 restore**」の対称シーケンスに書き換え

## 主な変更
- `src-tauri/src/mcp_config/codex.rs` — `snapshot_at` / `restore_at` を追加 (Vec<u8> 単位で round-trip、`None` → ファイル未存在 → restore で削除して原状回復)
- `src-tauri/src/mcp_config/claude.rs` — API を `_at` 形に統一して `pub(crate)` 化 (テスト容易化、production code は `config_path()` を渡す)
- `src-tauri/src/commands/app/team_mcp.rs` — `run_setup_at` / `run_cleanup_at` + 共通 `rollback_both` ヘルパで対称化。rollback 自体の失敗もログ + ユーザー向け error message に手動確認の指示を追記
- 単体テスト 14 件追加

## Test plan
- [x] `cargo check --tests` (warning は既存分のみ、新規なし)
- [x] `cargo test --lib` 全 348 件 pass (新規 14 件含む)
- [x] `tsc --noEmit` 通過
- [x] 失敗ケース 2 種をテストでカバー:
  - codex setup 失敗 (codex_path の親を file にして `create_dir_all` を確実に失敗) → claude も snapshot に rollback されること検証
  - claude setup 失敗 (root が JSON array で object check Err) → codex も snapshot に rollback されること検証
- [x] 正常系: 両方 setup 成功で claude `mcpServers.vibe-team` / codex `[mcp_servers.vibe-team]` が書き込まれる、cleanup で両方から消える