### PR TITLE
fix(canvas): #596 連続 handoff で unreadInboxCount が undercount する race を修正

### DIFF
--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -33,6 +33,7 @@ import { deriveHealth, type HealthState } from '../../../../lib/agent-health';
 import { useTeamInjectFailed } from '../../../../lib/use-team-inject-failed';
 import { useTeamInboxRead } from '../../../../lib/use-team-inbox-read';
 import { useTeamHandoff } from '../../../../lib/use-team-handoff';
+import { applyHandoffArrival, applyInboxRead } from './unread-inbox-count';
 import { useSettings } from '../../../../lib/settings-context';
 import {
   useCanvasStore,
@@ -556,52 +557,25 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   // `team_read` を呼んだことが確定するので、自分宛の発火なら count を減らす。
   // 一番古い未読が 60s 以上残っている場合は警告色に切り替えて Leader に督促を促す
   // (`team_diagnostics.stalledInbound: true` と意味的に揃えてある)。
+  // Issue #596: closure-captured payload を読んでから書く形では 1 frame 内 2 件以上の
+  //  handoff/inbox_read が来ると undercount する race があった。
+  //  applyHandoffArrival / applyInboxRead は zustand store から最新値を直読みする
+  //  helper。React tree から切り離して unit test 可能。詳細は
+  //  `./unread-inbox-count.ts` の docstring 参照。
   useTeamHandoff(
     useCallback(
       (evt) => {
-        if (!payload.agentId || evt.toAgentId !== payload.agentId) return;
-        // 既存 oldestUnreadDeliveredAt は維持。新しく到着した分は last (新しい) なので
-        // oldest としては古い方を残す = undefined のときだけ初期化する。
-        const oldest = payload.oldestUnreadDeliveredAt ?? evt.timestamp;
-        setCardPayload(id, {
-          unreadInboxCount: (payload.unreadInboxCount ?? 0) + 1,
-          oldestUnreadDeliveredAt: oldest
-        });
+        applyHandoffArrival(useCanvasStore, id, evt, payload.agentId);
       },
-      [
-        id,
-        payload.agentId,
-        payload.unreadInboxCount,
-        payload.oldestUnreadDeliveredAt,
-        setCardPayload
-      ]
+      [id, payload.agentId]
     )
   );
   useTeamInboxRead(
     useCallback(
       (evt) => {
-        if (!payload.agentId || evt.readByAgentId !== payload.agentId) return;
-        const next = Math.max(
-          0,
-          (payload.unreadInboxCount ?? 0) - evt.messageIds.length
-        );
-        // 全件読了なら oldestUnreadDeliveredAt も undefined にして clean state に戻す。
-        // 部分既読 (= まだ未読が残っている) のときは oldest を維持 (本当の oldest が
-        // どれかを正確に知るには messageIds と delivered_at の照合が必要だが、現状
-        // event-driven 集計では粗い近似で十分)。
-        setCardPayload(id, {
-          unreadInboxCount: next,
-          oldestUnreadDeliveredAt:
-            next === 0 ? undefined : payload.oldestUnreadDeliveredAt
-        });
+        applyInboxRead(useCanvasStore, id, evt, payload.agentId);
       },
-      [
-        id,
-        payload.agentId,
-        payload.unreadInboxCount,
-        payload.oldestUnreadDeliveredAt,
-        setCardPayload
-      ]
+      [id, payload.agentId]
     )
   );
 

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/__tests__/unread-inbox-count.test.ts
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/__tests__/unread-inbox-count.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Issue #596: AgentNodeCard の unreadInboxCount race fix の単体テスト。
+ *
+ * 旧実装は closure-captured payload を読んでから setCardPayload で書き戻していたため、
+ * 1 frame (16ms) 以内に同 agentId へ複数 handoff/inbox_read が来ると undercount した。
+ * 本テストは「同 tick 連続呼び出しでも store の最新値を base に書く」ことを検証する。
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useCanvasStore } from '../../../../../stores/canvas';
+import { applyHandoffArrival, applyInboxRead } from '../unread-inbox-count';
+
+function setStoreNodes(
+  nodes: { id: string; agentId?: string; unreadInboxCount?: number; oldestUnreadDeliveredAt?: string }[]
+): void {
+  useCanvasStore.setState({
+    nodes: nodes.map((n) => ({
+      id: n.id,
+      type: 'agent',
+      position: { x: 0, y: 0 },
+      data: {
+        cardType: 'agent' as const,
+        title: n.id,
+        payload: {
+          agentId: n.agentId,
+          unreadInboxCount: n.unreadInboxCount,
+          oldestUnreadDeliveredAt: n.oldestUnreadDeliveredAt
+        }
+      }
+    })) as never,
+    edges: [],
+    teamLocks: {}
+  } as never);
+}
+
+function getPayload(id: string): {
+  unreadInboxCount?: number;
+  oldestUnreadDeliveredAt?: string;
+} {
+  const node = useCanvasStore.getState().nodes.find((n) => n.id === id);
+  return (node?.data?.payload ?? {}) as {
+    unreadInboxCount?: number;
+    oldestUnreadDeliveredAt?: string;
+  };
+}
+
+const baseHandoff = {
+  toAgentId: 'programmer-1',
+  timestamp: '2026-05-09T08:00:00Z'
+};
+
+const baseInboxRead = {
+  readByAgentId: 'programmer-1',
+  messageIds: [101]
+};
+
+describe('applyHandoffArrival / applyInboxRead (Issue #596 race fix)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ nodes: [], edges: [], teamLocks: {} } as never);
+  });
+
+  afterEach(() => {
+    useCanvasStore.setState({ nodes: [], edges: [], teamLocks: {} } as never);
+  });
+
+  it('handoff 1 件で unreadInboxCount=1 / oldest=evt.timestamp', () => {
+    setStoreNodes([{ id: 'card-1', agentId: 'programmer-1', unreadInboxCount: 0 }]);
+    const ok = applyHandoffArrival(useCanvasStore, 'card-1', baseHandoff, 'programmer-1');
+    expect(ok).toBe(true);
+    expect(getPayload('card-1')).toMatchObject({
+      unreadInboxCount: 1,
+      oldestUnreadDeliveredAt: '2026-05-09T08:00:00Z'
+    });
+  });
+
+  it('1 frame 以内 handoff 連続 2 件で unreadInboxCount=2 になる (race fix)', () => {
+    // 旧実装の bug: 同 tick 連続呼び出しで closure-captured payload (= 0) を読んでしまい
+    //  両方が 0+1=1 を書いて最終 1 で止まる。新実装は store.getState() を毎回読むので 2 になる。
+    setStoreNodes([{ id: 'card-1', agentId: 'programmer-1', unreadInboxCount: 0 }]);
+    applyHandoffArrival(
+      useCanvasStore,
+      'card-1',
+      { toAgentId: 'programmer-1', timestamp: '2026-05-09T08:00:00Z' },
+      'programmer-1'
+    );
+    applyHandoffArrival(
+      useCanvasStore,
+      'card-1',
+      { toAgentId: 'programmer-1', timestamp: '2026-05-09T08:00:00.010Z' },
+      'programmer-1'
+    );
+    expect(getPayload('card-1')).toMatchObject({
+      // 2 件分加算されている (= race 解消の核心)
+      unreadInboxCount: 2,
+      // oldest は最初に入った値を尊重 (新着で上書きしない)
+      oldestUnreadDeliveredAt: '2026-05-09T08:00:00Z'
+    });
+  });
+
+  it('handoff 5 連投でも unreadInboxCount=5 まで正しく加算される', () => {
+    setStoreNodes([{ id: 'card-1', agentId: 'programmer-1', unreadInboxCount: 0 }]);
+    for (let i = 0; i < 5; i++) {
+      applyHandoffArrival(
+        useCanvasStore,
+        'card-1',
+        {
+          toAgentId: 'programmer-1',
+          timestamp: `2026-05-09T08:00:00.${String(i).padStart(3, '0')}Z`
+        },
+        'programmer-1'
+      );
+    }
+    expect(getPayload('card-1').unreadInboxCount).toBe(5);
+    expect(getPayload('card-1').oldestUnreadDeliveredAt).toBe('2026-05-09T08:00:00.000Z');
+  });
+
+  it('toAgentId が自分以外なら更新されない', () => {
+    setStoreNodes([{ id: 'card-1', agentId: 'programmer-1', unreadInboxCount: 3 }]);
+    const ok = applyHandoffArrival(
+      useCanvasStore,
+      'card-1',
+      { toAgentId: 'programmer-2', timestamp: '2026-05-09T08:00:00Z' },
+      'programmer-1'
+    );
+    expect(ok).toBe(false);
+    expect(getPayload('card-1').unreadInboxCount).toBe(3);
+  });
+
+  it('expectedAgentId 未設定 (Leader 等の identity 未確定) なら更新されない', () => {
+    setStoreNodes([{ id: 'card-1', unreadInboxCount: 3 }]);
+    const ok = applyHandoffArrival(
+      useCanvasStore,
+      'card-1',
+      { toAgentId: 'programmer-1', timestamp: '2026-05-09T08:00:00Z' },
+      undefined
+    );
+    expect(ok).toBe(false);
+    expect(getPayload('card-1').unreadInboxCount).toBe(3);
+  });
+
+  it('inbox_read 1 件で unreadInboxCount を 1 件分減算する', () => {
+    setStoreNodes([
+      {
+        id: 'card-1',
+        agentId: 'programmer-1',
+        unreadInboxCount: 3,
+        oldestUnreadDeliveredAt: '2026-05-09T07:59:00Z'
+      }
+    ]);
+    applyInboxRead(useCanvasStore, 'card-1', baseInboxRead, 'programmer-1');
+    expect(getPayload('card-1')).toMatchObject({
+      unreadInboxCount: 2,
+      oldestUnreadDeliveredAt: '2026-05-09T07:59:00Z' // 部分既読では oldest を維持
+    });
+  });
+
+  it('inbox_read で全件読了 (next=0) になると oldestUnreadDeliveredAt が undefined になる', () => {
+    setStoreNodes([
+      {
+        id: 'card-1',
+        agentId: 'programmer-1',
+        unreadInboxCount: 2,
+        oldestUnreadDeliveredAt: '2026-05-09T07:59:00Z'
+      }
+    ]);
+    applyInboxRead(
+      useCanvasStore,
+      'card-1',
+      { readByAgentId: 'programmer-1', messageIds: [101, 102] },
+      'programmer-1'
+    );
+    expect(getPayload('card-1')).toMatchObject({
+      unreadInboxCount: 0,
+      oldestUnreadDeliveredAt: undefined
+    });
+  });
+
+  it('1 frame 以内 inbox_read 連続 2 件 (1 件ずつ) でも race undercount せず 0 まで減る', () => {
+    setStoreNodes([
+      {
+        id: 'card-1',
+        agentId: 'programmer-1',
+        unreadInboxCount: 2,
+        oldestUnreadDeliveredAt: '2026-05-09T07:59:00Z'
+      }
+    ]);
+    applyInboxRead(
+      useCanvasStore,
+      'card-1',
+      { readByAgentId: 'programmer-1', messageIds: [101] },
+      'programmer-1'
+    );
+    applyInboxRead(
+      useCanvasStore,
+      'card-1',
+      { readByAgentId: 'programmer-1', messageIds: [102] },
+      'programmer-1'
+    );
+    // 旧実装の bug: closure-captured 2 を 2 回読み、両方が 2-1=1 を書いて最終 1 で止まる。
+    // 新実装は最新値 (1 回目後は 1) を base に -1 するので 0 になる。
+    expect(getPayload('card-1').unreadInboxCount).toBe(0);
+    expect(getPayload('card-1').oldestUnreadDeliveredAt).toBeUndefined();
+  });
+
+  it('inbox_read で count が負にならない (Math.max(0, ...))', () => {
+    setStoreNodes([
+      { id: 'card-1', agentId: 'programmer-1', unreadInboxCount: 1 }
+    ]);
+    applyInboxRead(
+      useCanvasStore,
+      'card-1',
+      { readByAgentId: 'programmer-1', messageIds: [101, 102, 103] },
+      'programmer-1'
+    );
+    expect(getPayload('card-1').unreadInboxCount).toBe(0);
+  });
+
+  it('inbox_read で readByAgentId が他人なら更新されない', () => {
+    setStoreNodes([
+      { id: 'card-1', agentId: 'programmer-1', unreadInboxCount: 3 }
+    ]);
+    const ok = applyInboxRead(
+      useCanvasStore,
+      'card-1',
+      { readByAgentId: 'programmer-2', messageIds: [101] },
+      'programmer-1'
+    );
+    expect(ok).toBe(false);
+    expect(getPayload('card-1').unreadInboxCount).toBe(3);
+  });
+
+  it('handoff → inbox_read の交互連続でも store 最新値が常に base になる (mixed race)', () => {
+    setStoreNodes([{ id: 'card-1', agentId: 'programmer-1', unreadInboxCount: 0 }]);
+    // +1 +1 +1 -2 +1 → 2 になることを確認 (= 0+1=1, 1+1=2, 2+1=3, 3-2=1, 1+1=2)
+    applyHandoffArrival(
+      useCanvasStore,
+      'card-1',
+      { toAgentId: 'programmer-1', timestamp: '2026-05-09T08:00:00Z' },
+      'programmer-1'
+    );
+    applyHandoffArrival(
+      useCanvasStore,
+      'card-1',
+      { toAgentId: 'programmer-1', timestamp: '2026-05-09T08:00:01Z' },
+      'programmer-1'
+    );
+    applyHandoffArrival(
+      useCanvasStore,
+      'card-1',
+      { toAgentId: 'programmer-1', timestamp: '2026-05-09T08:00:02Z' },
+      'programmer-1'
+    );
+    applyInboxRead(
+      useCanvasStore,
+      'card-1',
+      { readByAgentId: 'programmer-1', messageIds: [101, 102] },
+      'programmer-1'
+    );
+    applyHandoffArrival(
+      useCanvasStore,
+      'card-1',
+      { toAgentId: 'programmer-1', timestamp: '2026-05-09T08:00:03Z' },
+      'programmer-1'
+    );
+    expect(getPayload('card-1').unreadInboxCount).toBe(2);
+  });
+});

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/unread-inbox-count.ts
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/unread-inbox-count.ts
@@ -1,0 +1,78 @@
+/**
+ * Issue #596: AgentNodeCard の `unreadInboxCount` 加減算ロジック (closure stale race fix)。
+ *
+ * 旧実装は `useCallback` の closure で `payload.unreadInboxCount` を読んでから
+ * `setCardPayload` で書き戻していたため、1 frame (16ms) 以内に同じ agentId へ
+ * 複数 `team:handoff` / `team:inbox_read` が連投されると、両 callback が
+ * **stale な closure 値** (= まだ React commit 前の payload) を base に書き、
+ * 最終 `unreadInboxCount` が undercount する race があった (CRITICAL bug)。
+ *
+ * 修正: callback 内で zustand `useCanvasStore.getState()` を毎回叩いて
+ * **callback 実行時点の最新 payload** を直読みする。zustand の `set` は同期反映
+ * なので、同 tick で 2 回呼んでも 2 回目は 1 回目の結果を見て +1 できる。
+ *
+ * 本ファイルは React tree から切り離して unit test できるよう store API を
+ * 引数で受ける形にしている (CardFrame 本体は `useCanvasStore` をそのまま渡す)。
+ */
+
+import type { HandoffPayload } from '../../../../lib/use-team-handoff';
+import type { TeamInboxReadEvent } from '../../../../../../types/shared';
+import { useCanvasStore } from '../../../../stores/canvas';
+import type { AgentPayload } from './types';
+
+/** test と本体で `useCanvasStore` を共有するための型 alias。 */
+export type CanvasStoreApi = typeof useCanvasStore;
+
+function readLatestPayload(store: CanvasStoreApi, id: string): AgentPayload {
+  const node = store.getState().nodes.find((n) => n.id === id);
+  return ((node?.data?.payload as AgentPayload | undefined) ?? {}) as AgentPayload;
+}
+
+/**
+ * `team:handoff` が **自分宛** だった場合に unreadInboxCount を +1 する。
+ *
+ * @returns 自分宛で更新したら true、対象外なら false (caller 側で副作用判定したい場合用)。
+ */
+export function applyHandoffArrival(
+  store: CanvasStoreApi,
+  id: string,
+  evt: Pick<HandoffPayload, 'toAgentId' | 'timestamp'>,
+  expectedAgentId: string | undefined
+): boolean {
+  if (!expectedAgentId || evt.toAgentId !== expectedAgentId) return false;
+  const latest = readLatestPayload(store, id);
+  const prevCount = latest.unreadInboxCount ?? 0;
+  // 既存 oldestUnreadDeliveredAt は維持。新着分は最新側なので「一番古い」を残す観点では
+  // 既存 (= より古い) 値を尊重し、未設定 (count=0 → 1) のときだけ初期化する。
+  const oldest = latest.oldestUnreadDeliveredAt ?? evt.timestamp;
+  store.getState().setCardPayload(id, {
+    unreadInboxCount: prevCount + 1,
+    oldestUnreadDeliveredAt: oldest
+  });
+  return true;
+}
+
+/**
+ * `team:inbox_read` が **自分による既読** だった場合に unreadInboxCount を減算する。
+ *
+ * @returns 自分の read だったら true、他人の read なら false。
+ */
+export function applyInboxRead(
+  store: CanvasStoreApi,
+  id: string,
+  evt: Pick<TeamInboxReadEvent, 'readByAgentId' | 'messageIds'>,
+  expectedAgentId: string | undefined
+): boolean {
+  if (!expectedAgentId || evt.readByAgentId !== expectedAgentId) return false;
+  const latest = readLatestPayload(store, id);
+  const prevCount = latest.unreadInboxCount ?? 0;
+  const next = Math.max(0, prevCount - evt.messageIds.length);
+  // 全件読了なら oldestUnreadDeliveredAt も undefined にして clean state に戻す。
+  // 部分既読のときは oldest を維持 (本当の oldest 推定には messageIds と
+  // delivered_at の照合が必要だが、event-driven 集計では粗い近似で十分)。
+  store.getState().setCardPayload(id, {
+    unreadInboxCount: next,
+    oldestUnreadDeliveredAt: next === 0 ? undefined : latest.oldestUnreadDeliveredAt
+  });
+  return true;
+}


### PR DESCRIPTION
## Summary
- `useTeamHandoff` / `useTeamInboxRead` の callback が **closure-captured payload** を読んでから `setCardPayload` で書き戻していたため、1 frame (16ms) 以内に同じ agentId へ複数 `team:handoff` / `team:inbox_read` が連投されると、両 callback が stale な `unreadInboxCount` を base に書いて undercount する CRITICAL race を起こしていた (Tier S-3)。
- 加減算ロジックを `unread-inbox-count.ts` に `applyHandoffArrival` / `applyInboxRead` として切り出し、callback 実行時点で `useCanvasStore.getState()` を毎回叩いて最新 payload を直読みする形に変更。zustand の `set` は同期反映なので、同 tick 連続呼び出しでも 2 回目は 1 回目の結果を base に +1 / -1 できる。
- `CardFrame` 側は両 helper を呼ぶだけの薄い wrapper にし、`useCallback` の deps からも `payload.unreadInboxCount` / `oldestUnreadDeliveredAt` を外して再 render churn を抑制。
- vitest 11 件追加。1 frame 内 2 件 handoff で `count=2` になること、5 連投で `count=5`、handoff↔inbox_read の交互連続、自分以外宛、agentId 未設定、全件読了で oldest クリア、負値防止 (`Math.max(0, ...)`) 等を直接検証。

## なぜ helper を切り出したか
- React tree (Tauri listen / xterm / role profiles 等) を mount せずに「同 tick 連続呼び出しで store 最新値を base に積めるか」を unit test できるようにするため。
- `applyHandoffArrival` / `applyInboxRead` は **store API を引数で受ける** 形にしてあり、CardFrame 本体は `useCanvasStore` をそのまま渡す。挙動は不変。

## 関連 Issue
Closes #596

## Test plan
- [x] `npm run typecheck` pass
- [x] `npx vitest run` pass (54 files / 342 tests)
- [x] `npx vite build` pass (renderer 本番ビルド)
- [x] 1 frame 内 handoff 2 連 / 5 連で `unreadInboxCount = 2 / 5` になることを vitest で直接検証
- [x] handoff → inbox_read の交互連続 (+1 +1 +1 -2 +1 = 2) でも store 最新値が常に base になることを検証
- [ ] (実機) Canvas で leader→worker へ短時間連投し、unread badge が正しい数で停止することを目視確認