### PR TITLE
fix(canvas): #586 HUD のステータス表示を view 操作と別枠の glass pill に分離

### DIFF
--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -227,77 +227,82 @@ export function StageHud(): JSX.Element {
   const dashboardProjectRoot = settings.lastOpenedRoot || null;
 
   return (
-    <div className="tc__hud glass-surface" role="toolbar" aria-label="Canvas view">
+    <>
+      {/*
+       * Issue #586: AI エージェントの状態サマリ (active / blocked / stale / dead / completed) は
+       * 「読み取り専用の状態表示」であり、view 切替や zoom などの「ユーザー操作」とは役割が
+       * 異なるため、別枠の glass pill (`.tc__hud-status`) として分離する。HUD と同じ
+       * bottom-center 縦積みで視覚的にもグルーピングする。0 件のときは render しない。
+       */}
       {showTeamSummary ? (
-        <>
-          <div
-            className="tc__hud-summary"
-            role="group"
-            aria-label={t('canvas.hud.summary.label')}
+        <div
+          className="tc__hud-status glass-surface"
+          role="status"
+          aria-live="polite"
+          aria-label={t('canvas.hud.summary.label')}
+        >
+          <span
+            className="tc__hud-summary-pill tc__hud-summary-pill--active"
+            title={t('canvas.hud.summary.active.tooltip')}
           >
-            <span
-              className="tc__hud-summary-pill tc__hud-summary-pill--active"
-              title={t('canvas.hud.summary.active.tooltip')}
-            >
-              <CircleDot size={11} strokeWidth={2.2} aria-hidden="true" />
-              <span className="tc__hud-summary-num">{teamSummary.active}</span>
-              <span className="tc__hud-summary-text">
-                {t('canvas.hud.summary.active')}
-              </span>
+            <CircleDot size={11} strokeWidth={2.2} aria-hidden="true" />
+            <span className="tc__hud-summary-num">{teamSummary.active}</span>
+            <span className="tc__hud-summary-text">
+              {t('canvas.hud.summary.active')}
             </span>
-            <span
-              className={
-                'tc__hud-summary-pill tc__hud-summary-pill--blocked' +
-                (teamSummary.blocked > 0 ? ' is-on' : '')
-              }
-              title={t('canvas.hud.summary.blocked.tooltip')}
-            >
-              <AlertTriangle size={11} strokeWidth={2.2} aria-hidden="true" />
-              <span className="tc__hud-summary-num">{teamSummary.blocked}</span>
-              <span className="tc__hud-summary-text">
-                {t('canvas.hud.summary.blocked')}
-              </span>
+          </span>
+          <span
+            className={
+              'tc__hud-summary-pill tc__hud-summary-pill--blocked' +
+              (teamSummary.blocked > 0 ? ' is-on' : '')
+            }
+            title={t('canvas.hud.summary.blocked.tooltip')}
+          >
+            <AlertTriangle size={11} strokeWidth={2.2} aria-hidden="true" />
+            <span className="tc__hud-summary-num">{teamSummary.blocked}</span>
+            <span className="tc__hud-summary-text">
+              {t('canvas.hud.summary.blocked')}
             </span>
-            <span
-              className={
-                'tc__hud-summary-pill tc__hud-summary-pill--stale' +
-                (teamSummary.stale > 0 ? ' is-on' : '')
-              }
-              title={t('canvas.hud.summary.stale.tooltip')}
-            >
-              <Hourglass size={11} strokeWidth={2.2} aria-hidden="true" />
-              <span className="tc__hud-summary-num">{teamSummary.stale}</span>
-              <span className="tc__hud-summary-text">
-                {t('canvas.hud.summary.stale')}
-              </span>
+          </span>
+          <span
+            className={
+              'tc__hud-summary-pill tc__hud-summary-pill--stale' +
+              (teamSummary.stale > 0 ? ' is-on' : '')
+            }
+            title={t('canvas.hud.summary.stale.tooltip')}
+          >
+            <Hourglass size={11} strokeWidth={2.2} aria-hidden="true" />
+            <span className="tc__hud-summary-num">{teamSummary.stale}</span>
+            <span className="tc__hud-summary-text">
+              {t('canvas.hud.summary.stale')}
             </span>
-            <span
-              className={
-                'tc__hud-summary-pill tc__hud-summary-pill--dead' +
-                (deadCount > 0 ? ' is-on' : '')
-              }
-              title={t('canvas.hud.summary.dead.tooltip')}
-            >
-              <Skull size={11} strokeWidth={2.2} aria-hidden="true" />
-              <span className="tc__hud-summary-num">{deadCount}</span>
-              <span className="tc__hud-summary-text">
-                {t('canvas.hud.summary.dead')}
-              </span>
+          </span>
+          <span
+            className={
+              'tc__hud-summary-pill tc__hud-summary-pill--dead' +
+              (deadCount > 0 ? ' is-on' : '')
+            }
+            title={t('canvas.hud.summary.dead.tooltip')}
+          >
+            <Skull size={11} strokeWidth={2.2} aria-hidden="true" />
+            <span className="tc__hud-summary-num">{deadCount}</span>
+            <span className="tc__hud-summary-text">
+              {t('canvas.hud.summary.dead')}
             </span>
-            <span
-              className="tc__hud-summary-pill tc__hud-summary-pill--completed"
-              title={t('canvas.hud.summary.completed.tooltip')}
-            >
-              <CheckCircle2 size={11} strokeWidth={2.2} aria-hidden="true" />
-              <span className="tc__hud-summary-num">{teamSummary.completed}</span>
-              <span className="tc__hud-summary-text">
-                {t('canvas.hud.summary.completed')}
-              </span>
+          </span>
+          <span
+            className="tc__hud-summary-pill tc__hud-summary-pill--completed"
+            title={t('canvas.hud.summary.completed.tooltip')}
+          >
+            <CheckCircle2 size={11} strokeWidth={2.2} aria-hidden="true" />
+            <span className="tc__hud-summary-num">{teamSummary.completed}</span>
+            <span className="tc__hud-summary-text">
+              {t('canvas.hud.summary.completed')}
             </span>
-          </div>
-          <span className="tc__hud-sep" aria-hidden="true" />
-        </>
+          </span>
+        </div>
       ) : null}
+      <div className="tc__hud glass-surface" role="toolbar" aria-label="Canvas view">
       {views.map((v) => (
         <button
           key={v.id}
@@ -434,6 +439,7 @@ export function StageHud(): JSX.Element {
           </div>
         ) : null}
       </div>
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -1166,7 +1166,38 @@
  * Issue #521: HUD 左端の Canvas 全体サマリ (active / blocked / stale / completed)。
  * 既存 view ボタン群と並ぶピル型バッジ。0 件のときは render 側で非表示。
  * 視認性を保つため数値を強調、ラベルは muted 色で添える。
+ *
+ * Issue #586: AI エージェントのステータス表示は view 切替/zoom 等の操作系とは
+ * 役割が異なるため、独立した glass pill (`.tc__hud-status`) として `.tc__hud` の
+ * 上に縦積みで配置する。.tc__hud と同じ bottom-center anchor で揃える。
  * ---------- */
+.tc__hud-status {
+  position: absolute;
+  bottom: 70px; /* .tc__hud (bottom: 22px) + ボタン高 ~36px + 余白 12px */
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--surface-glass, rgba(20, 20, 19, 0.62));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))
+    brightness(var(--glass-brightness, 1));
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 5px 8px;
+  box-shadow: var(--shadow-md);
+  z-index: 20;
+  font-size: 11.5px;
+  max-width: calc(100vw - 32px);
+  overflow-x: auto;
+  scrollbar-width: thin;
+  pointer-events: auto;
+}
+.tc__hud-status > .tc__hud-summary-pill {
+  flex-shrink: 0;
+}
 .tc__hud-summary {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 概要

Issue #586 の 2 つ目の指摘「AI エージェントのステータス表示は役割が違うので別枠で表示するべき」に対応する最小修正。

Canvas 中央下部の `.tc__hud` (glass pill) に同居していた以下 2 つの異なる役割の UI を視覚的に分離する。

- **読み取り専用のステータス表示** (active / blocked / stale / dead / completed) — どのエージェントがいま何件動いているかを示す
- **ユーザー操作の view コントロール** (Stage / List / Focus / fit / zoom / dashboard / preset / arrange) — view を切り替えたり zoom したりする

これらが 1 本の glass pill に詰め込まれていたため、用途の違うものが視覚的に混ざる UX 上の問題があった (#586 のスクリーンショット参照)。

## 変更内容

### `src/renderer/src/components/canvas/StageHud.tsx`
- 戻り値を Fragment 化し、ステータス pill と view HUD pill を兄弟要素として並べる構造に変更
- ステータス pill には `role="status"` + `aria-live="polite"` を付与し、screen reader への live region フィードバックを改善 (元は `role="group"`)
- ステータスと view HUD の間に挟まっていた `.tc__hud-sep` separator は別 pill 化により不要になったので削除
- 0 件のとき (showTeamSummary === false) はステータス pill 自体を render しない (既存仕様維持)

### `src/renderer/src/styles/components/canvas.css`
- `.tc__hud-status` を新規追加。`.tc__hud` と同じ glass pill ルック (背景 / blur / border / box-shadow) で統一感を保ちつつ、bottom: 70px の位置に縦積みで配置
- `bottom: 70px` は `.tc__hud (bottom: 22px)` + ボタン高 ~36px + 間隔 12px から逆算
- `max-width: calc(100vw - 32px)` + `overflow-x: auto` で狭幅でもはみ出さない (PR #669 と同じ方針)

### `npm run typecheck`
pass。glass-css-contract test も pass (`.tc__hud-status` は `.tc__hud` を含むので allowlist に通る)。

## 注意

Issue #586 の 1 つ目の指摘 (Stage / List / Focus が日本語縦書き化) は #614 / PR #669 で既に解消済みのため、本 PR では扱わない。

dual preset 等での複数 team 集約 (#615) は別 issue として並行進行する設計のため、本 PR の scope 外。

Closes #586