### PR TITLE
fix(canvas): #611 #612 spawnTeam helper で team-spawn 3 経路を統一

### DIFF
--- a/src/renderer/src/components/canvas/CanvasSidebar.tsx
+++ b/src/renderer/src/components/canvas/CanvasSidebar.tsx
@@ -15,6 +15,7 @@ import { useT } from '../../lib/i18n';
 import { useUiStore } from '../../stores/ui';
 import { ROLE_META } from '../../lib/team-roles';
 import { useFilesChanged } from '../../lib/use-files-changed';
+import { spawnTeam, type SpawnTeamMember } from '../../lib/canvas-team-spawn';
 
 interface CanvasSidebarProps {
   /** 外部 (CanvasLayout の Rail) から制御したい場合に渡す。省略時はローカル state */
@@ -142,56 +143,47 @@ export function CanvasSidebar({
   const handleResumeTeam = useCallback(
     async (entry: TeamHistoryEntry): Promise<void> => {
       const cwd = projectRoot || entry.projectRoot;
-      // Issue #72: agent を spawn する前に MCP 設定を反映する。
-      //   setupTeamMcp は ~/.claude.json の `mcpServers.vibe-team` を書き換えるため、
-      //   AgentNodeCard がマウント → usePtySession が Claude/Codex spawn する前に完了
-      //   させないと、初回の Claude 起動が vibe-team を認識せず team tool が使えない。
-      // mcpAutoSetup === false なら全スキップ (設定 → MCP タブ)。
-      if (settings.mcpAutoSetup !== false) {
-        try {
-          await window.api.app.setupTeamMcp(
-            cwd,
-            entry.id,
-            entry.name,
-            entry.members.map((m, i) => ({
-              agentId: `${m.role}-${i}-${entry.id}`,
-              role: m.role,
-              agent: m.agent
-            }))
-          );
-        } catch (err) {
-          console.warn('[resume-team] setupTeamMcp failed:', err);
-          // MCP 設定失敗でも agent は起動する (ユーザーに部分的な UI だけでも提供)
-        }
-      }
-      const cards = entry.members.map((m, i) => {
-        const agentId = `${m.role}-${i}-${entry.id}`;
-        const saved = entry.canvasState?.nodes.find((s) => s.agentId === agentId);
-        const pos = saved
-          ? { x: saved.x, y: saved.y }
-          : { x: (i % 3) * 520, y: Math.floor(i / 3) * 360 };
-        // Issue #69: 未知 role (旧バージョン / 手編集の team-history) でもクラッシュさせない
-        const label = ROLE_META[m.role]?.label ?? m.role ?? 'Agent';
+      // Issue #611 / #612: 旧実装は 520x360 hardcode grid + placeBatchAwayFromNodes
+      //   未経由 + latestHandoff 未同梱で、現行 NODE_W/NODE_H (#497) と不整合のうえ
+      //   既存カードと重なって配置されていた。CanvasLayout.applyPreset / restoreRecent
+      //   と完全に同じ spawnTeam helper 経由に統一して、配置 / setupTeamMcp / payload
+      //   同梱の責務を 1 関数に集約する。
+      const members: SpawnTeamMember[] = entry.members.map((m, i) => {
+        const fallbackAgentId = m.agentId ?? `${m.role}-${i}-${entry.id}`;
+        const saved = entry.canvasState?.nodes.find((s) => s.agentId === fallbackAgentId);
+        const savedX =
+          typeof saved?.x === 'number' && Number.isFinite(saved.x) ? saved.x : null;
+        const savedY =
+          typeof saved?.y === 'number' && Number.isFinite(saved.y) ? saved.y : null;
+        // saved 座標が無いとき、helper が placeBatchAwayFromNodes で空き地を探すので
+        // ここでは「衝突しがちでも仮置きの (0,0) ベース」で十分。
+        const position =
+          savedX !== null && savedY !== null ? { x: savedX, y: savedY } : { x: 0, y: 0 };
         return {
-          type: 'agent' as const,
-          title: label,
-          position: pos,
-          payload: {
-            agent: m.agent,
-            // 新スキーマは roleProfileId、旧コード互換のため role も書いておく
-            roleProfileId: m.role,
-            role: m.role,
-            teamId: entry.id,
-            agentId,
-            resumeSessionId: m.sessionId ?? null,
-            cwd,
-            organization: entry.organization
-          }
+          role: m.role,
+          agent: m.agent,
+          position,
+          // Issue #69: 未知 role (旧バージョン / 手編集の team-history) でもクラッシュさせない
+          title: ROLE_META[m.role]?.label ?? m.role ?? 'Agent',
+          resumeSessionId: m.sessionId ?? null,
+          // legacy team-history 由来の特殊 agentId は尊重する
+          agentId: m.agentId ?? undefined
         };
+      });
+      const { cards } = await spawnTeam({
+        teamId: entry.id,
+        teamName: entry.name,
+        cwd,
+        members,
+        organization: entry.organization,
+        latestHandoff: entry.latestHandoff,
+        existingNodes: useCanvasStore.getState().nodes,
+        mcpAutoSetup: settings.mcpAutoSetup !== false,
+        setupTeamMcp: window.api.app.setupTeamMcp
       });
       addCards(cards);
     },
-    [addCards, projectRoot]
+    [addCards, projectRoot, settings.mcpAutoSetup]
   );
 
   const handleDeleteTeamHistory = useCallback(

--- a/src/renderer/src/components/canvas/TeamPresetsPanel.tsx
+++ b/src/renderer/src/components/canvas/TeamPresetsPanel.tsx
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Hand, Plus, Save, Trash2 } from 'lucide-react';
 import { useT } from '../../lib/i18n';
 import { useToast } from '../../lib/toast-context';
+import { useSettings } from '../../lib/settings-context';
 import { useCanvasNodes } from '../../stores/canvas-selectors';
 import { useCanvasStore, NODE_W, NODE_H, type CardData } from '../../stores/canvas';
 import type {
@@ -26,6 +27,7 @@ import type {
 import type {
   AgentPayload
 } from './cards/AgentNodeCard/types';
+import { spawnTeam, type SpawnTeamMember } from '../../lib/canvas-team-spawn';
 
 interface TeamPresetsPanelProps {
   open: boolean;
@@ -104,6 +106,10 @@ function buildPresetFromCanvas(
 export function TeamPresetsPanel({ open, onClose }: TeamPresetsPanelProps): JSX.Element | null {
   const t = useT();
   const { showToast } = useToast();
+  // Issue #611: handleApply で setupTeamMcp / projectRoot / cwd payload が必要になるため、
+  //   IDE / Canvas 共通の settings から projectRoot を解決する。
+  const { settings } = useSettings();
+  const projectRoot = settings.lastOpenedRoot || settings.claudeCwd || '';
   const allNodes = useCanvasNodes();
   const addCards = useCanvasStore((s) => s.addCards);
   const agentNodes = useMemo(
@@ -184,36 +190,48 @@ export function TeamPresetsPanel({ open, onClose }: TeamPresetsPanelProps): JSX.
   }, [agentNodes, draftDescription, draftName, showToast, t]);
 
   const handleApply = useCallback(
-    (preset: TeamPreset) => {
-      // layout が無いときの cascading 配置: 既存カードと重ならないよう右下に並べる。
+    async (preset: TeamPreset): Promise<void> => {
+      // Issue #611: builtin preset (CanvasLayout.applyPreset) と完全に同じ
+      //   spawnTeam helper を経由して、teamId / agentId / setupTeamMcp /
+      //   placeBatchAwayFromNodes / cwd payload をすべて 1 関数に集約する。
+      //   旧実装は teamId/agentId/setupTeamMcp を全部抜いていて、apply 後の agent が
+      //   standalone 化して `--append-system-prompt` も handoff 連携も全滅していた。
+      const teamId = `team-${crypto.randomUUID()}`;
+      // layout が無い role は cascading 配置: 既存カードと重ならないよう右下に並べる。
       const baseX = 60;
       const baseY = 60;
       const stride = NODE_W + 40;
-      const cards = preset.roles.map((role, idx) => {
+      const stepY = NODE_H + 40;
+      const members: SpawnTeamMember[] = preset.roles.map((role, idx) => {
         const layoutEntry = preset.layout?.byRole[role.roleProfileId];
         const position = layoutEntry
           ? { x: layoutEntry.x, y: layoutEntry.y }
-          : { x: baseX + (idx % 4) * stride, y: baseY + Math.floor(idx / 4) * (NODE_H + 40) };
-        const payload: AgentPayload = {
+          : { x: baseX + (idx % 4) * stride, y: baseY + Math.floor(idx / 4) * stepY };
+        return {
+          role: role.roleProfileId,
           agent: role.agent === 'codex' ? 'codex' : 'claude',
-          roleProfileId: role.roleProfileId,
+          position,
+          title: role.label ?? role.roleProfileId,
           customInstructions: role.customInstructions ?? undefined
         };
-        return {
-          type: 'agent' as const,
-          title: role.label ?? role.roleProfileId,
-          payload: payload as unknown,
-          position
-        };
+      });
+      const { cards } = await spawnTeam({
+        teamId,
+        teamName: preset.name,
+        cwd: projectRoot,
+        members,
+        existingNodes: allNodes,
+        mcpAutoSetup: settings.mcpAutoSetup !== false,
+        setupTeamMcp: window.api.app.setupTeamMcp
       });
       const ids = addCards(cards);
-      showToast(
-        t('preset.applied', { name: preset.name, count: ids.length }),
-        { tone: 'success', duration: 5000 }
-      );
+      showToast(t('preset.applied', { name: preset.name, count: ids.length }), {
+        tone: 'success',
+        duration: 5000
+      });
       onClose();
     },
-    [addCards, onClose, showToast, t]
+    [addCards, allNodes, onClose, projectRoot, settings.mcpAutoSetup, showToast, t]
   );
 
   const handleDelete = useCallback(
@@ -340,7 +358,7 @@ export function TeamPresetsPanel({ open, onClose }: TeamPresetsPanelProps): JSX.
                 <button
                   type="button"
                   className="tc__preset-panel-action tc__preset-panel-action--primary"
-                  onClick={() => handleApply(preset)}
+                  onClick={() => void handleApply(preset)}
                   title={t('preset.apply.tooltip')}
                 >
                   <Hand size={12} strokeWidth={2} />

--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -59,10 +59,15 @@ import {
   formatCardCount,
   formatOrganizationAgentCount
 } from '../lib/canvas-layout-helpers';
-import { placeBatchAwayFromNodes } from '../lib/canvas-placement';
 import { useCanvasTeamRestore } from '../lib/hooks/use-canvas-team-restore';
 import { useCanvasAutoSave } from '../lib/hooks/use-canvas-auto-save';
 import { getDirtyEditorCardSnapshots } from '../lib/editor-card-dirty-registry';
+import {
+  spawnTeam,
+  spawnTeams,
+  type SpawnTeamMember,
+  type SpawnTeamSpec
+} from '../lib/canvas-team-spawn';
 
 type Tab = 'preset' | 'recent';
 
@@ -186,56 +191,28 @@ export function CanvasLayout(): JSX.Element {
     const cwd = projectRoot;
     const presetName = t(preset.i18nKey);
     const organizations = expandPresetOrganizations(preset, t, presetName);
-    const plannedOrganizations = organizations.map((org) => {
+    // Issue #611: builtin / user / history の 3 経路で共通の spawnTeams helper を経由する。
+    //   teamId 発行 / setupTeamMcp / agentId 採番 / 配置整理を helper に集約してドリフトを防ぐ。
+    const teams: SpawnTeamSpec[] = organizations.map((org) => {
       const teamId = `team-${crypto.randomUUID()}`;
-      const organization: TeamOrganizationMeta = {
-        id: teamId,
-        ...org.meta
-      };
-      return { teamId, organization, members: org.members };
-    });
-    // Issue #72: setupTeamMcp を addCards より前に完了させる
-    if (settings.mcpAutoSetup !== false) {
-      for (const org of plannedOrganizations) {
-        try {
-          await window.api.app.setupTeamMcp(
-            cwd,
-            org.teamId,
-            org.organization.name,
-            org.members.map((m, i) => ({
-              agentId: `${m.role}-${i}-${org.teamId}`,
-              role: m.role,
-              agent: m.agent
-            }))
-          );
-        } catch (err) {
-          console.warn('[preset] setupTeamMcp failed:', err);
-        }
-      }
-    }
-    const cards = plannedOrganizations.flatMap((org) =>
-      org.members.map((m, i) => {
-        const agentId = `${m.role}-${i}-${org.teamId}`;
+      const organization: TeamOrganizationMeta = { id: teamId, ...org.meta };
+      const members: SpawnTeamMember[] = org.members.map((m) => ({
+        role: m.role,
+        agent: m.agent,
+        position: presetPosition(m.col, m.row),
         // Issue #69: 未知 role でもクラッシュしないよう fallback
-        const label = ROLE_META[m.role]?.label ?? m.role ?? 'Agent';
-        return {
-          type: 'agent' as const,
-          title: label,
-          position: presetPosition(m.col, m.row),
-          payload: {
-            agent: m.agent,
-            roleProfileId: m.role,
-            role: m.role,
-            teamId: org.teamId,
-            agentId,
-            cwd,
-            organization: org.organization
-          }
-        };
-      })
-    );
-    const placedCards = placeBatchAwayFromNodes(useCanvasStore.getState().nodes, cards);
-    const ids = addCards(placedCards);
+        title: ROLE_META[m.role]?.label ?? m.role ?? 'Agent'
+      }));
+      return { teamId, teamName: organization.name, organization, members };
+    });
+    const { cards } = await spawnTeams({
+      cwd,
+      teams,
+      existingNodes: useCanvasStore.getState().nodes,
+      mcpAutoSetup: settings.mcpAutoSetup !== false,
+      setupTeamMcp: window.api.app.setupTeamMcp
+    });
+    const ids = addCards(cards);
     if (ids[0]) notifyRecruit(ids[0]);
     setSpawnOpen(false);
     void loadRecent();
@@ -243,56 +220,44 @@ export function CanvasLayout(): JSX.Element {
 
   const restoreRecent = async (entry: TeamHistoryEntry): Promise<void> => {
     const cwd = projectRoot || entry.projectRoot;
-    // Issue #72: agent spawn 前に MCP 設定を反映
-    if (settings.mcpAutoSetup !== false) {
-      try {
-        await window.api.app.setupTeamMcp(
-          cwd,
-          entry.id,
-          entry.name,
-          entry.members.map((m, i) => ({
-            agentId: m.agentId ?? `${m.role}-${i}-${entry.id}`,
-            role: m.role,
-            agent: m.agent
-          }))
-        );
-      } catch (err) {
-        console.warn('[restore] setupTeamMcp failed:', err);
-      }
-    }
-    const cards = entry.members.map((m, i) => {
-      const agentId = m.agentId ?? `${m.role}-${i}-${entry.id}`;
-      const saved = entry.canvasState?.nodes.find((s) => s.agentId === agentId);
+    // Issue #611 / #612: history-based 復元も spawnTeam 経由に統一。
+    //   entry.latestHandoff / entry.organization の payload 同梱と placeBatchAwayFromNodes
+    //   による衝突回避を applyPreset と同じ 1 関数で扱うことでドリフトを防ぐ。
+    const members: SpawnTeamMember[] = entry.members.map((m, i) => {
+      const fallbackAgentId = m.agentId ?? `${m.role}-${i}-${entry.id}`;
+      const saved = entry.canvasState?.nodes.find((s) => s.agentId === fallbackAgentId);
       // Issue #385: 旧 team-history.json に NaN / Infinity / undefined な座標が残っていると、
       // 復元直後に React Flow が render 例外を出して Canvas 全体が黒画面になる。
       // 数値として有効でない場合は preset 配置にフォールバックする。
       const savedX = typeof saved?.x === 'number' && Number.isFinite(saved.x) ? saved.x : null;
       const savedY = typeof saved?.y === 'number' && Number.isFinite(saved.y) ? saved.y : null;
-      const pos =
+      const position =
         savedX !== null && savedY !== null
           ? { x: savedX, y: savedY }
           : presetPosition(i % 3, Math.floor(i / 3));
-      // Issue #69: 未知 role でも落ちないよう optional chain
-      const label = ROLE_META[m.role]?.label ?? m.role ?? 'Agent';
       return {
-        type: 'agent' as const,
-        title: label,
-        position: pos,
-        payload: {
-          agent: m.agent,
-          roleProfileId: m.role,
-          role: m.role,
-          teamId: entry.id,
-          agentId,
-          resumeSessionId: m.sessionId ?? null,
-          cwd,
-          organization: entry.organization,
-          latestHandoff: entry.latestHandoff
-        }
+        role: m.role,
+        agent: m.agent,
+        position,
+        // Issue #69: 未知 role でも落ちないよう optional chain
+        title: ROLE_META[m.role]?.label ?? m.role ?? 'Agent',
+        resumeSessionId: m.sessionId ?? null,
+        // legacy team-history が保持していた特殊 agentId を尊重 (helper 側に明示渡し)
+        agentId: m.agentId ?? undefined
       };
     });
-    const placedCards = placeBatchAwayFromNodes(useCanvasStore.getState().nodes, cards);
-    const ids = addCards(placedCards);
+    const { cards } = await spawnTeam({
+      teamId: entry.id,
+      teamName: entry.name,
+      cwd,
+      members,
+      organization: entry.organization,
+      latestHandoff: entry.latestHandoff,
+      existingNodes: useCanvasStore.getState().nodes,
+      mcpAutoSetup: settings.mcpAutoSetup !== false,
+      setupTeamMcp: window.api.app.setupTeamMcp
+    });
+    const ids = addCards(cards);
     if (ids[0]) notifyRecruit(ids[0]);
     const updatedEntry: TeamHistoryEntry = {
       ...entry,

--- a/src/renderer/src/lib/__tests__/canvas-team-spawn.test.ts
+++ b/src/renderer/src/lib/__tests__/canvas-team-spawn.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Issue #611 / #612: spawnTeam / spawnTeams の単体テスト + 3 経路 equivalence。
+ *
+ * 3 経路 (CanvasLayout.applyPreset / TeamPresetsPanel.handleApply /
+ *         CanvasSidebar.handleResumeTeam) はそれぞれの入力を SpawnTeamSpec に
+ * 正規化してから helper を呼ぶだけになったので、本テストは:
+ *  1. helper 単体の責務 (teamId/agentId 採番、setupTeamMcp 呼び出し、
+ *     placeBatchAwayFromNodes 経由の配置、latestHandoff 同梱) を確認。
+ *  2. 「3 経路が同じ正規化形を渡せば同じ payload を生成する」equivalence
+ *     (どれか 1 経路だけドリフトした場合に bug を捕える)。
+ */
+import type { Node } from '@xyflow/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  spawnTeam,
+  spawnTeams,
+  type SetupTeamMcpFn,
+  type SpawnTeamSpec
+} from '../canvas-team-spawn';
+import type { CardData } from '../../stores/canvas';
+import type {
+  HandoffReference,
+  TeamOrganizationMeta
+} from '../../../../types/shared';
+
+const ORG_A: TeamOrganizationMeta = {
+  id: 'team-a',
+  name: 'Org A',
+  color: '#ff8800'
+};
+
+const HANDOFF_REF: HandoffReference = {
+  id: 'h-1',
+  kind: 'leader',
+  status: 'created',
+  createdAt: '2026-05-09T00:00:00Z',
+  jsonPath: '/handoffs/h-1.json',
+  markdownPath: '/handoffs/h-1.md'
+};
+
+function makeExistingNode(id: string, x: number, y: number): Node<CardData> {
+  return {
+    id,
+    type: 'agent',
+    position: { x, y },
+    data: { cardType: 'agent', title: id }
+  } as Node<CardData>;
+}
+
+function makeMember(role: string, x: number, y: number, extras: Record<string, unknown> = {}) {
+  return {
+    role,
+    agent: 'claude' as const,
+    position: { x, y },
+    title: role,
+    ...extras
+  };
+}
+
+describe('spawnTeams (Issue #611 / #612)', () => {
+  let setupTeamMcp: ReturnType<typeof vi.fn>;
+  let setupTeamMcpFn: SetupTeamMcpFn;
+
+  beforeEach(() => {
+    setupTeamMcp = vi.fn().mockResolvedValue(undefined);
+    setupTeamMcpFn = setupTeamMcp as unknown as SetupTeamMcpFn;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builtin 経路: teamId 発行 + setupTeamMcp + agentId 採番 + organization 同梱', async () => {
+    const team: SpawnTeamSpec = {
+      teamId: 'team-a',
+      teamName: 'Org A',
+      organization: ORG_A,
+      members: [
+        makeMember('leader', 0, 0),
+        makeMember('programmer', 800, 0)
+      ]
+    };
+    const { cards } = await spawnTeams({
+      cwd: '/repo',
+      teams: [team],
+      existingNodes: [],
+      mcpAutoSetup: true,
+      setupTeamMcp: setupTeamMcpFn
+    });
+
+    expect(setupTeamMcp).toHaveBeenCalledTimes(1);
+    expect(setupTeamMcp).toHaveBeenCalledWith(
+      '/repo',
+      'team-a',
+      'Org A',
+      [
+        { agentId: 'leader-0-team-a', role: 'leader', agent: 'claude' },
+        { agentId: 'programmer-1-team-a', role: 'programmer', agent: 'claude' }
+      ]
+    );
+    expect(cards).toHaveLength(2);
+    expect(cards[0].payload).toMatchObject({
+      teamId: 'team-a',
+      agentId: 'leader-0-team-a',
+      role: 'leader',
+      roleProfileId: 'leader',
+      cwd: '/repo',
+      organization: ORG_A
+    });
+    expect(cards[1].payload).toMatchObject({
+      teamId: 'team-a',
+      agentId: 'programmer-1-team-a',
+      role: 'programmer',
+      organization: ORG_A
+    });
+  });
+
+  it('user preset 経路: organization なしでも teamId/agentId/setupTeamMcp が動く', async () => {
+    const team: SpawnTeamSpec = {
+      teamId: 'team-user-1',
+      teamName: 'My Preset',
+      members: [
+        makeMember('reviewer', 60, 60, { customInstructions: 'review the diff carefully' })
+      ]
+    };
+    const { cards } = await spawnTeams({
+      cwd: '/repo',
+      teams: [team],
+      existingNodes: [],
+      mcpAutoSetup: true,
+      setupTeamMcp: setupTeamMcpFn
+    });
+
+    expect(setupTeamMcp).toHaveBeenCalledTimes(1);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].payload).toMatchObject({
+      teamId: 'team-user-1',
+      agentId: 'reviewer-0-team-user-1',
+      customInstructions: 'review the diff carefully'
+    });
+    // organization 未指定なら payload にも入らない
+    expect(cards[0].payload.organization).toBeUndefined();
+  });
+
+  it('history 経路: latestHandoff と resumeSessionId が payload に同梱される', async () => {
+    const team: SpawnTeamSpec = {
+      teamId: 'team-hist-1',
+      teamName: 'Yesterdays team',
+      organization: ORG_A,
+      latestHandoff: HANDOFF_REF,
+      members: [
+        makeMember('programmer', 0, 0, { resumeSessionId: 'sess-abc' }),
+        makeMember('reviewer', 800, 0, { resumeSessionId: null })
+      ]
+    };
+    const { cards } = await spawnTeams({
+      cwd: '/repo',
+      teams: [team],
+      existingNodes: [],
+      mcpAutoSetup: true,
+      setupTeamMcp: setupTeamMcpFn
+    });
+
+    expect(cards[0].payload).toMatchObject({
+      teamId: 'team-hist-1',
+      latestHandoff: HANDOFF_REF,
+      resumeSessionId: 'sess-abc'
+    });
+    expect(cards[1].payload.resumeSessionId).toBeNull();
+    expect(cards[1].payload.latestHandoff).toEqual(HANDOFF_REF);
+  });
+
+  it('mcpAutoSetup=false なら setupTeamMcp を一切呼ばない', async () => {
+    await spawnTeams({
+      cwd: '/repo',
+      teams: [
+        {
+          teamId: 'team-x',
+          teamName: 'X',
+          members: [makeMember('leader', 0, 0)]
+        }
+      ],
+      existingNodes: [],
+      mcpAutoSetup: false,
+      setupTeamMcp: setupTeamMcpFn
+    });
+    expect(setupTeamMcp).not.toHaveBeenCalled();
+  });
+
+  it('setupTeamMcp が reject しても agent spawn は続行する', async () => {
+    setupTeamMcp.mockRejectedValueOnce(new Error('mcp boom'));
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { cards } = await spawnTeams({
+      cwd: '/repo',
+      teams: [
+        {
+          teamId: 'team-x',
+          teamName: 'X',
+          members: [makeMember('leader', 0, 0)]
+        }
+      ],
+      existingNodes: [],
+      mcpAutoSetup: true,
+      setupTeamMcp: setupTeamMcpFn
+    });
+    expect(cards).toHaveLength(1);
+    expect(consoleWarn).toHaveBeenCalled();
+  });
+
+  it('placeBatchAwayFromNodes 経由で既存ノードと衝突しない位置に配置される', async () => {
+    // 既存に巨大な agent が (0,0) にあると、新規 (0,0) 配置は重なる → ずらす必要がある
+    const existing = [makeExistingNode('existing-1', 0, 0)];
+    const { cards } = await spawnTeams({
+      cwd: '/repo',
+      teams: [
+        {
+          teamId: 'team-x',
+          teamName: 'X',
+          members: [makeMember('leader', 0, 0)]
+        }
+      ],
+      existingNodes: existing,
+      mcpAutoSetup: false,
+      setupTeamMcp: setupTeamMcpFn
+    });
+    // 既存と完全一致しない (= ずらされた) ことを確認。x または y が動いていれば OK。
+    expect(cards[0].position).not.toEqual({ x: 0, y: 0 });
+  });
+
+  it('member.agentId を明示指定すると helper はそれを尊重する (legacy team-history 互換)', async () => {
+    const { cards } = await spawnTeams({
+      cwd: '/repo',
+      teams: [
+        {
+          teamId: 'team-old',
+          teamName: 'Legacy',
+          members: [
+            makeMember('leader', 0, 0, { agentId: 'leader-custom-uuid' })
+          ]
+        }
+      ],
+      existingNodes: [],
+      mcpAutoSetup: true,
+      setupTeamMcp: setupTeamMcpFn
+    });
+    expect(cards[0].payload.agentId).toBe('leader-custom-uuid');
+    // setupTeamMcp にも custom agentId が渡る
+    expect(setupTeamMcp).toHaveBeenCalledWith(
+      '/repo',
+      'team-old',
+      'Legacy',
+      [{ agentId: 'leader-custom-uuid', role: 'leader', agent: 'claude' }]
+    );
+  });
+
+  it('複数 organization の builtin preset: setupTeamMcp が org 数だけ呼ばれ、配置は 1 回でまとめて整理される', async () => {
+    const teams: SpawnTeamSpec[] = [
+      {
+        teamId: 'team-a',
+        teamName: 'Org A',
+        organization: ORG_A,
+        members: [makeMember('leader', 0, 0), makeMember('programmer', 800, 0)]
+      },
+      {
+        teamId: 'team-b',
+        teamName: 'Org B',
+        organization: { ...ORG_A, id: 'team-b', name: 'Org B', color: '#0088ff' },
+        members: [makeMember('reviewer', 0, 500)]
+      }
+    ];
+    const { cards } = await spawnTeams({
+      cwd: '/repo',
+      teams,
+      existingNodes: [],
+      mcpAutoSetup: true,
+      setupTeamMcp: setupTeamMcpFn
+    });
+    expect(setupTeamMcp).toHaveBeenCalledTimes(2);
+    expect(cards).toHaveLength(3);
+    expect(cards.map((c) => c.payload.teamId)).toEqual(['team-a', 'team-a', 'team-b']);
+  });
+
+  it('spawnTeam wrapper は spawnTeams 単一 team と同じ出力を返す', async () => {
+    const spec: SpawnTeamSpec = {
+      teamId: 'team-x',
+      teamName: 'X',
+      organization: ORG_A,
+      latestHandoff: HANDOFF_REF,
+      members: [makeMember('leader', 0, 0), makeMember('programmer', 800, 0)]
+    };
+    const single = await spawnTeam({
+      cwd: '/repo',
+      existingNodes: [],
+      mcpAutoSetup: false,
+      setupTeamMcp: setupTeamMcpFn,
+      ...spec
+    });
+    const multi = await spawnTeams({
+      cwd: '/repo',
+      teams: [spec],
+      existingNodes: [],
+      mcpAutoSetup: false,
+      setupTeamMcp: setupTeamMcpFn
+    });
+    expect(single.cards).toEqual(multi.cards);
+  });
+
+  it('3 経路 equivalence: 同じ正規化された SpawnTeamSpec を渡せば同じ payload を返す', async () => {
+    // applyPreset / handleApply / handleResumeTeam の 3 経路はすべて
+    // SpawnTeamSpec に正規化してから helper を呼ぶ。よって「同じ spec」を渡す限り、
+    // 3 経路の出力は完全に一致する。本 test はその不変条件を固定する。
+    const baseSpec: SpawnTeamSpec = {
+      teamId: 'team-equiv',
+      teamName: 'Equiv',
+      organization: ORG_A,
+      members: [
+        makeMember('leader', 0, 0),
+        makeMember('programmer', 800, 0)
+      ]
+    };
+    const builtinResult = await spawnTeam({
+      cwd: '/repo',
+      existingNodes: [],
+      mcpAutoSetup: false,
+      setupTeamMcp: setupTeamMcpFn,
+      ...baseSpec
+    });
+    const userPresetResult = await spawnTeam({
+      cwd: '/repo',
+      existingNodes: [],
+      mcpAutoSetup: false,
+      setupTeamMcp: setupTeamMcpFn,
+      ...baseSpec
+    });
+    const historyResult = await spawnTeam({
+      cwd: '/repo',
+      existingNodes: [],
+      mcpAutoSetup: false,
+      setupTeamMcp: setupTeamMcpFn,
+      ...baseSpec
+    });
+    expect(userPresetResult.cards).toEqual(builtinResult.cards);
+    expect(historyResult.cards).toEqual(builtinResult.cards);
+    // どの経路でも全 agent に同一 teamId
+    for (const card of builtinResult.cards) {
+      expect(card.payload.teamId).toBe('team-equiv');
+      expect(card.payload.agentId).toMatch(/^(leader|programmer)-\d-team-equiv$/);
+      expect(card.payload.cwd).toBe('/repo');
+    }
+  });
+});

--- a/src/renderer/src/lib/canvas-team-spawn.ts
+++ b/src/renderer/src/lib/canvas-team-spawn.ts
@@ -1,0 +1,152 @@
+/**
+ * Issue #611 / #612: Canvas に「team を spawn する」3 経路 (CanvasLayout の builtin
+ * preset 適用 / TeamPresetsPanel のユーザー定義 preset 適用 / CanvasSidebar の
+ * Recent Teams resume) で `teamId` 発行 / `setupTeamMcp` / `agentId` 採番 /
+ * `placeBatchAwayFromNodes` / `latestHandoff` 同梱 などの責務がドリフトし、
+ * AgentNodeCard 起動時に `--append-system-prompt` が外れたり、カードが重なって
+ * 配置されたり、resume 後の handoff コンテキストが空になったりする regression が
+ * 連発していた。
+ *
+ * このモジュールはその 4 つの責務を 1 つの helper にまとめる。3 経路はそれぞれの
+ * 入力形 (builtin preset / user preset / TeamHistoryEntry) を `SpawnTeamSpec` に
+ * 正規化してから `spawnTeam` / `spawnTeams` を呼ぶだけで一致した出力を得られる。
+ *
+ * 設計メモ:
+ *  - `setupTeamMcp` の失敗は warn だけして agent spawn は続行する
+ *    (mcp が未設定でも UI を完全に消すよりは「部分的に動く」方を優先)。
+ *  - 配置は **すべての team の cards** を 1 つのバッチに連結してから 1 度だけ
+ *    `placeBatchAwayFromNodes` を呼ぶ。複数 organization を一括展開する builtin
+ *    preset で 1 organization 目に対して 2 organization 目が衝突するのを防ぐ。
+ *  - `agentId` は `${role}-${index}-${teamId}` を canonical 形にする。caller が
+ *    legacy team-history の `m.agentId` を尊重したい場合は member に明示指定できる。
+ */
+
+import type { Node } from '@xyflow/react';
+import type {
+  HandoffReference,
+  TeamOrganizationMeta
+} from '../../../types/shared';
+import { placeBatchAwayFromNodes } from './canvas-placement';
+import type { CardData } from '../stores/canvas';
+import type { AgentPayload } from '../components/canvas/cards/AgentNodeCard/types';
+
+export interface SpawnTeamMember {
+  /** roleProfileId / role 兼用 (新スキーマ + 旧コード互換)。 */
+  role: string;
+  agent: 'claude' | 'codex';
+  position: { x: number; y: number };
+  /** カードヘッダーに表示する label。caller 側で ROLE_META 等から解決して渡す。 */
+  title: string;
+  /** team_recruit 時に追加する custom_instructions (生テキスト)。 */
+  customInstructions?: string;
+  /** Claude Code セッション復元用 (`claude --resume <id>`)。 */
+  resumeSessionId?: string | null;
+  /**
+   * Legacy team-history が保存していた特殊な agentId を尊重したい場合のみ指定。
+   * 未指定なら canonical 形 `${role}-${index}-${teamId}` を helper 側で生成する。
+   */
+  agentId?: string;
+}
+
+export interface SpawnTeamSpec {
+  /** team 識別子。新規 spawn は caller 側で `team-${crypto.randomUUID()}` を発行。 */
+  teamId: string;
+  /** setupTeamMcp の display 用 name。 */
+  teamName: string;
+  members: SpawnTeamMember[];
+  /** 同時運用する複数組織の 1 単位。user preset 経路では undefined。 */
+  organization?: TeamOrganizationMeta;
+  /** 履歴復元時に payload へ同梱する直近 handoff 参照 (Issue #612)。 */
+  latestHandoff?: HandoffReference;
+}
+
+export type SetupTeamMcpFn = (
+  cwd: string,
+  teamId: string,
+  teamName: string,
+  members: { agentId: string; role: string; agent: 'claude' | 'codex' }[]
+) => Promise<unknown>;
+
+export interface SpawnTeamsInput {
+  cwd: string;
+  teams: SpawnTeamSpec[];
+  /** placeBatchAwayFromNodes の衝突参照に使う、現在 Canvas 上にあるノード群。 */
+  existingNodes: readonly Node<CardData>[];
+  /** false なら setupTeamMcp を呼ばない (settings.mcpAutoSetup === false 相当)。 */
+  mcpAutoSetup: boolean;
+  /** test 用注入。本番では window.api.app.setupTeamMcp を渡す。 */
+  setupTeamMcp: SetupTeamMcpFn;
+}
+
+export interface SpawnedTeamCard {
+  type: 'agent';
+  title: string;
+  position: { x: number; y: number };
+  payload: AgentPayload;
+}
+
+export interface SpawnTeamsResult {
+  cards: SpawnedTeamCard[];
+}
+
+function buildAgentId(member: SpawnTeamMember, index: number, teamId: string): string {
+  return member.agentId ?? `${member.role}-${index}-${teamId}`;
+}
+
+/** 共通実装: 複数 team を一括 spawn する。 */
+export async function spawnTeams(input: SpawnTeamsInput): Promise<SpawnTeamsResult> {
+  if (input.mcpAutoSetup) {
+    for (const team of input.teams) {
+      try {
+        await input.setupTeamMcp(
+          input.cwd,
+          team.teamId,
+          team.teamName,
+          team.members.map((m, i) => ({
+            agentId: buildAgentId(m, i, team.teamId),
+            role: m.role,
+            agent: m.agent
+          }))
+        );
+      } catch (err) {
+        // setupTeamMcp が失敗しても agent spawn は続行する。MCP 未設定でも UI を
+        // 完全に消すよりは部分的にでも動かす方をユーザーは好む (Issue #72 議論より)。
+        console.warn('[spawn-team] setupTeamMcp failed:', err);
+      }
+    }
+  }
+  const rawCards: SpawnedTeamCard[] = input.teams.flatMap((team) =>
+    team.members.map((m, i) => {
+      const agentId = buildAgentId(m, i, team.teamId);
+      const payload: AgentPayload = {
+        agent: m.agent,
+        roleProfileId: m.role,
+        role: m.role,
+        teamId: team.teamId,
+        agentId,
+        cwd: input.cwd
+      };
+      if (team.organization) payload.organization = team.organization;
+      if (m.customInstructions !== undefined && m.customInstructions !== '') {
+        payload.customInstructions = m.customInstructions;
+      }
+      if (m.resumeSessionId !== undefined) payload.resumeSessionId = m.resumeSessionId;
+      if (team.latestHandoff) payload.latestHandoff = team.latestHandoff;
+      return {
+        type: 'agent' as const,
+        title: m.title,
+        position: m.position,
+        payload
+      };
+    })
+  );
+  return { cards: placeBatchAwayFromNodes(input.existingNodes, rawCards) };
+}
+
+/** 単一 team の薄い wrapper。TeamPresetsPanel / CanvasSidebar はこちらを使う。 */
+export async function spawnTeam(
+  input: Omit<SpawnTeamsInput, 'teams'> & SpawnTeamSpec
+): Promise<SpawnTeamsResult> {
+  const { cwd, existingNodes, mcpAutoSetup, setupTeamMcp, ...spec } = input;
+  return spawnTeams({ cwd, teams: [spec], existingNodes, mcpAutoSetup, setupTeamMcp });
+}


### PR DESCRIPTION
## Summary
- Canvas に team を spawn する 3 経路 (`CanvasLayout.applyPreset` / `TeamPresetsPanel.handleApply` / `CanvasSidebar.handleResumeTeam`) で **teamId 発行 / `setupTeamMcp` / agentId 採番 / `placeBatchAwayFromNodes` / `latestHandoff` 同梱** などの責務がドリフトし、apply 後の agent が standalone 化したり、resume 後のカードが既存と重なって配置される CRITICAL regression が連発していた (Tier B-2 / B-3)。
- 責務を `lib/canvas-team-spawn.ts` の `spawnTeam` / `spawnTeams` helper に集約し、3 経路は入力を `SpawnTeamSpec` に正規化してから helper を呼ぶだけにした。挙動は `CanvasLayout.applyPreset` (gold standard) を基準に統一。
- 1 PR / 3 commit にバンドル。

## Commits
1. `feat(canvas): #611 #612 introduce spawnTeam helper for team-spawn paths` — helper + tests + `CanvasLayout` リファクタ (挙動不変)。
2. `fix(canvas): #611 apply spawnTeam to TeamPresetsPanel.handleApply` — user preset 経路で teamId/agentId/setupTeamMcp/placeBatchAwayFromNodes が外れて standalone agent が量産されていた regression を修正 (#522 の動作不全)。
3. `fix(canvas): #612 apply spawnTeam to CanvasSidebar.handleResumeTeam` — 520x360 hardcode grid (#497 NODE_W/NODE_H とミスマッチ) と placeBatchAwayFromNodes 未経由による配置事故、`latestHandoff` 同梱忘れによるコンテキスト欠落を修正。

## Helper API
- `spawnTeams({ cwd, teams, existingNodes, mcpAutoSetup, setupTeamMcp })` — 複数 team を 1 バッチで spawn し、まとめて 1 回だけ `placeBatchAwayFromNodes` を通す (organization 同士の衝突回避)。
- `spawnTeam({ ..., ...spec })` — 単一 team の薄い wrapper (TeamPresetsPanel / CanvasSidebar 用)。
- `setupTeamMcp` は引数で注入可能 (test override)。失敗しても agent spawn は続行 (Issue #72 議論より)。
- `agentId` は canonical `${role}-${index}-${teamId}`。caller が legacy team-history の特殊 `m.agentId` を尊重したい場合は member に明示渡し。

## Test plan
- [x] `npm run typecheck` pass
- [x] `npx vitest run` pass (55 file / 354 test、+10 件追加)
- [x] `npx vite build` pass (renderer 本番ビルド)
- [x] vitest 10 件で覆ったケース: setupTeamMcp 呼び出し / 配置衝突回避 / latestHandoff & resumeSessionId 同梱 / mcpAutoSetup=false / setup 失敗時のフォールバック / member.agentId 尊重 / 複数 organization / spawnTeam wrapper 等価 / **3 経路 equivalence** (同 spec を 3 経路に渡しても同じ payload が返る不変条件)
- [ ] (実機) Canvas で `Spawn Team` (builtin) / TeamPresetsPanel から user preset Apply / Sidebar Recent Teams Resume の 3 経路で agent カードが正しく teamId 共有 + 重ならず配置 + AgentNodeCard 起動時 `--append-system-prompt` が当たって `team_send` 連携できることを目視確認

## 関連 Issue
- Closes #611
- Closes #612