### PR TITLE
fix(backend): #601 team_diagnostics_read を active team set に限定 (Tier A-3 security)

### DIFF
--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -16,12 +16,22 @@ use std::sync::Mutex;
 
 use crate::commands::error::{CommandError, CommandResult};
 use crate::state::lock_project_root_recover;
+use crate::team_hub::TeamHub;
 
 /// 監査ログに raw path を出すときの clamp (制御文字を `?` に置換 + 240 文字で truncate)。
 /// renderer 由来の project_root に改行や ESC が混じっていても tracing 行を破壊しないようにする。
 fn clamp_for_log(raw: &str) -> String {
     raw.chars()
         .take(240)
+        .map(|c| if c.is_control() { '?' } else { c })
+        .collect()
+}
+
+/// 監査ログ用に team_id を clamp する (制御文字 `?` 置換 + 96 文字 truncate)。
+/// `team_id` 自体は ASCII 系の short string が想定だが、renderer から来る入力は信用しない。
+fn clamp_team_id_for_log(raw: &str) -> String {
+    raw.chars()
+        .take(96)
         .map(|c| if c.is_control() { '?' } else { c })
         .collect()
 }
@@ -102,6 +112,46 @@ pub async fn assert_active_project_root(
     }
 
     Ok(active_canon)
+}
+
+/// Issue #601 (Tier A-3): renderer 由来の `team_id` が `TeamHub` の active set に含まれるかを
+/// 検証する。`team_diagnostics_read` (#601) のような **renderer がリーダー視点を impersonate
+/// する** IPC で、過去 / 別プロジェクト / 任意 fabricated な team_id を probe されないように
+/// recon を抑止するための helper。
+///
+/// 設計判断:
+/// - 「空 team_id」「未登録 team_id」「正常な team_id」のうち最初の 2 つは同じ
+///   `Authz("team is not active or does not exist")` で reject する。これは存在 / 非存在を
+///   区別しない recon 抑止の方針 (issue #601 案1)。
+/// - reject 時は `tracing::warn!` で clamp 済み team_id を audit log に残す。
+/// - 返却型は `()` (active 確認だけが目的、戻り値で team の詳細を返さない)。
+pub async fn assert_active_team(hub: &TeamHub, team_id: &str) -> CommandResult<()> {
+    let trimmed = team_id.trim();
+    if trimmed.is_empty() {
+        tracing::warn!(
+            team_id = %clamp_team_id_for_log(team_id),
+            "[authz] assert_active_team rejected: empty team_id"
+        );
+        return Err(CommandError::authz(
+            "team is not active or does not exist",
+        ));
+    }
+
+    let state = hub.state.lock().await;
+    if !state.active_teams.contains(trimmed) {
+        // `members` の中に過去の (= dismiss 済み) team_id が残っていても probe させない。
+        let active_count = state.active_teams.len();
+        drop(state);
+        tracing::warn!(
+            team_id = %clamp_team_id_for_log(team_id),
+            active_count,
+            "[authz] assert_active_team rejected: team_id not in active set"
+        );
+        return Err(CommandError::authz(
+            "team is not active or does not exist",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -216,5 +266,99 @@ mod tests {
             .await
             .expect("trailing separator should canonicalize equal");
         assert_eq!(canon, std::fs::canonicalize(project.path()).expect("canon"));
+    }
+
+    // ===== Issue #601 (Tier A-3): assert_active_team helper =====
+
+    mod active_team {
+        use super::*;
+        use crate::pty::SessionRegistry;
+        use crate::team_hub::TeamHub;
+        use std::sync::Arc;
+
+        async fn insert_active_team(hub: &TeamHub, team_id: &str) {
+            let mut s = hub.state.lock().await;
+            s.active_teams.insert(team_id.to_string());
+        }
+
+        /// active set に登録された team_id は accept される。
+        #[tokio::test]
+        async fn accepts_team_id_in_active_set() {
+            let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+            insert_active_team(&hub, "team-active-001").await;
+            assert_active_team(&hub, "team-active-001")
+                .await
+                .expect("active team_id should be accepted");
+        }
+
+        /// active set に居ない team_id は recon 抑止の generic message で reject される。
+        #[tokio::test]
+        async fn rejects_team_id_not_in_active_set() {
+            let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+            insert_active_team(&hub, "team-active-002").await;
+            // 別の team_id (= 過去に dismiss した / 別 project の team / fabricated) を渡す
+            let err = assert_active_team(&hub, "team-of-projectA-fabricated")
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, CommandError::Authz(ref m) if m == "team is not active or does not exist"),
+                "got: {err}"
+            );
+        }
+
+        /// 存在しない / 空の team_id は同じ generic message で reject される
+        /// (= recon 抑止: 存在 / 非存在を区別しない)。
+        #[tokio::test]
+        async fn rejects_empty_team_id_with_same_message_as_unknown() {
+            let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+            insert_active_team(&hub, "team-active-003").await;
+
+            let err_empty = assert_active_team(&hub, "").await.unwrap_err();
+            let err_whitespace = assert_active_team(&hub, "   ").await.unwrap_err();
+            let err_unknown = assert_active_team(&hub, "team-unknown-xyz").await.unwrap_err();
+
+            // 全部同じ generic message にすることで「team_id がそもそも空」と
+            // 「team_id が active set に居ない」を caller から区別できなくする。
+            for err in [&err_empty, &err_whitespace, &err_unknown] {
+                assert!(
+                    matches!(err, CommandError::Authz(ref m) if m == "team is not active or does not exist"),
+                    "got: {err}"
+                );
+            }
+        }
+
+        /// dismiss された team_id は accept されない
+        /// (= state.active_teams.remove で集合から外れているはず)。
+        #[tokio::test]
+        async fn rejects_team_id_after_remove() {
+            let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+            insert_active_team(&hub, "team-tmp").await;
+            // 一度 accept される
+            assert_active_team(&hub, "team-tmp")
+                .await
+                .expect("should accept while in active set");
+            // 集合から外す (dismiss 相当)
+            {
+                let mut s = hub.state.lock().await;
+                s.active_teams.remove("team-tmp");
+            }
+            // 以降は generic reject に変わる
+            let err = assert_active_team(&hub, "team-tmp").await.unwrap_err();
+            assert!(
+                matches!(err, CommandError::Authz(ref m) if m == "team is not active or does not exist"),
+                "got: {err}"
+            );
+        }
+
+        /// `team_id` を trim したうえで active set と比較する
+        /// (= `"  team-x  "` のような padding は無害化して accept させる)。
+        #[tokio::test]
+        async fn accepts_team_id_after_trim() {
+            let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+            insert_active_team(&hub, "team-trimmed").await;
+            assert_active_team(&hub, "  team-trimmed  ")
+                .await
+                .expect("trim 済み team_id should be accepted");
+        }
     }
 }

--- a/src-tauri/src/commands/team_diagnostics.rs
+++ b/src-tauri/src/commands/team_diagnostics.rs
@@ -8,6 +8,13 @@
 // Hub 内ロジック (`build_member_diagnostics_row` の row 構築) を 100% 共有することで、
 // Issue #524 で追加された PTY 由来 fields (`lastPtyOutputAt` / `autoStale` / `lastPtyActivityAgeMs`
 // / `stalenessThresholdMs`) が自動的に renderer 側にも届く。
+//
+// Issue #601 (Tier A-3): renderer から任意 `team_id` を渡されると、Hub 内部で
+// `role: "leader"` の `CallContext` を組み立てて `Permission::ViewDiagnostics` check を
+// 常に通過させていた = 過去 / 別プロジェクト / fabricated team_id の `serverLogPath` /
+// 全 member の `agent_id` / `recruitedAt` 等が漏洩していた。`commands/authz.rs` の
+// `assert_active_team` を冒頭で呼んで `state.active_teams` に含まれない team_id は reject
+// する (recon 抑止のため empty / unknown / dismissed 全て同じ generic message で返す)。
 
 use crate::state::AppState;
 use crate::team_hub::protocol::tools::team_diagnostics;
@@ -15,23 +22,32 @@ use crate::team_hub::CallContext;
 use serde_json::Value;
 use tauri::State;
 
-/// renderer 経由で TeamHub diagnostics を読む。team_id 未登録 / Hub 未起動の場合は
-/// `members: []` と等価な「空集計」を返す (UI 側で空状態として描画する)。
+/// renderer 経由で TeamHub diagnostics を読む。Issue #601: `team_id` が `state.active_teams` に
+/// 居ない場合は `Authz("team is not active or does not exist")` で reject する。
 ///
 /// 引数 `team_id` のみ。プロジェクトルートは Hub 内の current state から自動決定される。
 /// Permission check は内部で leader 役を impersonate して通過させる ("renderer = Leader が
-/// UI から見ている" という semantic を体現)。
+/// UI から見ている" という semantic を体現)。impersonation は active set に含まれる team_id
+/// に限定されるので、過去 / 別プロジェクト の team_id を probe しても情報は漏れない。
 #[tauri::command]
 pub async fn team_diagnostics_read(
     state: State<'_, AppState>,
     team_id: String,
 ) -> Result<Value, String> {
+    // Issue #601: active な team_id でなければ reject。
+    // empty / unknown / dismissed は同じ generic message にして recon 抑止。
+    crate::commands::authz::assert_active_team(&state.team_hub, &team_id)
+        .await
+        .map_err(String::from)?;
+
     let hub = state.team_hub.clone();
     let ctx = CallContext {
         team_id,
         // Leader 役で impersonate: ViewDiagnostics permission を通すため。
         // 物理シグナル (lastPtyOutputAt / autoStale 等) は agent_id ごとに per-member で
         // 計算されるため、caller 側の agent_id は permission check 以外には影響しない。
+        // Issue #601: 上の `assert_active_team` で active set 内に絞っているので、
+        // この impersonation で読める情報は「現在 active な team の自身の Hub state」のみ。
         role: "leader".to_string(),
         // 既存 agent と衝突しない synthetic id。pending_inbox_summary の "from_agent_id == self"
         // フィルタで誤って team message を除外しないよう、いずれの agent_id とも被らない名前。


### PR DESCRIPTION
## Summary

- `team_diagnostics_read` IPC が renderer 由来の任意 `team_id` を Hub 内部で `role: "leader"` に impersonate して `Permission::ViewDiagnostics` 検証を常時 bypass し、過去 / 別プロジェクト / fabricated team_id の `serverLogPath` / 全 member の `agent_id` / `recruitedAt` 等を読み出せていた **Tier A-3 data leak / impersonation** 穴を塞ぐ。
- `commands/authz.rs` に `assert_active_team(hub, team_id) -> CommandResult<()>` を追加し、`state.active_teams` (= active な team_id の `HashSet`) に含まれない team_id を reject する。
- #600 (Tier A-2) で先行設置した `assert_active_project_root` と同じ `commands/authz.rs` module に集約。後続の A-8 (`handoffs_*`) 等でも同 module から helper を呼ぶ構造。

## 背景 / Why

`src-tauri/src/commands/team_diagnostics.rs:24-41` (旧版) の `team_diagnostics_read` は:

```rust
let ctx = CallContext {
    team_id,                           // renderer 由来
    role: "leader".to_string(),        // ← Hub 内部で impersonate
    agent_id: "vibe-editor.renderer".to_string(),
};
team_diagnostics(&hub, &ctx).await
```

これにより:
1. Hub 側で実装されている `Permission::ViewDiagnostics` permission check は `role == "leader"` のため常に true
2. `state.active_teams` との照合がない = 任意の team_id (= 別プロジェクト / 過去 / fabricated) でも team_diagnostics() が返る
3. レスポンスに `serverLogPath` (= 環境変数 `VIBE_TEAM_LOG_PATH` の絶対 path) や全 member の `agent_id` / `recruitedAt` / `currentStatus` / `lastPtyOutputAt` などが含まれる

malicious extension / compromised renderer / dev-tools から `invoke('team_diagnostics_read', { teamId: 'team-of-projectA' })` を呼ぶだけで cross-project recon + data leak が成立していた。

## Changes

### `src-tauri/src/commands/authz.rs` (#600 で新設した module)
- `assert_active_team(hub: &TeamHub, team_id: &str) -> CommandResult<()>` を追加。
  - `team_id` を trim し、空なら直ちに reject (recon 抑止のため後段と同じ message を使う)。
  - `hub.state.lock().await.active_teams.contains(trimmed)` で active set 照合。
  - **存在 / 非存在を区別しない** ため `empty / unknown / dismissed` の 3 ケースは全て `Authz("team is not active or does not exist")` で reject。
  - reject 時は `tracing::warn!` で `clamp_team_id_for_log(team_id)` (= 制御文字 `?` 置換 + 96 文字 truncate) を audit log に出力。

### `src-tauri/src/commands/team_diagnostics.rs`
- `team_diagnostics_read` の冒頭で `crate::commands::authz::assert_active_team(&state.team_hub, &team_id).await.map_err(String::from)?` を呼び、active set にない team_id は reject。
- 既存の `CallContext { role: "leader", ... }` impersonation はそのまま残すが、active set に絞ったあとの実行になるので「現在 active な team の Hub state を読む」だけに用途が限定される。
- module 冒頭の comment block に Issue #601 の背景説明を追加。

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` pass (warnings は既存の has_conflicts / warn_message のみ)
- [x] `cargo test --lib commands::authz` — 11/11 pass (既存 6 本 + 新規 5 本)
- [x] `cargo test --lib commands` — 126/126 pass (既存 git / settings / sessions / atomic_write などは無影響)

新規ユニットテスト (`commands::authz::tests::active_team` モジュール):
- `accepts_team_id_in_active_set` — active 中の team_id は accept。
- `rejects_team_id_not_in_active_set` — 別 team_id (= 別 project / fabricated) は generic message で reject。
- `rejects_empty_team_id_with_same_message_as_unknown` — `""` / `"   "` / `"team-unknown-xyz"` の 3 つを assert で **同じ message** で reject (recon 抑止)。
- `rejects_team_id_after_remove` — `active_teams.remove` (dismiss 相当) 後は accept から reject へ遷移。
- `accepts_team_id_after_trim` — `"  team-x  "` の padding は trim して accept。

Closes #601