### PR TITLE
fix(pty): #620 inject_codex_prompt_to_pty を spawn_blocking 経由に揃える

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -145,6 +145,11 @@ fn filter_resume_args_in_place(args: Vec<String>) -> Vec<String> {
 ///   3. 各チャンクを順に書き込み、最後に \r で確定送信。
 ///
 /// チームメッセージの inject() と違って banner は付けない (Codex に対する初手のユーザー指示として届く)。
+///
+/// Issue #620: `SessionHandle::write` は内部で `std::sync::Mutex::lock` + 同期 `write_all`/`flush`
+/// なので、tokio multi-thread runtime の async task 内から直接呼ぶと ConPTY back-pressure 時に
+/// worker thread を 1 本占有してしまう。`team_hub::inject::inject_once` と同じく
+/// `tokio::task::spawn_blocking` で blocking pool に逃がし、async runtime を解放する。
 async fn inject_codex_prompt_to_pty(
     registry: Arc<crate::pty::SessionRegistry>,
     term_id: String,
@@ -167,9 +172,24 @@ async fn inject_codex_prompt_to_pty(
     }
     let mut iter = chunks.into_iter();
     if let Some(first) = iter.next() {
-        if session.write(&first).is_err() {
-            session.set_injecting(false);
-            return;
+        // Issue #620: spawn_blocking で同期 write を blocking pool に逃がす。
+        let s = session.clone();
+        match tokio::task::spawn_blocking(move || s.write(&first)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    "[terminal] codex prompt write(first) failed for {term_id}: {e}"
+                );
+                session.set_injecting(false);
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[terminal] codex prompt spawn_blocking(first) failed for {term_id}: {e}"
+                );
+                session.set_injecting(false);
+                return;
+            }
         }
     }
     for chunk in iter {
@@ -178,13 +198,40 @@ async fn inject_codex_prompt_to_pty(
             session.set_injecting(false);
             return;
         }
-        if session.write(&chunk).is_err() {
-            session.set_injecting(false);
-            return;
+        // Issue #620: 各チャンクの write も spawn_blocking 経由。
+        let s = session.clone();
+        match tokio::task::spawn_blocking(move || s.write(&chunk)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    "[terminal] codex prompt write(chunk) failed for {term_id}: {e}"
+                );
+                session.set_injecting(false);
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[terminal] codex prompt spawn_blocking(chunk) failed for {term_id}: {e}"
+                );
+                session.set_injecting(false);
+                return;
+            }
         }
     }
     sleep(Duration::from_millis(15)).await;
-    let _ = session.write(b"\r");
+    // Issue #620: 末尾の確定 `\r` も spawn_blocking 経由で送る。
+    let s = session.clone();
+    match tokio::task::spawn_blocking(move || s.write(b"\r")).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            tracing::warn!("[terminal] codex prompt write(\\r) failed for {term_id}: {e}");
+        }
+        Err(e) => {
+            tracing::warn!(
+                "[terminal] codex prompt spawn_blocking(\\r) failed for {term_id}: {e}"
+            );
+        }
+    }
     session.set_injecting(false);
     tracing::info!(
         "[terminal] codex prompt injected into pty {term_id} ({} bytes)",


### PR DESCRIPTION
## Summary

- `inject_codex_prompt_to_pty` の 3 箇所の `session.write(...)` 呼び出しを `tokio::task::spawn_blocking` 経由に揃え、ConPTY back-pressure 時に tokio multi-thread runtime の worker を 1 本占有して他の async task が固まる問題を解消。
- 既存の `team_hub::inject::inject_once` (Issue #145 で確立) と同じパターンに統一し、Codex prompt 経路だけが pattern から外れていた状態を是正。
- write 失敗 / spawn_blocking join 失敗の両方で `tracing::warn!` ログを残すように変更し、可観測性を改善 (旧実装は `is_err()` で握り潰していた)。

## Background

`SessionHandle::write` は内部で `std::sync::Mutex::lock` + 同期 `std::io::Write::write_all` + `flush` という純 blocking I/O。これを async task 内から直接呼ぶと ConPTY のバッファが詰まったとき tokio worker を専有する。Canvas で 4 並列以上 codex agent を Recruit すると、worker 数 = CPU 数の環境では runtime が一瞬固まり、`team_*` IPC や `fs_watch` の応答性が落ちる (特に Windows ConPTY)。

## Behavioral compatibility

- 1.8s 初期 sleep / 15ms チャンク間隔 / `build_chunks("", &instructions)` による 64B チャンク化 / `set_injecting(true/false)` フラグ管理はすべて従来通り。
- 早期 return 経路を維持しつつ、spawn_blocking の join error も含めて `session.set_injecting(false)` が必ず呼ばれることを保証。
- 末尾 `\r` (確定送信) の挙動も従来同様 fire-and-forget (warn ログのみ追加)。

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib commands::terminal` 55 tests pass
- [ ] Canvas で codex agent を 4 並列 Recruit して、各 prompt が正しく届くこと / 起動中も他 IPC (team_status, fs_watch) が固まらないこと
- [ ] Windows ConPTY back-pressure 時 (大きめ instructions ~10KB) でも UI が固まらないこと

Closes #620