### PR TITLE
fix(canvas): #615 HUD / TeamDashboard を複数 team 集約に対応

### DIFF
--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -25,7 +25,7 @@ import {
   aggregateTeamSummary,
   type CardSummary
 } from '../../lib/agent-summary';
-import { useTeamHealth } from '../../lib/use-team-health';
+import { useTeamHealthMulti } from '../../lib/use-team-health';
 import { deriveHealth } from '../../lib/agent-health';
 import { TeamPresetsPanel } from './TeamPresetsPanel';
 import { TeamDashboard } from './TeamDashboard';
@@ -181,22 +181,19 @@ export function StageHud(): JSX.Element {
   );
   const showTeamSummary = teamSummary.total > 0;
 
-  // Issue #510: TeamHub diagnostics から dead 数を集計し、HUD に 5 番目のピルとして出す。
-  // teamId は activeTeamId 1 件しか想定しないので、agent ノード群の最頻 teamId を採る。
-  // teamId が無い (= スタンドアロンカードのみ) なら null で hook が no-op になる。
-  const aggregatedTeamId = useMemo<string | null>(() => {
-    let leader: string | null = null;
-    let first: string | null = null;
+  // Issue #510 / #615: TeamHub diagnostics から dead 数を集計し、HUD に 5 番目のピルとして出す。
+  // dual preset (`dual-claude-claude` 等) で 2 つの team が並ぶケースに対応するため、
+  // canvas 上に存在する **全ての agent teamId** を集めて useTeamHealthMulti で同時購読する。
+  // 単一 team preset のときは長さ 1 の配列になり、従来挙動と等価。
+  const aggregatedTeamIds = useMemo<string[]>(() => {
+    const seen = new Set<string>();
     for (const node of agentNodes) {
       const payload = (node.data as CardData | undefined)?.payload as AgentPayload | undefined;
-      if (!payload?.teamId) continue;
-      if (first === null) first = payload.teamId;
-      const role = payload.roleProfileId ?? payload.role;
-      if (role === 'leader' && leader === null) leader = payload.teamId;
+      if (payload?.teamId) seen.add(payload.teamId);
     }
-    return leader ?? first;
+    return Array.from(seen);
   }, [agentNodes]);
-  const healthSnapshot = useTeamHealth(aggregatedTeamId);
+  const healthSnapshot = useTeamHealthMulti(aggregatedTeamIds);
   const deadCount = useMemo(() => {
     let n = 0;
     for (const node of agentNodes) {
@@ -209,20 +206,30 @@ export function StageHud(): JSX.Element {
     return n;
   }, [agentNodes, healthSnapshot]);
 
-  // Issue #514: dashboard に渡す teamId / projectRoot を canvas state + settings から導出。
-  // 複数 team が並ぶ稀なケースは「Leader カードがある team を優先」、無ければ最初の agent team を採る。
+  // Issue #514 / #615: dashboard に渡す teamId / projectRoot を canvas state + settings から導出。
+  // dual preset で 2 team が並ぶケースに対応するため、active な全 teamId を array で渡す。
+  // ソート順は「Leader カードがある team を先頭」。Leader 不在の team は末尾に。
   const { settings } = useSettings();
-  const dashboardTeamId = useMemo<string | null>(() => {
-    let leaderTeam: string | null = null;
-    let firstTeam: string | null = null;
+  const dashboardTeamIds = useMemo<string[]>(() => {
+    const leaderTeams = new Set<string>();
+    const allTeams: string[] = [];
+    const seen = new Set<string>();
     for (const node of agentNodes) {
       const payload = (node.data as CardData | undefined)?.payload as AgentPayload | undefined;
       if (!payload?.teamId) continue;
-      if (firstTeam === null) firstTeam = payload.teamId;
+      if (!seen.has(payload.teamId)) {
+        seen.add(payload.teamId);
+        allTeams.push(payload.teamId);
+      }
       const role = payload.roleProfileId ?? payload.role;
-      if (role === 'leader' && leaderTeam === null) leaderTeam = payload.teamId;
+      if (role === 'leader') leaderTeams.add(payload.teamId);
     }
-    return leaderTeam ?? firstTeam;
+    // Leader を持つ team を先に、無い team を後に並べる (順序のみ調整、欠落させない)。
+    return allTeams.slice().sort((a, b) => {
+      const la = leaderTeams.has(a) ? 0 : 1;
+      const lb = leaderTeams.has(b) ? 0 : 1;
+      return la - lb;
+    });
   }, [agentNodes]);
   const dashboardProjectRoot = settings.lastOpenedRoot || null;
 
@@ -356,7 +363,7 @@ export function StageHud(): JSX.Element {
         </button>
         {dashboardOpen ? (
           <TeamDashboard
-            teamId={dashboardTeamId}
+            teamIds={dashboardTeamIds}
             projectRoot={dashboardProjectRoot}
             onClose={() => setDashboardOpen(false)}
           />

--- a/src/renderer/src/components/canvas/TeamDashboard.tsx
+++ b/src/renderer/src/components/canvas/TeamDashboard.tsx
@@ -1,23 +1,31 @@
 /**
- * TeamDashboard — Issue #514.
+ * TeamDashboard — Issue #514 / Issue #615.
  *
  * Canvas 上のチーム (= 同 teamId の agent カード群) を一覧化する集約 UI。
  * 4 名以上のチームでも Leader が状態を破綻させず把握できることをゴールとする。
  *
  * 設計:
- *   - 親 (StageHud) が popover として表示する。teamId は active leader 経由で受け取る。
- *   - 行データは `useTeamDashboard` hook が canvas + agent-activity + team_state_read を
- *     合成して返す。本コンポーネントは表示のみに集中する。
+ *   - 親 (StageHud) が popover として表示する。teamIds は Canvas 上の active な
+ *     全 team を array で受け取る (Issue #615: dual preset 対応)。
+ *   - 行データは `useTeamDashboardMulti` hook が canvas + agent-activity + team_state_read
+ *     を合成して返す。本コンポーネントは表示のみに集中する。
  *   - 状態色: active=success, blocked=warning, stale=info-mute, completed=accent。
  *   - 0 件 / teamId 未確定時は空状態メッセージを出す。
+ *   - 複数 team が active のときは team ごとに section を分けて表示し、片方の team の
+ *     dead/stale/blocked 行が誤って隠れないようにする。
  */
 import { useMemo } from 'react';
 import { AlertTriangle, CheckCircle2, CircleDot, Hourglass, MoonStar } from 'lucide-react';
 import { useT } from '../../lib/i18n';
-import { useTeamDashboard, type TeamDashboardRow } from '../../lib/use-team-dashboard';
+import {
+  useTeamDashboardMulti,
+  type TeamDashboardRow,
+  type TeamDashboardSection
+} from '../../lib/use-team-dashboard';
 
 interface TeamDashboardProps {
-  teamId: string | null;
+  /** Canvas 上で active な全 teamId。空配列なら "team 未確定" 扱い。 */
+  teamIds: readonly string[];
   projectRoot: string | null;
   onClose: () => void;
 }
@@ -74,12 +82,94 @@ function StateBadge({ state }: { state: TeamDashboardRow['state'] }): JSX.Elemen
   }
 }
 
-export function TeamDashboard({ teamId, projectRoot, onClose }: TeamDashboardProps): JSX.Element {
+/** Issue #615: 1 team 分の table を出すサブコンポーネント。multi-team の各 section に使う。 */
+function TeamSection({ section, now }: { section: TeamDashboardSection; now: number }): JSX.Element {
   const t = useT();
-  const { rows, aggregate, state, empty } = useTeamDashboard({ teamId, projectRoot });
+  const { state, rows } = section;
+  return (
+    <div className="tc__dashboard-section" data-team-id={section.teamId}>
+      {state?.humanGate?.blocked ? (
+        <div className="tc__dashboard-banner" role="status">
+          <AlertTriangle size={12} strokeWidth={2} aria-hidden="true" />
+          <span>{state.humanGate.reason ?? t('dashboard.banner.humanGate')}</span>
+        </div>
+      ) : null}
+      <table className="tc__dashboard-table">
+        <thead>
+          <tr>
+            <th scope="col">{t('dashboard.col.member')}</th>
+            <th scope="col">{t('dashboard.col.state')}</th>
+            <th scope="col">{t('dashboard.col.task')}</th>
+            <th scope="col">{t('dashboard.col.lastSeen')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.cardId}
+              className={'tc__dashboard-row tc__dashboard-row--' + row.state}
+            >
+              <td>
+                <div className="tc__dashboard-member">
+                  <span className="tc__dashboard-member-title">{row.title}</span>
+                  <span className="tc__dashboard-member-meta">
+                    {row.roleProfileId} · {row.agent}
+                  </span>
+                </div>
+              </td>
+              <td>
+                <StateBadge state={row.state} />
+                {row.alert ? (
+                  <div className="tc__dashboard-alert" title={row.alert}>
+                    {row.alert}
+                  </div>
+                ) : null}
+              </td>
+              <td className="tc__dashboard-task">
+                {row.task ? (
+                  <>
+                    <div
+                      className="tc__dashboard-task-title"
+                      title={row.task.summary ?? row.task.description}
+                    >
+                      {row.task.summary ?? row.task.description}
+                    </div>
+                    <div className="tc__dashboard-task-meta">
+                      #{row.task.id} · {row.task.status}
+                    </div>
+                  </>
+                ) : (
+                  <span className="tc__dashboard-task-empty">
+                    {t('dashboard.task.unassigned')}
+                  </span>
+                )}
+              </td>
+              <td className="tc__dashboard-cell-num">
+                {formatRelative(now, row.lastActivityAt) ?? t('dashboard.lastSeen.never')}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function TeamDashboard({ teamIds, projectRoot, onClose }: TeamDashboardProps): JSX.Element {
+  const t = useT();
+  const { sections, total, empty } = useTeamDashboardMulti({ teamIds, projectRoot });
   // 表示用の "now" は描画タイミングで固定。15 秒間隔の親 StageHud 再 render に乗る想定で
   // ここではフレーム単位の固定値とし、相対時間がチラつかないようにする。
-  const now = useMemo(() => Date.now(), [rows.length, aggregate.hasAttention, state?.updatedAt]);
+  // sections の updatedAt 合計を依存に入れ、IPC 更新で now が前進するようにする。
+  const sectionsKey = useMemo(
+    () =>
+      sections
+        .map((s) => `${s.teamId}:${s.rows.length}:${s.aggregate.hasAttention}:${s.state?.updatedAt ?? ''}`)
+        .join('|'),
+    [sections]
+  );
+  const now = useMemo(() => Date.now(), [sectionsKey]);
+  const showMultiTeamHeading = sections.length >= 2;
 
   return (
     <div
@@ -90,7 +180,7 @@ export function TeamDashboard({ teamId, projectRoot, onClose }: TeamDashboardPro
       <div className="tc__dashboard-header">
         <span className="tc__dashboard-title">{t('dashboard.title')}</span>
         <span className="tc__dashboard-count">
-          {t('dashboard.count', { count: aggregate.total })}
+          {t('dashboard.count', { count: total.total })}
         </span>
         <button
           type="button"
@@ -103,107 +193,60 @@ export function TeamDashboard({ teamId, projectRoot, onClose }: TeamDashboardPro
         </button>
       </div>
 
-      {state?.humanGate?.blocked ? (
-        <div className="tc__dashboard-banner" role="status">
-          <AlertTriangle size={12} strokeWidth={2} aria-hidden="true" />
-          <span>{state.humanGate.reason ?? t('dashboard.banner.humanGate')}</span>
-        </div>
-      ) : null}
-
       {empty ? (
         <div className="tc__dashboard-empty">
-          {teamId
+          {teamIds.length > 0
             ? t('dashboard.empty.noMembers')
             : t('dashboard.empty.noTeam')}
         </div>
       ) : (
-        <table className="tc__dashboard-table">
-          <thead>
-            <tr>
-              <th scope="col">{t('dashboard.col.member')}</th>
-              <th scope="col">{t('dashboard.col.state')}</th>
-              <th scope="col">{t('dashboard.col.task')}</th>
-              <th scope="col">{t('dashboard.col.lastSeen')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => (
-              <tr
-                key={row.cardId}
-                className={
-                  'tc__dashboard-row tc__dashboard-row--' + row.state
-                }
-              >
-                <td>
-                  <div className="tc__dashboard-member">
-                    <span className="tc__dashboard-member-title">{row.title}</span>
-                    <span className="tc__dashboard-member-meta">
-                      {row.roleProfileId} · {row.agent}
-                    </span>
-                  </div>
-                </td>
-                <td>
-                  <StateBadge state={row.state} />
-                  {row.alert ? (
-                    <div className="tc__dashboard-alert" title={row.alert}>
-                      {row.alert}
-                    </div>
-                  ) : null}
-                </td>
-                <td className="tc__dashboard-task">
-                  {row.task ? (
-                    <>
-                      <div
-                        className="tc__dashboard-task-title"
-                        title={row.task.summary ?? row.task.description}
-                      >
-                        {row.task.summary ?? row.task.description}
-                      </div>
-                      <div className="tc__dashboard-task-meta">
-                        #{row.task.id} · {row.task.status}
-                      </div>
-                    </>
-                  ) : (
-                    <span className="tc__dashboard-task-empty">
-                      {t('dashboard.task.unassigned')}
-                    </span>
-                  )}
-                </td>
-                <td className="tc__dashboard-cell-num">
-                  {formatRelative(now, row.lastActivityAt) ??
-                    t('dashboard.lastSeen.never')}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        sections
+          .filter((s) => s.rows.length > 0)
+          .map((section, idx) => (
+            <div key={section.teamId}>
+              {showMultiTeamHeading ? (
+                <div className="tc__dashboard-team-heading">
+                  <span className="tc__dashboard-team-label">
+                    {t('dashboard.team.label', { index: idx + 1 })}
+                  </span>
+                  <span className="tc__dashboard-team-id" title={section.teamId}>
+                    {section.teamId.slice(0, 8)}
+                  </span>
+                  <span className="tc__dashboard-team-count">
+                    ({section.aggregate.total})
+                  </span>
+                </div>
+              ) : null}
+              <TeamSection section={section} now={now} />
+            </div>
+          ))
       )}
 
       <div className="tc__dashboard-footer">
         <span className="tc__dashboard-foot-pill tc__dashboard-foot-pill--active">
-          {t('dashboard.state.active')}: {aggregate.active}
+          {t('dashboard.state.active')}: {total.active}
         </span>
         <span
           className={
             'tc__dashboard-foot-pill tc__dashboard-foot-pill--blocked' +
-            (aggregate.blocked > 0 ? ' is-on' : '')
+            (total.blocked > 0 ? ' is-on' : '')
           }
         >
-          {t('dashboard.state.blocked')}: {aggregate.blocked}
+          {t('dashboard.state.blocked')}: {total.blocked}
         </span>
         <span
           className={
             'tc__dashboard-foot-pill tc__dashboard-foot-pill--stale' +
-            (aggregate.stale > 0 ? ' is-on' : '')
+            (total.stale > 0 ? ' is-on' : '')
           }
         >
-          {t('dashboard.state.stale')}: {aggregate.stale}
+          {t('dashboard.state.stale')}: {total.stale}
         </span>
         <span className="tc__dashboard-foot-pill tc__dashboard-foot-pill--completed">
-          {t('dashboard.state.completed')}: {aggregate.completed}
+          {t('dashboard.state.completed')}: {total.completed}
         </span>
         <span className="tc__dashboard-foot-pill tc__dashboard-foot-pill--idle">
-          {t('dashboard.state.idle')}: {aggregate.idle}
+          {t('dashboard.state.idle')}: {total.idle}
         </span>
       </div>
     </div>

--- a/src/renderer/src/components/canvas/TeamDashboard.tsx
+++ b/src/renderer/src/components/canvas/TeamDashboard.tsx
@@ -23,6 +23,17 @@ import {
   type TeamDashboardSection
 } from '../../lib/use-team-dashboard';
 
+/**
+ * TeamDashboard の props。
+ *
+ * Issue #615 で props インターフェースは `teamId: string | null` から
+ * `teamIds: readonly string[]` に切り替わっている (breaking change)。
+ * 現時点で外部 caller は `StageHud.tsx` のみで、そこで dedupe + leader-first
+ * sort 済みの配列を渡している。新規 caller を追加する際は:
+ *   - 空配列を渡してよい (= "team 未確定" としてプレースホルダ表示)
+ *   - 重複 / 空文字混入は内部 hook (`useTeamDashboardMulti`) 側で正規化されるため
+ *     caller 側で気にしなくてよいが、表示順は caller 側の配列順が保たれる。
+ */
 interface TeamDashboardProps {
   /** Canvas 上で active な全 teamId。空配列なら "team 未確定" 扱い。 */
   teamIds: readonly string[];
@@ -157,7 +168,14 @@ function TeamSection({ section, now }: { section: TeamDashboardSection; now: num
 
 export function TeamDashboard({ teamIds, projectRoot, onClose }: TeamDashboardProps): JSX.Element {
   const t = useT();
-  const { sections, total, empty } = useTeamDashboardMulti({ teamIds, projectRoot });
+  // Issue #615: caller (= StageHud) は readonly string[] を渡す契約だが、
+  // 将来 any 経由で undefined / null が混入しても crash しないように defensive に
+  // 空配列へフォールバックする。dedupe / 空文字フィルタは hook 側で実施。
+  const safeTeamIds = Array.isArray(teamIds) ? teamIds : [];
+  const { sections, total, empty } = useTeamDashboardMulti({
+    teamIds: safeTeamIds,
+    projectRoot
+  });
   // 表示用の "now" は描画タイミングで固定。15 秒間隔の親 StageHud 再 render に乗る想定で
   // ここではフレーム単位の固定値とし、相対時間がチラつかないようにする。
   // sections の updatedAt 合計を依存に入れ、IPC 更新で now が前進するようにする。
@@ -195,7 +213,7 @@ export function TeamDashboard({ teamIds, projectRoot, onClose }: TeamDashboardPr
 
       {empty ? (
         <div className="tc__dashboard-empty">
-          {teamIds.length > 0
+          {safeTeamIds.length > 0
             ? t('dashboard.empty.noMembers')
             : t('dashboard.empty.noTeam')}
         </div>

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -400,7 +400,7 @@ const ja: Dict = {
     'このチームにはまだメンバーがいません。Leader から `team_recruit` でメンバーを招集してください',
   'dashboard.banner.humanGate': 'Human gate が blocked: Leader の判断待ちです',
   // Issue #615: dual / multi preset 対応の team section heading
-  'dashboard.team.label': 'Team {index}',
+  'dashboard.team.label': 'チーム {index}',
 
   // ---------- Sessions ----------
   'sessions.resume': 'セッション {id} に戻る',

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -399,6 +399,8 @@ const ja: Dict = {
   'dashboard.empty.noMembers':
     'このチームにはまだメンバーがいません。Leader から `team_recruit` でメンバーを招集してください',
   'dashboard.banner.humanGate': 'Human gate が blocked: Leader の判断待ちです',
+  // Issue #615: dual / multi preset 対応の team section heading
+  'dashboard.team.label': 'Team {index}',
 
   // ---------- Sessions ----------
   'sessions.resume': 'セッション {id} に戻る',
@@ -1056,6 +1058,8 @@ const en: Dict = {
   'dashboard.empty.noMembers':
     'This team has no members yet. Recruit members from the Leader using `team_recruit`.',
   'dashboard.banner.humanGate': 'Human gate blocked: waiting for leader decision',
+  // Issue #615: dual / multi preset support for team section heading
+  'dashboard.team.label': 'Team {index}',
 
   // ---------- Sessions ----------
   'sessions.resume': 'Resume session {id}',

--- a/src/renderer/src/lib/use-team-dashboard.ts
+++ b/src/renderer/src/lib/use-team-dashboard.ts
@@ -14,6 +14,9 @@
  *
  * 5 秒間隔で `team_state_read` を poll する (UI が固まらないことを優先する設計判断)。
  * 将来 Rust 側 diagnostics IPC が生えたら ここから列を追加する想定。
+ *
+ * Issue #615: dual / multi preset 対応のため `useTeamDashboardMulti` を提供。
+ * 単一 teamId 用 `useTeamDashboard` は薄いラッパとして残す (後方互換)。
  */
 import { useEffect, useMemo, useState } from 'react';
 import type { Node } from '@xyflow/react';
@@ -73,6 +76,24 @@ export interface TeamDashboardData {
   /** team_state_read 由来。Leader 行の表示や handoff バナーに使う。 */
   state: TeamOrchestrationState | null;
   /** dashboard が活きていない (= teamId が無い / カード 0 / projectRoot 不明) 状態 */
+  empty: boolean;
+}
+
+/** Issue #615: multi-team 用に 1 つの section データを表す。 */
+export interface TeamDashboardSection {
+  teamId: string;
+  rows: TeamDashboardRow[];
+  aggregate: TeamDashboardAggregate;
+  state: TeamOrchestrationState | null;
+}
+
+/** Issue #615: dual / multi preset 用に全 team を集約した dashboard データ。 */
+export interface MultiTeamDashboardData {
+  /** team ごとの section (teamIds の順序を保つ)。 */
+  sections: TeamDashboardSection[];
+  /** 全 team を合算した Canvas 全体集計。HUD ピル・空表示判定に使う。 */
+  total: TeamDashboardAggregate;
+  /** 全 sections の rows.length が 0 の状態 (= dashboard を出す意味がない)。 */
   empty: boolean;
 }
 
@@ -235,5 +256,215 @@ export function useTeamDashboard(input: {
     aggregate,
     state,
     empty: rows.length === 0
+  };
+}
+
+/**
+ * Issue #615: 複数 teamId 用の dashboard データ。
+ *
+ * dual preset (`dual-claude-claude` 等) で 2 つの team が canvas に並ぶケースに対応。
+ * 各 teamId ごとに `team_state_read` IPC を 5 秒間隔で poll し、合算した集計を返す。
+ *
+ * - 単一 teamId のときは長さ 1 の `sections` を返すので従来挙動と等価。
+ * - teamIds は呼び出し側が「Leader を持つ team を先頭に」並べた順序を保持する。
+ * - projectRoot が null の場合は state poll を行わず canvas 上の情報だけで構成する
+ *   (rows は出るが task / human_gate は付かない)。
+ */
+export function useTeamDashboardMulti(input: {
+  teamIds: readonly string[];
+  projectRoot: string | null;
+}): MultiTeamDashboardData {
+  const { teamIds, projectRoot } = input;
+
+  // teamIds 配列の参照ゆれで useEffect が頻繁に再起動しないよう、安定リスト + JSON key に正規化。
+  const stableTeamIds = useMemo<string[]>(() => {
+    const uniq = Array.from(
+      new Set(teamIds.filter((id) => typeof id === 'string' && id.length > 0))
+    );
+    return uniq;
+  }, [teamIds]);
+  const stableKey = useMemo(() => JSON.stringify(stableTeamIds), [stableTeamIds]);
+
+  const allNodes = useCanvasNodes();
+  // teamId ごとに agent ノードを分けて持つ。teamIds に含まれる team のみ対象。
+  const nodesByTeam = useMemo<Record<string, Node<CardData>[]>>(() => {
+    const out: Record<string, Node<CardData>[]> = {};
+    for (const id of stableTeamIds) out[id] = [];
+    for (const n of allNodes) {
+      if (n.type !== 'agent') continue;
+      const payload = (n.data as CardData | undefined)?.payload as AgentPayload | undefined;
+      const tid = payload?.teamId;
+      if (tid && out[tid]) out[tid].push(n);
+    }
+    return out;
+  }, [allNodes, stableTeamIds]);
+
+  const byCard = useAgentActivityStore((s) => s.byCard);
+
+  const [stateByTeam, setStateByTeam] = useState<Record<string, TeamOrchestrationState | null>>({});
+
+  // 全 teamId を 1 つの effect で並列 poll する。teamIds が変わったら全体を再構築する。
+  useEffect(() => {
+    if (stableTeamIds.length === 0 || !projectRoot) {
+      setStateByTeam({});
+      return;
+    }
+    let cancelled = false;
+    const tickFor = (teamId: string) => {
+      window.api.teamState
+        .read(projectRoot, teamId)
+        .then((next) => {
+          if (cancelled) return;
+          setStateByTeam((prev) => {
+            const cur = prev[teamId] ?? null;
+            if (cur && next && cur.updatedAt === next.updatedAt) return prev;
+            return { ...prev, [teamId]: next };
+          });
+        })
+        .catch((err) => {
+          if (!cancelled) console.warn('[team-dashboard-multi] read failed:', err);
+        });
+    };
+    // 初回は全 teamId を並列 fetch。
+    for (const id of stableTeamIds) tickFor(id);
+    const intervalId = window.setInterval(() => {
+      for (const id of stableTeamIds) tickFor(id);
+    }, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [stableKey, stableTeamIds, projectRoot]);
+
+  const sections = useMemo<TeamDashboardSection[]>(() => {
+    return stableTeamIds.map((teamId) => {
+      const nodes = nodesByTeam[teamId] ?? [];
+      const state = stateByTeam[teamId] ?? null;
+      const rows: TeamDashboardRow[] = nodes.map((node) => {
+        const data = node.data as CardData | undefined;
+        const payload = data?.payload as AgentPayload | undefined;
+        const agentId = payload?.agentId ?? null;
+        const roleProfileId = payload?.roleProfileId ?? payload?.role ?? 'unknown';
+        const agentKind = payload?.agent ?? 'claude';
+        const title = typeof data?.title === 'string' ? data.title : roleProfileId;
+        const runtime = byCard[node.id];
+        const activity = runtime?.activity ?? 'idle';
+        const lastActivityAt = runtime?.lastActivityAt ?? null;
+        const summary = runtime?.summary ?? null;
+
+        const candidateTasks = state
+          ? state.tasks.filter((t) => agentId !== null && t.assignedTo === agentId)
+          : [];
+        const orderedTasks = candidateTasks.slice().sort((a, b) => {
+          const score = (s: string) => (s === 'in_progress' ? 0 : s === 'pending' ? 1 : 2);
+          return score(a.status) - score(b.status);
+        });
+        const task = orderedTasks[0] ?? null;
+
+        let computed: TeamDashboardRow['state'] = 'idle';
+        if (summary?.isCompleted) computed = 'completed';
+        else if (
+          task?.status === 'blocked' ||
+          task?.blockedByHumanGate ||
+          summary?.needsLeaderInput
+        )
+          computed = 'blocked';
+        else if (summary?.isStale) computed = 'stale';
+        else if (summary?.isActive) computed = 'active';
+
+        const alert = (() => {
+          if (computed === 'blocked') {
+            return (
+              task?.blockedReason ??
+              task?.requiredHumanDecision ??
+              (state?.humanGate.blocked ? state.humanGate.reason ?? null : null) ??
+              'Leader 入力待ち'
+            );
+          }
+          if (computed === 'stale') return '5 分以上出力なし';
+          return null;
+        })();
+
+        return {
+          cardId: node.id,
+          agentId,
+          title,
+          roleProfileId,
+          agent: agentKind,
+          state: computed,
+          activity,
+          lastActivityAt,
+          task,
+          alert
+        };
+      });
+
+      let active = 0;
+      let blocked = 0;
+      let stale = 0;
+      let completed = 0;
+      let idle = 0;
+      for (const r of rows) {
+        switch (r.state) {
+          case 'active':
+            active += 1;
+            break;
+          case 'blocked':
+            blocked += 1;
+            break;
+          case 'stale':
+            stale += 1;
+            break;
+          case 'completed':
+            completed += 1;
+            break;
+          default:
+            idle += 1;
+        }
+      }
+      const aggregate: TeamDashboardAggregate = {
+        total: rows.length,
+        active,
+        blocked,
+        stale,
+        completed,
+        idle,
+        hasAttention: blocked > 0 || stale > 0
+      };
+
+      return { teamId, rows, aggregate, state };
+    });
+  }, [stableTeamIds, nodesByTeam, stateByTeam, byCard]);
+
+  const total = useMemo<TeamDashboardAggregate>(() => {
+    let total = 0;
+    let active = 0;
+    let blocked = 0;
+    let stale = 0;
+    let completed = 0;
+    let idle = 0;
+    for (const s of sections) {
+      total += s.aggregate.total;
+      active += s.aggregate.active;
+      blocked += s.aggregate.blocked;
+      stale += s.aggregate.stale;
+      completed += s.aggregate.completed;
+      idle += s.aggregate.idle;
+    }
+    return {
+      total,
+      active,
+      blocked,
+      stale,
+      completed,
+      idle,
+      hasAttention: blocked > 0 || stale > 0
+    };
+  }, [sections]);
+
+  return {
+    sections,
+    total,
+    empty: sections.every((s) => s.rows.length === 0)
   };
 }

--- a/src/renderer/src/lib/use-team-health.ts
+++ b/src/renderer/src/lib/use-team-health.ts
@@ -10,8 +10,12 @@
  *     活性 poll を持ち、追加 caller は同じ Map に subscribe するだけのレジストリパターン。
  *   - Tab が非フォーカスの間は poll を一時停止する (CPU / IPC コスト削減)。
  *   - teamId が null の間は何もしない。
+ *
+ * Issue #615: dual preset (`dual-claude-claude` 等) で 2 つの team が同時に active な場合、
+ * HUD / TeamDashboard は両方の team を集約する必要がある。`useTeamHealthMulti` は
+ * 任意の teamId 配列を購読し、merged な byAgentId と per-team byTeamId を返す。
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { TeamDiagnosticsMemberRow } from '../../../types/shared';
 
 /** poll 間隔。CPU 負荷と "agent が止まったとき何秒以内に気づくか" のバランス。 */
@@ -138,4 +142,118 @@ export function useTeamHealth(
     byAgentId: snapshot?.byAgentId ?? {},
     fetchedAt: snapshot?.fetchedAt ?? null
   };
+}
+
+/**
+ * 複数 teamId の diagnostics を同時購読する。Issue #615。
+ *
+ * dual / multi preset を canvas に展開した際、HUD は **全 active team の dead/stale**
+ * を 1 個の数字に集約する必要がある。本 hook は `useTeamHealth` のレジストリ機構を
+ * 各 teamId ごとに再利用し、merged な `byAgentId` と per-team `byTeamId` を返す。
+ *
+ * - `byAgentId`: agentId はチームを跨いで衝突しない (Hub 側で uuid 採番) ため、
+ *   全 team を 1 つの map にマージしても安全。HUD の dead 数集計のように
+ *   「agent 単位で 1 回だけ評価したい」用途で使う。
+ * - `byTeamId`: TeamDashboard など team ごとに分けて表示したい用途のために、
+ *   teamId → byAgentId の per-team snapshot も保持する。
+ *
+ * teamIds が空配列なら hook は no-op (空 map を返す)。teamIds の順序が異なっても
+ * 同一の集合なら同じ snapshot を返すよう、内部では Set で重複除去する。
+ */
+export function useTeamHealthMulti(teamIds: readonly string[]): {
+  byAgentId: Record<string, TeamDiagnosticsMemberRow>;
+  byTeamId: Record<string, Record<string, TeamDiagnosticsMemberRow>>;
+  fetchedAt: number | null;
+} {
+  // teamIds 配列の参照ゆれで useEffect が頻繁に再起動しないよう、ソート済みの
+  // 安定リストを派生させ、その JSON 表現を effect 依存キーに使う (順序非依存・重複除去)。
+  const stableTeamIds = useMemo<string[]>(() => {
+    const uniq = Array.from(new Set(teamIds.filter((id) => typeof id === 'string' && id.length > 0)));
+    uniq.sort();
+    return uniq;
+  }, [teamIds]);
+  const stableKey = useMemo(() => JSON.stringify(stableTeamIds), [stableTeamIds]);
+
+  const [snapshots, setSnapshots] = useState<Record<string, Snapshot | null>>({});
+
+  useEffect(() => {
+    if (stableTeamIds.length === 0) {
+      setSnapshots({});
+      return;
+    }
+    // 各 teamId ごとに registry に subscribe する。1 effect 内で複数 entry を持つ。
+    const cleanups: Array<() => void> = [];
+    for (const teamId of stableTeamIds) {
+      let entry = registry.get(teamId);
+      if (!entry) {
+        entry = {
+          refCount: 0,
+          snapshot: null,
+          listeners: new Set(),
+          timer: null,
+          inflight: false
+        };
+        registry.set(teamId, entry);
+      }
+      entry.refCount += 1;
+      const listener = (snap: Snapshot | null) => {
+        setSnapshots((prev) => {
+          if (prev[teamId] === snap) return prev;
+          return { ...prev, [teamId]: snap };
+        });
+      };
+      entry.listeners.add(listener);
+      // 既存スナップショットがあれば即座に反映 (poll を待たない)。
+      setSnapshots((prev) => ({ ...prev, [teamId]: entry?.snapshot ?? null }));
+      ensurePoll(teamId, entry);
+
+      const onVisibility = () => {
+        const e = registry.get(teamId);
+        if (!e) return;
+        if (document.hidden) {
+          stopPoll(e);
+        } else if (e.refCount > 0) {
+          ensurePoll(teamId, e);
+        }
+      };
+      document.addEventListener('visibilitychange', onVisibility);
+
+      cleanups.push(() => {
+        document.removeEventListener('visibilitychange', onVisibility);
+        const e = registry.get(teamId);
+        if (!e) return;
+        e.listeners.delete(listener);
+        e.refCount -= 1;
+        if (e.refCount <= 0) {
+          stopPoll(e);
+          registry.delete(teamId);
+        }
+      });
+    }
+    return () => {
+      for (const fn of cleanups) fn();
+    };
+    // stableKey は stableTeamIds と完全に対応する派生値。eslint への意思表示として両方積む。
+  }, [stableKey, stableTeamIds]);
+
+  return useMemo(() => {
+    const byAgentId: Record<string, TeamDiagnosticsMemberRow> = {};
+    const byTeamId: Record<string, Record<string, TeamDiagnosticsMemberRow>> = {};
+    let latestFetchedAt: number | null = null;
+    for (const teamId of stableTeamIds) {
+      const snap = snapshots[teamId];
+      if (!snap) {
+        byTeamId[teamId] = {};
+        continue;
+      }
+      byTeamId[teamId] = snap.byAgentId;
+      for (const [agentId, row] of Object.entries(snap.byAgentId)) {
+        byAgentId[agentId] = row;
+      }
+      if (latestFetchedAt === null || snap.fetchedAt > latestFetchedAt) {
+        latestFetchedAt = snap.fetchedAt;
+      }
+    }
+    return { byAgentId, byTeamId, fetchedAt: latestFetchedAt };
+  }, [snapshots, stableTeamIds]);
 }

--- a/src/renderer/src/styles/components/team-dashboard.css
+++ b/src/renderer/src/styles/components/team-dashboard.css
@@ -277,3 +277,50 @@
 [data-density='compact'] .tc__dashboard-task-meta {
   display: none;
 }
+
+/* ----------
+ * Issue #615: multi-team section
+ *
+ * dual preset 等で 2 team 以上が active のとき、各 team を section ごとに表示する。
+ * section の上に小さな heading を出して team を識別できるようにする。
+ * ---------- */
+.tc__dashboard-section {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.tc__dashboard-section + .tc__dashboard-section,
+.tc__dashboard-team-heading + .tc__dashboard-section {
+  margin-top: 8px;
+}
+.tc__dashboard-team-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 4px 4px 2px;
+  font-size: var(--text-xs, 11px);
+  color: var(--fg-subtle);
+  border-top: 1px dashed color-mix(in srgb, var(--border) 70%, transparent);
+  margin-top: 6px;
+}
+.tc__dashboard-team-heading:first-of-type {
+  border-top: 0;
+  margin-top: 0;
+  padding-top: 0;
+}
+.tc__dashboard-team-label {
+  font-weight: 600;
+  color: var(--fg);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.tc__dashboard-team-id {
+  font-family: var(--font-mono, ui-monospace);
+  color: var(--fg-subtle);
+  font-variant-numeric: tabular-nums;
+}
+.tc__dashboard-team-count {
+  margin-left: auto;
+  color: var(--fg-subtle);
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
Closes #615

## Summary
- `dual-claude-claude` 等の **dual preset** で 2 つの team が同時に canvas に並ぶとき、`StageHud` の `aggregatedTeamId` は「最初の leader / 最初の team」を 1 つだけ返す実装だったため、`useTeamHealth(aggregatedTeamId)` の集計範囲が片方の team に閉じてしまい、もう片方の team の leader を kill しても HUD の dead カウントが増えず、`TeamDashboard` でも片方の team の health/タスク行が完全に欠落していた。
- 集約ロジックを **「全 active team の合算」** に変更し、HUD dead ピル / TeamDashboard が両方の team の状態を漏れなく表示するようにした。

## 変更点
- **`use-team-health.ts`**: `useTeamHealthMulti(teamIds)` を追加。teamId 配列を同時購読し、merged な `byAgentId` (HUD 集計用) と per-team `byTeamId` を返す。registry は teamId ごとに reuse するため、既存 `useTeamHealth(teamId)` と poll を共有する。
- **`StageHud.tsx`**: `aggregatedTeamId: string | null` → `aggregatedTeamIds: string[]` に置換。`useTeamHealthMulti` を呼び、`deadCount` を canvas 上の全 agentNode に対して計算する。`TeamDashboard` には `teamIds` (Leader を持つ team を先頭) を渡す。
- **`use-team-dashboard.ts`**: `useTeamDashboardMulti({ teamIds, projectRoot })` を追加。`team_state_read` IPC を team ごとに 5 秒間隔で poll し、`sections: TeamDashboardSection[]` と全 team 合算の `total` aggregate を返す。
- **`TeamDashboard.tsx`**: `teamId: string | null` → `teamIds: readonly string[]` に変更。`useTeamDashboardMulti` の sections を team ごとの table に分割描画し、複数 team が active のときだけ section heading (`Team 1 / Team 2 …`) を表示する。footer のピルは全 team 合算で表示。
- **i18n**: `dashboard.team.label` (ja/en) を追加。
- **CSS**: `.tc__dashboard-section` / `.tc__dashboard-team-heading` 系のスタイルを `team-dashboard.css` に追加。

単一 team preset (legacy) では `teamIds.length === 1` の縮退ケースとして従来挙動と等価 (section heading は出ない)。

## Test plan
- [x] `npm run typecheck` pass
- [x] `npx vitest run` 全 372 tests pass
- [ ] dual preset (`dual-claude-claude`) を Canvas に apply → 両 team の dead/stale が HUD バッジに合算される
- [ ] 片方の team の leader を kill すると HUD dead count が +1 される (どちらの team でも)
- [ ] TeamDashboard で全 active team の health が section ごとに表示される
- [ ] 単一 team preset (legacy) でも従来どおり 1 team 分の集計が出る (section heading は出ず、見た目 unchanged)