### PR TITLE
fix(terminal): #607 args 内の --resume <id> を regex validate して引数注入を防ぐ

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -82,6 +82,60 @@ fn resolve_command(command: Option<String>, args: Option<Vec<String>>) -> (Strin
     command_validation::normalize_terminal_command(command, args)
 }
 
+/// Issue #607 (security): args に含まれる `--resume <id>` / `--resume=<id>` を validate して
+/// 不正な id を含むペアは strip + warn する defense-in-depth ヘルパー。
+///
+/// renderer (CardFrame / TerminalCard / use-team-launch-helpers / settings.claudeArgs) から
+/// 直接 args に積まれた `--resume <id>` も、構造化フィールド `opts.resume_session_id` と同じ
+/// `^[A-Za-z0-9_-]{8,64}$` 規則で守る。`--resume=<id>` の単一要素形式は 2 要素分離原則
+/// (`Command::arg("--resume").arg(&id)`) を破るため常に strip する。
+///
+/// 戻り値は filtered な args (Vec<String>) で、warn log は内部で発行済み。
+/// 入力が空または `--resume` を含まなければ no-op。
+fn filter_resume_args_in_place(args: Vec<String>) -> Vec<String> {
+    if args.is_empty() {
+        return args;
+    }
+    let mut out: Vec<String> = Vec::with_capacity(args.len());
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--resume" {
+            // 2 要素形式: 次の要素を validate
+            match iter.next() {
+                Some(id) if command_validation::is_valid_resume_session_id(&id) => {
+                    out.push(arg);
+                    out.push(id);
+                }
+                Some(bad) => {
+                    let preview: String = bad.chars().take(16).collect();
+                    tracing::warn!(
+                        "[terminal] --resume id in args rejected by validator (len={}, preview={:?}), stripping pair",
+                        bad.len(),
+                        preview
+                    );
+                }
+                None => {
+                    tracing::warn!(
+                        "[terminal] trailing --resume with no following id, stripping"
+                    );
+                }
+            }
+        } else if let Some(rest) = arg.strip_prefix("--resume=") {
+            // 単一要素形式 `--resume=<id>` は 2 要素分離原則を破るため、id の中身に関わらず
+            // 常に strip する。攻撃成立条件 (Claude CLI 側の parse 仕様) に依存しない厳しめの方針。
+            let preview: String = rest.chars().take(16).collect();
+            tracing::warn!(
+                "[terminal] --resume=<id> single-element form rejected (len={}, preview={:?}), stripping",
+                rest.len(),
+                preview
+            );
+        } else {
+            out.push(arg);
+        }
+    }
+    out
+}
+
 /// Codex の system prompt を、PTY (TUI) に直接「最初の入力」として注入する fallback 経路。
 ///
 /// 動作:
@@ -161,6 +215,19 @@ pub async fn terminal_create(
         });
     }
     let is_codex_command = command_validation::is_codex_command(&command);
+
+    // Issue #607 (security): Claude `--resume <id>` に渡される session id は renderer
+    // (CardFrame / TerminalCard / use-team-launch-helpers) が `args.push("--resume", id)`
+    // で直接積んでくる。id は `~/.claude/projects/<encoded>/<id>.jsonl` の file_stem や
+    // zustand persist の `team-history.json` 由来で信頼境界の外にあるため、`-` 始まりの
+    // 「フラグ風」文字列や shell metachar / 改行を含む id を埋められると引数注入や parse
+    // 破壊が成立する恐れがある。
+    //
+    // ここで args に含まれる `--resume <id>` / `--resume=<id>` をスキャンし、
+    // `^[A-Za-z0-9_-]{8,64}$` を満たさない id を含むペアは strip + warn で audit log に
+    // 残す (新規起動にフォールバック / UX 維持)。`--resume=<id>` の単一要素形式は
+    // 2 要素分離原則を破るため id 内容に関わらず常に strip。
+    args = filter_resume_args_in_place(args);
 
     // Issue #271: HMR remount 経路では renderer 側 hook が `attachIfExists: true` を立て、
     // 既存 PTY に bind し直したいシグナルを送る。allowlist / immediate-exec チェックを通った
@@ -498,4 +565,157 @@ pub async fn terminal_save_pasted_image(
     mime_type: String,
 ) -> SavePastedImageResult {
     paste_image::save(base64, mime_type).await
+}
+
+#[cfg(test)]
+mod resume_args_filter_tests {
+    use super::filter_resume_args_in_place;
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn keeps_valid_resume_pair() {
+        let input = s(&["--resume", "550e8400-e29b-41d4-a716-446655440000"]);
+        let out = filter_resume_args_in_place(input.clone());
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn keeps_valid_resume_pair_among_other_args() {
+        let input = s(&[
+            "--dangerously-skip-permissions",
+            "--resume",
+            "abcdef12-3456-7890-abcd-ef1234567890",
+            "--append-system-prompt",
+            "you are a helper",
+        ]);
+        let out = filter_resume_args_in_place(input.clone());
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn strips_invalid_resume_id_starting_with_dash() {
+        // `-c` / `-rf` / `--print=...` のような「フラグ風」id は引数注入の主経路。
+        let input = s(&["--resume", "--print=/etc/passwd"]);
+        let out = filter_resume_args_in_place(input);
+        assert!(out.is_empty(), "expected pair to be stripped, got {out:?}");
+    }
+
+    #[test]
+    fn strips_invalid_resume_id_with_shell_metachars() {
+        let input = s(&[
+            "--dangerously-skip-permissions",
+            "--resume",
+            "abc;rm -rf /",
+            "--append-system-prompt",
+            "trailing arg",
+        ]);
+        let out = filter_resume_args_in_place(input);
+        assert_eq!(
+            out,
+            s(&[
+                "--dangerously-skip-permissions",
+                "--append-system-prompt",
+                "trailing arg",
+            ])
+        );
+    }
+
+    #[test]
+    fn strips_invalid_resume_id_with_newline() {
+        let input = s(&["--resume", "line1\nline2-extra"]);
+        let out = filter_resume_args_in_place(input);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn strips_overlength_resume_id() {
+        let bad = "a".repeat(65);
+        let input = s(&["--resume", &bad]);
+        let out = filter_resume_args_in_place(input);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn strips_too_short_resume_id() {
+        let input = s(&["--resume", "abc"]);
+        let out = filter_resume_args_in_place(input);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn strips_empty_resume_id() {
+        let input = s(&["--resume", ""]);
+        let out = filter_resume_args_in_place(input);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn strips_trailing_resume_with_no_id() {
+        let input = s(&["--dangerously-skip-permissions", "--resume"]);
+        let out = filter_resume_args_in_place(input);
+        assert_eq!(out, s(&["--dangerously-skip-permissions"]));
+    }
+
+    #[test]
+    fn strips_single_element_resume_equals_form() {
+        // `--resume=<id>` は 2 要素分離原則を破るため id 内容に関わらず常に strip。
+        let input = s(&["--resume=550e8400-e29b-41d4-a716-446655440000"]);
+        let out = filter_resume_args_in_place(input);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn strips_single_element_resume_equals_with_injection() {
+        let input = s(&[
+            "--dangerously-skip-permissions",
+            "--resume=--print=/etc/passwd",
+            "tail",
+        ]);
+        let out = filter_resume_args_in_place(input);
+        assert_eq!(out, s(&["--dangerously-skip-permissions", "tail"]));
+    }
+
+    #[test]
+    fn does_not_touch_non_resume_args() {
+        let input = s(&[
+            "--dangerously-skip-permissions",
+            "--append-system-prompt",
+            "you are a helper; rm -rf /",
+            "--config",
+            "model_instructions_file=C:\\Users\\zooyo\\.vibe-editor\\instr.md",
+        ]);
+        let out = filter_resume_args_in_place(input.clone());
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn handles_empty_args() {
+        let out = filter_resume_args_in_place(Vec::new());
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn handles_multiple_resume_pairs_keeping_valid_only() {
+        let input = s(&[
+            "--resume",
+            "first-valid-uuid-1234",
+            "--resume",
+            "; rm -rf /",
+            "--resume",
+            "second-valid-uuid-5678",
+        ]);
+        let out = filter_resume_args_in_place(input);
+        assert_eq!(
+            out,
+            s(&[
+                "--resume",
+                "first-valid-uuid-1234",
+                "--resume",
+                "second-valid-uuid-5678",
+            ])
+        );
+    }
 }

--- a/src-tauri/src/commands/terminal/command_validation.rs
+++ b/src-tauri/src/commands/terminal/command_validation.rs
@@ -15,6 +15,22 @@ pub fn is_valid_terminal_id(s: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
+/// Issue #607: Claude `--resume <id>` に渡す session id を検証する (defense-in-depth)。
+///
+/// `resumeSessionId` は通常 `~/.claude/projects/<encoded>/<id>.jsonl` の file_stem や
+/// renderer の zustand persist (`team-history.json`) 由来で、信頼境界の外にある。
+/// `-` 始まりの文字列や shell metachar / 改行を埋められると `--resume <id>` の argv
+/// が引数注入や parse 破壊を起こすため、Rust 側で `^[A-Za-z0-9_-]{8,64}$` に絞る。
+///
+/// UUID v4 (36 文字, ハイフン含む) を最低限通すよう下限は 8 文字、Claude CLI 側の
+/// id 形式が将来変わる可能性を考慮して上限は 64 文字に緩めている。
+pub fn is_valid_resume_session_id(s: &str) -> bool {
+    let len = s.len();
+    (8..=64).contains(&len)
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
 pub fn command_basename(command: &str) -> String {
     let lower = command.trim().to_ascii_lowercase().replace('\\', "/");
     std::path::Path::new(&lower)
@@ -257,6 +273,75 @@ mod terminal_id_validation_tests {
     fn rejects_non_ascii() {
         assert!(!is_valid_terminal_id("日本語"));
         assert!(!is_valid_terminal_id("café"));
+    }
+}
+
+#[cfg(test)]
+mod resume_session_id_validation_tests {
+    use super::is_valid_resume_session_id;
+
+    #[test]
+    fn accepts_uuid_v4() {
+        assert!(is_valid_resume_session_id("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn accepts_alphanumeric_and_separators() {
+        assert!(is_valid_resume_session_id("abc_123-XYZ_456"));
+        assert!(is_valid_resume_session_id("session-1761800000000-abcd1234"));
+    }
+
+    #[test]
+    fn accepts_min_and_max_length() {
+        assert!(is_valid_resume_session_id(&"a".repeat(8)));
+        assert!(is_valid_resume_session_id(&"a".repeat(64)));
+    }
+
+    #[test]
+    fn rejects_too_short() {
+        assert!(!is_valid_resume_session_id(""));
+        assert!(!is_valid_resume_session_id("a"));
+        assert!(!is_valid_resume_session_id(&"a".repeat(7)));
+    }
+
+    #[test]
+    fn rejects_too_long() {
+        assert!(!is_valid_resume_session_id(&"a".repeat(65)));
+        assert!(!is_valid_resume_session_id(&"a".repeat(256)));
+    }
+
+    #[test]
+    fn rejects_argument_injection_via_leading_dash() {
+        // `-` 始まりは UUID v4 (8-4-4-4-12) でも合法だが、`-` のみで始まる「フラグ風」は
+        // charset 的には通る。これは Rust 側で `Command::arg("--resume").arg(&id)` の 2 要素
+        // 分離で防御するので charset には含めて良いが、shell metachar は確実に弾く。
+        assert!(!is_valid_resume_session_id("--print=/etc/passwd"));
+        assert!(!is_valid_resume_session_id("-c rm -rf"));
+    }
+
+    #[test]
+    fn rejects_shell_metachars_and_whitespace() {
+        assert!(!is_valid_resume_session_id("abc;rm -rf"));
+        assert!(!is_valid_resume_session_id("abc|true123"));
+        assert!(!is_valid_resume_session_id("abc$VAR_test"));
+        assert!(!is_valid_resume_session_id("abc`whoami`"));
+        assert!(!is_valid_resume_session_id("abc def_long"));
+        assert!(!is_valid_resume_session_id("abc\nrm_rf"));
+        assert!(!is_valid_resume_session_id("abc\rm_rf12"));
+        assert!(!is_valid_resume_session_id("abc\tdef_long"));
+    }
+
+    #[test]
+    fn rejects_path_traversal() {
+        assert!(!is_valid_resume_session_id("../etc/passwd"));
+        assert!(!is_valid_resume_session_id("./session"));
+        assert!(!is_valid_resume_session_id("/abs/path/id"));
+    }
+
+    #[test]
+    fn rejects_non_ascii() {
+        assert!(!is_valid_resume_session_id("セッション-12345"));
+        assert!(!is_valid_resume_session_id("café-session-id"));
     }
 }
 


### PR DESCRIPTION
## Summary

- `terminal_create` の前段に `filter_resume_args_in_place` を追加し、args に含まれる `--resume <id>` / `--resume=<id>` を `^[A-Za-z0-9_-]{8,64}$` の whitelist で validate する。
- 不正な id (例: `--print=/etc/passwd`, `; rm -rf /`, 改行入り, 過大長) を含むペアは strip + `tracing::warn!` で audit log に残し、新規起動にフォールバックさせる (UX 維持)。
- `--resume=<id>` の単一要素形式は 2 要素分離原則 (`Command::arg("--resume").arg(&id)`) を破るため id 内容に関わらず常に strip。
- `is_valid_resume_session_id` を `command_validation.rs` に切り出し、validator 単体で 8 ケース、フィルタ全体で 13 ケースの unit test を追加 (合計 23 テスト all green)。
- IPC 契約は変更しない (構造化フィールド追加 / renderer 移行は #645 で別途追跡)。

## Why this matters

`payload.resumeSessionId` は zustand persist (`team-history.json`) や `~/.claude/projects/<encoded>/<id>.jsonl` の file_stem 由来で、renderer 信頼境界の外。renderer (CardFrame / TerminalCard / use-team-launch-helpers) は `args.push("--resume", id)` で id を直接 PTY argv に積むため、`--print=/etc/passwd` のような「フラグ風」文字列や shell metachar / 改行を埋められると `claude --resume --print=/etc/passwd` のように Claude/Codex CLI 側の引数 parse が壊れ、任意フラグ注入が成立する恐れがあった (severity HIGH / argument injection)。

renderer 側の事前 validate は `tasks/refactor-2026-05/issues/wave1/A-9.md` で optional として記述されており、Tier D の roadmap issue #645 で別途追跡する。

## Test plan
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` が pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib resume` が 23/23 pass
  - 8 ケース: `is_valid_resume_session_id` (UUID v4 / charset / min-max / 過小過大 / `-` 始まり / shell metachar / path traversal / 非 ASCII)
  - 13 ケース: `filter_resume_args_in_place` (有効ペア保持 / `-` 始まり id 除去 / shell metachar / 改行 / 過大長 / 過小 / 空 / trailing `--resume` 単独 / `--resume=<id>` 形式 / 多重ペア)
- [x] vibe-editor-reviewer (bot) による auto-merge

Closes #607