### PR TITLE
fix(teamhub): #619 inject 中の user 入力混入を防ぐ RAII guard を導入

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -160,19 +160,19 @@ async fn inject_codex_prompt_to_pty(
     let Some(session) = registry.get(&term_id) else {
         return;
     };
-    // Issue #153: 注入中はユーザーの xterm 入力 (terminal_write) を抑止する。
+    // Issue #153 / #619: 注入中はユーザーの xterm 入力 (terminal_write) を抑止する。
+    // RAII guard (`begin_injecting`) を使うことで、関数を抜けるあらゆる経路 (early return /
+    // panic / `?` 伝播 / 正常終了) で `injecting` フラグが必ず false に戻る。
     // build_chunks は banner 込みで分割するが、Codex 注入では banner 不要なので空文字を渡す。
-    session.set_injecting(true);
-    // 関数を抜けるあらゆる経路で必ず injecting を下ろすため、内部処理を closure で wrap せず
-    // 早期 return ごとに明示 false に戻す。
+    let _inject_guard = session.begin_injecting();
     let chunks = build_chunks("", &instructions);
     if chunks.is_empty() {
-        session.set_injecting(false);
         return;
     }
     let mut iter = chunks.into_iter();
     if let Some(first) = iter.next() {
         // Issue #620: spawn_blocking で同期 write を blocking pool に逃がす。
+        // Issue #619: 早期 return しても `_inject_guard` の Drop で injecting=false に戻る。
         let s = session.clone();
         match tokio::task::spawn_blocking(move || s.write(&first)).await {
             Ok(Ok(())) => {}
@@ -180,14 +180,12 @@ async fn inject_codex_prompt_to_pty(
                 tracing::warn!(
                     "[terminal] codex prompt write(first) failed for {term_id}: {e}"
                 );
-                session.set_injecting(false);
                 return;
             }
             Err(e) => {
                 tracing::warn!(
                     "[terminal] codex prompt spawn_blocking(first) failed for {term_id}: {e}"
                 );
-                session.set_injecting(false);
                 return;
             }
         }
@@ -195,10 +193,10 @@ async fn inject_codex_prompt_to_pty(
     for chunk in iter {
         sleep(Duration::from_millis(15)).await;
         if registry.get(&term_id).is_none() {
-            session.set_injecting(false);
             return;
         }
         // Issue #620: 各チャンクの write も spawn_blocking 経由。
+        // Issue #619: 早期 return / panic でも guard Drop が injecting=false に戻す。
         let s = session.clone();
         match tokio::task::spawn_blocking(move || s.write(&chunk)).await {
             Ok(Ok(())) => {}
@@ -206,14 +204,12 @@ async fn inject_codex_prompt_to_pty(
                 tracing::warn!(
                     "[terminal] codex prompt write(chunk) failed for {term_id}: {e}"
                 );
-                session.set_injecting(false);
                 return;
             }
             Err(e) => {
                 tracing::warn!(
                     "[terminal] codex prompt spawn_blocking(chunk) failed for {term_id}: {e}"
                 );
-                session.set_injecting(false);
                 return;
             }
         }
@@ -232,7 +228,6 @@ async fn inject_codex_prompt_to_pty(
             );
         }
     }
-    session.set_injecting(false);
     tracing::info!(
         "[terminal] codex prompt injected into pty {term_id} ({} bytes)",
         instructions.len()

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -129,6 +129,26 @@ impl SessionHandle {
             .store(on, std::sync::atomic::Ordering::Release);
     }
 
+    /// Issue #619: `injecting` フラグの現在値。テスト・診断用。
+    /// 現状は `#[cfg(test)]` 配下からのみ使われるが、将来 diagnostics / tracing で参照する想定で
+    /// `pub` のまま残す (`dead_code` 警告を抑止)。
+    #[allow(dead_code)]
+    pub fn is_injecting(&self) -> bool {
+        self.injecting.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Issue #619: RAII guard で `injecting` フラグを必ず `true` → `false` で対にする。
+    ///
+    /// 旧経路 (`team_hub::inject::inject_once` / `commands::terminal::inject_codex_prompt_to_pty`) は
+    /// 早期 return / panic / `?` 経由で `set_injecting(false)` を呼び忘れる risk があり、
+    /// bracketed paste の途中で worker terminal にユーザー入力が紛れ込む事故 (#619) を起こしていた。
+    ///
+    /// `begin_injecting()` の戻り値 (`InjectingGuard`) を変数に束縛しておけば、関数を抜ける
+    /// あらゆる経路 (Ok 戻り / Err 戻り / panic) で Drop が走り、`injecting` が確実に false に戻る。
+    pub fn begin_injecting(self: &Arc<Self>) -> InjectingGuard {
+        InjectingGuard::new(self.clone())
+    }
+
     /// Issue #285 follow-up: attach 経路で renderer へ replay する用の現時点 snapshot。
     /// 末尾が multi-byte 文字途中なら切り詰め、UTF-8 安全な文字列に変換する。
     /// 空の場合は None を返す (renderer 側は空文字を区別しない用に短絡できる)。
@@ -196,6 +216,38 @@ impl Drop for SessionHandle {
         if let Err(e) = k.kill() {
             tracing::warn!(?e, "[pty] SessionHandle child kill failed during drop");
         }
+    }
+}
+
+/// Issue #619: `SessionHandle::injecting` を「true → false」で必ずペアで操作するための RAII guard。
+///
+/// `SessionHandle::begin_injecting()` が返す。戻り値を変数に束縛している間 `injecting == true`
+/// が維持され、変数のスコープを抜けた時点 (early return / panic / `?` 伝播 / 正常終了) で
+/// `Drop` が走って `injecting == false` に必ず戻る。
+///
+/// 旧実装 (set_injecting(true) / set_injecting(false) を手動でペアで書く) は、
+/// `inject_once` のように途中で多数の `?` / 早期 return / panic 経路があるコードでは
+/// 1 箇所でも `set_injecting(false)` が抜けると `injecting` が `true` に貼り付き、
+/// 以後その PTY のユーザー入力 (terminal_write 経路) が完全に無効化されたままになる
+/// 可能性があった (#619 の根本原因の対称ケース)。
+///
+/// `Arc<SessionHandle>` を保持するのは `inject_once` の async 経路で session が drop されるより前に
+/// guard 側で確実に reset したいため (Drop の時点で session が生きていることを保証する)。
+pub struct InjectingGuard {
+    session: Arc<SessionHandle>,
+}
+
+impl InjectingGuard {
+    fn new(session: Arc<SessionHandle>) -> Self {
+        session.set_injecting(true);
+        Self { session }
+    }
+}
+
+impl Drop for InjectingGuard {
+    fn drop(&mut self) {
+        // panic 経路 / 早期 return 経路 / 正常終了経路すべてで injecting=false に戻す。
+        self.session.set_injecting(false);
     }
 }
 
@@ -303,6 +355,85 @@ mod drop_tests {
         let kills = Arc::new(AtomicUsize::new(0));
         drop(test_handle(kills.clone()));
         assert_eq!(kills.load(Ordering::SeqCst), 1);
+    }
+
+    /// Issue #619: `begin_injecting()` の戻り値が drop されると `injecting` が必ず false に戻る。
+    #[test]
+    fn injecting_guard_resets_on_normal_drop() {
+        let kills = Arc::new(AtomicUsize::new(0));
+        let session = Arc::new(test_handle(kills));
+        assert!(!session.is_injecting(), "initial state should be false");
+
+        {
+            let _guard = session.begin_injecting();
+            assert!(session.is_injecting(), "guard should set injecting=true");
+        } // _guard drops here
+
+        assert!(
+            !session.is_injecting(),
+            "injecting must be reset to false after guard drop"
+        );
+    }
+
+    /// Issue #619: 早期 return / `?` 伝播経路でも guard の Drop が走り false に戻る。
+    /// クロージャを `?` で抜ける関数で wrap し、early return しても reset されることを確認。
+    #[test]
+    fn injecting_guard_resets_on_early_return() {
+        let kills = Arc::new(AtomicUsize::new(0));
+        let session = Arc::new(test_handle(kills));
+
+        fn body(s: &Arc<SessionHandle>) -> std::result::Result<(), &'static str> {
+            let _guard = s.begin_injecting();
+            // 中で early return (Err) するパス
+            Err("simulated early return")
+        }
+
+        let res = body(&session);
+        assert!(res.is_err());
+        assert!(
+            !session.is_injecting(),
+            "injecting must be false after early return path"
+        );
+    }
+
+    /// Issue #619: panic 経路でも guard の Drop が走り false に戻る (RAII の本質)。
+    #[test]
+    fn injecting_guard_resets_on_panic() {
+        let kills = Arc::new(AtomicUsize::new(0));
+        let session = Arc::new(test_handle(kills));
+
+        let s_for_panic = session.clone();
+        let _ = catch_unwind(AssertUnwindSafe(move || {
+            let _guard = s_for_panic.begin_injecting();
+            assert!(s_for_panic.is_injecting());
+            panic!("simulated panic during inject");
+        }));
+
+        assert!(
+            !session.is_injecting(),
+            "injecting must be false after panic unwind"
+        );
+    }
+
+    /// Issue #619: ネストして begin_injecting を取った場合、外側 guard の生存中は内側 drop でも
+    /// `set_injecting(false)` が無条件に走るため `false` になる。これは「inject_once は
+    /// 同一 PTY で同時実行されない」前提のための設計 (現在 inject 経路は serialize されている)。
+    /// テストはこの仕様を pin で固定する。
+    #[test]
+    fn injecting_guard_inner_drop_sets_false_even_when_outer_alive() {
+        let kills = Arc::new(AtomicUsize::new(0));
+        let session = Arc::new(test_handle(kills));
+
+        let outer = session.begin_injecting();
+        assert!(session.is_injecting());
+        {
+            let _inner = session.begin_injecting();
+            assert!(session.is_injecting());
+        }
+        // 仕様: 内側 guard drop で injecting は false に戻る (= 同時 inject 想定外)
+        assert!(!session.is_injecting());
+        drop(outer);
+        assert!(!session.is_injecting());
     }
 }
 

--- a/src-tauri/src/team_hub/inject.rs
+++ b/src-tauri/src/team_hub/inject.rs
@@ -335,6 +335,14 @@ async fn inject_once(
         tracing::warn!("[inject] no session for agent {agent_id} — registry has no by_agent entry");
         return Err(InjectError::NoSession);
     };
+    // Issue #619: bracketed-paste 注入中に renderer 側からの terminal_write (=ユーザー入力) が
+    // ConPTY に紛れ込むと worker prompt が破損する。`begin_injecting()` の戻り値を変数に
+    // 束縛しておくと、本関数を抜けるあらゆる経路 (Ok / Err / panic / `?` 伝播) で Drop が走り、
+    // `injecting` が確実に false に戻る (RAII guard)。
+    //
+    // `_inject_guard` を `let _ = ...` で受けると即座に Drop してしまうので、必ず named binding
+    // (`_inject_guard`) を使うこと。
+    let _inject_guard = session.begin_injecting();
     let banner = format!("[Team ← {from_role}] ");
     let chunks = build_chunks(&banner, text);
     if chunks.is_empty() {


### PR DESCRIPTION
Closes #619

## Summary
- `team_hub::inject::inject_once` と `commands::terminal::inject_codex_prompt_to_pty` が bracketed-paste を流す間に `SessionHandle::set_injecting(true)` を呼ばない / 早期 return 経路で `set_injecting(false)` を呼び忘れる risk があり、ConPTY (64B/15ms 制約) で worker terminal へユーザー入力が紛れ込み worker prompt を破損させる事故が発生していた。
- 修正は `InjectingGuard` (RAII) パターン: `SessionHandle::begin_injecting()` の戻り値を `let _inject_guard = ...` で束縛している間だけ `injecting == true`、Drop で必ず `false` に戻す。Ok / Err / panic / `?` 伝播すべての経路で対称になることを Rust の所有権で保証する。

## 変更点
- `src-tauri/src/pty/session.rs`
  - `pub struct InjectingGuard { session: Arc<SessionHandle> }` を追加。`Drop` 時に `set_injecting(false)`。
  - `SessionHandle::begin_injecting(self: &Arc<Self>) -> InjectingGuard` を追加。
  - `is_injecting()` を公開 (test / 将来診断用、`#[allow(dead_code)]`)。
  - 単体テストを追加: 正常 drop / early return / panic unwind / inner-drop 仕様。
- `src-tauri/src/team_hub/inject.rs`
  - `inject_once` 冒頭で `let _inject_guard = session.begin_injecting();` を取得。`build_chunks` が空 / 各チャンク write 失敗 / `SessionReplaced` / `FinalCrFailed` 等あらゆる early return / Err 経路で guard が drop され `injecting=false` に戻る。
- `src-tauri/src/commands/terminal.rs`
  - `inject_codex_prompt_to_pty` を同じ RAII guard 経路に揃え、散在していた `set_injecting(false)` 呼び出しを撤去 (Issue #620 の `spawn_blocking` 化はそのまま維持)。

## Test plan
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` pass (新規警告なし)
- [x] `cargo test --lib` pass (437 tests pass, 2 ignored)
- [x] 新規 `injecting_guard_resets_on_normal_drop` / `injecting_guard_resets_on_early_return` / `injecting_guard_resets_on_panic` / `injecting_guard_inner_drop_sets_false_even_when_outer_alive` ユニットテストを追加し、ガードが Ok / Err / panic / nested の各経路で `injecting` を確実に false に戻すことを検証
- [ ] 5 KB handoff inject 中に user 入力 (`hello\n`) を打っても worker prompt に混ざらないこと (manual / 後続 E2E)

## Notes
- `inject` 同時実行 (= 同一 PTY に対する重複 inject_once) は現状想定外。`InjectingGuard::drop` は無条件で `false` を書くため、ネスト時は内側 drop でも `false` になる仕様。テスト `injecting_guard_inner_drop_sets_false_even_when_outer_alive` で pin。