### PR TITLE
fix(types): teamReports の共有型を追加

### DIFF
--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -740,6 +740,33 @@ export interface HandoffLifecycleEvent {
   createdAt: string;
 }
 
+/**
+ * `team_report` findings の TS 投影。Rust 側 `TeamReportFinding` (camelCase) と一致させる。
+ */
+export interface TeamReportFinding {
+  severity: string;
+  file: string;
+  message: string;
+}
+
+/**
+ * `team_reports` backlog の TS 投影。Rust 側 `TeamReportSnapshot` (camelCase) と一致させる。
+ */
+export interface TeamReportSnapshot {
+  id: string;
+  taskId: string;
+  taskIdNum?: number;
+  fromRole: string;
+  fromAgentId: string;
+  status: string;
+  summary: string;
+  findings?: TeamReportFinding[];
+  changedFiles?: string[];
+  artifactRefs?: string[];
+  nextActions?: string[];
+  createdAt: string;
+}
+
 export interface TeamOrchestrationState {
   schemaVersion: number;
   projectRoot: string;
@@ -749,6 +776,7 @@ export interface TeamOrchestrationState {
   tasks: TeamTaskSnapshot[];
   pendingTasks: TeamTaskSnapshot[];
   workerReports: WorkerReport[];
+  teamReports?: TeamReportSnapshot[];
   humanGate: HumanGateState;
   nextActions: string[];
   handoffEvents: HandoffLifecycleEvent[];


### PR DESCRIPTION
## 概要
- Rust 側 TeamReportFinding / TeamReportSnapshot に対応する TypeScript interface を追加
- TeamOrchestrationState に teamReports を追加し、team_state_read の戻り値を型安全に参照できるように変更
- 既存 state JSON との互換のため teamReports と空配列で省略されるサブ配列は optional として扱う

## 検証
- npm run typecheck
- cargo check --locked --manifest-path src-tauri/Cargo.toml
- git diff --check

Closes #598