### PR TITLE
fix(pty): drop テストの Linux 型参照を修正

### DIFF
--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -249,7 +249,7 @@ mod drop_tests {
         }
 
         #[cfg(unix)]
-        fn process_group_leader(&self) -> Option<libc::pid_t> {
+        fn process_group_leader(&self) -> Option<i32> {
             None
         }
 


### PR DESCRIPTION
## 概要
- PR #672 で追加したテスト用 DummyMaster の unix signature から直接 libc crate 参照を外す
- Linux CI の cargo check --all-targets で E0433 にならないように修正

## 検証
- cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets
- cargo test --locked --manifest-path src-tauri/Cargo.toml drop_tests
- git diff --check

Closes #673