### PR TITLE
fix(canvas): #613 #616 #593 keybinding gate + Pane context menu race

### DIFF
--- a/src/renderer/src/components/ContextMenu.tsx
+++ b/src/renderer/src/components/ContextMenu.tsx
@@ -67,6 +67,15 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps): JSX.Ele
   }, [items]);
 
   useEffect(() => {
+    // Issue #616 / #593: 旧実装は `mousedown` で外クリックを検知していたが、ContextMenu を
+    //  開いた当の右クリックの mousedown 自体が、React の commit + useEffect 登録までの
+    //  わずかな間に document に bubble して「外クリック」として誤検知され、メニューが
+    //  即閉じていた (Pane 上で `e.stopPropagation()` 抜けが trigger だが、開いた経路に
+    //  関わらず race し得る)。
+    //  `click` (mouseup 完了後の合成イベント) に切替えると、メニューを開いた右クリックは
+    //  contextmenu イベントを発火するだけで `click` を発火しないため、安全に外クリック
+    //  クローズだけを拾える。defense-in-depth として handlePaneContextMenu 側にも
+    //  stopPropagation を追加してある。
     const handleClick = (e: MouseEvent): void => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         onClose();
@@ -103,10 +112,10 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps): JSX.Ele
         itemRefs.current[next]?.focus();
       }
     };
-    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('click', handleClick);
     document.addEventListener('keydown', handleKey);
     return () => {
-      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('click', handleClick);
       document.removeEventListener('keydown', handleKey);
     };
   }, [onClose, items, focusedIndex]);

--- a/src/renderer/src/components/__tests__/ContextMenu.test.tsx
+++ b/src/renderer/src/components/__tests__/ContextMenu.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * ContextMenu outside-click test (Issue #616 / #593).
+ *
+ * 旧実装は document の `mousedown` で外クリックを検知していた。Canvas Pane で
+ * `e.stopPropagation()` を抜いていた combination で「ContextMenu を開いた当の右クリック
+ * の mousedown 自身」が外クリックとして誤検出され、メニューが即閉じる race を起こしていた。
+ *
+ * 修正後は `click` (mouseup 完了後の合成イベント) を listen するようにしたので、
+ * 「メニューを開いた右クリック自体」では closure が起きず、外側を通常クリックしたら
+ * 閉じる。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ContextMenu, type ContextMenuItem } from '../ContextMenu';
+
+const ITEMS: ContextMenuItem[] = [
+  { label: 'Add Claude here', action: vi.fn() },
+  { label: 'Delete card', action: vi.fn() }
+];
+
+function renderMenu(onClose = vi.fn()) {
+  const result = render(
+    <ContextMenu x={50} y={60} items={ITEMS} onClose={onClose} />
+  );
+  return { ...result, onClose };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ContextMenu outside-click handling (Issue #616 / #593)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('right-click 直後に bubble する mousedown では close しない (Issue #616 race fix)', () => {
+    const { onClose } = renderMenu();
+    // 旧実装は mousedown listener で close していたため、ここで close されてしまっていた。
+    // 新実装は click listener なので、mousedown だけでは何も起きない。
+    fireEvent.mouseDown(document.body);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('document に対する click (= mousedown + mouseup) で外クリック扱いされ close する', () => {
+    const { onClose } = renderMenu();
+    // body 直下の何もない領域を click → outside-click として close
+    fireEvent.click(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('menu 内部の menuitem を click しても外クリック扱いはしない (action 実行 + onClose)', () => {
+    const action = vi.fn();
+    const items: ContextMenuItem[] = [
+      { label: 'Add Claude here', action }
+    ];
+    const onClose = vi.fn();
+    render(<ContextMenu x={10} y={10} items={items} onClose={onClose} />);
+    const button = screen.getByRole('menuitem', { name: 'Add Claude here' });
+    fireEvent.click(button);
+    expect(action).toHaveBeenCalledTimes(1);
+    // onClose は item.onClick handler 内で 1 回呼ばれるが、その後 document の click bubble
+    // で再度発火することは contains() ガードのおかげで起きない (= onClose は 1 回のみ)。
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape キーで close する', () => {
+    const { onClose } = renderMenu();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Tab キーで close する (menu pattern: 次の focusable へ抜ける扱い)', () => {
+    const { onClose } = renderMenu();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -328,10 +328,16 @@ function FlowApp(): JSX.Element {
 
   // ---- Phase 4: keybindings ----
   const setViewMode = useUiStore((s) => s.setViewMode);
+  // Issue #613: <CanvasLayout> は IDE モードでも常時 mount されているため、Canvas 内の
+  //  useKeybinding が IDE モード中も capture phase で window keydown を奪っていた。
+  //  Ctrl+Shift+K (QuickNav) / Ctrl+Shift+I (Inspector ≒ DevTools) / Ctrl+Shift+N (新規 agent)
+  //  は **Canvas モード時のみ** 有効にして、IDE 中は Chromium 標準ショートカット (DevTools) や
+  //  通常の入力に影響を与えないようにする。
+  const isCanvasActive = useUiStore((s) => s.viewMode === 'canvas');
   const [quickNavOpen, setQuickNavOpen] = useState(false);
-  useKeybinding(KEYS.quickNav, () => setQuickNavOpen(true));
-  useKeybinding(KEYS.toggleIde, () => setViewMode('ide'));
-  useKeybinding(KEYS.newTerminal, handleAddClaudeAgent);
+  useKeybinding(KEYS.quickNav, () => setQuickNavOpen(true), isCanvasActive);
+  useKeybinding(KEYS.toggleIde, () => setViewMode('ide'), isCanvasActive);
+  useKeybinding(KEYS.newTerminal, handleAddClaudeAgent, isCanvasActive);
 
   const stageView = useCanvasStageView();
 

--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -285,6 +285,12 @@ function FlowApp(): JSX.Element {
   const handlePaneContextMenu = useCallback(
     (e: React.MouseEvent | MouseEvent) => {
       e.preventDefault();
+      // Issue #616 / #593: stopPropagation を抜いていたため React Flow の pane の
+      //  mousedown が document まで bubble し、ContextMenu 内の outside-click 検知
+      //  に「メニューを開いた当の右クリック自身」が外クリックとして誤検出されて
+      //  即閉じる race を起こしていた (handleNodeContextMenu は両方呼んでいるので
+      //  node 上の右クリックは正常)。Pane 経路にも stopPropagation を揃える。
+      e.stopPropagation();
       const items: ContextMenuItem[] = [
         {
           label: t('canvasMenu.addClaudeHere'),

--- a/src/renderer/src/lib/__tests__/keybindings.test.ts
+++ b/src/renderer/src/lib/__tests__/keybindings.test.ts
@@ -1,0 +1,95 @@
+/**
+ * useKeybinding gate test (Issue #613).
+ *
+ * <CanvasLayout> は IDE モードでも常時 mount されているため、Canvas.tsx 内の
+ * useKeybinding が IDE 中も capture phase で window keydown を奪う問題があった。
+ * `enabled` 引数で gate されたとき addEventListener が走らない (= handler が呼ばれず、
+ * 標準のショートカットが奪われない) ことを保証する。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { KEYS, useKeybinding } from '../keybindings';
+
+function dispatchKey(key: string, mods: { ctrl?: boolean; shift?: boolean; alt?: boolean; meta?: boolean } = {}): void {
+  const ev = new KeyboardEvent('keydown', {
+    key,
+    ctrlKey: mods.ctrl ?? false,
+    shiftKey: mods.shift ?? false,
+    altKey: mods.alt ?? false,
+    metaKey: mods.meta ?? false,
+    bubbles: true,
+    cancelable: true
+  });
+  window.dispatchEvent(ev);
+}
+
+describe('useKeybinding (Issue #613 gate)', () => {
+  beforeEach(() => {
+    // jsdom default body の focus は <body> なので isInTextEditing は false
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('enabled=true (default) なら handler が発火する', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeybinding(KEYS.quickNav, handler));
+    dispatchKey('k', { ctrl: true, shift: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('enabled=false なら addEventListener も走らず handler は発火しない', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeybinding(KEYS.quickNav, handler, false));
+    dispatchKey('k', { ctrl: true, shift: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('enabled=false で Ctrl+Shift+I を押しても Inspector handler が発火しない (DevTools 解放を保証)', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeybinding(KEYS.toggleIde, handler, false));
+    dispatchKey('i', { ctrl: true, shift: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('enabled=false で Ctrl+Shift+N を 10 回押しても handler は 1 度も呼ばれない (空 agent カード regression 防止)', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeybinding(KEYS.newTerminal, handler, false));
+    for (let i = 0; i < 10; i++) {
+      dispatchKey('n', { ctrl: true, shift: true });
+    }
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('rerender で enabled が false → true に変わると、その後の keydown では発火する', () => {
+    const handler = vi.fn();
+    const { rerender } = renderHook(({ enabled }) => useKeybinding(KEYS.quickNav, handler, enabled), {
+      initialProps: { enabled: false }
+    });
+    dispatchKey('k', { ctrl: true, shift: true });
+    expect(handler).not.toHaveBeenCalled();
+    rerender({ enabled: true });
+    dispatchKey('k', { ctrl: true, shift: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('rerender で enabled が true → false に変わると、それ以降は発火しない', () => {
+    const handler = vi.fn();
+    const { rerender } = renderHook(({ enabled }) => useKeybinding(KEYS.quickNav, handler, enabled), {
+      initialProps: { enabled: true }
+    });
+    dispatchKey('k', { ctrl: true, shift: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+    rerender({ enabled: false });
+    dispatchKey('k', { ctrl: true, shift: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('別キー (Ctrl+K だけ) では Ctrl+Shift+K の handler は発火しない (modifier 完全一致を保証)', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeybinding(KEYS.quickNav, handler));
+    dispatchKey('k', { ctrl: true, shift: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Canvas.tsx を主戦場にした 2 つの UX bug を 1 PR / 2 commit で修正 (Tier B-4 / B-7)。

### #613 (B-4): Canvas keybindings が IDE 中も発火し DevTools / IDE 操作を奪う
`<CanvasLayout>` は IDE モードでも常時 mount されているため、`<Canvas />` 内の `useKeybinding` が IDE 中も capture phase で `window` の keydown を奪っていた:
- Ctrl+Shift+K → QuickNav state リーク
- Ctrl+Shift+I → Chromium 標準の DevTools ショートカットを奪う
- Ctrl+Shift+N → IDE 連打で空 agent カードが Canvas に量産される

修正: `useUiStore((s) => s.viewMode === 'canvas')` で求めた `isCanvasActive` を 3 つの useKeybinding すべての `enabled` 引数に渡す。useKeybinding 本体は既に `if (!enabled) return;` で addEventListener 自体をスキップする実装になっていたので、IDE 中は listener が一切貼られず、Chromium 標準も入力欄も自由に動く。

### #616 / #593 (B-7): Pane 右クリックメニューの mousedown 伝播競合
2 つの相互作用が race を起こしていた:
1. `handlePaneContextMenu` が `e.stopPropagation()` を呼んでいなかった (`handleNodeContextMenu` は呼んでいる → node 経路は正常)。
2. `ContextMenu` の outside-click 検知は document の `mousedown` を listen していたため、メニュー mount 直後に「同じ右クリックの mousedown」が外クリック誤検出される。

修正 (defense-in-depth):
- `handlePaneContextMenu` に `e.stopPropagation()` を追加。
- ContextMenu の outside-click を `mousedown` から `click` (mouseup 完了後の合成イベント) に切替。メニューを開く右クリックは `click` を発火しないため、原理的に「自分を外クリック扱い」しなくなる。Escape / Tab / 矢印キーの WAI-ARIA navigation は引き続き `keydown` で処理。

## Commits
1. `fix(canvas): #613 gate Canvas keybindings on viewMode='canvas' to release IDE shortcuts`
2. `fix(canvas): #616 #593 stop propagation + click-based outside detection for context menu`

## Test plan
- [x] `npm run typecheck` pass
- [x] `npx vitest run` pass (57 file / 366 test、+12 件追加)
- [x] `npx vite build` pass (renderer 本番ビルド)
- [x] keybindings test 7 件: enabled=false で handler 不発火 / Ctrl+Shift+I 解放 / Ctrl+Shift+N 10 連打で 0 callback / enabled の rerender 切替 / modifier 完全一致
- [x] ContextMenu test 5 件: mousedown だけでは close しない (race fix の核心) / document.click で close / menu item click で action+close 1 回のみ / Escape & Tab で close
- [ ] (実機) IDE モードで Ctrl+Shift+I で DevTools が開く / Ctrl+Shift+N 連打しても Canvas に空 agent カードが増えない / Canvas Pane 右クリックでメニューが安定 open + 左クリック / Esc で close、node 上の右クリックも従来通り動作

## 関連 Issue
- Closes #613
- Closes #616
- Closes #593