### PR TITLE
feat(terminal): #660 #661 #662 Claude session 復元を全 OS standalone 化

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub mod team_inject;
 pub mod team_presets;
 pub mod team_state;
 pub mod terminal;
+pub mod terminal_tabs;
 pub mod vibe_team_skill;
 
 /// Issue #494: `commands/*.rs` の integration test を集約する test-only module。

--- a/src-tauri/src/commands/terminal_tabs.rs
+++ b/src-tauri/src/commands/terminal_tabs.rs
@@ -107,7 +107,11 @@ async fn ensure_loaded(cache: &mut Option<PersistedTerminalTabsFile>) {
 async fn save_to_disk(file: &PersistedTerminalTabsFile) -> Result<(), String> {
     let path = store_path();
     let json = serde_json::to_vec_pretty(file).map_err(|e| e.to_string())?;
-    crate::commands::atomic_write::atomic_write(&path, &json)
+    // Issue #608: terminal-tabs.json は Claude session id (UUID) と cwd を持ち、漏洩すると
+    // `~/.claude/projects/<encoded>/<uuid>.jsonl` の会話履歴に間接アクセスできるため
+    // 機密ファイル扱い。`~/.claude.json` / role-profiles 等と同じく 0o600 を強制する。
+    // Windows では mode は no-op (Windows ACL 強制は別 issue で対応)。
+    crate::commands::atomic_write::atomic_write_with_mode(&path, &json, Some(0o600))
         .await
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/terminal_tabs.rs
+++ b/src-tauri/src/commands/terminal_tabs.rs
@@ -1,0 +1,257 @@
+// terminal_tabs.* command — Issue #661
+//
+// IDE モード terminal タブの永続化。~/.vibe-editor/terminal-tabs.json を atomic write で
+// 読み書きする。team-history.json とは独立した SSOT で、IDE 単独タブの cwd / cols / rows /
+// Claude session id を再起動跨ぎで保持する。
+//
+// 設計原則:
+//   - schemaVersion 一致しないファイルは読まずに `None` 返却 (= 旧データ無視で素の起動)
+//   - byProject は raw projectRoot を key とし、検索/書込側で `normalize_project_root` 経由
+//   - cache + LOCK で disk I/O 最小化 (team_history.rs と同流儀)
+
+use crate::commands::team_history::MutationResult;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tokio::fs;
+use tokio::sync::Mutex;
+
+/// renderer 側 `TERMINAL_TABS_SCHEMA_VERSION` と一致させる
+pub const TERMINAL_TABS_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedTerminalTab {
+    pub tab_id: String,
+    pub kind: String,
+    pub cwd: String,
+    pub cols: u32,
+    pub rows: u32,
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedTerminalTabsByProject {
+    pub tabs: Vec<PersistedTerminalTab>,
+    pub active_tab_id: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedTerminalTabsFile {
+    pub schema_version: u32,
+    pub last_saved_at: String,
+    pub by_project: HashMap<String, PersistedTerminalTabsByProject>,
+}
+
+impl Default for PersistedTerminalTabsFile {
+    fn default() -> Self {
+        Self {
+            schema_version: TERMINAL_TABS_SCHEMA_VERSION,
+            last_saved_at: String::new(),
+            by_project: HashMap::new(),
+        }
+    }
+}
+
+/// in-memory cache。`None` = 未ロード、`Some(...)` = ディスクと同期済み。
+static CACHE: once_cell::sync::Lazy<Mutex<Option<PersistedTerminalTabsFile>>> =
+    once_cell::sync::Lazy::new(|| Mutex::new(None));
+
+static LOCK: once_cell::sync::Lazy<Mutex<()>> = once_cell::sync::Lazy::new(|| Mutex::new(()));
+
+fn store_path() -> PathBuf {
+    crate::util::config_paths::terminal_tabs_path()
+}
+
+/// disk からロードする。schemaVersion 不一致は `None` を返して旧データを無視する。
+async fn load_from_disk() -> Option<PersistedTerminalTabsFile> {
+    let path = store_path();
+    let bytes = fs::read(&path).await.ok()?;
+    let file: PersistedTerminalTabsFile = match serde_json::from_slice(&bytes) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!(
+                "[terminal_tabs] parse failed (treating as missing): {e}"
+            );
+            return None;
+        }
+    };
+    if file.schema_version != TERMINAL_TABS_SCHEMA_VERSION {
+        tracing::info!(
+            "[terminal_tabs] schemaVersion mismatch (file={}, current={}), ignoring",
+            file.schema_version,
+            TERMINAL_TABS_SCHEMA_VERSION
+        );
+        return None;
+    }
+    Some(file)
+}
+
+async fn ensure_loaded(cache: &mut Option<PersistedTerminalTabsFile>) {
+    if cache.is_some() {
+        return;
+    }
+    *cache = Some(load_from_disk().await.unwrap_or_default());
+}
+
+async fn save_to_disk(file: &PersistedTerminalTabsFile) -> Result<(), String> {
+    let path = store_path();
+    let json = serde_json::to_vec_pretty(file).map_err(|e| e.to_string())?;
+    crate::commands::atomic_write::atomic_write(&path, &json)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// load: 永続化ファイルが空 / 未存在 / schemaVersion 不一致なら `None` 返却。
+/// renderer 側はこれで「素の IDE モード起動」と判定して順序復元をスキップする。
+#[tauri::command]
+pub async fn terminal_tabs_load() -> Option<PersistedTerminalTabsFile> {
+    let _g = LOCK.lock().await;
+    let mut cache = CACHE.lock().await;
+    ensure_loaded(&mut cache).await;
+    let file = cache.as_ref().expect("ensured");
+    if file.by_project.is_empty() && file.last_saved_at.is_empty() {
+        return None;
+    }
+    Some(file.clone())
+}
+
+/// save: renderer から渡された全体を atomic 上書き。
+/// renderer 側 hook が「他プロジェクト entry 保持 + 自分の entry 更新」を行う read-modify-write
+/// なので、ここは渡された file をそのまま採用する (= cache 更新 + disk write)。
+#[tauri::command]
+pub async fn terminal_tabs_save(file: PersistedTerminalTabsFile) -> MutationResult {
+    let _g = LOCK.lock().await;
+    let mut cache = CACHE.lock().await;
+    *cache = Some(file.clone());
+    match save_to_disk(&file).await {
+        Ok(()) => MutationResult {
+            ok: true,
+            error: None,
+        },
+        Err(e) => MutationResult {
+            ok: false,
+            error: Some(e),
+        },
+    }
+}
+
+/// clear: ファイル削除 + cache を空に戻す。設定からの「タブ復元を全消去」操作などで使う。
+/// 既に存在しないときも `ok=true` を返す (idempotent)。
+#[tauri::command]
+pub async fn terminal_tabs_clear() -> MutationResult {
+    let _g = LOCK.lock().await;
+    let mut cache = CACHE.lock().await;
+    let path = store_path();
+    *cache = Some(PersistedTerminalTabsFile::default());
+    match fs::remove_file(&path).await {
+        Ok(()) => MutationResult {
+            ok: true,
+            error: None,
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => MutationResult {
+            ok: true,
+            error: None,
+        },
+        Err(e) => MutationResult {
+            ok: false,
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_tab(id: &str) -> PersistedTerminalTab {
+        PersistedTerminalTab {
+            tab_id: id.to_string(),
+            kind: "claude".to_string(),
+            cwd: "/tmp/repo".to_string(),
+            cols: 100,
+            rows: 30,
+            session_id: Some("11111111-2222-3333-4444-555555555555".to_string()),
+            label: None,
+            team_id: None,
+            agent_id: None,
+            role: None,
+        }
+    }
+
+    #[test]
+    fn schema_version_constant_matches_default_file() {
+        let f = PersistedTerminalTabsFile::default();
+        assert_eq!(f.schema_version, TERMINAL_TABS_SCHEMA_VERSION);
+        assert!(f.by_project.is_empty());
+    }
+
+    #[test]
+    fn round_trip_serde_preserves_fields() {
+        let mut by_project = HashMap::new();
+        by_project.insert(
+            "C:\\repo".to_string(),
+            PersistedTerminalTabsByProject {
+                tabs: vec![sample_tab("1"), sample_tab("2")],
+                active_tab_id: Some("1".to_string()),
+            },
+        );
+        let file = PersistedTerminalTabsFile {
+            schema_version: TERMINAL_TABS_SCHEMA_VERSION,
+            last_saved_at: "2026-05-09T00:00:00Z".to_string(),
+            by_project,
+        };
+        let json = serde_json::to_string(&file).unwrap();
+        // camelCase 確認 (snake_case が漏れていないこと)
+        assert!(json.contains("\"schemaVersion\""));
+        assert!(json.contains("\"byProject\""));
+        assert!(json.contains("\"activeTabId\""));
+        assert!(json.contains("\"tabId\""));
+        assert!(json.contains("\"sessionId\""));
+        let restored: PersistedTerminalTabsFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.schema_version, TERMINAL_TABS_SCHEMA_VERSION);
+        assert_eq!(restored.by_project.len(), 1);
+        assert_eq!(restored.by_project["C:\\repo"].tabs.len(), 2);
+        assert_eq!(
+            restored.by_project["C:\\repo"].active_tab_id.as_deref(),
+            Some("1")
+        );
+    }
+
+    #[test]
+    fn missing_optional_fields_default_to_none() {
+        let json = r#"{
+            "schemaVersion": 1,
+            "lastSavedAt": "",
+            "byProject": {
+                "/tmp/r": {
+                    "tabs": [{
+                        "tabId": "1",
+                        "kind": "claude",
+                        "cwd": "/tmp/r",
+                        "cols": 80,
+                        "rows": 24,
+                        "sessionId": null
+                    }],
+                    "activeTabId": null
+                }
+            }
+        }"#;
+        let file: PersistedTerminalTabsFile = serde_json::from_str(json).unwrap();
+        let tab = &file.by_project["/tmp/r"].tabs[0];
+        assert!(tab.label.is_none());
+        assert!(tab.team_id.is_none());
+        assert!(tab.agent_id.is_none());
+        assert!(tab.role.is_none());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -165,6 +165,10 @@ pub fn run() {
             commands::terminal::terminal_resize,
             commands::terminal::terminal_kill,
             commands::terminal::terminal_save_pasted_image,
+            // ---- terminal tabs persistence (Issue #661) ----
+            commands::terminal_tabs::terminal_tabs_load,
+            commands::terminal_tabs::terminal_tabs_save,
+            commands::terminal_tabs::terminal_tabs_clear,
             // ---- vibe-team Skill ----
             commands::vibe_team_skill::app_install_vibe_team_skill,
         ])

--- a/src-tauri/src/pty/claude_watcher.rs
+++ b/src-tauri/src/pty/claude_watcher.rs
@@ -9,6 +9,15 @@
 //      `terminal:sessionId:{terminal_id}` event を emit
 //   4. is_alive (`SessionRegistry.get(terminal_id).is_some()`) で false になったら停止
 //
+// Issue #660 後の役割 (= "fallback detector"):
+//   - 通常経路では renderer 側が UUID を事前生成し `claude --session-id <uuid>` を args に
+//     注入する。renderer が session id を **先に** 知っているため、watcher が emit する
+//     値は renderer の値と一致する no-op になる。renderer 側の cb は冪等 (同値書込みで
+//     zustand が skip / `markSessionPersisted` も idempotent) なので副作用は無い。
+//   - 本 watcher の存在意義は (a) 外部から `claude` を直接起動された場合 (= vibe-editor
+//     経由でない PTY)、(b) 旧 schema の永続化データで `--session-id` 注入未対応の tab、
+//     の 2 ケースで session id を後追い検出して renderer に届けること。
+//
 // 注意:
 //   - Claude Code 以外 (codex 等) は jsonl を作らないので呼び出さない (renderer 制御)
 //   - notify は OS の inotify/ReadDirectoryChangesW に依存。Windows でも動く

--- a/src-tauri/src/pty/path_norm.rs
+++ b/src-tauri/src/pty/path_norm.rs
@@ -71,4 +71,46 @@ mod tests {
     fn windows_case_insensitive_normalization() {
         assert_eq!(normalize_project_root("D:/Repo"), normalize_project_root("d:\\repo"));
     }
+
+    /// Issue #662: cross-OS で `~/.claude/projects/<encoded>/` のディレクトリ名が
+    /// 公式 Claude CLI の規則 (= ASCII alnum 以外を `-`) と一致することを実機検証で
+    /// 確定した値で固定する。jsonl のパス計算が renderer 側 / watcher 側 / 将来の
+    /// renderer UI で必ず同じ値になるよう、回帰テストとして残す。
+    #[test]
+    fn encode_project_path_matches_official_claude_directory_layout() {
+        // Windows: ドライブ文字 + `\`、`:` と `\` がそれぞれ `-` になる
+        assert_eq!(encode_project_path("F:\\vive-editor"), "F--vive-editor");
+        assert_eq!(
+            encode_project_path("C:\\Users\\yusei\\Downloads\\vibe-editor"),
+            "C--Users-yusei-Downloads-vibe-editor"
+        );
+        // macOS: 先頭 `/` がそのまま `-` に
+        assert_eq!(
+            encode_project_path("/Users/yusei/repo"),
+            "-Users-yusei-repo"
+        );
+        // Linux: 先頭 `/` も `-` に。区切りはすべて `-`
+        assert_eq!(
+            encode_project_path("/home/yusei/projects/vibe"),
+            "-home-yusei-projects-vibe"
+        );
+        // WSL UNC (`\\wsl.localhost\\Ubuntu\\home\\yusei`): `\` が連続して `--` になる
+        assert_eq!(
+            encode_project_path("\\\\wsl.localhost\\Ubuntu\\home\\yusei"),
+            "--wsl-localhost-Ubuntu-home-yusei"
+        );
+        // 末尾 slash も `-` (encode 関数は trim しない: 上位で normalize する)
+        assert_eq!(encode_project_path("/tmp/repo/"), "-tmp-repo-");
+        // 大小区別は保持される (`F` と `f` を別 encoded ディレクトリにする)
+        assert_ne!(encode_project_path("F:\\repo"), encode_project_path("f:\\repo"));
+    }
+
+    #[test]
+    fn encode_project_path_is_pure_ascii_alnum_passthrough() {
+        // ASCII 英数字はそのまま、それ以外 (`.` `-` `_` も含む) はすべて `-` になる挙動を固定。
+        // claude_watcher.rs の jsonl ディレクトリ計算がこの規則を前提にしている。
+        assert_eq!(encode_project_path("abc123"), "abc123");
+        assert_eq!(encode_project_path("a.b_c-d"), "a-b-c-d");
+        assert_eq!(encode_project_path("日本語"), "---");
+    }
 }

--- a/src-tauri/src/util/config_paths.rs
+++ b/src-tauri/src/util/config_paths.rs
@@ -29,3 +29,10 @@ pub fn handoffs_path() -> PathBuf {
 pub fn role_profiles_path() -> PathBuf {
     vibe_root().join("role-profiles.json")
 }
+
+/// Issue #661: IDE モード terminal タブの永続化先 `~/.vibe-editor/terminal-tabs.json` のパス。
+/// `team-history.json` とは独立した SSOT で、IDE 単独タブの cwd / cols / rows / Claude
+/// session id を再起動跨ぎで保持する。
+pub fn terminal_tabs_path() -> PathBuf {
+    vibe_root().join("terminal-tabs.json")
+}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -61,6 +61,7 @@ import {
   useTerminalTabs
 } from './lib/hooks/use-terminal-tabs';
 import type { TerminalTab } from './lib/hooks/use-terminal-tabs';
+import { useTerminalTabsPersistence } from './lib/hooks/use-terminal-tabs-persistence';
 import { useTeamManagement } from './lib/hooks/use-team-management';
 import { useLayoutResize } from './lib/hooks/use-layout-resize';
 import { useAppShortcuts } from './lib/hooks/use-app-shortcuts';
@@ -247,6 +248,20 @@ export function App(): JSX.Element {
     projectRoot,
     showToast,
     closeTeam: stableCloseTeam
+  });
+
+  // Issue #661: IDE タブを `~/.vibe-editor/terminal-tabs.json` に永続化し、
+  // 再起動時に復元する。reportSize / reportCwd は Issue #662 (Commit 3) で
+  // TerminalView の `onResize` / cwd 経由で呼ばれるようになる。
+  const {
+    reportSize: reportTerminalSize,
+    reportCwd: reportTerminalCwd
+  } = useTerminalTabsPersistence({
+    projectRoot,
+    terminalTabs,
+    activeTerminalTabId,
+    setActiveTerminalTabId,
+    addTerminalTab
   });
 
   // Phase 1-4 (Issue #373): teams / team-history / launch helpers を hook に集約。

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1117,7 +1117,7 @@ export function App(): JSX.Element {
                       if (el) terminalRefs.current.set(tab.id, el);
                       else terminalRefs.current.delete(tab.id);
                     }}
-                    cwd={settings.claudeCwd || projectRoot}
+                    cwd={tab.cwd || settings.claudeCwd || projectRoot}
                     fallbackCwd={projectRoot}
                     command={
                       tab.agent === 'codex'
@@ -1149,6 +1149,7 @@ export function App(): JSX.Element {
                       // 確認できたので freshSessionId を倒す。次回以降は --resume 経路。
                       markSessionPersisted(tab.id);
                     }}
+                    onResize={(cols, rows) => reportTerminalSize(tab.id, cols, rows)}
                   />
                 ) : claudeCheck.state === 'checking' ? (
                   <div className="claude-not-found__body" style={{ padding: 40, textAlign: 'center' }}>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -250,13 +250,10 @@ export function App(): JSX.Element {
     closeTeam: stableCloseTeam
   });
 
-  // Issue #661: IDE タブを `~/.vibe-editor/terminal-tabs.json` に永続化し、
-  // 再起動時に復元する。reportSize / reportCwd は Issue #662 (Commit 3) で
-  // TerminalView の `onResize` / cwd 経由で呼ばれるようになる。
-  const {
-    reportSize: reportTerminalSize,
-    reportCwd: reportTerminalCwd
-  } = useTerminalTabsPersistence({
+  // Issue #661 / #662: IDE タブを `~/.vibe-editor/terminal-tabs.json` に永続化し、
+  // 再起動時に復元する。reportTerminalSize は TerminalView の `onResize` 経由で
+  // PTY size 変化を hook に流す。cwd は load 時の片方向のみ更新する v1 設計。
+  const { reportSize: reportTerminalSize } = useTerminalTabsPersistence({
     projectRoot,
     terminalTabs,
     activeTerminalTabId,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -239,7 +239,8 @@ export function App(): JSX.Element {
     editingLabelTabId,
     setEditingLabelTabId,
     nextTerminalIdRef,
-    resetForProjectSwitch: resetTerminalsForProjectSwitch
+    resetForProjectSwitch: resetTerminalsForProjectSwitch,
+    markSessionPersisted
   } = useTerminalTabs({
     viewMode,
     claudeReady: claudeCheck.state === 'ok',
@@ -1127,7 +1128,12 @@ export function App(): JSX.Element {
                         prev.map((t) => (t.id === tab.id ? { ...t, exited: true } : t))
                       )
                     }
-                    onSessionId={(sid) => handleTerminalSessionId(tab, sid)}
+                    onSessionId={(sid) => {
+                      handleTerminalSessionId(tab, sid);
+                      // Issue #660: 初回 spawn の `--session-id` 注入 → jsonl 永続化が
+                      // 確認できたので freshSessionId を倒す。次回以降は --resume 経路。
+                      markSessionPersisted(tab.id);
+                    }}
                   />
                 ) : claudeCheck.state === 'checking' ? (
                   <div className="claude-not-found__body" style={{ padding: 40, textAlign: 'center' }}>

--- a/src/renderer/src/components/TerminalView.tsx
+++ b/src/renderer/src/components/TerminalView.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useRef, useState, useCallback } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState, useCallback } from 'react';
 import { useSettings } from '../lib/settings-context';
 import { useT } from '../lib/i18n';
 import { useXtermInstance } from '../lib/use-xterm-instance';
@@ -65,6 +65,12 @@ interface TerminalViewProps {
   onExit?: () => void;
   /** Claude Code の起動ログから session id を抽出したとき（初回1回のみ） */
   onSessionId?: (sessionId: string) => void;
+  /**
+   * Issue #662: PTY size が変化したときに呼ばれる。永続化復元用。
+   * xterm の `term.onResize` を経由するため、re-fit / 手動 resize / SIGWINCH 等
+   * 全ての size 変化を 1 か所で捕まえる。
+   */
+  onResize?: (cols: number, rows: number) => void;
   /** ユーザーが xterm 上で入力したキーストロークの sniff (タイトル auto-summary 等の用途) */
   onUserInput?: (data: string) => void;
   /**
@@ -130,6 +136,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       onActivity,
       onExit,
       onSessionId,
+      onResize,
       onUserInput,
       onSpawnError,
       disableWebgl,
@@ -257,6 +264,34 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       writeToPty,
       langRef
     });
+
+    // --- xterm `term.onResize` を caller (永続化 hook 等) にブリッジ (Issue #662) ---
+    // term は useXtermInstance の useEffect 内で生成される。このコンポーネントの
+    // 別 useEffect は登録順で必ずその後に走るが、term ready が遅延するケースに備えて
+    // setTimeout で再試行する。実 size 変化のときのみ発火するため、初期 size は
+    // emit されない (= 永続化値の初期 seed として cols/rows を渡す側で補完する)。
+    useEffect(() => {
+      if (!onResize) return;
+      let disposed = false;
+      let unbind: (() => void) | null = null;
+      const tryBind = (): void => {
+        if (disposed) return;
+        const term = termRef.current;
+        if (!term) {
+          window.setTimeout(tryBind, 50);
+          return;
+        }
+        const handler = term.onResize((evt) => onResize(evt.cols, evt.rows));
+        unbind = (): void => handler.dispose();
+      };
+      tryBind();
+      return () => {
+        disposed = true;
+        unbind?.();
+      };
+      // termRef は stable
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [onResize]);
 
     // --- ResizeObserver + 可視化時 re-fit (不変式 #5) ---
     // Issue #113: refitTriggers に terminalFontFamily が抜けていてフォント変更時に

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -318,6 +318,24 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   //          プロンプト注入方法が不明のため、チーム役割分担の注入はスキップ)
   const isClaude = payload.agent === 'claude' || !payload.agent;
   const isCodex = payload.agent === 'codex';
+
+  // Issue #660: client-side UUID 事前注入。
+  // payload.resumeSessionId が無い (= 新規 mount) なら UUID v4 を採番して
+  // `--session-id <uuid>` で起動 → 新規 jsonl が確定する。次回以降は payload に
+  // 焼き付いた id を `--resume <uuid>` で読み戻す経路に切替わる。
+  const ensuredSessionId = useMemo<string | null>(() => {
+    if (!isClaude) return null;
+    return payload.resumeSessionId ?? crypto.randomUUID();
+  }, [isClaude, payload.resumeSessionId]);
+
+  useEffect(() => {
+    // 採番した UUID を Canvas store に書き戻して永続化する。
+    // payload に既に値があれば書き込まない (zustand 側で同値検出)。
+    if (isClaude && ensuredSessionId && !payload.resumeSessionId) {
+      setCardPayload(id, { resumeSessionId: ensuredSessionId });
+    }
+  }, [id, isClaude, ensuredSessionId, payload.resumeSessionId, setCardPayload]);
+
   const args = useMemo<string[] | undefined>(() => {
     const rawArgs = isClaude
       ? settings.claudeArgs || ''
@@ -334,11 +352,17 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
         base.push('-c', 'disable_paste_burst=true');
       }
     }
-    // Claude のみ `--resume <id>` で前回会話を復元 (Codex は --resume 非対応)。
-    // payload.resumeSessionId は onSessionId で書き戻されるため、
-    // アプリ再起動時もそのまま `--resume` 付き spawn になる。
-    if (isClaude && payload.resumeSessionId) {
-      base.push('--resume', payload.resumeSessionId);
+    // Issue #660: Claude のみ session 制御フラグを付与 (Codex は両方とも非対応)。
+    //   - payload.resumeSessionId 既存 → 永続化済みなので `--resume` で前回会話を継続
+    //   - payload.resumeSessionId 空 → 採番した UUID を `--session-id` で強制注入
+    // useEffect 側で payload に書き戻すと次 render で `--resume` 経路に切り替わる。
+    // 初回 spawn の args は本 render の値が snapRef に固定されるので問題ない。
+    if (isClaude && ensuredSessionId) {
+      if (payload.resumeSessionId) {
+        base.push('--resume', ensuredSessionId);
+      } else {
+        base.push('--session-id', ensuredSessionId);
+      }
     }
     return base.length > 0 ? base : undefined;
   }, [
@@ -347,6 +371,7 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
     resolved.args,
     sysPrompt,
     payload.teamId,
+    ensuredSessionId,
     payload.resumeSessionId,
     settings.claudeArgs,
     settings.codexArgs

--- a/src/renderer/src/lib/hooks/use-team-launch-helpers.ts
+++ b/src/renderer/src/lib/hooks/use-team-launch-helpers.ts
@@ -47,7 +47,14 @@ export function useTeamLaunchHelpers(
       const isCodex = tab.agent === 'codex';
       const base = parseShellArgs(isCodex ? codexArgs || '' : claudeArgs || '');
       if (tab.resumeSessionId && !isCodex) {
-        base.push('--resume', tab.resumeSessionId);
+        // Issue #660: 初回 spawn は `--session-id <uuid>` で id を claude に強制注入し、
+        // 新規 jsonl を確定させる。`onSessionId` 受信で freshSessionId が false に倒れた
+        // 後 (= jsonl 永続化済み) の再 spawn は `--resume <uuid>` で前回会話を resume する。
+        if (tab.freshSessionId) {
+          base.push('--session-id', tab.resumeSessionId);
+        } else {
+          base.push('--resume', tab.resumeSessionId);
+        }
       }
       // Claude のチーム指示は --append-system-prompt で直接渡す。
       if (!isCodex && tab.teamId) {

--- a/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
@@ -97,7 +97,8 @@ export function useTerminalTabsPersistence(
             role: p.role ?? null,
             teamId: p.teamId ?? null,
             agentId: p.agentId ?? undefined,
-            customLabel: p.label ?? null
+            customLabel: p.label ?? null,
+            cwd: p.cwd
           });
           if (newId !== null) {
             numericByPersistedId.set(p.tabId, newId);

--- a/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
@@ -7,12 +7,13 @@
  * 流れ:
  *   1. projectRoot 確定後に `terminal_tabs_load()` を 1 度だけ呼ぶ
  *   2. 該当プロジェクトの persisted tabs を順に `addTerminalTab` で復元 (= --resume 経路)
- *   3. 以降 `terminalTabs` / `activeTerminalTabId` / `reportSize` / `reportCwd` の変化を
+ *   3. 以降 `terminalTabs` / `activeTerminalTabId` / `reportSize` の変化を
  *      500ms debounce で `terminal_tabs_save()` する
  *   4. ファイル全体の他プロジェクト entry は read-modify-write で保持する
  *
- * Issue #663 (Commit 3) で TerminalView の `onResize` / cwd 経由で reportSize / reportCwd を
- * 実際に呼ぶようになる。Commit 2 の段階では caller 不在で default 値が保存される。
+ * cwd は v1 では「mount 時 load → 復元」の片方向のみ更新する (runtime 中に cwd を
+ * 切替える UI が存在しないため)。サイズは TerminalView の `onResize` 経由で
+ * `reportSize()` が呼ばれる。
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '../tauri-api';
@@ -43,10 +44,8 @@ export interface UseTerminalTabsPersistenceOptions {
 export interface UseTerminalTabsPersistenceResult {
   /** 永続化ファイルから復元処理が完了 (or 復元対象なし確定) したか */
   isReady: boolean;
-  /** PTY size 変化を hook に通知 (TerminalView の onResize から呼ぶ予定) */
+  /** PTY size 変化を hook に通知 (TerminalView の onResize から呼ばれる) */
   reportSize: (tabId: number, cols: number, rows: number) => void;
-  /** cwd 変化を hook に通知 (将来 cwd 切替 UI で使う) */
-  reportCwd: (tabId: number, cwd: string) => void;
 }
 
 export function useTerminalTabsPersistence(
@@ -65,7 +64,7 @@ export function useTerminalTabsPersistence(
   const restoringRef = useRef(false);
   /** 各 tabId の PTY size。reportSize で更新、save で参照 */
   const sizeMapRef = useRef(new Map<number, { cols: number; rows: number }>());
-  /** 各 tabId の cwd。reportCwd で更新、save で参照。未設定なら projectRoot を fallback */
+  /** 各 tabId の cwd。load 時に焼き付ける (v1 では runtime 更新無し)。save で参照、未設定なら projectRoot を fallback */
   const cwdMapRef = useRef(new Map<number, string>());
   /** 永続化ファイルの直近キャッシュ。save 時に他プロジェクトの entry を保持する用途 */
   const fileCacheRef = useRef<PersistedTerminalTabsFile | null>(null);
@@ -177,15 +176,5 @@ export function useTerminalTabsPersistence(
     [bumpTick]
   );
 
-  const reportCwd = useCallback(
-    (tabId: number, cwd: string) => {
-      const prev = cwdMapRef.current.get(tabId);
-      if (prev === cwd) return;
-      cwdMapRef.current.set(tabId, cwd);
-      bumpTick();
-    },
-    [bumpTick]
-  );
-
-  return { isReady, reportSize, reportCwd };
+  return { isReady, reportSize };
 }

--- a/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
@@ -1,0 +1,190 @@
+/**
+ * use-terminal-tabs-persistence — Issue #661
+ *
+ * IDE モード terminal タブを `~/.vibe-editor/terminal-tabs.json` に atomic 永続化し、
+ * mount 時に load → 各タブを `addTerminalTab` で復元する hook。
+ *
+ * 流れ:
+ *   1. projectRoot 確定後に `terminal_tabs_load()` を 1 度だけ呼ぶ
+ *   2. 該当プロジェクトの persisted tabs を順に `addTerminalTab` で復元 (= --resume 経路)
+ *   3. 以降 `terminalTabs` / `activeTerminalTabId` / `reportSize` / `reportCwd` の変化を
+ *      500ms debounce で `terminal_tabs_save()` する
+ *   4. ファイル全体の他プロジェクト entry は read-modify-write で保持する
+ *
+ * Issue #663 (Commit 3) で TerminalView の `onResize` / cwd 経由で reportSize / reportCwd を
+ * 実際に呼ぶようになる。Commit 2 の段階では caller 不在で default 値が保存される。
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { api } from '../tauri-api';
+import {
+  TERMINAL_TABS_SCHEMA_VERSION,
+  type PersistedTerminalTab,
+  type PersistedTerminalTabsByProject,
+  type PersistedTerminalTabsFile
+} from '../../../../types/shared';
+import type {
+  AddTerminalTabOptions,
+  TerminalTab
+} from './use-terminal-tabs';
+
+const SAVE_DEBOUNCE_MS = 500;
+/** 復元時の PTY default size (xterm 既定値)。Commit 3 で実 PTY size に置換される */
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+
+export interface UseTerminalTabsPersistenceOptions {
+  projectRoot: string;
+  terminalTabs: TerminalTab[];
+  activeTerminalTabId: number;
+  setActiveTerminalTabId: React.Dispatch<React.SetStateAction<number>>;
+  addTerminalTab: (opts?: AddTerminalTabOptions) => number | null;
+}
+
+export interface UseTerminalTabsPersistenceResult {
+  /** 永続化ファイルから復元処理が完了 (or 復元対象なし確定) したか */
+  isReady: boolean;
+  /** PTY size 変化を hook に通知 (TerminalView の onResize から呼ぶ予定) */
+  reportSize: (tabId: number, cols: number, rows: number) => void;
+  /** cwd 変化を hook に通知 (将来 cwd 切替 UI で使う) */
+  reportCwd: (tabId: number, cwd: string) => void;
+}
+
+export function useTerminalTabsPersistence(
+  opts: UseTerminalTabsPersistenceOptions
+): UseTerminalTabsPersistenceResult {
+  const {
+    projectRoot,
+    terminalTabs,
+    activeTerminalTabId,
+    addTerminalTab,
+    setActiveTerminalTabId
+  } = opts;
+
+  const [isReady, setIsReady] = useState(false);
+  /** 復元中に save loop が走らないようガードするフラグ */
+  const restoringRef = useRef(false);
+  /** 各 tabId の PTY size。reportSize で更新、save で参照 */
+  const sizeMapRef = useRef(new Map<number, { cols: number; rows: number }>());
+  /** 各 tabId の cwd。reportCwd で更新、save で参照。未設定なら projectRoot を fallback */
+  const cwdMapRef = useRef(new Map<number, string>());
+  /** 永続化ファイルの直近キャッシュ。save 時に他プロジェクトの entry を保持する用途 */
+  const fileCacheRef = useRef<PersistedTerminalTabsFile | null>(null);
+  /** size/cwd の Map 更新を save effect に観測させるための tick */
+  const [tickNonce, setTickNonce] = useState(0);
+  const bumpTick = useCallback(() => setTickNonce((n) => n + 1), []);
+
+  // mount 時に 1 度だけ load → 復元
+  useEffect(() => {
+    if (!projectRoot) return;
+    let disposed = false;
+    void (async () => {
+      let file: PersistedTerminalTabsFile | null = null;
+      try {
+        file = await api.terminalTabs.load();
+      } catch (err) {
+        console.warn('[terminal-tabs] load failed:', err);
+      }
+      if (disposed) return;
+      fileCacheRef.current = file;
+      const slot = file?.byProject?.[projectRoot];
+      if (slot && slot.tabs.length > 0 && terminalTabs.length === 0) {
+        restoringRef.current = true;
+        const numericByPersistedId = new Map<string, number>();
+        for (const p of slot.tabs) {
+          const newId = addTerminalTab({
+            agent: p.kind,
+            resumeSessionId: p.sessionId,
+            role: p.role ?? null,
+            teamId: p.teamId ?? null,
+            agentId: p.agentId ?? undefined,
+            customLabel: p.label ?? null
+          });
+          if (newId !== null) {
+            numericByPersistedId.set(p.tabId, newId);
+            sizeMapRef.current.set(newId, { cols: p.cols, rows: p.rows });
+            cwdMapRef.current.set(newId, p.cwd);
+          }
+        }
+        if (slot.activeTabId !== null) {
+          const target = numericByPersistedId.get(slot.activeTabId);
+          if (target !== undefined) setActiveTerminalTabId(target);
+        }
+        restoringRef.current = false;
+      }
+      setIsReady(true);
+    })();
+    return () => {
+      disposed = true;
+    };
+    // 復元は projectRoot 確定 1 回限り。
+    // addTerminalTab / setActiveTerminalTabId の identity 変化で再復元しないよう deps から外す。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectRoot]);
+
+  // terminalTabs / activeTerminalTabId / size/cwd Map の変化を 500ms debounce で save
+  useEffect(() => {
+    if (!isReady || !projectRoot || restoringRef.current) return;
+    const timer = setTimeout(() => {
+      const persisted: PersistedTerminalTab[] = terminalTabs.map((t) => {
+        const size = sizeMapRef.current.get(t.id) ?? {
+          cols: DEFAULT_COLS,
+          rows: DEFAULT_ROWS
+        };
+        const cwd = cwdMapRef.current.get(t.id) ?? projectRoot;
+        return {
+          tabId: String(t.id),
+          kind: t.agent,
+          cwd,
+          cols: size.cols,
+          rows: size.rows,
+          sessionId: t.resumeSessionId,
+          label: t.customLabel,
+          teamId: t.teamId,
+          agentId: t.agentId,
+          role: t.role
+        };
+      });
+      const slot: PersistedTerminalTabsByProject = {
+        tabs: persisted,
+        activeTabId: activeTerminalTabId > 0 ? String(activeTerminalTabId) : null
+      };
+      const prevFile = fileCacheRef.current ?? {
+        schemaVersion: TERMINAL_TABS_SCHEMA_VERSION,
+        lastSavedAt: '',
+        byProject: {}
+      };
+      const nextFile: PersistedTerminalTabsFile = {
+        schemaVersion: TERMINAL_TABS_SCHEMA_VERSION,
+        lastSavedAt: new Date().toISOString(),
+        byProject: { ...prevFile.byProject, [projectRoot]: slot }
+      };
+      fileCacheRef.current = nextFile;
+      void api.terminalTabs.save(nextFile).catch((err) => {
+        console.warn('[terminal-tabs] save failed:', err);
+      });
+    }, SAVE_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [terminalTabs, activeTerminalTabId, projectRoot, isReady, tickNonce]);
+
+  const reportSize = useCallback(
+    (tabId: number, cols: number, rows: number) => {
+      const prev = sizeMapRef.current.get(tabId);
+      if (prev && prev.cols === cols && prev.rows === rows) return;
+      sizeMapRef.current.set(tabId, { cols, rows });
+      bumpTick();
+    },
+    [bumpTick]
+  );
+
+  const reportCwd = useCallback(
+    (tabId: number, cwd: string) => {
+      const prev = cwdMapRef.current.get(tabId);
+      if (prev === cwd) return;
+      cwdMapRef.current.set(tabId, cwd);
+      bumpTick();
+    },
+    [bumpTick]
+  );
+
+  return { isReady, reportSize, reportCwd };
+}

--- a/src/renderer/src/lib/hooks/use-terminal-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs.ts
@@ -20,6 +20,15 @@ export interface TerminalTab {
   status: string;
   exited: boolean;
   resumeSessionId: string | null;
+  /**
+   * Issue #660: Claude session id がまだ jsonl に永続化されていない初回 spawn かどうか。
+   * - true: タブ生成時に renderer が UUID を採番した直後。args 構築時に
+   *   `--session-id <uuid>` を渡して claude に id を強制注入する (新規 jsonl 作成)。
+   * - false: 既に jsonl が存在する (team-history resume / restart / 永続化復元) ので
+   *   `--resume <uuid>` で再接続する。
+   * `markSessionPersisted` で `onSessionId` 受信時に false へ倒す。
+   */
+  freshSessionId: boolean;
   /** チーム履歴で使う member インデックス。未所属タブは null */
   teamHistoryMemberIdx: number | null;
   /** 自動生成されたデフォルトラベル（"Claude #1" / "Programmer A" など） */
@@ -102,6 +111,11 @@ export interface UseTerminalTabsResult {
   doCloseTab: (tabId: number) => void;
   restartTerminalTab: (tabId: number) => void;
   restartTerminal: () => void;
+  /**
+   * Issue #660: `onSessionId` で claude の session 永続化が確認できたら呼び、
+   * `freshSessionId` を false に倒す。次回以降の spawn は `--resume <uuid>` 経路になる。
+   */
+  markSessionPersisted: (tabId: number) => void;
 
   // ---- tab create menu UI ----
   tabCreateMenuOpen: boolean;
@@ -218,6 +232,25 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
       // updater 内から呼ぶのは「同コンポーネント内の setState を queue する」だけなので
       // strict mode の二重実行下でも同じ id を再代入するだけで idempotent。
       const agentType = addOpts?.agent ?? 'claude';
+      // Issue #660: client-side UUID 事前注入。
+      //   - resumeSessionId が外部指定 (team-history resume / 永続化復元) → そのまま使い
+      //     freshSessionId=false (既に jsonl が存在する前提なので `--resume` 経路)
+      //   - 未指定 & claude → UUID v4 を採番して `--session-id` 経路で起動 (新規 jsonl 作成)
+      //   - 未指定 & codex/その他 → resumeSessionId は null (--session-id も --resume も付けない)
+      // updater の外で生成するのは副作用 (UUID) のため。strict mode 二重呼び出しでも同 UUID で
+      // idempotent。MAX_TERMINALS で reject されたら 1 個無駄になるが極小コストなので許容。
+      let resumeSessionId: string | null;
+      let freshSessionId: boolean;
+      if (addOpts?.resumeSessionId !== undefined) {
+        resumeSessionId = addOpts.resumeSessionId;
+        freshSessionId = false;
+      } else if (agentType === 'claude') {
+        resumeSessionId = crypto.randomUUID();
+        freshSessionId = true;
+      } else {
+        resumeSessionId = null;
+        freshSessionId = false;
+      }
       let assignedId: number | null = null;
       setTerminalTabs((prev) => {
         if (prev.length >= MAX_TERMINALS) {
@@ -250,7 +283,8 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
           agentId: addOpts?.agentId ?? `agent-${id}`,
           status: '',
           exited: false,
-          resumeSessionId: addOpts?.resumeSessionId ?? null,
+          resumeSessionId,
+          freshSessionId,
           teamHistoryMemberIdx: addOpts?.teamHistoryMemberIdx ?? null,
           label,
           customLabel: addOpts?.customLabel ?? null
@@ -319,6 +353,21 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
     );
   }, []);
 
+  /**
+   * Issue #660: Claude session が jsonl に永続化された (= `onSessionId` 受信) 時点で呼び、
+   * `freshSessionId` を false に倒す。これ以降の spawn は `--resume <uuid>` 経路になる。
+   * 既に false なら no-op (zustand-style 同値 skip)。
+   */
+  const markSessionPersisted = useCallback((tabId: number) => {
+    setTerminalTabs((prev) => {
+      const idx = prev.findIndex((t) => t.id === tabId);
+      if (idx < 0 || !prev[idx].freshSessionId) return prev;
+      const next = [...prev];
+      next[idx] = { ...prev[idx], freshSessionId: false };
+      return next;
+    });
+  }, []);
+
   const restartTerminal = useCallback(() => {
     restartTerminalTab(activeTerminalTabId);
   }, [activeTerminalTabId, restartTerminalTab]);
@@ -384,6 +433,7 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
     doCloseTab,
     restartTerminalTab,
     restartTerminal,
+    markSessionPersisted,
     tabCreateMenuOpen,
     setTabCreateMenuOpen,
     pendingTeamClose,

--- a/src/renderer/src/lib/hooks/use-terminal-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs.ts
@@ -29,6 +29,11 @@ export interface TerminalTab {
    * `markSessionPersisted` で `onSessionId` 受信時に false へ倒す。
    */
   freshSessionId: boolean;
+  /**
+   * Issue #662: 起動時に PTY に渡す cwd (絶対パス)。永続化復元用。
+   * null なら App.tsx 側 fallback (`settings.claudeCwd ?? projectRoot`) を使う。
+   */
+  cwd: string | null;
   /** チーム履歴で使う member インデックス。未所属タブは null */
   teamHistoryMemberIdx: number | null;
   /** 自動生成されたデフォルトラベル（"Claude #1" / "Programmer A" など） */
@@ -58,6 +63,11 @@ export interface AddTerminalTabOptions {
   teamHistoryMemberIdx?: number | null;
   /** team-history からの resume 時に復元する手動リネーム名 */
   customLabel?: string | null;
+  /**
+   * Issue #662: 永続化復元時に PTY 起動 cwd として渡す絶対パス。
+   * 未指定なら App.tsx 側 fallback (`settings.claudeCwd ?? projectRoot`) を使う。
+   */
+  cwd?: string | null;
 }
 
 type ToastFn = (
@@ -285,6 +295,7 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
           exited: false,
           resumeSessionId,
           freshSessionId,
+          cwd: addOpts?.cwd ?? null,
           teamHistoryMemberIdx: addOpts?.teamHistoryMemberIdx ?? null,
           label,
           customLabel: addOpts?.customLabel ?? null

--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -27,6 +27,7 @@ import { teamHistory } from './tauri-api/team-history';
 import { teamPresets } from './tauri-api/team-presets';
 import { teamState } from './tauri-api/team-state';
 import { terminal } from './tauri-api/terminal';
+import { terminalTabs } from './tauri-api/terminal-tabs';
 
 // 既存 import { RoleProfileSummary } from '../lib/tauri-api' との互換維持。
 // Tauri 側 TeamHub に同期する role profile の要約形。
@@ -52,7 +53,8 @@ export const api = {
   settings,
   roleProfiles,
   logs,
-  terminal
+  terminal,
+  terminalTabs
 };
 
 export type Api = typeof api;

--- a/src/renderer/src/lib/tauri-api/terminal-tabs.ts
+++ b/src/renderer/src/lib/tauri-api/terminal-tabs.ts
@@ -1,0 +1,26 @@
+// tauri-api/terminal-tabs.ts — Issue #661 IDE タブ永続化 IPC namespace
+//
+// `~/.vibe-editor/terminal-tabs.json` を Rust 側で atomic write する API のラッパ。
+// 読込時は schemaVersion 不一致 / 未存在で `null` を返す (renderer は素の IDE 起動に
+// フォールバックする)。
+
+import { invoke } from '@tauri-apps/api/core';
+import type { PersistedTerminalTabsFile } from '../../../../types/shared';
+
+interface MutationResult {
+  ok: boolean;
+  error?: string;
+}
+
+export const terminalTabs = {
+  /** 永続化ファイルを読む。未存在 / schemaVersion mismatch / parse 失敗で null。 */
+  load: async (): Promise<PersistedTerminalTabsFile | null> => {
+    const result = await invoke<PersistedTerminalTabsFile | null>('terminal_tabs_load');
+    return result ?? null;
+  },
+  /** 全体を atomic 上書き。read-modify-write は呼び出し側責務。 */
+  save: (file: PersistedTerminalTabsFile): Promise<MutationResult> =>
+    invoke('terminal_tabs_save', { file }),
+  /** ファイルを削除して cache を空に戻す。idempotent。 */
+  clear: (): Promise<MutationResult> => invoke('terminal_tabs_clear')
+};

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -936,6 +936,57 @@ export interface TerminalExitInfo {
   signal?: number;
 }
 
+// ---------- IDE 端末タブ永続化 (Issue #661) ----------
+
+/** terminal-tabs.json schema 版番号。format 互換が壊れる変更で bump する。 */
+export const TERMINAL_TABS_SCHEMA_VERSION = 1;
+
+/**
+ * 1 個の terminal タブを再起動跨ぎで復元するためのスナップショット。
+ *
+ * 永続化先は `~/.vibe-editor/terminal-tabs.json`。`team-history.json` (Canvas / TeamHub
+ * 配下のタブ) とは独立した SSOT で、IDE モードの単独タブが対象。
+ */
+export interface PersistedTerminalTab {
+  /** renderer 側 stable id。v1 では `String(numericId)` で number 採番をそのまま文字列化 */
+  tabId: string;
+  /** Claude / Codex / 素 shell / カスタム engine (`TerminalAgent` と同じ) */
+  kind: TerminalAgent;
+  /** 起動時に渡した cwd (絶対パス)。symlink 解決はしない (jsonl の cwd と乖離するため) */
+  cwd: string;
+  /** 最終 PTY size。復元時に `terminal.create({ cols, rows })` の initial seed として渡す */
+  cols: number;
+  rows: number;
+  /** Claude のみ事前注入 UUID。codex / shell は null */
+  sessionId: string | null;
+  /** ユーザーが手動でリネームしたタブ名。null / 未指定なら自動生成名にフォールバック */
+  label?: string | null;
+  /** TeamHub に attach していたタブを将来検出するための任意参照 (v1 では検出しない) */
+  teamId?: string | null;
+  agentId?: string | null;
+  role?: string | null;
+}
+
+/** 1 プロジェクトの全タブ + アクティブタブ id。 */
+export interface PersistedTerminalTabsByProject {
+  /** 配列順 = タブの表示順序 */
+  tabs: PersistedTerminalTab[];
+  /** 最後にアクティブだった tabId (復元時にフォーカスする)。null で先頭タブ採用 */
+  activeTabId: string | null;
+}
+
+/** terminal-tabs.json のトップレベル形 (atomic write 単位)。 */
+export interface PersistedTerminalTabsFile {
+  schemaVersion: number;
+  /** 最後に save した RFC3339 (debug / orphan 検出用) */
+  lastSavedAt: string;
+  /**
+   * プロジェクトルート毎のタブ集合。raw projectRoot を key にし、検索側で
+   * `normalize_project_root` を経由して照合する (`team_history.rs` と同流儀)。
+   */
+  byProject: Record<string, PersistedTerminalTabsByProject>;
+}
+
 // ---------- TeamHub inject failure (Issue #511) ----------
 
 /**


### PR DESCRIPTION
## Summary

Claude session の再起動跨ぎ自動復元を全 OS で standalone (ユーザー設定不要) で完璧に動かす。3 issue を 1 PR にバンドル + セキュリティ統一。

- **#660** `--session-id` 事前注入: renderer 側で UUID v4 を採番して `claude --session-id <uuid>` で起動する flag 方式に切替え、watcher の jsonl 検出 race を構造排除
- **#661** IDE タブ永続化: `~/.vibe-editor/terminal-tabs.json` (atomic_write + 0o600) で IDE モードのタブを再起動跨ぎで復元
- **#662** cwd / PTY size 復元: 永続化スキーマに cwd / cols / rows を含め、TerminalView の `onResize` 経由で更新

watcher (`claude_watcher.rs`) は外部起動 claude / 旧 schema 救済の fallback として残す。

Closes #660, #661, #662

## 主な変更点

| commit | 概要 |
|---|---|
| `feat(terminal): #660` | CardFrame.tsx で UUID 採番 + payload 書き戻し、IDE タブに `freshSessionId` flag、`getTerminalArgs` を `--session-id` / `--resume` で分岐、`onSessionId` 受信で `markSessionPersisted` |
| `feat(terminal): #661` | 新 IPC `terminal_tabs_load/save/clear`、`shared.ts` に `PersistedTerminalTab*` 型、`use-terminal-tabs-persistence` hook (mount load → addTerminalTab で復元、500ms debounce save) |
| `feat(terminal): #662` | `TerminalView` の `onResize` prop、`AddTerminalTabOptions` / `TerminalTab` に `cwd` 追加、`path_norm.rs` の cross-OS encode 回帰テスト |
| `fix(terminal): #661 #608` | terminal-tabs.json を `atomic_write_with_mode(.., Some(0o600))` で書き出して機密ファイル統一 |

## 設計判断

- **flag 方式 (`--session-id` / `--resume` 切替)**: Claude CLI の `--session-id` が「未存在 UUID 専用」かが公式 doc 未確定のため、安全側で初回のみ `--session-id`、`onSessionId` 受信後は `--resume` に倒す
- **IDE タブと Canvas タブの衝突を避ける**: IDE は新 SSOT (terminal-tabs.json)、Canvas は既存 team-history.json。`registry.rs::find_attach_target` の sessionKey 空間で直交
- **encoded-cwd 規則**: 既存 `encode_project_path` の「ASCII alnum 以外 → `-`」は公式 Claude CLI と一致 (`F:\vive-editor` → `F--vive-editor` を実機 + doc で確認済)。Win/macOS/Linux/WSL UNC 全パターンを test で固定

## Test plan

- [x] `npm run typecheck`
- [x] `cargo check --all-targets`
- [x] `cargo test pty::path_norm commands::terminal_tabs` 8/8 pass
- [ ] `npm run dev` で IDE タブ (Claude × 2 + codex × 1) 作成 → 完全終了 → 再起動でタブ復元 + `claude --resume` 動作確認
- [ ] `~/.vibe-editor/terminal-tabs.json` のパーミッションが Linux/macOS で `0600`
- [ ] Canvas モードと IDE モード両方で session 復元が動作

## 互換性

- watcher は維持しているので外部起動 claude / 旧データはそのまま動く
- terminal-tabs.json は schemaVersion 1 で開始、parse 失敗 / 未存在は素の起動にフォールバック
- TerminalTab に追加した `freshSessionId` / `cwd` は in-memory のみ (永続化は terminal-tabs.json 側で別管理)