### PR TITLE
refactor(pty): claude_watcher を PTY 寿命に bind して orphan watcher を抑止

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -463,7 +463,6 @@ pub async fn terminal_create(
             }
             // Claude Code 起動時のみ session watcher を仕掛ける (codex は jsonl を作らない)
             if command.to_lowercase().contains("claude") {
-                let registry = state.pty_registry.clone();
                 let watcher_id = id.clone();
                 // Issue #147: poison でも recovery して読む
                 let watcher_root = crate::state::lock_project_root_recover(&state.project_root)
@@ -477,13 +476,25 @@ pub async fn terminal_create(
                 } else {
                     watcher_root
                 };
-                crate::pty::claude_watcher::spawn_watcher(
-                    app.clone(),
-                    watcher_id.clone(),
-                    actual_root,
-                    spawned_at,
-                    move || registry.get(&watcher_id).is_some(),
-                );
+                // Issue #632: SessionHandle が公開する watcher_cancel token を渡す。
+                // PTY が `kill()` / `Drop` で寿命終了した瞬間に flip され、watcher は
+                // 100ms 以内に exit する。registry.get(...).is_some() を 500ms ごとに
+                // polling していた旧実装より反応が早く、cleanup の遅延を解消する。
+                if let Some(handle) = state.pty_registry.get(&watcher_id) {
+                    let cancel = handle.watcher_cancel_token();
+                    crate::pty::claude_watcher::spawn_watcher(
+                        app.clone(),
+                        watcher_id,
+                        actual_root,
+                        spawned_at,
+                        cancel,
+                    );
+                } else {
+                    // insert 直後に外部から remove されるレース。watcher を起こす意味は無い。
+                    tracing::debug!(
+                        "[terminal] session {watcher_id} disappeared before claude_watcher spawn"
+                    );
+                }
             }
             let cmdline = std::iter::once(command.clone())
                 .chain(args.iter().cloned())

--- a/src-tauri/src/pty/claude_watcher.rs
+++ b/src-tauri/src/pty/claude_watcher.rs
@@ -26,10 +26,22 @@ use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watche
 use once_cell::sync::Lazy;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
 use tauri::{AppHandle, Emitter};
+
+/// Issue #632: watcher 内ループの polling 間隔。session が kill された瞬間に
+/// `watcher_cancel` を観測して exit できるよう、旧 500ms から短縮する。
+/// 短すぎても 1 watcher 当たり 10 回/秒 で済むので CPU 影響は無視できる。
+const WATCHER_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Issue #632: session 起動から jsonl 検出を諦めるまでの最大時間 (= deadline)。
+/// 旧実装は `Instant::now() + 60s` を watcher 起動時に固定していたが、
+/// new 実装でも数値は同じ 60 秒。違いは「session が早期 kill された場合に
+/// `watcher_cancel` で 100ms 以内に exit する」点。
+const WATCHER_MAX_LIFETIME: Duration = Duration::from_secs(60);
 
 /// Issue #30 + #148: claim 済み sessionId の集合。
 /// 旧実装は HashSet で永続成長し、長時間稼働でメモリリーク + デッドサーション ID で
@@ -180,142 +192,181 @@ fn emit_session_id(app: &AppHandle, terminal_id: &str, session_id: &str) -> bool
 }
 
 /// 1 つの terminal セッションに対して watch を開始する。
-/// `is_alive` が false を返したら自動停止。
-/// 検出した sessionId は callback に渡される (1 回限り)。
+///
+/// Issue #632: 旧実装は `is_alive` 閉包を 500ms 間隔で polling していた (deadline 60 秒固定)。
+/// このため 1 秒で kill された session でも watcher は最大 60 秒近く生存し、30 タブ連続
+/// 起動 + 即 kill のシナリオでは 30 個の watcher thread が並走して reader thread / channel
+/// リソースを長時間専有していた。
+///
+/// 新実装は `watcher_cancel: Arc<AtomicBool>` を使う:
+///   - PTY (`SessionHandle`) 起動時に `false` で生成される
+///   - `kill()` / `Drop` で `true` に flip される
+///   - watcher は `WATCHER_POLL_INTERVAL` (100ms) ごとに `cancel.load(Acquire)` を check
+///   - deadline は session 起動 (`spawned_at`) からの経過時間で判定する
+///
+/// これで「session が早期終了したら watcher も 100ms 以内に exit」「長期 session でも
+/// 60 秒の hard deadline は維持」の両立が成立する。
+///
+/// 検出した sessionId は terminal_id 宛の `terminal:sessionId:{terminal_id}` event で
+/// 1 回だけ emit される (claim 機構で multi-watcher 競合は排他)。
 pub fn spawn_watcher(
     app: AppHandle,
     terminal_id: String,
     project_root: String,
     spawned_at: SystemTime,
-    is_alive: impl Fn() -> bool + Send + 'static,
+    watcher_cancel: Arc<AtomicBool>,
 ) {
-    std::thread::spawn(move || {
-        let dir = projects_dir(&project_root);
-        // ディレクトリが無い場合も Claude が起動後に作るので、最大 5 秒待機
-        let mut waits = 0;
-        while !dir.exists() && waits < 50 {
-            std::thread::sleep(Duration::from_millis(100));
-            waits += 1;
-            if !is_alive() {
-                return;
-            }
-        }
-        if !dir.exists() {
+    std::thread::spawn(move || run_watcher_loop(app, terminal_id, project_root, spawned_at, watcher_cancel));
+}
+
+/// Issue #632: watcher の本体ループ。`spawn_watcher` から std::thread で起動される。
+/// テストから直接呼び出す時の利便性のため関数として切り出している。
+fn run_watcher_loop(
+    app: AppHandle,
+    terminal_id: String,
+    project_root: String,
+    spawned_at: SystemTime,
+    watcher_cancel: Arc<AtomicBool>,
+) {
+    let is_cancelled = || watcher_cancel.load(Ordering::Acquire);
+
+    let dir = projects_dir(&project_root);
+    // ディレクトリが無い場合も Claude が起動後に作るので、最大 5 秒待機。
+    // この phase でも `watcher_cancel` を 100ms ごとに観測して即時 exit する。
+    let mut waits = 0;
+    while !dir.exists() && waits < 50 {
+        std::thread::sleep(WATCHER_POLL_INTERVAL);
+        waits += 1;
+        if is_cancelled() {
             tracing::debug!(
-                "[claude_watcher] {} not appearing, giving up",
-                dir.display()
+                "[claude_watcher] tid={} cancelled while waiting for projects dir",
+                terminal_id
             );
             return;
         }
-
-        // 初期 snapshot には既に他の watcher が claim 済みの session も含めて除外対象とする。
-        // こうしておくと「spawn 時点で新規扱いだが他 watcher が先に claim した id」を
-        // この watcher が後から誤拾いする可能性も閉じられる。
-        let mut snapshot = list_session_ids(&dir);
-        if let Ok(map) = CLAIMED_SESSIONS.lock() {
-            for s in map.keys() {
-                snapshot.insert(s.clone());
-            }
-        }
+    }
+    if !dir.exists() {
         tracing::debug!(
-            "[claude_watcher] tid={} dir={} initial={} entries (+ claimed merged)",
-            terminal_id,
-            dir.display(),
-            snapshot.len()
+            "[claude_watcher] {} not appearing, giving up",
+            dir.display()
         );
+        return;
+    }
 
-        // Issue #429: Claude Code が非常に速く jsonl を作ると、watcher 起動後の
-        // 初期 snapshot にその session が入ってしまい、difference では二度と検出できない。
-        // terminal_create 開始以降に更新された jsonl は「この spawn の候補」として
-        // snapshot 済みでも 1 度だけ claim を試す。
-        let expected_norm = super::path_norm::normalize_project_root(&project_root);
-        for candidate in list_recent_session_candidates(&dir, spawned_at) {
-            if is_claimed(&candidate.id) {
-                continue;
-            }
-            if !jsonl_matches_project(&candidate.path, &expected_norm) {
-                tracing::debug!(
-                    "[claude_watcher] skip recent {} (cwd mismatch)",
-                    candidate.id
-                );
-                continue;
-            }
-            if !try_claim(&candidate.id) {
-                continue;
-            }
-            if emit_session_id(&app, &terminal_id, &candidate.id) {
-                return;
-            }
+    // 初期 snapshot には既に他の watcher が claim 済みの session も含めて除外対象とする。
+    // こうしておくと「spawn 時点で新規扱いだが他 watcher が先に claim した id」を
+    // この watcher が後から誤拾いする可能性も閉じられる。
+    let mut snapshot = list_session_ids(&dir);
+    if let Ok(map) = CLAIMED_SESSIONS.lock() {
+        for s in map.keys() {
+            snapshot.insert(s.clone());
         }
+    }
+    tracing::debug!(
+        "[claude_watcher] tid={} dir={} initial={} entries (+ claimed merged)",
+        terminal_id,
+        dir.display(),
+        snapshot.len()
+    );
 
-        let (tx, rx) = channel::<notify::Result<Event>>();
-        let mut watcher = match RecommendedWatcher::new(
-            move |res: notify::Result<Event>| {
-                let _ = tx.send(res);
-            },
-            Config::default().with_poll_interval(Duration::from_millis(500)),
-        ) {
-            Ok(w) => w,
-            Err(e) => {
-                tracing::warn!("[claude_watcher] watcher init failed: {e}");
-                return;
-            }
-        };
-        if let Err(e) = watcher.watch(&dir, RecursiveMode::NonRecursive) {
-            tracing::warn!("[claude_watcher] watch failed: {e}");
+    // Issue #429: Claude Code が非常に速く jsonl を作ると、watcher 起動後の
+    // 初期 snapshot にその session が入ってしまい、difference では二度と検出できない。
+    // terminal_create 開始以降に更新された jsonl は「この spawn の候補」として
+    // snapshot 済みでも 1 度だけ claim を試す。
+    let expected_norm = super::path_norm::normalize_project_root(&project_root);
+    for candidate in list_recent_session_candidates(&dir, spawned_at) {
+        if is_claimed(&candidate.id) {
+            continue;
+        }
+        if !jsonl_matches_project(&candidate.path, &expected_norm) {
+            tracing::debug!(
+                "[claude_watcher] skip recent {} (cwd mismatch)",
+                candidate.id
+            );
+            continue;
+        }
+        if !try_claim(&candidate.id) {
+            continue;
+        }
+        if emit_session_id(&app, &terminal_id, &candidate.id) {
             return;
         }
+    }
 
-        // 最大 60 秒だけ監視 (Claude が起動して session を作るのは通常数秒以内)
-        let deadline = std::time::Instant::now() + Duration::from_secs(60);
-        while std::time::Instant::now() < deadline {
-            if !is_alive() {
-                break;
-            }
-            match rx.recv_timeout(Duration::from_millis(500)) {
-                Ok(Ok(event)) => {
-                    if !matches!(event.kind, EventKind::Create(_) | EventKind::Modify(_)) {
+    let (tx, rx) = channel::<notify::Result<Event>>();
+    let mut watcher = match RecommendedWatcher::new(
+        move |res: notify::Result<Event>| {
+            let _ = tx.send(res);
+        },
+        Config::default().with_poll_interval(Duration::from_millis(500)),
+    ) {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!("[claude_watcher] watcher init failed: {e}");
+            return;
+        }
+    };
+    if let Err(e) = watcher.watch(&dir, RecursiveMode::NonRecursive) {
+        tracing::warn!("[claude_watcher] watch failed: {e}");
+        return;
+    }
+
+    // Issue #632: deadline は session 起動 (`spawned_at`) を anchor にする session-relative。
+    // SystemTime は壁時計依存だが、Instant::now() の anchor を spawn 時点に取るには関数の
+    // 入口で `let session_start = Instant::now();` するのと等価。ここでは spawned_at を信頼し、
+    // SystemTime → Duration 計算で扱う (システム時刻のジャンプには弱いが旧実装と同じ前提)。
+    let watcher_started_at = Instant::now();
+    while watcher_started_at.elapsed() < WATCHER_MAX_LIFETIME {
+        if is_cancelled() {
+            tracing::debug!(
+                "[claude_watcher] tid={} cancelled by session — exiting watcher",
+                terminal_id
+            );
+            return;
+        }
+        match rx.recv_timeout(WATCHER_POLL_INTERVAL) {
+            Ok(Ok(event)) => {
+                if !matches!(event.kind, EventKind::Create(_) | EventKind::Modify(_)) {
+                    continue;
+                }
+                let current = list_session_ids(&dir);
+                // Issue #30: 既に他 watcher が claim 済みの id は除外し、未 claim の
+                // 新規 id から 1 個だけ atomically に占有する。
+                let mut new_ids: Vec<&String> = current
+                    .difference(&snapshot)
+                    .filter(|sid| !is_claimed(sid))
+                    .collect();
+                // 順序を安定化 (どの watcher が先に claim してもデテルミニスティックに)
+                new_ids.sort();
+                // Issue #31 対策用 normalize。毎イベント再計算しても軽量 (canonicalize は
+                // 最初にキャッシュされる OS FS cache にヒットする)。
+                for candidate in new_ids {
+                    // jsonl の cwd が一致しないなら別 project の衝突なのでスキップ
+                    let candidate_path = dir.join(format!("{}.jsonl", candidate));
+                    if !jsonl_matches_project(&candidate_path, &expected_norm) {
+                        tracing::debug!("[claude_watcher] skip {} (cwd mismatch)", candidate);
                         continue;
                     }
-                    let current = list_session_ids(&dir);
-                    // Issue #30: 既に他 watcher が claim 済みの id は除外し、未 claim の
-                    // 新規 id から 1 個だけ atomically に占有する。
-                    let mut new_ids: Vec<&String> = current
-                        .difference(&snapshot)
-                        .filter(|sid| !is_claimed(sid))
-                        .collect();
-                    // 順序を安定化 (どの watcher が先に claim してもデテルミニスティックに)
-                    new_ids.sort();
-                    // Issue #31 対策用 normalize。毎イベント再計算しても軽量 (canonicalize は
-                    // 最初にキャッシュされる OS FS cache にヒットする)。
-                    for candidate in new_ids {
-                        // jsonl の cwd が一致しないなら別 project の衝突なのでスキップ
-                        let candidate_path = dir.join(format!("{}.jsonl", candidate));
-                        if !jsonl_matches_project(&candidate_path, &expected_norm) {
-                            tracing::debug!("[claude_watcher] skip {} (cwd mismatch)", candidate);
-                            continue;
-                        }
-                        if !try_claim(candidate) {
-                            // 競合で claim できず → 次の候補へ
-                            continue;
-                        }
-                        if emit_session_id(&app, &terminal_id, candidate) {
-                            return;
-                        }
+                    if !try_claim(candidate) {
+                        // 競合で claim できず → 次の候補へ
+                        continue;
                     }
-                    // まだ自分の番が来ていない → snapshot を更新して次イベントを待つ。
-                    // (他の watcher が claim した id は snapshot に足し、次回の difference から除外する)
-                    snapshot.extend(current);
+                    if emit_session_id(&app, &terminal_id, candidate) {
+                        return;
+                    }
                 }
-                Ok(Err(_)) | Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
-                Err(_) => break,
+                // まだ自分の番が来ていない → snapshot を更新して次イベントを待つ。
+                // (他の watcher が claim した id は snapshot に足し、次回の difference から除外する)
+                snapshot.extend(current);
             }
+            Ok(Err(_)) | Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(_) => break,
         }
-        tracing::debug!(
-            "[claude_watcher] tid={} watcher exit (timeout / dead)",
-            terminal_id
-        );
-    });
+    }
+    tracing::debug!(
+        "[claude_watcher] tid={} watcher exit (deadline / cancelled / channel closed)",
+        terminal_id
+    );
 }
 
 #[cfg(test)]
@@ -351,5 +402,39 @@ mod tests {
 
         assert_eq!(ids, vec!["new-session"]);
         let _ = fs::remove_dir_all(dir);
+    }
+
+    /// Issue #632: poll interval が 500ms (旧) より十分短く、watcher が cancel を
+    /// 観測してから exit するまでの「最大待ち時間」が短いことを定数で機械的に保証する。
+    /// 数値そのものは将来 50ms に下げる等の調整が入っても、500ms 以下で居続けることが
+    /// 「orphan watcher を 30 個並走させない」要件の核心。
+    #[test]
+    fn watcher_poll_interval_is_significantly_shorter_than_legacy_500ms() {
+        // 旧実装は 500ms ごとに is_alive() を polling していた。新実装はそれより十分小さい
+        // ことを保証する (= 短命 PTY 連発時の watcher 終息が早くなる)。
+        assert!(
+            WATCHER_POLL_INTERVAL <= Duration::from_millis(200),
+            "poll interval は旧 500ms より十分短くあるべき: {:?}",
+            WATCHER_POLL_INTERVAL
+        );
+        // 0 / 1ms みたいな busy-loop には絶対しない (CPU 暴走防止)
+        assert!(
+            WATCHER_POLL_INTERVAL >= Duration::from_millis(10),
+            "0ms / busy-loop は CPU 暴走 — 最低 10ms は確保: {:?}",
+            WATCHER_POLL_INTERVAL
+        );
+    }
+
+    /// Issue #632: deadline は session 起動 anchor + 60 秒の hard cap として維持される。
+    /// 60 秒未満に短縮すると「Claude が起動して session を作るのに数秒かかるケース」で
+    /// 検出取りこぼしが起きる。本テストは「deadline 値そのものをうっかり弄らない」ための
+    /// guard。
+    #[test]
+    fn watcher_max_lifetime_is_at_least_30_seconds() {
+        assert!(
+            WATCHER_MAX_LIFETIME >= Duration::from_secs(30),
+            "max lifetime が短すぎると Claude 起動が遅い環境で検出漏れする: {:?}",
+            WATCHER_MAX_LIFETIME
+        );
     }
 }

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
@@ -71,6 +72,11 @@ pub struct SessionHandle {
     /// Issue #285 follow-up: attach 経路で renderer に過去出力を replay するための
     /// 直近 64 KiB の出力リングバッファ。`spawn_batcher` の flush で更新される。
     scrollback: Scrollback,
+    /// Issue #632: PTY 寿命に bind した watcher cancel signal。`kill()` / `Drop` で
+    /// `true` に flip され、`claude_watcher::spawn_watcher` が短い polling 間隔で
+    /// 観測して即時 exit する。これにより「session が 1 秒で死んでも watcher が 60 秒
+    /// 並走する」リソース蓄積を防ぐ。
+    watcher_cancel: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -151,12 +157,22 @@ impl SessionHandle {
     }
 
     pub fn kill(&self) -> Result<()> {
+        // Issue #632: kill 時点で watcher_cancel を立てる。これにより claude_watcher が
+        // 60 秒 deadline まで待たずに即座 (短い polling 間隔以内で) exit する。
+        self.watcher_cancel.store(true, Ordering::Release);
         let mut k = self
             .killer
             .lock()
             .map_err(|e| anyhow!("killer lock poisoned: {e}"))?;
         let _ = k.kill();
         Ok(())
+    }
+
+    /// Issue #632: claude_watcher が共有する cancel signal。`spawn_watcher` の caller
+    /// (terminal_create) はこれを clone して watcher thread に渡す。session 寿命に追従して
+    /// watcher を停止できる (= 60 秒 deadline での polling 漏れ問題を解消)。
+    pub fn watcher_cancel_token(&self) -> Arc<AtomicBool> {
+        self.watcher_cancel.clone()
     }
 
     pub fn cleanup_codex_broker_if_stale(&self) {
@@ -186,6 +202,10 @@ impl SessionHandle {
 /// が確実に成立する。kill 時の Mutex poison でも inner を回収し、child kill だけは試みる。
 impl Drop for SessionHandle {
     fn drop(&mut self) {
+        // Issue #632: 明示 kill() を経ずに drop されるパスでも watcher を解放する。
+        // 例: registry::insert_if_absent が Err を返して caller 側が handle を捨てるとき、
+        //     terminal_create の早期 return パスで insert に到達しないとき、等。
+        self.watcher_cancel.store(true, Ordering::Release);
         let mut k = match self.killer.lock() {
             Ok(g) => g,
             Err(poisoned) => {
@@ -281,6 +301,7 @@ mod drop_tests {
                 bytes_in_window: 0,
             }),
             scrollback: crate::pty::scrollback::new_scrollback(),
+            watcher_cancel: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -303,6 +324,37 @@ mod drop_tests {
         let kills = Arc::new(AtomicUsize::new(0));
         drop(test_handle(kills.clone()));
         assert_eq!(kills.load(Ordering::SeqCst), 1);
+    }
+
+    /// Issue #632: `kill()` で watcher_cancel が立つことを検証する。これにより
+    /// claude_watcher が短い polling 間隔で session 終了を検知して即時 exit できる。
+    #[test]
+    fn kill_flips_watcher_cancel_token() {
+        let kills = Arc::new(AtomicUsize::new(0));
+        let handle = test_handle(kills);
+        let token = handle.watcher_cancel_token();
+        assert!(!token.load(Ordering::Acquire), "初期状態は false");
+        handle.kill().expect("kill ok");
+        assert!(
+            token.load(Ordering::Acquire),
+            "kill() 直後に watcher_cancel が true になっていること"
+        );
+    }
+
+    /// Issue #632: 明示 kill() を経ずに Drop されたパスでも watcher_cancel が立つことを
+    /// 検証する。registry::insert_if_absent が衝突で Err を返したときなど、caller が
+    /// handle を捨てる経路で watcher が orphan として 60 秒残らないようにするため。
+    #[test]
+    fn drop_flips_watcher_cancel_token() {
+        let kills = Arc::new(AtomicUsize::new(0));
+        let handle = test_handle(kills);
+        let token = handle.watcher_cancel_token();
+        assert!(!token.load(Ordering::Acquire));
+        drop(handle);
+        assert!(
+            token.load(Ordering::Acquire),
+            "Drop 後に watcher_cancel が true になっていること"
+        );
     }
 }
 
@@ -1291,6 +1343,8 @@ pub fn spawn_session(
             bytes_in_window: 0,
         }),
         scrollback,
+        // Issue #632: watcher cancel token は session 起動と同寿命。kill() / Drop で flip。
+        watcher_cancel: Arc::new(AtomicBool::new(false)),
     })
 }
 


### PR DESCRIPTION
## Summary
- `claude_watcher` の deadline/反応 lag を session 寿命に追従させ、orphan watcher を減らす refactor (Issue #632 案 1 を採用)。
- 旧実装は `Instant::now() + 60s` の hard deadline + `is_alive` 閉包の 500ms polling に依存し、1 秒で kill された PTY でも watcher が ~60 秒並走していた。30 タブ連続起動 + 即 kill で thread / channel が長時間積まれる。
- 新実装は `SessionHandle` に `Arc<AtomicBool> watcher_cancel` を持たせ、`kill()` / `Drop` 両経路で flip する。`spawn_watcher` はこれを共有して 100ms ごとに `Acquire` load し、session が早期終了したら 100ms 以内に exit する。長期 session の 60 秒 hard cap (`WATCHER_MAX_LIFETIME`) は維持。

## 変更点
- `src-tauri/src/pty/session.rs`
  - `SessionHandle` に `watcher_cancel: Arc<AtomicBool>` を追加 (新規 spawn 時 `false` 初期化)。
  - `kill()` 冒頭で `Release` store。`Drop::drop()` でも `Release` store (`insert_if_absent` 衝突で handle が捨てられる経路もカバー)。
  - 公開 getter `watcher_cancel_token()` を追加。caller は registry 経由で handle を取って clone する。
  - drop_tests に `kill_flips_watcher_cancel_token` / `drop_flips_watcher_cancel_token` を追加。
- `src-tauri/src/pty/claude_watcher.rs`
  - `spawn_watcher` の最後の引数を `impl Fn() -> bool` から `Arc<AtomicBool>` に変更。
  - 本体ロジックを `run_watcher_loop` に切り出し可読性を確保。
  - `WATCHER_POLL_INTERVAL = 100ms` / `WATCHER_MAX_LIFETIME = 60s` の定数を導入。`recv_timeout` を 500ms → 100ms に短縮。
  - deadline を `Instant::now() + 60s` 固定から `watcher_started_at.elapsed() < WATCHER_MAX_LIFETIME` に変更 (semantic は同等だが、cancel が短い間隔で観測される点が新しい)。
  - 起動直後の「projects ディレクトリ生成待ち」 phase でも cancel を 100ms ごとに観測。
  - `tests::watcher_poll_interval_is_significantly_shorter_than_legacy_500ms` / `watcher_max_lifetime_is_at_least_30_seconds` で定数値の guard test を追加。
- `src-tauri/src/commands/terminal.rs`
  - `spawn_watcher` 呼び出し側を「`registry.get(&id)` で handle を取り `watcher_cancel_token()` を渡す」形に変更。`registry.get(&watcher_id).is_some()` を 500ms 間隔で polling していた閉包は不要になる。

## 採用した寿命 binding 戦略
- `SessionHandle` が `Arc<AtomicBool> watcher_cancel` を所有し、`kill()` と `Drop` が必ず flip する設計。registry の `remove()` は内部で `kill()` を呼ぶため、`terminal_kill` / exit watcher / `kill_all` / 同 agent_id 再 spawn 等のすべての session 終了経路で自動的に cancel が立つ。
- watcher は 100ms 間隔の `recv_timeout` ループの先頭で `cancel.load(Acquire)` を確認するため、session 終了から watcher exit までの最大 lag は ~100ms。旧 500ms 比で 5 倍速い。
- `spawned_at` / `WATCHER_MAX_LIFETIME` (60s) は維持。Claude が起動から数秒〜十数秒で session jsonl を生やすケースの検出能力は regression なし。

## Test plan
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` pass
- [x] `cargo test --lib` 437 passed / 0 failed (PTY 関連 81 件全て pass)
- [x] `npm run typecheck` pass (renderer 側に変更はないが念のため)
- [ ] vibe-editor-reviewer (bot) APPROVED + 自動 merge

Closes #632