### PR TITLE
fix(canvas): #610 Background grid の color を CSS variable + テーマ別 token に切替

### DIFF
--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -73,7 +73,13 @@ const FLOW_DELETE_KEYS = ['Delete'];
 const FLOW_PAN_BUTTONS = [0, 1, 2];
 const FLOW_PRO_OPTIONS = { hideAttribution: true } as const;
 const FLOW_STAGE_STYLE = { position: 'absolute' as const, inset: 0 };
-const BACKGROUND_COLOR_VAR = 'var(--canvas-grid, #1c1c20)';
+// Issue #610: 旧実装は `<Background color="var(--canvas-grid, #1c1c20)" />` のように
+//  CSS variable 文字列を SVG attribute に直接渡していたが、SVG attribute は CSS
+//  context ではないため `var(...)` は解釈されず、ブラウザは attribute 値を不正
+//  扱いして fallback の灰色 / 黒で固定描画していた (#585 縦線の根因)。
+//  CSS で `.react-flow__background-pattern circle` の fill を `var(--canvas-grid)`
+//  で上書きする方式 (styles/components/canvas.css 参照) に切替えたため、ここでは
+//  color prop を渡さず、xyflow の default attribute の上に CSS が乗るようにする。
 /** Issue #259 継承: zoom が 0.7 を下回ると TUI が読めなくなるため recruit focus 時のクランプ閾値。 */
 const MIN_RECRUIT_ZOOM = 0.7;
 
@@ -428,7 +434,7 @@ function FlowApp(): JSX.Element {
         // 多少の DOM 増加は呑んで全カードを常時マウントしておく。
         proOptions={FLOW_PRO_OPTIONS}
       >
-        <Background gap={32} color={BACKGROUND_COLOR_VAR} />
+        <Background gap={32} />
         {/* React Flow デフォルトの白い縦 4 ボタン (zoom/+/-、fit、lock) は UI と不整合なので非表示。
             ズームはマウスホイール / トラックパッド、fit はキー (KEYS.fitView)、lock は不要なため。 */}
         <MiniMap

--- a/src/renderer/src/styles/__tests__/canvas-css-contract.test.ts
+++ b/src/renderer/src/styles/__tests__/canvas-css-contract.test.ts
@@ -48,4 +48,31 @@ describe('Canvas CSS contract', () => {
       /\.tc-list-row__status-dot\s*\{[\s\S]*background:\s*var\(--agent-accent,\s*var\(--role-color,\s*var\(--success\)\)\)\s*;/
     );
   });
+
+  it('Issue #610: --canvas-grid is defined for every theme so the Background grid follows the theme', () => {
+    const tokens = stripCssComments(readStyleFile('tokens.css'));
+
+    // 全 6 テーマ + :root fallback がカバーされていることを保証する。新規テーマを足したら
+    // 同じく tokens.css に --canvas-grid を 1 行足すことで Canvas.tsx は触らずに対応できる。
+    for (const theme of ['claude-dark', 'claude-light', 'dark', 'light', 'midnight', 'glass']) {
+      const blockRe = new RegExp(
+        String.raw`\[data-theme='${theme}'\][^{]*\{[\s\S]*?--canvas-grid\s*:[^;]+;[\s\S]*?\}`
+      );
+      expect(tokens, `theme '${theme}' must define --canvas-grid`).toMatch(blockRe);
+    }
+  });
+
+  it('Issue #610: canvas.css targets the React Flow background pattern via CSS so SVG attributes do not strand var()', () => {
+    const canvas = stripCssComments(readComponentCss('canvas.css'));
+
+    // dots variant (`<circle>`) と lines/cross variant (`<path>`) の両方を
+    // var(--canvas-grid) で上書きすることで、xyflow がどの variant を選んでも
+    // テーマ追従する。フォールバック値も hex で残しておく (variable 未定義時の保険)。
+    expect(canvas).toMatch(
+      /\.react-flow__background-pattern\s+circle\s*\{[\s\S]*fill:\s*var\(--canvas-grid[^)]*\)\s*;/
+    );
+    expect(canvas).toMatch(
+      /\.react-flow__background-pattern\s+path\s*\{[\s\S]*stroke:\s*var\(--canvas-grid[^)]*\)\s*;/
+    );
+  });
 });

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -8,6 +8,25 @@
  *   - 寸法・色はすべてテーマ変数 (--bg/--fg/--border/--accent) と揃える
  * =========================================================================== */
 
+/* ---------- Background grid (Issue #610) ----------
+ * xyflow `<Background>` は受け取った `color` prop を SVG attribute (`fill` /
+ * `stroke`) に直接書き込むため、CSS variable 文字列を渡しても評価されず固定色
+ * になっていた (#585 縦線・テーマ追従しないグリッドの根因)。
+ *
+ * 修正: Canvas.tsx 側では `color` prop を渡さず、ここで CSS 経由で fill / stroke
+ * を `var(--canvas-grid)` に上書きする。CSS プロパティは SVG presentation
+ * attribute より優先されるので、xyflow が attribute に何を入れていても CSS が勝つ。
+ *  - `dots` variant: `<circle>` のみ
+ *  - `lines` / `cross` variant: `<path>` の stroke
+ * 両方カバーしておく。`--canvas-grid` の各テーマ値は tokens.css 参照。
+ */
+.react-flow__background-pattern circle {
+  fill: var(--canvas-grid, #1c1c20);
+}
+.react-flow__background-pattern path {
+  stroke: var(--canvas-grid, #1c1c20);
+}
+
 /* ---------- layout root ---------- */
 .canvas-layout {
   position: fixed;

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -324,6 +324,11 @@ samp,
   --surface-hover: var(--bg-hover);
   --surface-active: var(--bg-active);
   --surface-glass: rgba(23, 23, 22, 0.62);
+  /* Issue #610: Canvas Background grid (xyflow `<Background variant="dots">`) の
+   *  dot 色をテーマ追従させるための変数。SVG attribute では `var(...)` が解釈
+   *  されないため、Canvas.tsx 側で color prop は渡さず、CSS で
+   *  `.react-flow__background-pattern circle/path` の fill/stroke を上書きする。 */
+  --canvas-grid: #2a2a2e;
   --focus-ring: 0 0 0 3px rgba(217, 119, 87, 0.28);
   color-scheme: dark;
 }
@@ -367,6 +372,8 @@ samp,
   --surface-hover: var(--bg-hover);
   --surface-active: var(--bg-active);
   --surface-glass: rgba(248, 248, 246, 0.72);
+  /* Issue #610: dot 色は light bg (#f8f8f6) と弱コントラストの薄灰に。 */
+  --canvas-grid: #d4d4d8;
   --focus-ring: 0 0 0 3px rgba(217, 119, 87, 0.22);
   color-scheme: light;
 }
@@ -406,6 +413,8 @@ samp,
   --surface-hover: var(--bg-hover);
   --surface-active: var(--bg-active);
   --surface-glass: rgba(11, 13, 18, 0.62);
+  /* Issue #610: 旧 hardcode default と同じ #1c1c20 を維持 (= 互換)。 */
+  --canvas-grid: #1c1c20;
   --focus-ring: 0 0 0 1px rgba(8, 9, 10, 0.8), 0 0 0 3px rgba(94, 106, 210, 0.3);
   color-scheme: dark;
 }
@@ -445,6 +454,8 @@ samp,
   --surface-hover: var(--bg-hover);
   --surface-active: var(--bg-active);
   --surface-glass: rgba(5, 7, 12, 0.62);
+  /* Issue #610: midnight (#05070c) とほぼ同等の極暗色。 */
+  --canvas-grid: #15151a;
   --focus-ring: 0 0 0 1px rgba(5, 7, 12, 0.86), 0 0 0 3px rgba(124, 92, 255, 0.28);
   color-scheme: dark;
 }
@@ -484,6 +495,8 @@ samp,
   --surface-hover: var(--bg-hover);
   --surface-active: var(--bg-active);
   --surface-glass: rgba(255, 255, 255, 0.62);
+  /* Issue #610: pure white bg に対して薄灰 dot。 */
+  --canvas-grid: #d4d4d8;
   --focus-ring: 0 0 0 1px rgba(255, 255, 255, 0.92), 0 0 0 3px rgba(0, 0, 0, 0.14);
   color-scheme: light;
 }
@@ -529,6 +542,8 @@ samp,
   --surface-hover: var(--bg-hover);
   --surface-active: var(--bg-active);
   --surface-glass: rgba(10, 10, 26, 0.68);
+  /* Issue #610: 半透明白 dot で acrylic 上でも視認可、Cyber Neon の世界観を壊さない。 */
+  --canvas-grid: rgba(255, 255, 255, 0.18);
   --focus-ring: 0 0 0 2px rgba(0, 255, 255, 0.40);
   color-scheme: dark;
 }


### PR DESCRIPTION
## Summary
- xyflow `<Background>` は受け取った `color` prop を SVG `<circle fill={...}>` / `<path stroke={...}>` の attribute に直接書き込むため、`var(--canvas-grid, #1c1c20)` のような CSS variable 文字列を渡しても評価されず、ブラウザが attribute を不正扱いして固定色で描画していた (Tier B-1)。さらに `--canvas-grid` 自体が tokens.css に未定義で、Issue #585 の「謎の縦線・テーマ追従しない」現象の根因となっていた。
- 修正: SVG attribute に渡すのを止め、`.react-flow__background-pattern circle/path` の fill/stroke を CSS で `var(--canvas-grid)` に上書きする。CSS プロパティは SVG presentation attribute より優先されるので、xyflow の default attribute は CSS が上から塗る。
- `tokens.css` に全 6 テーマ (claude-dark / claude-light / dark / light / midnight / glass) で `--canvas-grid` を定義。Cyber Neon の glass は半透明白で acrylic 上でも視認可。
- `Canvas.tsx`: `BACKGROUND_COLOR_VAR` 定数撤去、`<Background>` から `color` prop を外す。
- `canvas-css-contract.test.ts` に契約テスト 2 件追加: 全テーマで `--canvas-grid` 定義と、circle/path 両方を CSS variable で targeting していることを固定。新規テーマ追加時の同期忘れを CI で検出できる。

## なぜ案 3 (CSS targeting) を採用したか
- 案 1 (テーマ ID 分岐 hex 渡し) は新規テーマで Canvas.tsx も更新が必要になり 4 層同期 (themes.ts / tokens.css / monaco-setup.ts / Canvas.tsx) に肥大化する。
- 案 2 (`getComputedStyle`) はテーマ切替時に再計算が必要で xyflow の Background 再描画タイミングに左右される。
- 案 3 は CSS variable cascade に乗るので `data-theme` 属性が変わるだけで自動追従し、Canvas.tsx に色情報が残らない。新規テーマは tokens.css に 1 行足すだけで済む (theme-customization skill の 4 層同期と整合)。

## 関連 Issue
- Closes #610
- Closes #585 (背景縦線・色見え報告 — 上記 attribute 不正評価が根因なので同時 close)

## Test plan
- [x] `npm run typecheck` pass
- [x] `npx vitest run` pass (54 file / 344 test、契約テスト 2 件追加で +2)
- [x] `npx vite build` pass (renderer 本番ビルド)
- [x] canvas-css-contract test で全 6 テーマの `--canvas-grid` 定義と circle/path targeting を CI 固定
- [ ] (実機) Ctrl+Shift+M で Canvas に切替え、Settings から claude-dark / claude-light / dark / light / midnight / glass の 6 テーマを切替えて grid 色が追従、#585 の縦線が消えていることを目視確認