### PR TITLE
fix(pty): #618 Windows ConPTY 起動時に UTF-8 codepage を強制 (CP932 化対策)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -102,6 +102,11 @@ pub struct Settings {
     pub file_tree_expanded: Option<HashMap<String, Vec<String>>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub file_tree_collapsed_roots: Option<Vec<String>>,
+    /// Issue #618: Windows ConPTY で cmd.exe / PowerShell を起動する際に、初期コマンドとして
+    /// `chcp 65001` 等を inject して console output を UTF-8 へ強制するか (default true)。
+    /// 既存ユーザーは renderer 側 v10→v11 migration で `true` が入る。
+    #[serde(default = "default_terminal_force_utf8")]
+    pub terminal_force_utf8: bool,
 }
 
 /// shared.ts `AgentConfig` を mirror。`cwd` / `color` は optional。
@@ -151,16 +156,22 @@ impl Default for Settings {
             webview_zoom: None,
             file_tree_expanded: Some(HashMap::new()),
             file_tree_collapsed_roots: Some(Vec::new()),
+            terminal_force_utf8: default_terminal_force_utf8(),
         }
     }
+}
+
+/// Issue #618: Windows ConPTY + cmd.exe / PowerShell の出力 UTF-8 強制 (default true)。
+fn default_terminal_force_utf8() -> bool {
+    true
 }
 
 // ---- per-field defaults (`#[serde(default = "...")]` から参照) ----
 //
 // renderer 側 `DEFAULT_SETTINGS` と完全一致させる。新フィールド追加時は両方を同時に更新する。
 
-/// Issue #75 / #449: 現在のスキーマ版数。`shared.ts APP_SETTINGS_SCHEMA_VERSION` と同期。
-pub const APP_SETTINGS_SCHEMA_VERSION: u32 = 10;
+/// Issue #75 / #449 / #618: 現在のスキーマ版数。`shared.ts APP_SETTINGS_SCHEMA_VERSION` と同期。
+pub const APP_SETTINGS_SCHEMA_VERSION: u32 = 11;
 
 fn default_language() -> String {
     "ja".to_string()
@@ -283,8 +294,37 @@ mod tests {
         assert_eq!(v["sidebarWidth"], json!(272.0));
         assert_eq!(v["mcpAutoSetup"], json!(true));
         assert_eq!(v["hasCompletedOnboarding"], json!(false));
+        // Issue #618: Windows ConPTY UTF-8 強制 (default true)
+        assert_eq!(v["terminalForceUtf8"], json!(true));
         // webviewZoom は None なので skip_serializing
         assert!(v.get("webviewZoom").is_none());
+    }
+
+    /// Issue #618: 旧 settings.json (terminalForceUtf8 フィールドなし) を load しても、
+    /// `#[serde(default = "default_terminal_force_utf8")]` で `true` が入る。
+    #[test]
+    fn legacy_settings_without_terminal_force_utf8_default_to_true() {
+        let raw = json!({
+            "schemaVersion": 10,
+            "language": "ja",
+            "theme": "claude-dark",
+            // terminalForceUtf8 を意図的に省略
+        });
+        let s: Settings = serde_json::from_value(raw).unwrap();
+        assert!(s.terminal_force_utf8, "expected default true");
+    }
+
+    /// Issue #618: `terminalForceUtf8: false` を保存しているユーザー値はそのまま load される。
+    #[test]
+    fn explicit_false_terminal_force_utf8_is_preserved() {
+        let raw = json!({
+            "schemaVersion": 11,
+            "language": "ja",
+            "theme": "claude-dark",
+            "terminalForceUtf8": false,
+        });
+        let s: Settings = serde_json::from_value(raw).unwrap();
+        assert!(!s.terminal_force_utf8);
     }
 
     /// Issue #170 互換: 部分的な JSON でも `serde(default)` で field 単位 fallback が効く。

--- a/src-tauri/src/commands/terminal/command_validation.rs
+++ b/src-tauri/src/commands/terminal/command_validation.rs
@@ -101,6 +101,47 @@ pub fn normalize_terminal_command(
     (cmd, parts)
 }
 
+/// Issue #618: `~/.vibe-editor/settings.json` から `terminalForceUtf8` を読み出す。
+/// settings.json が無い / parse 失敗 / フィールド未定義のいずれの場合も `true` (default) を返す。
+/// `terminal_create` 経路から spawn 直前にだけ呼ぶ想定 (1 spawn = 1 file read のオーバーヘッドのみ)。
+pub fn settings_terminal_force_utf8() -> bool {
+    let path = crate::util::config_paths::settings_path();
+    let Ok(bytes) = std::fs::read(path) else {
+        return true;
+    };
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return true;
+    };
+    value
+        .get("terminalForceUtf8")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)
+}
+
+/// Issue #618: Windows ConPTY で起動するシェルが UTF-8 になるよう、最初に PTY 入力ストリームへ
+/// 流す初期コマンドを返す (バイト列 + `\r` 終端で「Enter 押下」相当の確定送信になる)。
+///
+/// - cmd.exe (`cmd` / `cmd.exe`): `chcp 65001 > nul\r`
+///   `> nul` で active code page 切替の echo を抑止する (banner 直後の余分な行を avoid)。
+/// - PowerShell (`pwsh` / `powershell`): `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); chcp 65001 > $null\r`
+///   PowerShell は `[Console]::OutputEncoding` を別途 UTF-8 にしないと .NET 出力 (Write-Host 等) が
+///   UTF-8 にならないので、`chcp` と同時に設定する。
+/// - その他 (bash / sh / zsh / fish / nu / claude / codex / 解決前の任意 path): `None`
+///   modern な POSIX シェルや WSL は既定で UTF-8。Claude / Codex CLI は ConPTY 経由でも文字列
+///   出力を内部で UTF-8 で書き出す (chcp inject すると CLI 側の prompt が壊れる懸念がある)。
+///
+/// 非 Windows OS ではそもそも CP932 問題が無いので、呼び出し側で `cfg!(windows)` でガードする想定。
+pub fn windows_utf8_init_command(command: &str) -> Option<&'static [u8]> {
+    let basename = command_basename(command);
+    match basename.as_str() {
+        "cmd" => Some(b"chcp 65001 > nul\r"),
+        "powershell" | "pwsh" => Some(
+            b"[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); chcp 65001 > $null\r",
+        ),
+        _ => None,
+    }
+}
+
 pub fn configured_terminal_commands() -> HashSet<String> {
     let mut out = HashSet::new();
     let path = crate::util::config_paths::settings_path();
@@ -342,6 +383,85 @@ mod resume_session_id_validation_tests {
     fn rejects_non_ascii() {
         assert!(!is_valid_resume_session_id("セッション-12345"));
         assert!(!is_valid_resume_session_id("café-session-id"));
+    }
+}
+
+#[cfg(test)]
+mod windows_utf8_init_command_tests {
+    use super::windows_utf8_init_command;
+
+    #[test]
+    fn cmd_returns_chcp_only() {
+        let init = windows_utf8_init_command("cmd").expect("cmd should have init");
+        assert_eq!(init, b"chcp 65001 > nul\r");
+    }
+
+    #[test]
+    fn cmd_exe_path_returns_chcp() {
+        let init = windows_utf8_init_command(r"C:\Windows\System32\cmd.exe").expect("cmd.exe");
+        assert_eq!(init, b"chcp 65001 > nul\r");
+    }
+
+    #[test]
+    fn cmd_uppercase_returns_chcp() {
+        let init = windows_utf8_init_command("CMD.EXE").expect("CMD.EXE");
+        assert_eq!(init, b"chcp 65001 > nul\r");
+    }
+
+    #[test]
+    fn powershell_returns_combined_init() {
+        let init = windows_utf8_init_command("powershell").expect("powershell");
+        let s = std::str::from_utf8(init).unwrap();
+        assert!(s.starts_with("[Console]::OutputEncoding ="));
+        assert!(s.contains("UTF8Encoding"));
+        assert!(s.contains("chcp 65001"));
+        assert!(s.contains("> $null"));
+        assert!(s.ends_with("\r"));
+    }
+
+    #[test]
+    fn pwsh_returns_combined_init() {
+        let init = windows_utf8_init_command("pwsh").expect("pwsh");
+        let s = std::str::from_utf8(init).unwrap();
+        assert!(s.contains("[Console]::OutputEncoding"));
+        assert!(s.contains("chcp 65001"));
+    }
+
+    #[test]
+    fn pwsh_full_path_returns_init() {
+        let init =
+            windows_utf8_init_command(r"C:\Program Files\PowerShell\7\pwsh.exe").expect("pwsh.exe");
+        let s = std::str::from_utf8(init).unwrap();
+        assert!(s.contains("[Console]::OutputEncoding"));
+    }
+
+    #[test]
+    fn bash_returns_none() {
+        assert!(windows_utf8_init_command("bash").is_none());
+        assert!(windows_utf8_init_command("/usr/bin/bash").is_none());
+    }
+
+    #[test]
+    fn other_posix_shells_return_none() {
+        assert!(windows_utf8_init_command("sh").is_none());
+        assert!(windows_utf8_init_command("zsh").is_none());
+        assert!(windows_utf8_init_command("fish").is_none());
+        assert!(windows_utf8_init_command("nu").is_none());
+    }
+
+    #[test]
+    fn claude_and_codex_return_none() {
+        // Claude / Codex は内部で UTF-8 出力する CLI なので chcp inject しない。
+        // CLI の prompt / banner と衝突する懸念の方が大きい。
+        assert!(windows_utf8_init_command("claude").is_none());
+        assert!(windows_utf8_init_command("codex").is_none());
+        assert!(windows_utf8_init_command(r"C:\tools\codex.exe").is_none());
+    }
+
+    #[test]
+    fn empty_or_unknown_returns_none() {
+        assert!(windows_utf8_init_command("").is_none());
+        assert!(windows_utf8_init_command("nonexistent-shell").is_none());
     }
 }
 

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -1028,7 +1028,33 @@ pub fn spawn_session(
 
     // reader thread (blocking IO -> mpsc)
     let mut reader = pair.master.try_clone_reader()?;
-    let writer = pair.master.take_writer()?;
+    let mut writer = pair.master.take_writer()?;
+
+    // Issue #618: Windows ConPTY で cmd.exe / PowerShell を起動する場合、最初に
+    // `chcp 65001` 等を inject してシェル出力を UTF-8 に強制する。これをしないと
+    // 既定の OEM コードページ (CP932 / ja-JP) で動くシェルが書き出すバイト列を
+    // batcher が `String::from_utf8_lossy` でそのまま UTF-8 として解釈してしまい、
+    // `dir` の漢字ファイル名 / `python -c "print('日本語')"` の出力が全 U+FFFD に
+    // 化ける (`#120` で files 経路に入れた CP932 デコードは PTY には届いていない)。
+    //
+    // inject 失敗は致命的ではない (子プロセス側の stdin が EOF / 既に閉じている等):
+    // tracing::warn! でログだけ残して spawn は続行する。
+    if cfg!(windows) {
+        let force_utf8 = command_validation::settings_terminal_force_utf8();
+        match maybe_inject_windows_utf8_init(&mut *writer, &opts.command, force_utf8) {
+            Ok(Some(injected)) => tracing::info!(
+                "[pty] Windows UTF-8 init command injected (command={}, len={})",
+                opts.command,
+                injected.len()
+            ),
+            Ok(None) => {} // not applicable / disabled — no-op
+            Err(e) => tracing::warn!(
+                "[pty] Windows UTF-8 init command write failed (command={}): {}",
+                opts.command,
+                e
+            ),
+        }
+    }
 
     let data_event = format!("terminal:data:{id}");
     let exit_event = format!("terminal:exit:{id}");
@@ -1152,4 +1178,277 @@ pub fn spawn_session(
         }),
         scrollback,
     })
+}
+
+/// Issue #618: Windows ConPTY 起動直後に shell の出力 codepage を UTF-8 に強制する初期コマンドを
+/// `writer` (PTY master) に流すヘルパー。`force_utf8` が false、対象シェルが cmd / pwsh /
+/// powershell でないとき、または `command_validation::windows_utf8_init_command` が None を
+/// 返すとき (= bash / sh / nu / claude / codex / 不明シェル) は no-op で `Ok(None)`。
+///
+/// 戻り値は inject されたバイト列の参照 (test 用、failure path と区別するため `Result<Option>`):
+///   - `Ok(Some(bytes))`: bytes が writer に書き込まれた
+///   - `Ok(None)`: no-op (force_utf8=false / 対象外シェル)
+///   - `Err(io::Error)`: writer.write_all / writer.flush 失敗
+///
+/// platform check (`cfg!(windows)`) は呼び出し側で行う想定。本関数自体は platform-agnostic で
+/// テスト時も統一的に動く (Linux CI でも `cmd` を渡せば bytes を返す)。
+fn maybe_inject_windows_utf8_init(
+    writer: &mut dyn Write,
+    command: &str,
+    force_utf8: bool,
+) -> std::io::Result<Option<&'static [u8]>> {
+    if !force_utf8 {
+        return Ok(None);
+    }
+    let Some(init) = command_validation::windows_utf8_init_command(command) else {
+        return Ok(None);
+    };
+    writer.write_all(init)?;
+    writer.flush()?;
+    Ok(Some(init))
+}
+
+/// Issue #618: Windows + cmd.exe で `chcp 65001` 後に `dir` が漢字ファイル名を UTF-8 で
+/// 吐くことを実機で確認する integration test。
+///
+/// **重要**: `cmd.exe /D /Q /C "chcp 65001 && dir"` のような 1 ショット混合では、cmd.exe が
+/// `/C` 起動時に固定した OEM codepage を内部 `dir` に引き継いでしまうため UTF-8 化されない。
+/// 一方、本 PR の prod 経路 (spawn_session 内で writer.write_all による inject) は対話的な
+/// cmd.exe に対し独立したコマンドとして `chcp 65001\r` → ユーザの `dir\r` を流すため正しく
+/// 切り替わる。本 test では同じセマンティクス (= stdin パイプで chcp と dir を順番に流す)
+/// を `std::process::Command` の piped stdin で再現して検証する。
+///
+/// CI では走らせず (`#[ignore]`)、ローカル Windows 環境で
+/// `cargo test ... -- --ignored issue_618` で実行する想定。
+#[cfg(test)]
+#[cfg(windows)]
+mod windows_utf8_e2e_tests {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    /// chcp + dir を **別々のコマンド** として cmd.exe にパイプで流す。これは prod 経路の
+    /// PTY writer による sequential inject と同じセマンティクス。
+    #[test]
+    #[ignore = "requires Windows + cmd.exe; run manually via -- --ignored"]
+    fn issue_618_dir_displays_japanese() {
+        // 1) 一時ディレクトリ + 漢字ファイル
+        let tmp = std::env::temp_dir().join(format!("vibe-issue-618-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).expect("mkdir tmp");
+        let jp_file = tmp.join("テスト_漢字_618.txt");
+        std::fs::write(&jp_file, b"hello").expect("write jp file");
+
+        // 2) cmd.exe /D /Q を起動し、stdin に chcp + dir + exit を順番に流す
+        let mut child = Command::new("cmd.exe")
+            .args(["/D", "/Q"])
+            .current_dir(&tmp)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn cmd.exe failed (PATH に cmd.exe が無い?)");
+
+        // stdin 経由で sequential 入力。これが prod の PTY writer 経由 inject と等価。
+        {
+            let stdin = child.stdin.as_mut().expect("stdin");
+            // prod 経路と同じバイト列を流す (chcp 65001 > nul + dir + exit)
+            stdin.write_all(b"chcp 65001 > nul\r\n").expect("write chcp");
+            stdin.write_all(b"dir\r\n").expect("write dir");
+            stdin.write_all(b"exit\r\n").expect("write exit");
+            stdin.flush().expect("flush stdin");
+        }
+
+        let output = child.wait_with_output().expect("wait child");
+        let stdout_lossy = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr_lossy = String::from_utf8_lossy(&output.stderr).to_string();
+        eprintln!(
+            "[issue-618 e2e] exit={:?} stdout={} bytes\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            output.status.code(),
+            output.stdout.len(),
+            stdout_lossy,
+            stderr_lossy
+        );
+
+        // 3) lossy UTF-8 decode しても U+FFFD で化けず、漢字ファイル名がそのまま含まれること
+        assert!(output.status.success(), "cmd.exe exited non-zero");
+        assert!(!output.stdout.is_empty(), "expected non-empty dir output");
+        assert!(
+            !stdout_lossy.contains("\u{FFFD}_618.txt"),
+            "expected Japanese filename in UTF-8 (no U+FFFD before _618.txt), got:\n{stdout_lossy}"
+        );
+        assert!(
+            stdout_lossy.contains("テスト_漢字_618.txt"),
+            "expected exact Japanese filename in UTF-8 dir output, got:\n{stdout_lossy}"
+        );
+
+        // cleanup
+        let _ = std::fs::remove_file(&jp_file);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    /// 対比用: chcp 65001 を入れず、素の cmd.exe で `dir` を流すと CP932 で書かれ、
+    /// `String::from_utf8_lossy` で漢字が U+FFFD に化けることを示す。
+    /// host が既に UTF-8 codepage の場合 (例: chcp 65001 が host グローバルに効いている / ja 以外
+    /// の locale) はこの baseline が成立しないので、その時は assertion をスキップして pass させる。
+    #[test]
+    #[ignore = "requires Windows + cmd.exe (CP932 default); run manually via -- --ignored"]
+    fn issue_618_baseline_without_chcp_corrupts_japanese() {
+        let tmp = std::env::temp_dir().join(format!("vibe-issue-618-base-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).expect("mkdir tmp");
+        let jp_file = tmp.join("テスト_漢字_618.txt");
+        std::fs::write(&jp_file, b"hello").expect("write jp file");
+
+        // chcp なしで dir
+        let mut child = Command::new("cmd.exe")
+            .args(["/D", "/Q"])
+            .current_dir(&tmp)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn cmd.exe failed");
+        {
+            let stdin = child.stdin.as_mut().expect("stdin");
+            stdin.write_all(b"dir\r\n").expect("write dir");
+            stdin.write_all(b"exit\r\n").expect("write exit");
+        }
+        let output = child.wait_with_output().expect("wait child");
+        let stdout_lossy = String::from_utf8_lossy(&output.stdout).to_string();
+
+        eprintln!(
+            "[issue-618 e2e baseline] {} bytes, decoded as UTF-8:\n{}",
+            output.stdout.len(),
+            stdout_lossy
+        );
+        assert!(output.status.success());
+        assert!(!output.stdout.is_empty());
+
+        // host の active codepage を確認。932 のときだけ U+FFFD を期待 (= baseline 条件).
+        let active_cp = Command::new("cmd.exe")
+            .args(["/D", "/Q", "/C", "chcp"])
+            .output()
+            .expect("chcp query");
+        let cp_str = String::from_utf8_lossy(&active_cp.stdout).to_string();
+        eprintln!("[issue-618 e2e baseline] active codepage: {}", cp_str.trim());
+        if cp_str.contains("932") {
+            assert!(
+                stdout_lossy.contains("\u{FFFD}"),
+                "on CP932 host expected U+FFFD in lossy-UTF8 decode, got:\n{stdout_lossy}"
+            );
+        }
+
+        let _ = std::fs::remove_file(&jp_file);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+}
+
+#[cfg(test)]
+mod windows_utf8_inject_tests {
+    use super::maybe_inject_windows_utf8_init;
+    use std::io;
+
+    /// 書き込みが必ず失敗する Writer (write_all 試行で error を返す)。
+    /// inject failure path のログを検証するための test double。
+    struct FailingWriter;
+
+    impl io::Write for FailingWriter {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "test EPIPE"))
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn writes_chcp_for_cmd_when_enabled() {
+        let mut buf: Vec<u8> = Vec::new();
+        let res = maybe_inject_windows_utf8_init(&mut buf, "cmd", true).unwrap();
+        assert_eq!(res, Some(&b"chcp 65001 > nul\r"[..]));
+        assert_eq!(buf, b"chcp 65001 > nul\r");
+    }
+
+    #[test]
+    fn writes_chcp_for_cmd_exe_full_path() {
+        let mut buf: Vec<u8> = Vec::new();
+        let res =
+            maybe_inject_windows_utf8_init(&mut buf, r"C:\Windows\System32\cmd.exe", true).unwrap();
+        assert!(res.is_some());
+        assert_eq!(buf, b"chcp 65001 > nul\r");
+    }
+
+    #[test]
+    fn writes_combined_init_for_powershell() {
+        let mut buf: Vec<u8> = Vec::new();
+        let res = maybe_inject_windows_utf8_init(&mut buf, "powershell", true).unwrap();
+        assert!(res.is_some());
+        let s = std::str::from_utf8(&buf).unwrap();
+        assert!(s.contains("[Console]::OutputEncoding"));
+        assert!(s.contains("UTF8Encoding"));
+        assert!(s.contains("chcp 65001"));
+        assert!(s.contains("> $null"));
+        assert!(s.ends_with("\r"));
+    }
+
+    #[test]
+    fn writes_combined_init_for_pwsh() {
+        let mut buf: Vec<u8> = Vec::new();
+        let res = maybe_inject_windows_utf8_init(&mut buf, "pwsh", true).unwrap();
+        assert!(res.is_some());
+        let s = std::str::from_utf8(&buf).unwrap();
+        assert!(s.contains("[Console]::OutputEncoding"));
+    }
+
+    #[test]
+    fn no_op_when_force_utf8_false() {
+        let mut buf: Vec<u8> = Vec::new();
+        let res = maybe_inject_windows_utf8_init(&mut buf, "cmd", false).unwrap();
+        assert!(res.is_none());
+        assert!(buf.is_empty(), "writer should not be touched when disabled");
+    }
+
+    #[test]
+    fn no_op_for_bash() {
+        let mut buf: Vec<u8> = Vec::new();
+        let res = maybe_inject_windows_utf8_init(&mut buf, "bash", true).unwrap();
+        assert!(res.is_none());
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn no_op_for_zsh_fish_nu() {
+        for shell in ["zsh", "fish", "nu", "/usr/bin/zsh"] {
+            let mut buf: Vec<u8> = Vec::new();
+            let res = maybe_inject_windows_utf8_init(&mut buf, shell, true).unwrap();
+            assert!(res.is_none(), "expected no-op for {shell}");
+            assert!(buf.is_empty(), "expected empty buf for {shell}");
+        }
+    }
+
+    #[test]
+    fn no_op_for_claude_and_codex() {
+        // Issue #618: Claude / Codex CLI は内部で UTF-8 出力するので chcp inject すると
+        // CLI 側の prompt / banner と衝突する懸念があるため対象外。
+        for cli in ["claude", "codex", r"C:\tools\codex.exe", "/usr/local/bin/claude"] {
+            let mut buf: Vec<u8> = Vec::new();
+            let res = maybe_inject_windows_utf8_init(&mut buf, cli, true).unwrap();
+            assert!(res.is_none(), "expected no-op for {cli}");
+        }
+    }
+
+    #[test]
+    fn no_op_for_empty_or_unknown_command() {
+        for cmd in ["", "nonexistent-shell"] {
+            let mut buf: Vec<u8> = Vec::new();
+            let res = maybe_inject_windows_utf8_init(&mut buf, cmd, true).unwrap();
+            assert!(res.is_none(), "expected no-op for {:?}", cmd);
+        }
+    }
+
+    #[test]
+    fn propagates_write_error() {
+        let mut writer = FailingWriter;
+        let res = maybe_inject_windows_utf8_init(&mut writer, "cmd", true);
+        assert!(res.is_err(), "writer error should bubble up");
+        assert_eq!(res.unwrap_err().kind(), io::ErrorKind::BrokenPipe);
+    }
 }

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -1214,7 +1214,7 @@ fn maybe_inject_windows_utf8_init(
 /// **重要**: `cmd.exe /D /Q /C "chcp 65001 && dir"` のような 1 ショット混合では、cmd.exe が
 /// `/C` 起動時に固定した OEM codepage を内部 `dir` に引き継いでしまうため UTF-8 化されない。
 /// 一方、本 PR の prod 経路 (spawn_session 内で writer.write_all による inject) は対話的な
-/// cmd.exe に対し独立したコマンドとして `chcp 65001\r` → ユーザの `dir\r` を流すため正しく
+/// cmd.exe に対し独立したコマンドとして `chcp 65001\r` → ユーザーの `dir\r` を流すため正しく
 /// 切り替わる。本 test では同じセマンティクス (= stdin パイプで chcp と dir を順番に流す)
 /// を `std::process::Command` の piped stdin で再現して検証する。
 ///

--- a/src/renderer/src/lib/__tests__/settings-migrate.test.ts
+++ b/src/renderer/src/lib/__tests__/settings-migrate.test.ts
@@ -105,4 +105,64 @@ describe('migrateSettings', () => {
       expect(migrated.codexArgs).toBe('–foo');
     });
   });
+
+  // ---------- Issue #618: v10 → v11 terminalForceUtf8 default ----------
+  describe('v10 → v11 terminalForceUtf8 default (Issue #618)', () => {
+    it('inserts terminalForceUtf8 = true for legacy v10 settings', () => {
+      const migrated = migrateSettings({
+        schemaVersion: 10,
+        language: 'ja',
+        theme: 'claude-dark'
+      });
+
+      expect(migrated.terminalForceUtf8).toBe(true);
+      expect(migrated.schemaVersion).toBe(APP_SETTINGS_SCHEMA_VERSION);
+    });
+
+    it('inserts terminalForceUtf8 = true even for very old v0 settings', () => {
+      // v0 (= schemaVersion 未定義) でも shallow merge 後に true が入ること。
+      const migrated = migrateSettings({
+        language: 'en',
+        theme: 'dark'
+      });
+
+      expect(migrated.terminalForceUtf8).toBe(true);
+    });
+
+    it('preserves an explicit false from the user', () => {
+      // ユーザーが OEM コードページを意図的に維持したくて false を保存しているケース。
+      const migrated = migrateSettings({
+        schemaVersion: 11,
+        language: 'ja',
+        theme: 'claude-dark',
+        terminalForceUtf8: false
+      });
+
+      expect(migrated.terminalForceUtf8).toBe(false);
+    });
+
+    it('preserves an explicit false set on legacy v10 (re-migration)', () => {
+      // v10 のうちに先行で false が書き込まれていたら、v10 → v11 migration はそれを尊重する。
+      const migrated = migrateSettings({
+        schemaVersion: 10,
+        language: 'ja',
+        theme: 'claude-dark',
+        terminalForceUtf8: false
+      });
+
+      expect(migrated.terminalForceUtf8).toBe(false);
+    });
+
+    it('coerces non-boolean values to true (default)', () => {
+      // 型壊れ (string や null) はサポート外なので default に戻す。
+      const migrated = migrateSettings({
+        schemaVersion: 10,
+        language: 'ja',
+        theme: 'claude-dark',
+        terminalForceUtf8: 'yes' as unknown as boolean
+      });
+
+      expect(migrated.terminalForceUtf8).toBe(true);
+    });
+  });
 });

--- a/src/renderer/src/lib/settings-migrate.ts
+++ b/src/renderer/src/lib/settings-migrate.ts
@@ -214,6 +214,16 @@ export function migrateSettings(raw: unknown): AppSettings {
     }
   }
 
+  // --- Version 10 → 11: Windows ConPTY UTF-8 強制フラグの導入 (Issue #618) ---
+  // 旧 settings.json には `terminalForceUtf8` フィールドが存在しないため、`true` (default) で
+  // 在来挙動から切り替える: Windows + cmd.exe / PowerShell 起動時に `chcp 65001` を inject して
+  // CP932 シェルでの U+FFFD 化を防ぐ。ユーザーが既に明示的に false を保存している場合は尊重する。
+  if (version < 11) {
+    if (typeof data.terminalForceUtf8 !== 'boolean') {
+      data.terminalForceUtf8 = true;
+    }
+  }
+
   data.schemaVersion = APP_SETTINGS_SCHEMA_VERSION;
   // 最終マージで欠損フィールドを DEFAULT_SETTINGS で埋める
   return { ...DEFAULT_SETTINGS, ...data } as AppSettings;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -17,9 +17,11 @@ export type StatusMascotVariant = 'vibe' | 'spark' | 'mono';
 /**
  * Issue #75: AppSettings の現在スキーマ。
  * Issue #449 で claudeArgs / codexArgs / customAgents[].args の Unicode dash (U+2013 等)
- * を ASCII '-' に正規化する migration を追加し v10。スキーマ自体のフィールド構成は v9 と同じ。
+ * を ASCII '-' に正規化する migration を追加し v10。
+ * Issue #618 で `terminalForceUtf8` (default true) を追加し v11。Windows + cmd.exe / PowerShell
+ * で起動時に `chcp 65001` を inject して CP932 シェルでの U+FFFD 化を防ぐ。
  */
-export const APP_SETTINGS_SCHEMA_VERSION = 10;
+export const APP_SETTINGS_SCHEMA_VERSION = 11;
 
 /**
  * ユーザーが自由に追加できるエージェントの設定。
@@ -128,6 +130,20 @@ export interface AppSettings {
    * primary は通常展開、ユーザーが手動で折り畳んだものだけここに残る。
    */
   fileTreeCollapsedRoots?: string[];
+  /**
+   * Issue #618: Windows ConPTY で cmd.exe / PowerShell を起動する際に、初期コマンドとして
+   * `chcp 65001` 等を inject して console output を UTF-8 へ強制するか。default true。
+   *
+   * - cmd.exe: `chcp 65001 > nul\r` を流す (CP932 → UTF-8)。`dir` 等の漢字ファイル名や
+   *   `python -c "print('日本語')"` の出力が U+FFFD 化するのを防ぐ。
+   * - PowerShell (pwsh / powershell): `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); chcp 65001 > $null\r`
+   *   を流す。
+   * - その他のシェル (bash / zsh / fish / nu) や非 Windows 環境では何もしない (no-op)。
+   *
+   * OEM コードページを意図的に使いたい (= chcp 932 のままにしたい) ユーザーは
+   * 設定で false に opt-out できる。
+   */
+  terminalForceUtf8?: boolean;
 }
 
 export interface ClaudeCheckResult {
@@ -186,7 +202,10 @@ export const DEFAULT_SETTINGS: AppSettings = {
   customAgents: [],
   mcpAutoSetup: true,
   fileTreeExpanded: {},
-  fileTreeCollapsedRoots: []
+  fileTreeCollapsedRoots: [],
+  // Issue #618: Windows + cmd.exe / PowerShell で UTF-8 を強制する (CP932 化対策)。
+  // 既存ユーザーも v11 migration で true 既定が入る。
+  terminalForceUtf8: true
 };
 
 /** git status --porcelain のエントリ */


### PR DESCRIPTION
## Summary

- `Settings.terminalForceUtf8` (default `true`) を 5 点同期で追加 (TS / Rust / migrate v10→v11)。OEM コードページを意図的に維持したいユーザーは settings.json で `false` に opt-out 可。
- `pty/session.rs::spawn_session` で master writer 取得直後、Windows + cmd.exe / PowerShell の場合に限り UTF-8 化の初期コマンドを inject:
  - cmd.exe: `chcp 65001 > nul\r`
  - PowerShell (pwsh / powershell): `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); chcp 65001 > $null\r`
  - bash / sh / zsh / fish / nu / claude / codex は no-op (POSIX シェル / WSL / git bash は既定 UTF-8、CLI は内部で UTF-8 出力するため)。
- inject ロジックを `maybe_inject_windows_utf8_init` ヘルパーに抽出して `Vec<u8>` writer / `FailingWriter` で完全に unit-test 化 (10 cases)。`windows_utf8_init_command` の shell 別判定も 10 cases。
- Windows e2e integration test (`#[ignore]`) で実 cmd.exe に sequential stdin (`chcp 65001 > nul\r\n` + `dir\r\n`) を流し、漢字ファイル名「テスト_漢字_618.txt」が UTF-8 で残ることを実機確認。baseline (chcp なし) では CP932 codepage host (本 PR の検証 host = chcp 932) で漢字が U+FFFD に化けることも確認。

## Why this matters

renderer 側 (xterm.js → batcher) は `String::from_utf8_lossy(&buf)` でバイト列を UTF-8 として解釈する前提だが、Windows + ja-JP では既定 OEM (CP932) で動くシェルが書き出すバイト列がこれに合致せず、`dir` 漢字ファイル名 / `python -c "print('日本語')"` / `git log` の native error が全部 U+FFFD (replacement character) に化けていた。Issue #120 で files 経路には CP932 デコードを入れたが、PTY batcher / scrollback 経路は射程外だった。

issue 本文の案 (b) を採用し、起動時に `chcp 65001` 等を inject することで以下が成立する:
- すべての PTY 出力が UTF-8 になるので batcher / scrollback の既存 lossy decode がそのまま動く
- WSL / git bash / nu shell / Claude / Codex CLI 等の non-cmd / non-pwsh では `windows_utf8_init_command` が None を返し、no-op で regression を起こさない
- 案 (a) の decoder pipeline 抽象化 (chunk 境界 multi-byte 対応 / SHIFT_JIS 以外の codepage) は roadmap (#645) に残す

## Manual verification on Windows

本 PR 検証 host: Windows 11 (Build 26200), CP932 (ja-JP) console, active codepage 932。

```
cargo test --manifest-path src-tauri/Cargo.toml --lib -- --ignored issue_618
```

実行結果:
- `issue_618_dir_displays_japanese`: ✅ pass
  ```
  [issue-618 e2e] exit=Some(0) stdout=647 bytes
  Microsoft Windows [Version 10.0.26200.8246]
  ...
  2026/05/09  19:18                 5 テスト_漢字_618.txt
  ...
  ```
  (= chcp 65001 を sequential stdin で流したあとの dir 出力に「テスト_漢字_618.txt」が UTF-8 でそのまま含まれている)

- `issue_618_baseline_without_chcp_corrupts_japanese`: ✅ pass
  ```
  [issue-618 e2e baseline] active codepage: 現在のコード ページ: 932
  ...
                   5 �e�X�g_����_618.txt
  ```
  (= chcp なしで dir すると CP932 で書かれ、UTF-8 lossy decode で U+FFFD に化ける = bug 再現)

## Test plan
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` が pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` が 407 pass / 0 fail / 2 ignored (e2e)
  - `windows_utf8_init_command_tests`: 10 cases (cmd / cmd.exe / CMD.EXE / pwsh / powershell / pwsh full path / bash / posix shells / claude+codex / empty)
  - `windows_utf8_inject_tests`: 10 cases (cmd / cmd.exe full path / powershell / pwsh / disabled / bash / zsh-fish-nu / claude-codex / empty / FailingWriter)
- [x] `cargo test --lib -- --ignored issue_618_*` が CP932 host で 2 pass (e2e + baseline)
- [x] `npm run typecheck` が clean
- [x] `npx vitest run src/renderer/src/lib/__tests__/settings-migrate.test.ts` が 13 pass (含 v10→v11 migration の新規 5 cases)
- [x] vibe-editor-reviewer (bot) による auto-merge

Closes #618