### PR TITLE
fix(security): #608 atomic_write に mode 引数を追加し機密ファイルを 0o600 強制

### DIFF
--- a/src-tauri/src/commands/atomic_write.rs
+++ b/src-tauri/src/commands/atomic_write.rs
@@ -7,6 +7,11 @@
 //
 // 対策: `<target>.tmp.<pid>.<rand>` に書き、fsync して rename で atomic 置換する。
 // POSIX も Windows も rename は same-volume なら atomic (Windows は MoveFileEx + REPLACE_EXISTING)。
+//
+// Issue #608 (Security): `~/.claude.json` / `~/.codex/config.toml` / role-profiles 等の
+// 機密ファイルは 0o600 を強制したい。temp ファイル作成時の OpenOptions::mode + rename 後の
+// set_permissions の二段で defense-in-depth に umask 漏れを潰す (Unix のみ effective、
+// Windows は no-op で fallback。Windows ACL 強制は別 issue で対応)。
 
 use anyhow::{anyhow, Result};
 use std::path::{Path, PathBuf};
@@ -14,7 +19,25 @@ use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
 /// 指定 path にバイト列を atomic に書き込む。親ディレクトリは自動作成。
+/// mode は OS デフォルト (umask 反映) — 0o600 等を強制したいケースは
+/// [`atomic_write_with_mode`] を使う。
 pub async fn atomic_write(target: &Path, bytes: &[u8]) -> Result<()> {
+    atomic_write_with_mode(target, bytes, None).await
+}
+
+/// 指定 path にバイト列を atomic に書き込む。`mode` を `Some(m)` で渡すと
+/// Unix では (1) tmp ファイル作成時に `OpenOptions::mode(m)` で開き、
+/// (2) rename 後にも `set_permissions(m)` で defense-in-depth な再設定を行う。
+/// Windows では mode は無視 (no-op) — Windows ACL 強制は別 issue 案件。
+///
+/// `mode = None` は OS デフォルト動作 (= [`atomic_write`] と等価) を意味する。
+pub async fn atomic_write_with_mode(
+    target: &Path,
+    bytes: &[u8],
+    // Windows では mode 引数は no-op なので unused variable 警告が出る。
+    // unix / non-unix で同じシグネチャを公開したいので cfg_attr で抑制。
+    #[cfg_attr(not(unix), allow(unused_variables))] mode: Option<u32>,
+) -> Result<()> {
     if let Some(parent) = target.parent() {
         fs::create_dir_all(parent).await?;
     }
@@ -52,6 +75,11 @@ pub async fn atomic_write(target: &Path, bytes: &[u8]) -> Result<()> {
             opts.custom_flags(0x20000); // O_NOFOLLOW (Linux)
             #[cfg(target_os = "macos")]
             opts.custom_flags(0x0100); // O_NOFOLLOW (macOS / BSD)
+            // Issue #608: tmp ファイル作成時点で mode を反映 (umask の影響を受けない)。
+            // mode=None のときは OpenOptions::mode を呼ばず、従来通り OS デフォルトに任せる。
+            if let Some(m) = mode {
+                opts.mode(m);
+            }
         }
         let mut f = match opts.open(&tmp).await {
             Ok(f) => f,
@@ -72,6 +100,25 @@ pub async fn atomic_write(target: &Path, bytes: &[u8]) -> Result<()> {
         let _ = fs::remove_file(&tmp).await;
         return Err(e.into());
     }
+
+    // Issue #608 (Security): defense-in-depth — rename 後にも明示的に set_permissions。
+    // OpenOptions::mode は umask の AND を取るため、`umask 0o077` のような厳しい設定環境では
+    // 期待値より絞られるだけだが、逆に caller が rename で既存 0o644 ファイルを上書きする
+    // ケースで「temp の 0o600 が target に引き継がれない」OS 実装も存在する (POSIX 仕様外動作)。
+    // 安全側に倒すため set_permissions で確実に設定する。
+    // permissions 設定の失敗は致命的ではない (ファイル本体は書けている) ので tracing で警告のみ。
+    #[cfg(unix)]
+    if let Some(m) = mode {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) = fs::set_permissions(target, std::fs::Permissions::from_mode(m)).await {
+            tracing::warn!(
+                "[atomic_write] set_permissions({:o}) failed for {}: {e}",
+                m,
+                target.display()
+            );
+        }
+    }
+
     Ok(())
 }
 
@@ -101,5 +148,71 @@ mod tests {
         let got = fs::read(&target).await.unwrap();
         assert_eq!(&got, b"v2");
         let _ = fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn atomic_write_with_mode_none_behaves_like_atomic_write() {
+        // mode=None は atomic_write と等価 (file は書けるが mode 強制は行わない)
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("plain.json");
+        atomic_write_with_mode(&target, b"v1", None).await.unwrap();
+        let got = fs::read(&target).await.unwrap();
+        assert_eq!(&got, b"v1");
+    }
+
+    /// Issue #608: Unix で mode=Some(0o600) を指定したとき、書き込まれた target の
+    /// permissions が 0o600 (= rw-------) で揃っていることを検証。
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn atomic_write_with_mode_enforces_0o600_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("secret.json");
+        atomic_write_with_mode(&target, b"sensitive", Some(0o600))
+            .await
+            .unwrap();
+        let meta = std::fs::metadata(&target).unwrap();
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "target should be enforced to 0o600 (got {mode:o})");
+    }
+
+    /// Issue #608: rename 上書きでも mode が 0o600 に再設定されること。
+    /// (元ファイルが 0o644 で先に存在していたケースの defense-in-depth 検証)
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn atomic_write_with_mode_re_tightens_permissions_on_overwrite() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("secret.json");
+        // 先に 0o644 で書いておく
+        fs::write(&target, b"old").await.unwrap();
+        fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644))
+            .await
+            .unwrap();
+        // 0o600 を強制して上書き
+        atomic_write_with_mode(&target, b"new", Some(0o600))
+            .await
+            .unwrap();
+        let meta = std::fs::metadata(&target).unwrap();
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "rename overwrite should re-tighten target to 0o600 (got {mode:o})"
+        );
+        let got = fs::read(&target).await.unwrap();
+        assert_eq!(&got, b"new");
+    }
+
+    /// Windows では mode 引数は no-op (失敗しないこと、内容が書けること) を確認。
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn atomic_write_with_mode_is_noop_on_windows() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("secret.json");
+        atomic_write_with_mode(&target, b"sensitive", Some(0o600))
+            .await
+            .unwrap();
+        let got = fs::read(&target).await.unwrap();
+        assert_eq!(&got, b"sensitive");
     }
 }

--- a/src-tauri/src/commands/handoffs.rs
+++ b/src-tauri/src/commands/handoffs.rs
@@ -265,12 +265,15 @@ async fn write_handoff(
     md_path: &Path,
 ) -> crate::commands::error::CommandResult<()> {
     let json = serde_json::to_vec_pretty(handoff).map_err(|e| e.to_string())?;
-    crate::commands::atomic_write::atomic_write(json_path, &json)
+    // Issue #608 (Security): handoff body には引き継ぎ context (file path / 内部メモ等)
+    // が含まれるため 0o600 で永続化。restrict_private_file() の二重 set は冗長だが、
+    // atomic_write_with_mode が umask 等で失敗してもリカバリできるよう defense-in-depth。
+    crate::commands::atomic_write::atomic_write_with_mode(json_path, &json, Some(0o600))
         .await
         .map_err(|e| e.to_string())?;
     restrict_private_file(json_path)?;
     let markdown = render_markdown(handoff);
-    crate::commands::atomic_write::atomic_write(md_path, markdown.as_bytes())
+    crate::commands::atomic_write::atomic_write_with_mode(md_path, markdown.as_bytes(), Some(0o600))
         .await
         .map_err(|e| e.to_string())?;
     restrict_private_file(md_path)

--- a/src-tauri/src/commands/role_profiles.rs
+++ b/src-tauri/src/commands/role_profiles.rs
@@ -3,7 +3,7 @@
 // ~/.vibe-editor/role-profiles.json (RoleProfilesFile) の load / save。
 // 形式の検証は renderer 側の TS で行う想定なので、ここでは raw JSON を扱うだけ。
 
-use crate::commands::atomic_write::atomic_write;
+use crate::commands::atomic_write::atomic_write_with_mode;
 use once_cell::sync::Lazy;
 use serde_json::Value;
 use tokio::fs;
@@ -27,7 +27,9 @@ pub async fn role_profiles_load() -> Value {
                 e
             );
             let bak = path.with_extension("json.bak");
-            let _ = atomic_write(&bak, &bytes).await;
+            // Issue #608 (Security): role profile instructions は injection-prone な
+            // ユーザー定義 prompt を含むため、バックアップも 0o600 で書く。
+            let _ = atomic_write_with_mode(&bak, &bytes, Some(0o600)).await;
             Value::Null
         }
     }
@@ -41,7 +43,8 @@ pub async fn role_profiles_save(file: Value) -> crate::commands::error::CommandR
         let _ = fs::create_dir_all(dir).await;
     }
     let json = serde_json::to_vec_pretty(&file).map_err(|e| e.to_string())?;
-    Ok(atomic_write(&path, &json)
+    // Issue #608 (Security): instructions が機密扱いなので 0o600 で永続化。
+    Ok(atomic_write_with_mode(&path, &json, Some(0o600))
         .await
         .map_err(|e| e.to_string())?)
 }

--- a/src-tauri/src/commands/team_history.rs
+++ b/src-tauri/src/commands/team_history.rs
@@ -148,9 +148,13 @@ async fn save_all(entries: &[TeamHistoryEntry]) -> crate::commands::error::Comma
     let path = store_path();
     let json = serde_json::to_vec_pretty(entries).map_err(|e| e.to_string())?;
     // Issue #37: クラッシュ耐性のため atomic write を使う
-    Ok(crate::commands::atomic_write::atomic_write(&path, &json)
-        .await
-        .map_err(|e| e.to_string())?)
+    // Issue #608 (Security): team-history.json は project_root / agent_id / session_id を
+    // 含み、外部から読まれると過去の作業範囲を推定されうるため 0o600 で永続化。
+    Ok(
+        crate::commands::atomic_write::atomic_write_with_mode(&path, &json, Some(0o600))
+            .await
+            .map_err(|e| e.to_string())?,
+    )
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/team_presets.rs
+++ b/src-tauri/src/commands/team_presets.rs
@@ -208,7 +208,9 @@ pub async fn team_presets_save(mut preset: TeamPreset) -> PresetMutationResult {
             }
         }
     };
-    match crate::commands::atomic_write::atomic_write(&path, &json).await {
+    // Issue #608 (Security): preset の roles[].custom_instructions は injection-prone な
+    // ユーザー定義 prompt を含み得るため 0o600 で永続化。
+    match crate::commands::atomic_write::atomic_write_with_mode(&path, &json, Some(0o600)).await {
         Ok(_) => PresetMutationResult {
             ok: true,
             preset: Some(preset),

--- a/src-tauri/src/mcp_config/claude.rs
+++ b/src-tauri/src/mcp_config/claude.rs
@@ -42,7 +42,8 @@ pub(crate) async fn setup_at(path: &Path, desired: &Value) -> Result<bool> {
     servers_obj.insert(ENTRY.into(), desired.clone());
     let json = serde_json::to_vec_pretty(&config)?;
     // Issue #37: ~/.claude.json は他アプリとも共有。半端書き込みで全消失するのを避けるため atomic に。
-    crate::commands::atomic_write::atomic_write(path, &json).await?;
+    // Issue #608 (Security): API token 等を含むため 0o600 を強制 (Unix のみ effective)。
+crate::commands::atomic_write::atomic_write_with_mode(path, &json, Some(0o600)).await?;
     Ok(true)
 }
 
@@ -60,7 +61,9 @@ pub(crate) async fn snapshot_at(path: &Path) -> Result<Option<Vec<u8>>> {
 pub(crate) async fn restore_at(path: &Path, snap: Option<Vec<u8>>) -> Result<()> {
     match snap {
         Some(bytes) => {
-            crate::commands::atomic_write::atomic_write(path, &bytes).await?;
+            // Issue #608 (Security): rollback 経路でも 0o600 を維持。
+            crate::commands::atomic_write::atomic_write_with_mode(path, &bytes, Some(0o600))
+                .await?;
         }
         None => {
             // 元々ファイルが無かった場合は削除して原状回復
@@ -88,7 +91,8 @@ pub(crate) async fn cleanup_at(path: &Path) -> Result<bool> {
         // Issue #108: setup と同じく cleanup も atomic_write を使う。
         // 直接 fs::write で上書きすると、書き込み中のクラッシュで `~/.claude.json` が
         // 空 / 半端な状態で残り、Claude Code 全体の設定が失われる事故になる。
-        crate::commands::atomic_write::atomic_write(path, &json).await?;
+        // Issue #608 (Security): API token 等を含むため 0o600 を強制 (Unix のみ effective)。
+crate::commands::atomic_write::atomic_write_with_mode(path, &json, Some(0o600)).await?;
     }
     Ok(removed)
 }

--- a/src-tauri/src/mcp_config/codex.rs
+++ b/src-tauri/src/mcp_config/codex.rs
@@ -74,8 +74,9 @@ pub(crate) async fn setup_at(path: &Path, bridge_path: &str) -> Result<()> {
         "\n[{SECTION}]\ncommand = \"node\"\nargs = [\"{escaped}\"]\nenv_vars = [\"VIBE_TEAM_ID\", \"VIBE_TEAM_ROLE\", \"VIBE_AGENT_ID\", \"VIBE_TEAM_SOCKET\", \"VIBE_TEAM_TOKEN\"]\n",
     );
     // Issue #37: ~/.codex/config.toml も他アプリと共有なので atomic に上書き
+    // Issue #608 (Security): codex の MCP 接続情報も機密。0o600 を強制 (Unix のみ effective)。
     let data = (content + &section).into_bytes();
-    crate::commands::atomic_write::atomic_write(path, &data).await?;
+    crate::commands::atomic_write::atomic_write_with_mode(path, &data, Some(0o600)).await?;
     Ok(())
 }
 
@@ -86,7 +87,9 @@ pub(crate) async fn cleanup_at(path: &Path) -> Result<()> {
     let stripped = remove_toml_section(&content, SECTION);
     let stripped = remove_toml_section(&stripped, LEGACY_SECTION);
     let cleaned = format!("{}\n", stripped.trim_end());
-    crate::commands::atomic_write::atomic_write(path, cleaned.as_bytes()).await?;
+    // Issue #608: cleanup でも 0o600 を維持。
+    crate::commands::atomic_write::atomic_write_with_mode(path, cleaned.as_bytes(), Some(0o600))
+        .await?;
     Ok(())
 }
 
@@ -105,7 +108,9 @@ pub(crate) async fn snapshot_at(path: &Path) -> Result<Option<Vec<u8>>> {
 pub(crate) async fn restore_at(path: &Path, snap: Option<Vec<u8>>) -> Result<()> {
     match snap {
         Some(bytes) => {
-            crate::commands::atomic_write::atomic_write(path, &bytes).await?;
+            // Issue #608 (Security): rollback 経路でも 0o600 を維持。
+            crate::commands::atomic_write::atomic_write_with_mode(path, &bytes, Some(0o600))
+                .await?;
         }
         None => {
             // 元々ファイルが無かった場合は削除して原状回復。


### PR DESCRIPTION
Closes #608

## Summary
- Unix で `atomic_write` の temp → rename は temp の mode を引き継ぐため、`~/.claude.json` (Claude API トークン) / `~/.codex/config.toml` (MCP 接続情報) 等の機密ファイルが OS デフォルト (typically 0o644) で残り、同 user 配下の他プロセスから読み出せる **privacy / token leak リスク** があった
- 既存 `atomic_write(path, bytes)` の signature を保ったまま、新規 `atomic_write_with_mode(path, bytes, mode: Option<u32>)` を追加
- Unix: tmp ファイル作成時 `OpenOptions::mode(m)` + rename 後 `set_permissions(m)` の **二段 defense-in-depth** (POSIX 仕様外動作 / umask 漏れの両方を潰す)
- Windows: mode 引数は no-op (`#[cfg(unix)]` ガード)、ACL 強制は別 issue (TODO コメント)

## 主な変更
- `src-tauri/src/commands/atomic_write.rs` — 新規 `atomic_write_with_mode` 追加。既存 `atomic_write` は内部で `atomic_write_with_mode(target, bytes, None)` に委譲するシンプルな wrapper に
- `src-tauri/src/mcp_config/{claude,codex}.rs` — `setup_at` / `cleanup_at` / `restore_at` の全書き込み経路で `Some(0o600)` を渡す
- `src-tauri/src/commands/role_profiles.rs` — 本体 + `.bak` の双方を `Some(0o600)` 経由に
- `src-tauri/src/commands/team_history.rs` — `Some(0o600)` (project_root / agent_id / session_id を含むため)
- `src-tauri/src/commands/team_presets.rs` — `Some(0o600)` (roles[].custom_instructions を含むため)
- `src-tauri/src/commands/handoffs.rs` — JSON / Markdown 両方を `Some(0o600)` 経由に (既存 `restrict_private_file` は defense-in-depth として残す)

## スコープ外 (本 PR では触らず)
- `settings.rs` — pty_specialist が他 task で保持中。同一 task の release 後に同 PR に追加 commit、または別 PR で対応
- `files.rs` / `team_state.rs` / `vibe_team_skill.rs` — 機密度が低いため対象外 (Tier D #645 roadmap で別途検討)

## Test plan
- [x] `cargo check --tests` (新規 warning 0、既存 warning のみ)
- [x] `cargo test --lib` 全 387 件 pass (新規 4 件含む)
- [x] `tsc --noEmit` 通過
- [x] テスト coverage:
  - `atomic_write_with_mode_none_behaves_like_atomic_write` — mode=None で従来挙動
  - `atomic_write_with_mode_enforces_0o600_on_unix` (Unix) — 新規ファイルで 0o600 が enforce される
  - `atomic_write_with_mode_re_tightens_permissions_on_overwrite` (Unix) — 0o644 既存ファイル上書きで 0o600 に再緊縮される (defense-in-depth)
  - `atomic_write_with_mode_is_noop_on_windows` (Windows) — mode 引数が no-op として動作する