### PR TITLE
fix(canvas): Canvas HUD とヘッダの不具合を修正

### DIFF
--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -83,7 +83,20 @@ const FLOW_STAGE_STYLE = { position: 'absolute' as const, inset: 0 };
 /** Issue #259 継承: zoom が 0.7 を下回ると TUI が読めなくなるため recruit focus 時のクランプ閾値。 */
 const MIN_RECRUIT_ZOOM = 0.7;
 
-function FlowApp(): JSX.Element {
+export interface CanvasActions {
+  addClaude: () => void;
+  addCodex: () => void;
+  addFileTree: () => void;
+  addChanges: () => void;
+  addEditor: () => void;
+  spawnDefaultTeam: () => void;
+}
+
+interface FlowAppProps {
+  actions: CanvasActions;
+}
+
+function FlowApp({ actions }: FlowAppProps): JSX.Element {
   const t = useT();
   const nodes = useCanvasNodes();
   const edges = useCanvasEdges();
@@ -92,7 +105,7 @@ function FlowApp(): JSX.Element {
   const setNodes = useCanvasStore((s) => s.setNodes);
   const setEdges = useCanvasStore((s) => s.setEdges);
   const setViewport = useCanvasStore((s) => s.setViewport);
-  const addCard = useCanvasStore((s) => s.addCard);
+  const setCanvasDragging = useCanvasStore((s) => s.setCanvasDragging);
   // ユーザー操作 (× / 右クリック / Delete) からの削除はチーム全員カスケード前に確認を挟む。
   const confirmRemoveCard = useConfirmRemoveCard();
   const pulseEdge = useCanvasStore((s) => s.pulseEdge);
@@ -122,6 +135,10 @@ function FlowApp(): JSX.Element {
         ? changes.filter((c) => c.type !== 'remove')
         : changes;
       if (remaining.length === 0) return;
+      const draggingNow = remaining.some((c) => c.type === 'position' && c.dragging);
+      if (useCanvasStore.getState().isDragging !== draggingNow) {
+        setCanvasDragging(draggingNow);
+      }
 
       // Issue #196: 旧実装は変更ごとに `nodes.find` + `for (other of nodes)` + 内側 `remaining.some(...)`
       // で O(N×M) になっており、6 人チーム × 4 種カード = 24 ノード規模で 1 px ドラッグごとに
@@ -224,7 +241,7 @@ function FlowApp(): JSX.Element {
       const allChanges = extra.length > 0 ? [...remaining, ...extra] : remaining;
       setNodes(applyNodeChanges(allChanges, currentNodes));
     },
-    [setNodes, confirmRemoveCard, isTeamLocked]
+    [setNodes, confirmRemoveCard, isTeamLocked, setCanvasDragging]
   );
   const onEdgesChange = useCallback(
     (changes: EdgeChange<Edge>[]) =>
@@ -243,18 +260,12 @@ function FlowApp(): JSX.Element {
     items: ContextMenuItem[];
   } | null>(null);
 
-  // Ctrl+Space / Pane 右クリック共通: 新規 AI Agent (Claude Code) を追加。
+  // Ctrl+Space: 新規 AI Agent (Claude Code) を追加。
   // 件数カウントは getState で都度参照し、callback 識別子を `nodes` の参照変化から切り離す
   // (ドラッグ中の毎フレーム再生成を抑え、useKeybinding の listener 再登録も発生させない)。
   const handleAddClaudeAgent = useCallback((): void => {
-    const currentNodes = useCanvasStore.getState().nodes;
-    const n = currentNodes.filter((x) => x.type === 'agent').length + 1;
-    addCard({
-      type: 'agent',
-      title: `Claude #${n}`,
-      payload: { agent: 'claude', role: 'leader' }
-    });
-  }, [addCard]);
+    actions.addClaude();
+  }, [actions]);
 
   const handleNodeContextMenu = useCallback(
     (e: React.MouseEvent, node: Node<CardData>) => {
@@ -279,7 +290,7 @@ function FlowApp(): JSX.Element {
     [isTeamLocked, confirmRemoveCard, setTeamLock, t]
   );
 
-  // 空のキャンバス (Pane) で右クリックされたとき: 「ここに Claude を追加」を出す。
+  // 空のキャンバス (Pane) で右クリックされたとき: カード追加 / チーム起動を集約する。
   // ユーザーが「右クリックしてもメニューが出ない」と感じる主因は、ノード上ではなく
   // Pane 上を狙ってしまっているケース。Pane 用にも明示的にハンドラを生やしておく。
   const handlePaneContextMenu = useCallback(
@@ -294,12 +305,33 @@ function FlowApp(): JSX.Element {
       const items: ContextMenuItem[] = [
         {
           label: t('canvasMenu.addClaudeHere'),
-          action: () => handleAddClaudeAgent()
+          action: actions.addClaude
+        },
+        {
+          label: t('canvasMenu.addCodexHere'),
+          action: actions.addCodex
+        },
+        {
+          label: t('canvasMenu.addFileTreeHere'),
+          action: actions.addFileTree
+        },
+        {
+          label: t('canvasMenu.addChangesHere'),
+          action: actions.addChanges
+        },
+        {
+          label: t('canvasMenu.addEditorHere'),
+          action: actions.addEditor,
+          divider: true
+        },
+        {
+          label: t('canvasMenu.spawnDefaultTeam'),
+          action: actions.spawnDefaultTeam
         }
       ];
       setContextMenu({ x: e.clientX, y: e.clientY, items });
     },
-    [t, handleAddClaudeAgent]
+    [t, actions]
   );
 
   // Issue #158: hand-off event は use-team-handoff の集約 listener 経由で受け取る。
@@ -369,7 +401,13 @@ function FlowApp(): JSX.Element {
   const recruitFocusRequestedAt = useCanvasStore(
     (s) => s.lastRecruitFocus?.requestedAt ?? 0
   );
+  const viewportResetSeq = useCanvasStore((s) => s.viewportResetSeq);
   const reactFlow = useReactFlow();
+  useEffect(() => {
+    if (viewportResetSeq === 0) return;
+    reactFlow.setViewport({ x: 0, y: 0, zoom: 1 }, { duration: 0 });
+  }, [viewportResetSeq, reactFlow]);
+
   useEffect(() => {
     if (!recruitFocusNodeId || !recruitFocusRequestedAt) return;
     const timer = window.setTimeout(() => {
@@ -528,10 +566,10 @@ function StageListOverlay(): JSX.Element {
   );
 }
 
-export function Canvas(): JSX.Element {
+export function Canvas({ actions }: { actions: CanvasActions }): JSX.Element {
   return (
     <ReactFlowProvider>
-      <FlowApp />
+      <FlowApp actions={actions} />
     </ReactFlowProvider>
   );
 }

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -209,22 +209,18 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   // CardFrame が unmount されても store にレコードを残さないよう effect で掃除する。
   const publishActivity = useAgentActivityStore((s) => s.setActivity);
   const clearActivity = useAgentActivityStore((s) => s.clearCard);
-  // setActivity wrapper: useState 更新 + store 通知を 1 関数にまとめる。
   // TerminalOverlay は React.Dispatch<SetStateAction<AgentStatus>> を期待するので、
-  // 関数形 updater を素通しできる shape を保つ。
+  // 関数形 updater を素通しできる shape を保つ。agent-activity store への publish は
+  // 下の effect に集約し、子コンポーネントの render 中に呼ばれても StageHud を同期更新しない。
   const setActivity: React.Dispatch<React.SetStateAction<AgentStatus>> = useCallback(
     (next) => {
-      setActivityState((prev) => {
-        const resolved =
-          typeof next === 'function'
-            ? (next as (p: AgentStatus) => AgentStatus)(prev)
-            : next;
-        publishActivity(id, resolved, Date.now());
-        return resolved;
-      });
+      setActivityState(next);
     },
-    [id, publishActivity]
+    []
   );
+  useEffect(() => {
+    publishActivity(id, activity, Date.now());
+  }, [id, activity, publishActivity]);
   useEffect(() => {
     return () => clearActivity(id);
   }, [id, clearActivity]);
@@ -245,8 +241,10 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   // 対策として primitive な signature 文字列 (agentId|role|agent を ; で連結) を購読し、
   // 文字列 equality で React がデフォルトで bailout できるようにする。drag/resize では
   // signature が変わらないので再レンダーが発生しない。
+  const lastTeamMembersSigRef = useRef('');
   const teamMembersSig = useCanvasStore((s) => {
     if (!payload.teamId) return '';
+    if (s.isDragging) return lastTeamMembersSigRef.current;
     const sigs: string[] = [];
     for (const n of s.nodes) {
       if (n.type !== 'agent') continue;
@@ -255,7 +253,9 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
       if (!p || p.teamId !== payload.teamId || !p.agentId || !rp) continue;
       sigs.push(`${p.agentId}:${rp}:${p.agent ?? 'claude'}`);
     }
-    return sigs.join(';');
+    const sig = sigs.join(';');
+    lastTeamMembersSigRef.current = sig;
+    return sig;
   });
   const teamMembers = useMemo(() => {
     if (!payload.teamId) return null;

--- a/src/renderer/src/components/canvas/cards/ChangesCard.tsx
+++ b/src/renderer/src/components/canvas/cards/ChangesCard.tsx
@@ -3,7 +3,7 @@
  *
  * payload: { projectRoot }
  */
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import type { GitStatus } from '../../../../../types/shared';
 import { CardFrame } from '../CardFrame';
@@ -26,15 +26,29 @@ function ChangesCardImpl({ id, data, positionAbsoluteX, positionAbsoluteY }: Nod
   const addCard = useCanvasStore((s) => s.addCard);
   const [status, setStatus] = useState<GitStatus | null>(null);
   const [loading, setLoading] = useState(true);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const refresh = useCallback(() => {
     if (!projectRoot) return;
     setLoading(true);
     void window.api.git
       .status(projectRoot)
-      .then(setStatus)
-      .catch(() => setStatus(null))
-      .finally(() => setLoading(false));
+      .then((next) => {
+        if (mountedRef.current) setStatus(next);
+      })
+      .catch(() => {
+        if (mountedRef.current) setStatus(null);
+      })
+      .finally(() => {
+        if (mountedRef.current) setLoading(false);
+      });
   }, [projectRoot]);
 
   useEffect(() => {

--- a/src/renderer/src/components/canvas/cards/DiffCard.tsx
+++ b/src/renderer/src/components/canvas/cards/DiffCard.tsx
@@ -3,7 +3,7 @@
  *
  * payload: { projectRoot, relPath }
  */
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import type { GitDiffResult } from '../../../../../types/shared';
 import { CardFrame } from '../CardFrame';
@@ -25,20 +25,32 @@ function DiffCardImpl({ id, data }: NodeProps): JSX.Element {
   const [result, setResult] = useState<GitDiffResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [sideBySide, setSideBySide] = useState(true);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const refresh = useCallback(() => {
     if (!projectRoot || !relPath) {
-      setLoading(false);
+      if (mountedRef.current) setLoading(false);
       return;
     }
     setLoading(true);
     void window.api.git
       .diff(projectRoot, relPath, originalRelPath)
-      .then(setResult)
+      .then((r) => {
+        if (mountedRef.current) setResult(r);
+      })
       .catch(() => {
         /* noop */
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (mountedRef.current) setLoading(false);
+      });
   }, [projectRoot, relPath, originalRelPath]);
 
   useEffect(() => {

--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -15,12 +15,15 @@ import type { Node } from '@xyflow/react';
 import {
   ArrowDownToLine,
   ChevronDown,
+  Command as CommandIcon,
+  ExternalLink,
   FilePlus,
   FolderTree,
   GitBranch,
   Layout,
   MonitorSmartphone,
   Plus,
+  Settings as SettingsIcon,
   Sparkles,
   History
 } from 'lucide-react';
@@ -32,10 +35,11 @@ import type {
   TeamRole,
   TerminalAgent
 } from '../../../types/shared';
-import { Canvas } from '../components/canvas/Canvas';
+import { Canvas, type CanvasActions } from '../components/canvas/Canvas';
 import { CanvasSidebar } from '../components/canvas/CanvasSidebar';
 import { Rail } from '../components/shell/Rail';
-import { WindowControls } from '../components/shell/WindowControls';
+import { Topbar } from '../components/shell/Topbar';
+import { MenuBar, MenuDivider, MenuItem } from '../components/shell/MenuBar';
 import type { SidebarView } from '../components/Sidebar';
 import { SettingsModal } from '../components/SettingsModal';
 import { useT } from '../lib/i18n';
@@ -106,8 +110,10 @@ export function CanvasLayout(): JSX.Element {
   const projectRoot = settings.lastOpenedRoot || settings.claudeCwd || '';
   const settingsOpen = useUiStore((s) => s.settingsOpen);
   const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
+  const setPaletteOpen = useUiStore((s) => s.setPaletteOpen);
   const sidebarCollapsed = useUiStore((s) => s.sidebarCollapsed);
   const availableUpdate = useUiStore((s) => s.availableUpdate);
+  const status = useUiStore((s) => s.status);
   const { showToast, dismissToast } = useToast();
   const [spawnOpen, setSpawnOpen] = useState(false);
   const [tab, setTab] = useState<'preset' | 'recent'>('preset');
@@ -328,6 +334,60 @@ export function CanvasLayout(): JSX.Element {
     setAddCardOpen(false);
   };
 
+  const handleRestart = async (): Promise<void> => {
+    const dirty = getDirtyEditorCardSnapshots();
+    if (dirty.length > 0) {
+      const paths = dirty.map((d) => `• ${d.relPath}`).join('\n');
+      const message = t('canvas.clearConfirmWithDirtyEditors', {
+        count: dirty.length,
+        paths
+      });
+      if (!window.confirm(message)) return;
+    }
+    await window.api.app.restart();
+  };
+
+  const handleClickUpdate = (): void => {
+    void import('../lib/updater-check').then((m) =>
+      m.runUpdateInstall({
+        language: settings.language,
+        showToast,
+        dismissToast,
+        manual: true
+      })
+    );
+  };
+
+  const clearCanvas = (): void => {
+    const dirty = getDirtyEditorCardSnapshots();
+    if (dirty.length === 0) {
+      if (window.confirm(t('canvas.clearConfirm'))) clear();
+      return;
+    }
+    const paths = dirty.map((d) => `• ${d.relPath}`).join('\n');
+    const message = t('canvas.clearConfirmWithDirtyEditors', {
+      count: dirty.length,
+      paths
+    });
+    if (window.confirm(message)) clear();
+  };
+
+  const canvasActions = useMemo<CanvasActions>(
+    () => ({
+      addClaude: () => addAgent('claude'),
+      addCodex: () => addAgent('codex'),
+      addFileTree: () => addByType('fileTree'),
+      addChanges: () => addByType('changes'),
+      addEditor: () => addByType('editor'),
+      spawnDefaultTeam: () => void applyPreset(DEFAULT_SPAWN_PRESET)
+    }),
+    // addAgent / addByType / applyPreset are recreated with the current project/settings values.
+    // Keeping this object memoized prevents Canvas context-menu handlers from rebinding on
+    // unrelated CanvasLayout state changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [projectRoot, nodes.length, settings.language, settings.mcpAutoSetup, addCards, notifyRecruit]
+  );
+
   return (
     <div
       className="canvas-layout"
@@ -335,183 +395,89 @@ export function CanvasLayout(): JSX.Element {
       style={isCanvasActive ? undefined : { display: 'none' }}
       aria-hidden={!isCanvasActive}
     >
+      <Topbar
+        projectRoot={projectRoot}
+        status={status}
+        onRestart={handleRestart}
+        onOpenPalette={() => setPaletteOpen(true)}
+        availableUpdate={availableUpdate}
+        onClickUpdate={handleClickUpdate}
+        menuBar={
+          <MenuBar
+            items={[
+              {
+                label: t('menubar.file'),
+                children: (
+                  <>
+                    <MenuItem
+                      icon={<Layout size={14} strokeWidth={1.8} />}
+                      label={t('canvas.switchToIde.tooltip')}
+                      shortcut="Ctrl+Shift+M"
+                      onClick={() => setViewMode('ide')}
+                    />
+                    <MenuDivider />
+                    <MenuItem
+                      icon={<ExternalLink size={14} strokeWidth={1.8} />}
+                      label={t('menubar.openGithub')}
+                      onClick={() => {
+                        void window.api.app.openExternal('https://github.com/yusei531642/vibe-editor');
+                      }}
+                    />
+                  </>
+                )
+              },
+              {
+                label: t('menubar.view'),
+                children: (
+                  <>
+                    <MenuItem
+                      icon={<CommandIcon size={14} strokeWidth={1.8} />}
+                      label={t('menubar.openPalette')}
+                      shortcut="Ctrl+Shift+P"
+                      onClick={() => setPaletteOpen(true)}
+                    />
+                    <MenuItem
+                      icon={<Layout size={14} strokeWidth={1.8} />}
+                      label={t('menubar.toggleCanvas')}
+                      shortcut="Ctrl+Shift+M"
+                      onClick={() => setViewMode('ide')}
+                    />
+                  </>
+                )
+              },
+              {
+                label: t('menubar.help'),
+                children: (
+                  <>
+                    <MenuItem
+                      icon={<SettingsIcon size={14} strokeWidth={1.8} />}
+                      label={t('menubar.openSettings')}
+                      shortcut="Ctrl+,"
+                      onClick={() => setSettingsOpen(true)}
+                    />
+                  </>
+                )
+              }
+            ]}
+          />
+        }
+      />
       <header className="canvas-header" data-tauri-drag-region>
         <span className="canvas-header__brand" data-tauri-drag-region>
           <MonitorSmartphone size={14} strokeWidth={1.75} data-tauri-drag-region />
-          Canvas
         </span>
         <span className="canvas-header__count" data-tauri-drag-region>{formatCardCount(cardCount, settings.language)}</span>
         <div className="canvas-header__spacer" data-tauri-drag-region />
-
-        <div className="canvas-popover__wrap" ref={addPopoverRef}>
-          <button
-            type="button"
-            className="canvas-btn"
-            onClick={() => setAddCardOpen((v) => !v)}
-            aria-label={t('canvas.add.tooltip')}
-            title={t('canvas.add.tooltip')}
-          >
-            <Plus size={13} strokeWidth={1.8} />
-            {t('canvas.add')}
-          </button>
-          {addCardOpen && (
-            <div className="canvas-popover">
-              <AddItem
-                icon={<AgentBadge label="C" color="#5c5cff" />}
-                label={t('canvas.add.claude')}
-                onClick={() => addAgent('claude')}
-              />
-              <AddItem
-                icon={<AgentBadge label="X" color="#10b981" />}
-                label={t('canvas.add.codex')}
-                onClick={() => addAgent('codex')}
-              />
-              <div className="canvas-popover__section">{t('canvas.panels')}</div>
-              <AddItem
-                icon={<FolderTree size={13} />}
-                label={t('canvas.add.fileTree')}
-                onClick={() => addByType('fileTree')}
-              />
-              <AddItem
-                icon={<GitBranch size={13} />}
-                label={t('canvas.add.gitChanges')}
-                onClick={() => addByType('changes')}
-              />
-              <AddItem
-                icon={<FilePlus size={13} />}
-                label={t('canvas.add.emptyEditor')}
-                onClick={() => addByType('editor')}
-              />
-            </div>
-          )}
-        </div>
-
-        <div className="canvas-popover__wrap" ref={spawnPopoverRef}>
-          {/* Spawn Team は split button: メインクリックで dynamic-team を即起動、
-              caret 部分でカスタム/最近使ったチームの popover を開く。 */}
-          <div className="canvas-btn-split">
-            <button
-              type="button"
-              className="canvas-btn canvas-btn--primary canvas-btn-split__main"
-              onClick={() => void applyPreset(DEFAULT_SPAWN_PRESET)}
-              aria-label={t('canvas.spawnTeam.tooltip')}
-              title={t('canvas.spawnTeam.tooltip')}
-            >
-              <Sparkles size={13} strokeWidth={1.8} />
-              {t('canvas.spawnTeam')}
-            </button>
-            <button
-              type="button"
-              className="canvas-btn canvas-btn--primary canvas-btn-split__caret"
-              onClick={() => setSpawnOpen((v) => !v)}
-              aria-label={t('canvas.spawnTeamMore.tooltip')}
-              title={t('canvas.spawnTeamMore.tooltip')}
-              aria-expanded={spawnOpen}
-            >
-              <ChevronDown size={12} strokeWidth={2} />
-            </button>
-          </div>
-          {spawnOpen && (
-            <div className="canvas-popover canvas-popover--wide">
-              <div className="canvas-popover__tabs">
-                <TabBtn active={tab === 'preset'} onClick={() => setTab('preset')}>
-                  <Sparkles size={11} /> {t('canvas.preset')}
-                </TabBtn>
-                <TabBtn active={tab === 'recent'} onClick={() => setTab('recent')}>
-                  <History size={11} /> {t('canvas.recent')}
-                  {closeRecent.length > 0 && (
-                    <span className="canvas-popover__tab-badge">{closeRecent.length}</span>
-                  )}
-                </TabBtn>
-              </div>
-              {tab === 'preset' && (
-                <>
-                  {BUILTIN_PRESETS.map((preset) => (
-                    <BuiltinPresetItem
-                      key={preset.id}
-                      preset={preset}
-                      label={t(preset.i18nKey)}
-                      agentCountLabel={formatOrganizationAgentCount(
-                        presetOrganizationCount(preset),
-                        presetMemberCount(preset),
-                        settings.language
-                      )}
-                      onClick={() => void applyPreset(preset)}
-                    />
-                  ))}
-                </>
-              )}
-              {tab === 'recent' && (
-                <>
-                  {closeRecent.length === 0 && (
-                    <div className="canvas-popover__empty">{t('canvas.noRecentTeams')}</div>
-                  )}
-                  {closeRecent.map((entry) => (
-                    <RecentItem
-                      key={entry.id}
-                      entry={entry}
-                      fallbackName={t('team.defaultName')}
-                      agentCountLabel={formatOrganizationAgentCount(
-                        entry.organization ? 1 : 0,
-                        entry.members.length,
-                        settings.language
-                      )}
-                      lastUsedLabel={t('canvas.lastUsed', {
-                        value: dateTimeFormatter.format(new Date(entry.lastUsedAt))
-                      })}
-                      onClick={() => void restoreRecent(entry)}
-                    />
-                  ))}
-                </>
-              )}
-            </div>
-          )}
-        </div>
 
         {cardCount > 0 && (
           <button
             type="button"
             className="canvas-btn canvas-btn--ghost"
-            onClick={() => {
-              // Issue #595: dirty な EditorCard が残っていればファイル名一覧を提示して
-              // 単一 confirm で確認する。dirty が無いときは既存の「全部消す?」だけ。
-              const dirty = getDirtyEditorCardSnapshots();
-              if (dirty.length === 0) {
-                if (window.confirm(t('canvas.clearConfirm'))) clear();
-                return;
-              }
-              const paths = dirty.map((d) => `• ${d.relPath}`).join('\n');
-              const message = t('canvas.clearConfirmWithDirtyEditors', {
-                count: dirty.length,
-                paths
-              });
-              if (window.confirm(message)) clear();
-            }}
+            onClick={clearCanvas}
             title={t('canvas.clear.tooltip')}
             aria-label={t('canvas.clear.tooltip')}
           >
             {t('canvas.clear')}
-          </button>
-        )}
-        {availableUpdate && (
-          <button
-            type="button"
-            className="canvas-btn canvas-btn--update"
-            onClick={() => {
-              void import('../lib/updater-check').then((m) =>
-                m.runUpdateInstall({
-                  language: settings.language,
-                  showToast,
-                  dismissToast,
-                  manual: true
-                })
-              );
-            }}
-            title={t('updater.button.title', { version: availableUpdate.version })}
-            aria-label={t('updater.button.title', { version: availableUpdate.version })}
-          >
-            <ArrowDownToLine size={13} strokeWidth={1.9} />
-            {t('updater.button.label', { version: availableUpdate.version })}
           </button>
         )}
         <button
@@ -524,7 +490,6 @@ export function CanvasLayout(): JSX.Element {
           <Layout size={13} strokeWidth={1.8} />
           IDE
         </button>
-        <WindowControls />
       </header>
       <div className="canvas-layout__body">
         <Rail
@@ -543,7 +508,7 @@ export function CanvasLayout(): JSX.Element {
           />
         )}
         <div className="canvas-layout__stage">
-          <Canvas />
+          <Canvas actions={canvasActions} />
         </div>
       </div>
 

--- a/src/renderer/src/lib/__tests__/use-canvas-visibility.test.ts
+++ b/src/renderer/src/lib/__tests__/use-canvas-visibility.test.ts
@@ -45,6 +45,7 @@ describe('useCanvasVisibility', () => {
 
   afterEach(() => {
     __resetCanvasVisibilityForTests();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -80,6 +81,7 @@ describe('useCanvasVisibility', () => {
   });
 
   it('subscribeOnVisible は hidden→visible 遷移時のみ発火する (edge trigger)', () => {
+    vi.useFakeTimers();
     const cb = vi.fn();
     const unsub = subscribeOnVisible(cb);
 
@@ -91,6 +93,8 @@ describe('useCanvasVisibility', () => {
     expect(cb).not.toHaveBeenCalled(); // hidden 遷移では発火しない
 
     setVisibilityState('visible');
+    expect(cb).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(200);
     expect(cb).toHaveBeenCalledTimes(1);
 
     // 連続して visible のまま focus が来ても再発火しない
@@ -100,15 +104,18 @@ describe('useCanvasVisibility', () => {
     // 再度 hidden → visible で再発火
     setVisibilityState('hidden');
     setVisibilityState('visible');
+    vi.advanceTimersByTime(200);
     expect(cb).toHaveBeenCalledTimes(2);
 
     unsub();
     setVisibilityState('hidden');
     setVisibilityState('visible');
+    vi.advanceTimersByTime(200);
     expect(cb).toHaveBeenCalledTimes(2); // unsub 後は発火しない
   });
 
   it('複数 subscriber が独立して発火する', () => {
+    vi.useFakeTimers();
     const a = vi.fn();
     const b = vi.fn();
     subscribeOnVisible(a);
@@ -116,8 +123,26 @@ describe('useCanvasVisibility', () => {
 
     setVisibilityState('hidden');
     setVisibilityState('visible');
+    vi.advanceTimersByTime(200);
 
     expect(a).toHaveBeenCalledTimes(1);
     expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('短時間の visible パカパカでは安定後に 1 回だけ発火する', () => {
+    vi.useFakeTimers();
+    const cb = vi.fn();
+    subscribeOnVisible(cb);
+
+    setVisibilityState('hidden');
+    setVisibilityState('visible');
+    vi.advanceTimersByTime(100);
+    setVisibilityState('hidden');
+    setVisibilityState('visible');
+    vi.advanceTimersByTime(199);
+    expect(cb).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(cb).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/renderer/src/lib/hooks/use-canvas-team-restore.ts
+++ b/src/renderer/src/lib/hooks/use-canvas-team-restore.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type { Node } from '@xyflow/react';
 import type { CardData } from '../../stores/canvas';
 
@@ -30,20 +30,12 @@ export function useCanvasTeamRestore(opts: UseCanvasTeamRestoreOptions): void {
   const restoredTeamsRef = useRef<Map<string, { state: RestoreState; nextRetryAt?: number }>>(
     new Map()
   );
-  useEffect(() => {
-    if (nodes.length === 0) {
-      // Clear 後は次のチームでまた setup したいので ref をリセット
-      restoredTeamsRef.current.clear();
-    }
-  }, [nodes.length]);
-  useEffect(() => {
-    if (!projectRoot) return;
-    if (mcpAutoSetup === false) return;
+  const byTeam = useMemo(() => {
     interface TeamRestoreInfo {
       name: string;
       members: { agentId: string; role: string; agent: string }[];
     }
-    const byTeam = new Map<string, TeamRestoreInfo>();
+    const map = new Map<string, TeamRestoreInfo>();
     for (const n of nodes) {
       const p = (n.data?.payload ?? {}) as {
         teamId?: string;
@@ -56,10 +48,22 @@ export function useCanvasTeamRestore(opts: UseCanvasTeamRestoreOptions): void {
       const role = p.roleProfileId ?? p.role;
       if (!p.teamId || !p.agentId || !role || !p.agent) continue;
       const title = String(n.data?.title ?? 'Team');
-      const tm = byTeam.get(p.teamId) ?? { name: p.organization?.name ?? title, members: [] };
+      const tm = map.get(p.teamId) ?? { name: p.organization?.name ?? title, members: [] };
       tm.members.push({ agentId: p.agentId, role, agent: p.agent });
-      byTeam.set(p.teamId, tm);
+      map.set(p.teamId, tm);
     }
+    return map;
+  }, [nodes]);
+
+  useEffect(() => {
+    if (nodes.length === 0) {
+      // Clear 後は次のチームでまた setup したいので ref をリセット
+      restoredTeamsRef.current.clear();
+    }
+  }, [nodes.length]);
+  useEffect(() => {
+    if (!projectRoot) return;
+    if (mcpAutoSetup === false) return;
     const now = Date.now();
     for (const [teamId, info] of byTeam) {
       const cur = restoredTeamsRef.current.get(teamId);
@@ -82,5 +86,5 @@ export function useCanvasTeamRestore(opts: UseCanvasTeamRestoreOptions): void {
           console.warn('[restore] setupTeamMcp failed:', err);
         });
     }
-  }, [projectRoot, nodes, mcpAutoSetup]);
+  }, [projectRoot, byTeam, mcpAutoSetup]);
 }

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -207,6 +207,11 @@ const ja: Dict = {
   'canvasMenu.unlockTeam': 'チーム固定を解除',
   'canvasMenu.deleteCard': 'カードを削除',
   'canvasMenu.addClaudeHere': 'ここに Claude を追加',
+  'canvasMenu.addCodexHere': 'ここに Codex を追加',
+  'canvasMenu.addFileTreeHere': 'ここにファイルツリーを追加',
+  'canvasMenu.addChangesHere': 'ここに Git 変更を追加',
+  'canvasMenu.addEditorHere': 'ここに空のエディタを追加',
+  'canvasMenu.spawnDefaultTeam': '既定チームを起動',
 
   // ---------- Claude Code panel ----------
   'claudePanel.title': 'IDEモード',
@@ -856,6 +861,11 @@ const en: Dict = {
   'canvasMenu.unlockTeam': 'Unlock team movement',
   'canvasMenu.deleteCard': 'Delete card',
   'canvasMenu.addClaudeHere': 'Add Claude here',
+  'canvasMenu.addCodexHere': 'Add Codex here',
+  'canvasMenu.addFileTreeHere': 'Add file tree here',
+  'canvasMenu.addChangesHere': 'Add Git changes here',
+  'canvasMenu.addEditorHere': 'Add empty editor here',
+  'canvasMenu.spawnDefaultTeam': 'Spawn default team',
 
   // ---------- Claude Code panel ----------
   'claudePanel.title': 'IDE Mode',

--- a/src/renderer/src/lib/use-canvas-visibility.ts
+++ b/src/renderer/src/lib/use-canvas-visibility.ts
@@ -42,6 +42,7 @@ const state: CanvasVisibilityState = {
 };
 
 const subscribers = new Set<() => void>();
+const VISIBLE_STABLE_MS = 200;
 
 let initialized = false;
 let unlistenDoc: (() => void) | null = null;
@@ -156,11 +157,24 @@ export function getHiddenSinceMs(): number | null {
  */
 export function subscribeOnVisible(cb: () => void): () => void {
   ensureInit();
+  let timer: number | null = null;
   const wrapped = (): void => {
-    if (isVisibleNowInternal()) cb();
+    if (timer !== null) {
+      window.clearTimeout(timer);
+      timer = null;
+    }
+    if (!isVisibleNowInternal()) return;
+    timer = window.setTimeout(() => {
+      timer = null;
+      if (isVisibleNowInternal()) cb();
+    }, VISIBLE_STABLE_MS);
   };
   subscribers.add(wrapped);
   return () => {
+    if (timer !== null) {
+      window.clearTimeout(timer);
+      timer = null;
+    }
     subscribers.delete(wrapped);
   };
 }

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -34,9 +34,13 @@ interface CanvasState {
   nodes: Node<CardData>[];
   edges: Edge[];
   viewport: Viewport;
+  isDragging: boolean;
   setNodes: (nodes: Node<CardData>[]) => void;
   setEdges: (edges: Edge[]) => void;
   setViewport: (v: Viewport) => void;
+  setCanvasDragging: (dragging: boolean) => void;
+  /** clear() 後に React Flow の内部 viewport も同期リセットするための signal。 */
+  viewportResetSeq: number;
   addCard: (card: {
     type: CardType;
     title: string;
@@ -150,9 +154,12 @@ export const useCanvasStore = create<CanvasState>()(
       nodes: [],
       edges: [],
       viewport: { x: 0, y: 0, zoom: 1 },
+      isDragging: false,
+      viewportResetSeq: 0,
       setNodes: (nodes) => set({ nodes }),
       setEdges: (edges) => set({ edges }),
       setViewport: (viewport) => set({ viewport }),
+      setCanvasDragging: (isDragging) => set({ isDragging }),
       addCard: ({ type, title, payload, position }) => {
         const id = newId(type);
         const existing = get().nodes;
@@ -261,7 +268,13 @@ export const useCanvasStore = create<CanvasState>()(
           window.clearTimeout(h);
         }
         pulseTimers.clear();
-        set({ nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 }, teamLocks: {} });
+        set((state) => ({
+          nodes: [],
+          edges: [],
+          viewport: { x: 0, y: 0, zoom: 1 },
+          viewportResetSeq: state.viewportResetSeq + 1,
+          teamLocks: {}
+        }));
       },
       stageView: 'stage',
       setStageView: (v) => set({ stageView: v }),

--- a/src/renderer/src/styles/__tests__/glass-css-contract.test.ts
+++ b/src/renderer/src/styles/__tests__/glass-css-contract.test.ts
@@ -124,9 +124,12 @@ describe('Glass CSS contract', () => {
     expect(glass).toMatch(
       /:root\[data-theme='glass'\][\s\S]*:root\[data-theme='glass'\]\s+body[\s\S]*:root\[data-theme='glass'\]\s+#root\s*\{[\s\S]*background:\s*transparent\s*!important/
     );
-    expect(glass).toMatch(
-      /:root\[data-theme='glass'\]\s+\.layout,\s*:root\[data-theme='glass'\]\s+\.canvas-layout\s*\{[\s\S]*backdrop-filter:\s*blur\(var\(--glass-blur\)\)/
-    );
+    const glassFilterSelectors = [
+      ...cssDeclarationsForProperty(glass, 'backdrop-filter'),
+      ...cssDeclarationsForProperty(glass, '-webkit-backdrop-filter')
+    ].map((d) => d.selector);
+    expect(glassFilterSelectors).not.toContain(":root[data-theme='glass'] .layout");
+    expect(glassFilterSelectors).not.toContain(":root[data-theme='glass'] .canvas-layout");
     expect(glass).toMatch(
       /:root\[data-theme='glass'\]\s+\.layout\s*\{[\s\S]*background:\s*var\(--glass-layout-tint,\s*rgba\(10,\s*10,\s*26,\s*0\.55\)\)/
     );

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -1124,10 +1124,14 @@
   box-shadow: var(--shadow-md);
   z-index: 20;
   font-size: 11.5px;
+  max-width: calc(100vw - 32px);
+  overflow-x: auto;
+  scrollbar-width: thin;
 }
 .tc__hud button {
   display: flex;
   align-items: center;
+  flex-shrink: 0;
   gap: 5px;
   padding: 5px 12px;
   border-radius: 999px;
@@ -1137,6 +1141,10 @@
   background: transparent;
   border: none;
   font: inherit;
+  white-space: nowrap;
+}
+.tc__hud button > span {
+  white-space: nowrap;
 }
 .tc__hud button:hover {
   color: var(--text);

--- a/src/renderer/src/styles/components/glass.css
+++ b/src/renderer/src/styles/components/glass.css
@@ -11,15 +11,6 @@
   background: transparent !important;
 }
 
-/* Keep the always-mounted IDE/Canvas roots dark enough over native Acrylic. */
-:root[data-theme='glass'] .layout,
-:root[data-theme='glass'] .canvas-layout {
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
-    brightness(var(--glass-brightness, 1));
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
-    brightness(var(--glass-brightness, 1));
-}
-
 :root[data-theme='glass'] .layout {
   background: var(--glass-layout-tint, rgba(10, 10, 26, 0.55));
 }

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -132,7 +132,7 @@
 
   /* ---------- Glass Effect ---------- */
   --glass-blur: 16px;
-  --glass-saturate: 180%;
+  --glass-saturate: 120%;
   --glass-border: rgba(255, 255, 255, 0.06);
   --glass-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 


### PR DESCRIPTION
## 概要
Canvas モード周りの小さな不具合・UI ノイズ・描画負荷をまとめて修正します。

## 変更内容
- Canvas モードにも共通 Topbar を表示し、設定・コマンドパレット・IDE への戻り導線を復活
- Canvas ヘッダから `Canvas` ラベルと Add / Spawn Team の常設トリガーを削除し、空白右クリックメニューへカード追加 / 既定チーム起動を集約
- AgentNodeCard の activity publish を effect 化し、render 中の StageHud 更新を回避
- Glass テーマの root backdrop-filter 合成を外し、saturate を抑えて白濁を軽減
- Canvas clear 後に React Flow 内部 viewport も `{ x: 0, y: 0, zoom: 1 }` へ同期
- DiffCard / ChangesCard の refresh が unmount 後に setState しないよう mounted ref で保護
- visible 復帰通知を 200ms debounce し、focus の短時間パカパカで recruit warning が早期 flush されるのを抑制
- HUD ボタンの折り返しを止め、狭幅では HUD 全体を横スクロール可能に変更
- drag 中は AgentNodeCard の teamMembersSig 計算を cached 値で bailout
- useCanvasTeamRestore の team 集計を memo 化し、effect 本体を差分処理へ分離

## 検証
- `npm run typecheck`
- `npm test`

Closes #668
Closes #667
Closes #666
Closes #664
Closes #625
Closes #628
Closes #629
Closes #614
Closes #626
Closes #627