### PR TITLE
fix(team-hub): #599 file_locks に traversal / 絶対 path 検出と team あたり lock 上限 (Tier A-1 security)

### DIFF
--- a/src-tauri/src/team_hub/file_locks.rs
+++ b/src-tauri/src/team_hub/file_locks.rs
@@ -23,6 +23,58 @@ use chrono::Utc;
 use serde::Serialize;
 use std::collections::HashMap;
 
+/// Issue #599 (Tier A-1): 1 path 文字列の最大バイト長。
+/// `MAX_LOCK_PATH_LEN` (4 KiB) は IPC 層の payload 上限、こちらは正規化後の論理 path 上限。
+/// 1024 byte で repo 内の現実的な深さ (git index も 1 KiB 前後で truncate される) をカバー。
+pub const MAX_LOCK_PATH_BYTES: usize = 1024;
+
+/// `normalize_path` で reject される入力理由。Issue #599: traversal / 絶対 path / 制御文字 /
+/// 過大長 / 空 path を validator として弾けるようにする。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FileLockError {
+    /// path が空 (trim 後)。
+    Empty,
+    /// path が `MAX_LOCK_PATH_BYTES` を超える。
+    TooLong { len: usize, limit: usize },
+    /// NUL や ESC などの制御文字 (0x00..=0x1F、tab 含む) を含む。
+    /// CRLF や ESC は audit log / Leader terminal 表示の prompt injection に使われ得る。
+    ControlChar,
+    /// 絶対 path (Unix の `/` 始まり / Windows の `C:\` `\\` `\\?\` 等) — repo-relative のみ許可。
+    Absolute,
+    /// `..` セグメントを含む — traversal 防止。
+    ParentDir,
+}
+
+impl std::fmt::Display for FileLockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FileLockError::Empty => write!(f, "path must not be empty"),
+            FileLockError::TooLong { len, limit } => {
+                write!(f, "path too long: {len} bytes (limit {limit})")
+            }
+            FileLockError::ControlChar => {
+                write!(f, "path must not contain control characters (0x00..=0x1F)")
+            }
+            FileLockError::Absolute => write!(
+                f,
+                "absolute path is not allowed (must be repo-relative; reject Unix '/...', Windows 'C:\\...' / '\\\\...')"
+            ),
+            FileLockError::ParentDir => {
+                write!(f, "parent directory ('..') segments are not allowed")
+            }
+        }
+    }
+}
+
+/// Issue #599: team あたり lock 数上限を超えたとき返す詳細。`team_lock_files` で
+/// `too_many_locks` ToolError にマップする。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FileLockCapExceeded {
+    pub current: usize,
+    pub requested: usize,
+    pub cap: usize,
+}
+
 /// 1 path に対する 1 件のロック情報。
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -69,17 +121,44 @@ pub struct UnlockResult {
     pub unlocked: Vec<String>,
 }
 
-/// path を正規化: backslash → slash、`./` prefix 除去、連続 slash 圧縮、末尾 slash 除去、trim。
-pub fn normalize_path(raw: &str) -> String {
+/// path を正規化 + バリデーションする。Issue #599 (Tier A-1) で `String` 返しから
+/// `Result<String, FileLockError>` に変更。`..` / 絶対 path / 制御文字 / 過大長 / 空 path を
+/// 全て reject することで、advisory lock 表に traversal や別 team の path が紛れ込まないようにする。
+///
+/// 正規化処理: backslash → slash、`./` prefix 除去、連続 slash 圧縮、末尾 slash 除去、trim。
+pub fn normalize_path(raw: &str) -> Result<String, FileLockError> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
-        return String::new();
+        return Err(FileLockError::Empty);
+    }
+    if trimmed.len() > MAX_LOCK_PATH_BYTES {
+        return Err(FileLockError::TooLong {
+            len: trimmed.len(),
+            limit: MAX_LOCK_PATH_BYTES,
+        });
+    }
+    // 制御文字 (NUL / 0x01..=0x1F、tab 含む) — audit log / Leader 端末 inject の改行混入を防ぐ。
+    if trimmed.bytes().any(|b| b <= 0x1F || b == 0x7F) {
+        return Err(FileLockError::ControlChar);
+    }
+    // Windows のドライブレター ("C:" / "c:" / "C:\..." / "C:/...") は backslash 統一の前に検出。
+    let bytes = trimmed.as_bytes();
+    if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+        return Err(FileLockError::Absolute);
+    }
+    // UNC / extended-length prefix ("\\\\server\\share" / "\\\\?\\..." / "//server/share") を弾く。
+    if trimmed.starts_with(r"\\") || trimmed.starts_with("//") {
+        return Err(FileLockError::Absolute);
     }
     // backslash → forward slash
     let unified: String = trimmed
         .chars()
         .map(|c| if c == '\\' { '/' } else { c })
         .collect();
+    // Unix 絶対 path (`/etc/passwd`) — UNC / `//` は上で弾いたので、ここは単発 `/` 始まりだけ。
+    if unified.starts_with('/') {
+        return Err(FileLockError::Absolute);
+    }
     // 連続 slash を 1 個に圧縮
     let mut compressed = String::with_capacity(unified.len());
     let mut prev_slash = false;
@@ -100,11 +179,42 @@ pub fn normalize_path(raw: &str) -> String {
     } else {
         compressed
     };
-    // 末尾 slash 削除 (root `/` だけは残す)
+    // 末尾 slash 削除
     while out.len() > 1 && out.ends_with('/') {
         out.pop();
     }
-    out
+    // `..` セグメントを含む path は traversal とみなして reject。
+    // 部分文字列ではなくセグメント単位で判定 (例: `..foo` や `foo..bar` は許可)。
+    if out.split('/').any(|seg| seg == "..") {
+        return Err(FileLockError::ParentDir);
+    }
+    Ok(out)
+}
+
+/// Issue #599 (Tier A-1): `try_acquire` を team-cap 付きで呼ぶ atomic helper。
+/// HubState の Mutex 内で「count → cap check → try_acquire」を 1 セッションで完結させ、
+/// race による cap 超過 (= 別 agent が同時に push して上限を踏み越える) を防ぐ。
+///
+/// idempotent な再 lock (= 同一 agent_id が既に持っている path) も `paths.len()` で数えるため、
+/// `current + paths.len() > cap` の判定はやや over-conservative だが、cap は DoS 防止のための
+/// 概算値なので正確性より単純さ・atomic 性を優先する。
+pub fn try_acquire_with_cap(
+    map: &mut HashMap<(String, String), FileLock>,
+    team_id: &str,
+    agent_id: &str,
+    role: &str,
+    paths: &[String],
+    cap: usize,
+) -> Result<LockResult, FileLockCapExceeded> {
+    let current = map.iter().filter(|((tid, _), _)| tid == team_id).count();
+    if current.saturating_add(paths.len()) > cap {
+        return Err(FileLockCapExceeded {
+            current,
+            requested: paths.len(),
+            cap,
+        });
+    }
+    Ok(try_acquire(map, team_id, agent_id, role, paths))
 }
 
 /// `paths` のうち取得できたものは map に追加し、既に他 agent が保持しているものは
@@ -121,10 +231,12 @@ pub fn try_acquire(
     let mut locked = Vec::new();
     let mut conflicts = Vec::new();
     for raw in paths {
-        let path = normalize_path(raw);
-        if path.is_empty() {
+        // Issue #599: invalid path (`..` / 絶対 / 制御文字 / 過大長 / 空) は silent skip。
+        // 通常 IPC 層 (`team_lock_files`) で先に reject される (= ここに到達しないはず) が、
+        // 内部 caller のための defense-in-depth として silent skip する。
+        let Ok(path) = normalize_path(raw) else {
             continue;
-        }
+        };
         let key = (team_id.to_string(), path.clone());
         if let Some(existing) = map.get(&key) {
             if existing.agent_id == agent_id {
@@ -165,10 +277,10 @@ pub fn release(
 ) -> UnlockResult {
     let mut unlocked = Vec::new();
     for raw in paths {
-        let path = normalize_path(raw);
-        if path.is_empty() {
+        // Issue #599: invalid path は silent skip (defense-in-depth、IPC で先に reject される)。
+        let Ok(path) = normalize_path(raw) else {
             continue;
-        }
+        };
         let key = (team_id.to_string(), path.clone());
         if let Some(existing) = map.get(&key) {
             if existing.agent_id == agent_id {
@@ -210,10 +322,10 @@ pub fn peek(
 ) -> Vec<LockConflict> {
     let mut out = Vec::new();
     for raw in paths {
-        let path = normalize_path(raw);
-        if path.is_empty() {
+        // Issue #599: invalid path は silent skip (defense-in-depth、IPC で先に reject される)。
+        let Ok(path) = normalize_path(raw) else {
             continue;
-        }
+        };
         let key = (team_id.to_string(), path);
         if let Some(existing) = map.get(&key) {
             if let Some(self_aid) = agent_id_filter {
@@ -253,34 +365,220 @@ mod tests {
 
     #[test]
     fn normalize_path_handles_basic_cases() {
-        assert_eq!(normalize_path("src/foo.ts"), "src/foo.ts");
-        assert_eq!(normalize_path("  src/foo.ts  "), "src/foo.ts");
-        assert_eq!(normalize_path(""), "");
-        assert_eq!(normalize_path("   "), "");
+        assert_eq!(normalize_path("src/foo.ts").unwrap(), "src/foo.ts");
+        assert_eq!(normalize_path("  src/foo.ts  ").unwrap(), "src/foo.ts");
+        // Issue #599: 空 / 空白のみは Empty で reject される。
+        assert_eq!(normalize_path(""), Err(FileLockError::Empty));
+        assert_eq!(normalize_path("   "), Err(FileLockError::Empty));
     }
 
     #[test]
     fn normalize_path_unifies_separators() {
-        assert_eq!(normalize_path(r"src\foo\bar.rs"), "src/foo/bar.rs");
-        assert_eq!(normalize_path("src/foo\\bar.rs"), "src/foo/bar.rs");
+        assert_eq!(normalize_path(r"src\foo\bar.rs").unwrap(), "src/foo/bar.rs");
+        assert_eq!(normalize_path("src/foo\\bar.rs").unwrap(), "src/foo/bar.rs");
     }
 
     #[test]
     fn normalize_path_compresses_double_slashes() {
-        assert_eq!(normalize_path("src//foo///bar.rs"), "src/foo/bar.rs");
+        assert_eq!(normalize_path("src//foo///bar.rs").unwrap(), "src/foo/bar.rs");
     }
 
     #[test]
     fn normalize_path_strips_dot_prefix() {
-        assert_eq!(normalize_path("./src/foo.ts"), "src/foo.ts");
+        assert_eq!(normalize_path("./src/foo.ts").unwrap(), "src/foo.ts");
     }
 
     #[test]
     fn normalize_path_strips_trailing_slash() {
-        assert_eq!(normalize_path("src/foo/"), "src/foo");
-        assert_eq!(normalize_path("src/foo///"), "src/foo");
-        // root `/` は残す
-        assert_eq!(normalize_path("/"), "/");
+        assert_eq!(normalize_path("src/foo/").unwrap(), "src/foo");
+        assert_eq!(normalize_path("src/foo///").unwrap(), "src/foo");
+        // Issue #599: root `/` は絶対 path として reject される。
+        assert_eq!(normalize_path("/"), Err(FileLockError::Absolute));
+    }
+
+    /// Issue #599 (Tier A-1): `..` セグメントを含む path は reject される。
+    /// セグメント単位での判定なので `..foo` や `foo..bar` (= 単独 `..` ではない) は通る。
+    #[test]
+    fn normalize_path_rejects_parent_dir_traversal() {
+        assert_eq!(
+            normalize_path("../etc/passwd"),
+            Err(FileLockError::ParentDir)
+        );
+        assert_eq!(
+            normalize_path("../../etc/passwd"),
+            Err(FileLockError::ParentDir)
+        );
+        assert_eq!(
+            normalize_path("src/../../etc/passwd"),
+            Err(FileLockError::ParentDir)
+        );
+        assert_eq!(
+            normalize_path(r"..\..\windows\system32"),
+            Err(FileLockError::ParentDir)
+        );
+        assert_eq!(
+            normalize_path("src/..//etc"),
+            Err(FileLockError::ParentDir)
+        );
+        // Issue #599: traversal で **ない** パターン (= `..` を部分文字列にしか含まない) は通る。
+        assert_eq!(normalize_path("src/foo..bar.rs").unwrap(), "src/foo..bar.rs");
+        assert_eq!(normalize_path("..foo/bar").unwrap(), "..foo/bar");
+    }
+
+    /// Issue #599: 絶対 path (Unix の `/` 始まり / Windows のドライブレター / UNC) は reject。
+    #[test]
+    fn normalize_path_rejects_absolute_paths() {
+        // Unix
+        assert_eq!(
+            normalize_path("/etc/passwd"),
+            Err(FileLockError::Absolute)
+        );
+        assert_eq!(normalize_path("/"), Err(FileLockError::Absolute));
+        // Windows drive letter (大文字 / 小文字 / forward / backward)
+        assert_eq!(
+            normalize_path(r"C:\Windows\System32"),
+            Err(FileLockError::Absolute)
+        );
+        assert_eq!(
+            normalize_path("C:/Windows/System32"),
+            Err(FileLockError::Absolute)
+        );
+        assert_eq!(
+            normalize_path("d:/users/yusei"),
+            Err(FileLockError::Absolute)
+        );
+        assert_eq!(normalize_path("C:"), Err(FileLockError::Absolute));
+        // UNC / extended-length
+        assert_eq!(
+            normalize_path(r"\\server\share\foo"),
+            Err(FileLockError::Absolute)
+        );
+        assert_eq!(
+            normalize_path(r"\\?\C:\foo"),
+            Err(FileLockError::Absolute)
+        );
+        assert_eq!(
+            normalize_path("//server/share/foo"),
+            Err(FileLockError::Absolute)
+        );
+    }
+
+    /// Issue #599: 制御文字 (NUL / 0x01..=0x1F、tab、DEL=0x7F) を含む path は reject。
+    /// 改行や ESC が path に紛れ込むと audit log や Leader 端末 inject の format を破壊するため。
+    #[test]
+    fn normalize_path_rejects_control_characters() {
+        assert_eq!(
+            normalize_path("src/foo\nbar.rs"),
+            Err(FileLockError::ControlChar)
+        );
+        assert_eq!(
+            normalize_path("src/foo\rbar.rs"),
+            Err(FileLockError::ControlChar)
+        );
+        assert_eq!(
+            normalize_path("src/foo\x1b[31mred.rs"),
+            Err(FileLockError::ControlChar)
+        );
+        assert_eq!(
+            normalize_path("src/foo\0bar.rs"),
+            Err(FileLockError::ControlChar)
+        );
+        assert_eq!(
+            normalize_path("src/foo\tbar.rs"),
+            Err(FileLockError::ControlChar)
+        );
+        assert_eq!(
+            normalize_path("src/foo\x7fbar.rs"),
+            Err(FileLockError::ControlChar)
+        );
+    }
+
+    /// Issue #599: `MAX_LOCK_PATH_BYTES` (1024) 超は reject。
+    #[test]
+    fn normalize_path_rejects_too_long() {
+        let just_ok = "a".repeat(MAX_LOCK_PATH_BYTES);
+        assert!(normalize_path(&just_ok).is_ok());
+
+        let over = "a".repeat(MAX_LOCK_PATH_BYTES + 1);
+        let err = normalize_path(&over).unwrap_err();
+        assert!(matches!(err, FileLockError::TooLong { .. }));
+    }
+
+    /// Issue #599 (Tier A-1): `try_acquire_with_cap` は team あたり lock 数上限を atomic に enforce。
+    /// 既存件数 + 新規要求 が cap を超えると `FileLockCapExceeded` で reject される。
+    /// idempotent な再 lock (= paths.len() に含まれるが新規 insert はゼロ) でも reject 側で数える
+    /// (over-conservative だが atomic 性を優先する設計)。
+    #[test]
+    fn try_acquire_with_cap_rejects_over_limit() {
+        let mut map = make_map();
+        let cap = 3;
+        // 3 件を pre-insert
+        try_acquire_with_cap(
+            &mut map,
+            "team-1",
+            "vc-alice",
+            "programmer",
+            &[
+                "src/a.rs".to_string(),
+                "src/b.rs".to_string(),
+                "src/c.rs".to_string(),
+            ],
+            cap,
+        )
+        .expect("3/3 should fit");
+
+        // 4 件目を追加 → cap 超過で reject。
+        let err = try_acquire_with_cap(
+            &mut map,
+            "team-1",
+            "vc-bob",
+            "reviewer",
+            &["src/d.rs".to_string()],
+            cap,
+        )
+        .unwrap_err();
+        assert_eq!(err.current, 3);
+        assert_eq!(err.requested, 1);
+        assert_eq!(err.cap, cap);
+        // map は変化しない (atomic)
+        assert_eq!(map.len(), 3);
+    }
+
+    /// Issue #599: cap は team scope。別 team の lock は count されない。
+    #[test]
+    fn try_acquire_with_cap_is_team_scoped() {
+        let mut map = make_map();
+        // team-2 に 5 件入れても team-1 の cap=3 には影響しない
+        try_acquire_with_cap(
+            &mut map,
+            "team-2",
+            "vc-other",
+            "programmer",
+            &[
+                "src/a.rs".to_string(),
+                "src/b.rs".to_string(),
+                "src/c.rs".to_string(),
+                "src/d.rs".to_string(),
+                "src/e.rs".to_string(),
+            ],
+            10,
+        )
+        .expect("team-2 fits in cap=10");
+        let result = try_acquire_with_cap(
+            &mut map,
+            "team-1",
+            "vc-alice",
+            "programmer",
+            &[
+                "src/a.rs".to_string(),
+                "src/b.rs".to_string(),
+                "src/c.rs".to_string(),
+            ],
+            3,
+        )
+        .expect("team-1 fits in its own cap=3");
+        assert_eq!(result.locked.len(), 3);
+        assert_eq!(map.len(), 8);
     }
 
     #[test]

--- a/src-tauri/src/team_hub/protocol/tools/assign_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/assign_task.rs
@@ -23,8 +23,24 @@ fn parse_target_paths(args: &Value) -> Vec<String> {
             let Some(raw) = v.as_str() else {
                 continue;
             };
-            let normalized = normalize_path(raw);
-            if !normalized.is_empty() && !out.contains(&normalized) {
+            // Issue #599: invalid path (`..` / 絶対 / 制御文字 / 過大長 / 空) は silent skip。
+            // task.target_paths は team_lock_files 側 validator と独立した経路なので、ここでも
+            // 同じ validator を通して traversal や絶対 path が task に紐付かないようにする。
+            // 完全 reject ではなく skip にする理由: target_paths は assign_task の "hint" 扱いで、
+            // 1 件壊れていても task 全体を作れないと assignee が困る。実害ある reject は
+            // team_lock_files / team_unlock_files の IPC 段で完了済み。
+            let normalized = match normalize_path(raw) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(
+                        raw_path = %raw.chars().take(80).collect::<String>(),
+                        error = %e,
+                        "[parse_target_paths] skipped invalid target_path"
+                    );
+                    continue;
+                }
+            };
+            if !out.contains(&normalized) {
                 out.push(normalized);
             }
         }

--- a/src-tauri/src/team_hub/protocol/tools/file_lock.rs
+++ b/src-tauri/src/team_hub/protocol/tools/file_lock.rs
@@ -12,6 +12,7 @@
 //! 権限: 全 team member が呼べる (`team_send` / `team_read` 同様、追加権限は不要)。
 //! ただし `paths` は最大 64 件 / 1 件あたり 4 KiB に制限する (DoS 抑止)。
 
+use crate::team_hub::file_locks::normalize_path;
 use crate::team_hub::{CallContext, TeamHub};
 use serde_json::{json, Value};
 
@@ -21,6 +22,52 @@ use super::error::ToolError;
 const MAX_LOCK_PATHS_PER_CALL: usize = 64;
 /// 1 path あたりの最大バイト長 (異常な巨大 path を弾く)。
 const MAX_LOCK_PATH_LEN: usize = 4 * 1024;
+/// Issue #599 (Tier A-1): team あたりの advisory lock 表サイズの上限。
+/// 正規化後 1 path あたり ~100 byte 想定で 128 件 ≒ 13 KiB / team。
+/// この上限で `team_lock_files` を 1024 byte path 64 件で連打されても 64 KiB で頭打ち。
+const MAX_LOCKS_PER_TEAM: usize = 128;
+
+/// `raw_path` を audit log に safe に出すための clamp (改行や ESC は normalize_path で reject 済みだが、
+/// 念のため 80 文字で切る + 制御文字を `?` 化する defense-in-depth)。
+fn clamp_for_log(raw: &str) -> String {
+    raw.chars()
+        .take(80)
+        .map(|c| if c.is_control() { '?' } else { c })
+        .collect()
+}
+
+/// Issue #599: paths を 1 件ずつ `normalize_path` で validate する。
+/// invalid なものが 1 件でもあれば全体を `lock_files_invalid_path` で reject し、
+/// `tracing::warn!` で agent_id / team_id / clamp 後の生 path / FileLockError を audit log に残す。
+fn validate_and_normalize_paths(
+    ctx: &CallContext,
+    raw_paths: &[String],
+    code_prefix: &str,
+) -> Result<Vec<String>, String> {
+    let mut out = Vec::with_capacity(raw_paths.len());
+    for raw in raw_paths {
+        match normalize_path(raw) {
+            Ok(p) => out.push(p),
+            Err(e) => {
+                tracing::warn!(
+                    team_id = %ctx.team_id,
+                    agent_id = %ctx.agent_id,
+                    role = %ctx.role,
+                    raw_path = %clamp_for_log(raw),
+                    error = %e,
+                    "[{}] invalid path rejected",
+                    code_prefix
+                );
+                return Err(ToolError::new(
+                    format!("{code_prefix}_invalid_path"),
+                    format!("invalid path '{}': {e}", clamp_for_log(raw)),
+                )
+                .into_err_string());
+            }
+        }
+    }
+    Ok(out)
+}
 
 fn parse_paths_arg(args: &Value, code_prefix: &str) -> Result<Vec<String>, String> {
     let arr = args.get("paths").and_then(|v| v.as_array()).ok_or_else(|| {
@@ -65,15 +112,48 @@ fn parse_paths_arg(args: &Value, code_prefix: &str) -> Result<Vec<String>, Strin
 }
 
 /// `team_lock_files`: paths を advisory に lock する。partial success (一部 conflict でも残りは locked)。
+///
+/// Issue #599 (Tier A-1): IPC 段で 2 段の validation を行う:
+/// 1. `normalize_path` で path 1 件ずつを validate (`..` / 絶対 / 制御文字 / 過大長 を reject)
+/// 2. `try_acquire_file_locks_with_cap` で team あたり `MAX_LOCKS_PER_TEAM` の cap を atomic に enforce
 pub async fn team_lock_files(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
 ) -> Result<Value, String> {
-    let paths = parse_paths_arg(args, "lock_files")?;
-    let result = hub
-        .try_acquire_file_locks(&ctx.team_id, &ctx.agent_id, &ctx.role, &paths)
-        .await;
+    let raw_paths = parse_paths_arg(args, "lock_files")?;
+    let paths = validate_and_normalize_paths(ctx, &raw_paths, "lock_files")?;
+    let result = match hub
+        .try_acquire_file_locks_with_cap(
+            &ctx.team_id,
+            &ctx.agent_id,
+            &ctx.role,
+            &paths,
+            MAX_LOCKS_PER_TEAM,
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(cap_exceeded) => {
+            tracing::warn!(
+                team_id = %ctx.team_id,
+                agent_id = %ctx.agent_id,
+                role = %ctx.role,
+                current_locks = cap_exceeded.current,
+                requested = cap_exceeded.requested,
+                limit = cap_exceeded.cap,
+                "[team_lock_files] team lock cap exceeded — refusing to add new locks"
+            );
+            return Err(ToolError::new(
+                "lock_files_too_many_locks",
+                format!(
+                    "team lock cap exceeded: {} existing + {} requested > {} (limit per team)",
+                    cap_exceeded.current, cap_exceeded.requested, cap_exceeded.cap,
+                ),
+            )
+            .into_err_string());
+        }
+    };
     Ok(json!({
         "success": true,
         "locked": result.locked,
@@ -82,12 +162,17 @@ pub async fn team_lock_files(
 }
 
 /// `team_unlock_files`: 自分が保持する paths のロックを解放。他 agent の lock は silent skip。
+///
+/// Issue #599: lock 側と同じ validator を通して、`..` や絶対 path を含む release 要求は
+/// `unlock_files_invalid_path` で reject する (= 内部 HashMap key の偽装で他者 lock を解除させる
+/// 経路を構造的に塞ぐ defense-in-depth)。
 pub async fn team_unlock_files(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
 ) -> Result<Value, String> {
-    let paths = parse_paths_arg(args, "unlock_files")?;
+    let raw_paths = parse_paths_arg(args, "unlock_files")?;
+    let paths = validate_and_normalize_paths(ctx, &raw_paths, "unlock_files")?;
     let result = hub
         .release_file_locks(&ctx.team_id, &ctx.agent_id, &paths)
         .await;
@@ -146,5 +231,133 @@ mod tests {
         let args = json!({ "paths": [big] });
         let err = parse_paths_arg(&args, "lock_files").unwrap_err();
         assert!(err.contains("path too long"));
+    }
+
+    /// Issue #599 (Tier A-1): `team_lock_files` IPC は traversal / 絶対 / 制御文字 / 過大長を
+    /// 1 件でも含むと `lock_files_invalid_path` で reject する。internal map には何も追加しない。
+    mod ipc_validation {
+        use super::*;
+        use crate::pty::SessionRegistry;
+        use crate::team_hub::TeamHub;
+        use std::sync::Arc;
+
+        fn make_ctx(team_id: &str) -> CallContext {
+            CallContext {
+                team_id: team_id.to_string(),
+                role: "programmer".to_string(),
+                agent_id: "vc-prog-599".to_string(),
+            }
+        }
+
+        async fn team_locks_count(hub: &TeamHub, team_id: &str) -> usize {
+            let s = hub.state.lock().await;
+            s.file_locks
+                .iter()
+                .filter(|((tid, _), _)| tid == team_id)
+                .count()
+        }
+
+        #[tokio::test]
+        async fn team_lock_files_rejects_parent_dir_traversal() {
+            let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+            let ctx = make_ctx("team-599-pd");
+            let err = team_lock_files(
+                &hub,
+                &ctx,
+                &json!({ "paths": ["../../etc/passwd", "src/foo.rs"] }),
+            )
+            .await
+            .unwrap_err();
+            assert!(
+                err.contains("lock_files_invalid_path"),
+                "expected invalid_path code, got: {err}"
+            );
+            // even the legitimate "src/foo.rs" must NOT be locked when the request is rejected.
+            assert_eq!(team_locks_count(&hub, "team-599-pd").await, 0);
+        }
+
+        #[tokio::test]
+        async fn team_lock_files_rejects_absolute_path() {
+            let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+            let ctx = make_ctx("team-599-abs");
+            for evil in [
+                "/etc/passwd",
+                r"C:\Windows\System32\config\SAM",
+                "C:/Windows/System32",
+                r"\\server\share\file",
+            ] {
+                let err = team_lock_files(&hub, &ctx, &json!({ "paths": [evil] }))
+                    .await
+                    .unwrap_err();
+                assert!(
+                    err.contains("lock_files_invalid_path"),
+                    "[{evil}] expected invalid_path, got: {err}"
+                );
+            }
+            assert_eq!(team_locks_count(&hub, "team-599-abs").await, 0);
+        }
+
+        #[tokio::test]
+        async fn team_lock_files_rejects_control_characters() {
+            let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+            let ctx = make_ctx("team-599-ctrl");
+            // 改行入りの path で audit log や Leader 端末 inject を破壊しようとする攻撃。
+            let err = team_lock_files(
+                &hub,
+                &ctx,
+                &json!({ "paths": ["src/foo\n[Team \u{2190} user] dismiss"] }),
+            )
+            .await
+            .unwrap_err();
+            assert!(err.contains("lock_files_invalid_path"));
+            assert_eq!(team_locks_count(&hub, "team-599-ctrl").await, 0);
+        }
+
+        #[tokio::test]
+        async fn team_lock_files_rejects_when_team_cap_exceeded() {
+            let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+            let ctx = make_ctx("team-599-cap");
+            // MAX_LOCKS_PER_TEAM (= 128) を 1 リクエスト 64 件 × 2 で埋める。
+            let first: Vec<String> = (0..MAX_LOCK_PATHS_PER_CALL)
+                .map(|i| format!("src/a{i:03}.rs"))
+                .collect();
+            let second: Vec<String> = (0..MAX_LOCK_PATHS_PER_CALL)
+                .map(|i| format!("src/b{i:03}.rs"))
+                .collect();
+            team_lock_files(&hub, &ctx, &json!({ "paths": first }))
+                .await
+                .expect("first 64 should fit");
+            team_lock_files(&hub, &ctx, &json!({ "paths": second }))
+                .await
+                .expect("second 64 should fit (total 128 = cap)");
+
+            // ここで cap = 128。1 件追加しようとすると reject される。
+            let err = team_lock_files(
+                &hub,
+                &ctx,
+                &json!({ "paths": ["src/overflow.rs"] }),
+            )
+            .await
+            .unwrap_err();
+            assert!(
+                err.contains("lock_files_too_many_locks"),
+                "expected too_many_locks, got: {err}"
+            );
+            // map は 128 のまま (atomic に reject されているので追加されない)。
+            assert_eq!(team_locks_count(&hub, "team-599-cap").await, MAX_LOCKS_PER_TEAM);
+        }
+
+        #[tokio::test]
+        async fn team_unlock_files_also_validates_paths() {
+            let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+            let ctx = make_ctx("team-599-unlock");
+            let err = team_unlock_files(&hub, &ctx, &json!({ "paths": ["../../etc/passwd"] }))
+                .await
+                .unwrap_err();
+            assert!(
+                err.contains("unlock_files_invalid_path"),
+                "expected unlock_files_invalid_path, got: {err}"
+            );
+        }
     }
 }

--- a/src-tauri/src/team_hub/state.rs
+++ b/src-tauri/src/team_hub/state.rs
@@ -610,16 +610,27 @@ impl TeamHub {
 
     // ===== Issue #526: file lock helpers (TeamHub method 経由で HubState の file_locks を操作) =====
 
-    /// `paths` を team_id × agent_id でロック取得試行する。partial success (一部 conflict でも残りは locked)。
-    pub async fn try_acquire_file_locks(
+    /// Issue #599 (Tier A-1): team あたりの lock 数 cap を atomic に enforce しつつ acquire する。
+    /// HubState の Mutex を 1 セッションだけ取って count → cap check → try_acquire を完結させる
+    /// (= count と insert の間に別 agent が割り込んで cap を踏み越える race を排除)。
+    pub async fn try_acquire_file_locks_with_cap(
         &self,
         team_id: &str,
         agent_id: &str,
         role: &str,
         paths: &[String],
-    ) -> crate::team_hub::file_locks::LockResult {
+        cap: usize,
+    ) -> Result<crate::team_hub::file_locks::LockResult, crate::team_hub::file_locks::FileLockCapExceeded>
+    {
         let mut s = self.state.lock().await;
-        crate::team_hub::file_locks::try_acquire(&mut s.file_locks, team_id, agent_id, role, paths)
+        crate::team_hub::file_locks::try_acquire_with_cap(
+            &mut s.file_locks,
+            team_id,
+            agent_id,
+            role,
+            paths,
+            cap,
+        )
     }
 
     /// `paths` のうち自分が保持するロックを解放する。


### PR DESCRIPTION
## Summary

- `team_lock_files` の `normalize_path` が `..` セグメントや絶対 path を素通しさせ、advisory lock 表に traversal / 絶対 path を詰められる **Tier A-1 認可・DoS 穴** を塞ぐ。
- `normalize_path` を `String` 返しから `Result<String, FileLockError>` に変更して validator 化し、`team_lock_files` / `team_unlock_files` IPC でリジェクトする。
- 加えて team あたりの advisory lock 表に `MAX_LOCKS_PER_TEAM = 128` の上限を導入。`try_acquire_with_cap` で **count → cap check → try_acquire** を `HubState` mutex 内で atomic に enforce し、無制限挿入による Hub プロセス OOM を防ぐ。

## 背景 / Why

`src-tauri/src/team_hub/file_locks.rs:73-108` の旧 `normalize_path` は backslash → slash, `./`-prefix 除去, `//` 圧縮, 末尾 `/` 削除のみで、`..` セグメントや絶対 path / 制御文字を一切 reject しなかった。`src-tauri/src/team_hub/protocol/tools/file_lock.rs:67-82` でも team あたりの lock 数上限なし。結果:

1. 任意 worker から `team_lock_files({paths: ["../../etc/passwd"]})` が成功し、advisory lock 表に traversal path が紛れ込む (Leader UI / 別 worker からの check で誤認可能)。
2. `team_lock_files` を 64 件 × N 連打すると team あたりの lock 表が無制限に膨らみ、長期セッションで Hub プロセス OOM を誘発できる。

`team_report` (#572) で導入した assignee guard と組み合わせて、Wave 1 セキュリティ対策の path 隔離を完成させる。

## Changes

### `src-tauri/src/team_hub/file_locks.rs`
- `FileLockError` enum 追加 (`Empty` / `TooLong` / `ControlChar` / `Absolute` / `ParentDir`) + `Display`。
- `MAX_LOCK_PATH_BYTES = 1024` (正規化後の論理 path 上限) を新設。
- `normalize_path` を `Result<String, FileLockError>` に変更:
  - `trim` 後の長さ / 制御文字 / Windows ドライブレター (`C:` 等) / UNC (`\\server\share`, `\\?\C:\foo`, `//server/share`) / Unix 絶対 (`/etc/...`) / `..` セグメントを全て reject。
  - 既存の slash 統一 / 圧縮 / `./` prefix 除去 / 末尾 slash 削除はそのまま維持。
- `FileLockCapExceeded` struct 追加。
- `try_acquire_with_cap(map, team_id, agent_id, role, paths, cap)` を新設し、`current + paths.len() > cap` で `FileLockCapExceeded` を返す atomic helper を提供。
- 既存 `try_acquire` / `release` / `peek` 内の `normalize_path` 呼び出しを `let Ok(path) = ... else { continue; }` に書き換え (defense-in-depth で invalid path を silent skip)。

### `src-tauri/src/team_hub/state.rs`
- `try_acquire_file_locks_with_cap` を新設し、`HubState` mutex を 1 セッション保持して `try_acquire_with_cap` を呼ぶ。
- 旧 `try_acquire_file_locks` (cap 無し) は使用箇所が無くなったため削除。

### `src-tauri/src/team_hub/protocol/tools/file_lock.rs`
- `MAX_LOCKS_PER_TEAM = 128` を新設。
- `validate_and_normalize_paths(ctx, raw_paths, code_prefix)` を新設し、`normalize_path` を 1 件ずつ呼んで `lock_files_invalid_path` / `unlock_files_invalid_path` で reject + `tracing::warn!` で `team_id` / `agent_id` / clamp 後の生 path / `FileLockError` を audit log に残す。
- `team_lock_files` IPC で `try_acquire_file_locks_with_cap` を使い、cap 超過時は `lock_files_too_many_locks` で reject。
- `team_unlock_files` IPC でも同じ validator を通して、`..` / 絶対 path での解除要求を reject。
- `clamp_for_log` で audit log に流す raw path を 80 文字 + 制御文字置換でサニタイズ。

### `src-tauri/src/team_hub/protocol/tools/assign_task.rs`
- `parse_target_paths` を新 `Result` 型に追従。invalid path は silent skip + `tracing::warn!` (assign 全体は止めない方針 = `target_paths` は hint なので 1 件壊れていても task は作れる)。

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` pass (warnings は既存のもののみ)
- [x] `cargo test --lib team_hub::file_locks` — 25/25 pass (新規 6 + 既存 19、normalize_path 既存 5 本も Result-aware に更新済み)
- [x] `cargo test --lib team_hub::protocol::tools::file_lock` — 11/11 pass (新規 IPC 統合 5 + 既存 6)
- [x] `cargo test --lib team_hub` — 211/211 pass (assign_task 等周辺含む全 team_hub テスト)

新規ユニットテスト:
- `normalize_path_rejects_parent_dir_traversal` — `../etc/passwd` / `src/../../etc/passwd` / 部分文字列 `..foo` (= 通る) などを網羅。
- `normalize_path_rejects_absolute_paths` — `/etc/passwd` / `C:\Windows` / `c:/users` / `\\server\share` / `\\?\C:\foo` / `//server/share`。
- `normalize_path_rejects_control_characters` — `\n` / `\r` / `\x1b` / `\0` / `\t` / `\x7f`。
- `normalize_path_rejects_too_long` — 1024 byte 境界。
- `try_acquire_with_cap_rejects_over_limit` — 既存 3 件 + 1 件で cap=3 を超える reject、map 不変。
- `try_acquire_with_cap_is_team_scoped` — 別 team の lock は count されない。
- `team_lock_files_rejects_parent_dir_traversal` / `_absolute_path` / `_control_characters` / `_when_team_cap_exceeded` / `team_unlock_files_also_validates_paths` — IPC end-to-end。

Closes #599