### PR TITLE
refactor(team): #637 agent_role_bindings の key を (team_id, agent_id) に拡張

### DIFF
--- a/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
+++ b/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
@@ -144,7 +144,15 @@ pub async fn team_diagnostics(hub: &TeamHub, ctx: &CallContext) -> Result<Value,
     let messages_snapshot: Vec<TeamMessage>;
     {
         let state = hub.state.lock().await;
-        bindings_snapshot = state.agent_role_bindings.clone();
+        // Issue #637: `agent_role_bindings` は `(team_id, agent_id)` 複合キー。
+        // diagnostics は呼び出し元 team の inconsistent 判定にしか使わないので、
+        // 当該 team_id のスコープを抽出した `agent_id -> role` マップに reduce する。
+        bindings_snapshot = state
+            .agent_role_bindings
+            .iter()
+            .filter(|((team_id, _), _)| team_id == &ctx.team_id)
+            .map(|((_, agent_id), role)| (agent_id.clone(), role.clone()))
+            .collect();
         diag_snapshot = state.member_diagnostics.clone();
         messages_snapshot = state
             .teams

--- a/src-tauri/src/team_hub/protocol/tools/dismiss.rs
+++ b/src-tauri/src/team_hub/protocol/tools/dismiss.rs
@@ -77,6 +77,17 @@ pub async fn team_dismiss(
             "[team_dismiss] released {released_lock_count} file lock(s) held by '{agent_id}'"
         );
     }
+    // Issue #637: dismiss された (team_id, agent_id) の role binding を取り除く。
+    // 残しておくと将来同 agent_id を別 role で再 recruit したい時に
+    // role mismatch で handshake が拒否される。team_id 次元で分離されているので
+    // 別 team の binding には影響しない。
+    if hub.remove_agent_role_binding(&ctx.team_id, &agent_id).await {
+        tracing::debug!(
+            "[team_dismiss] cleared role binding for team='{}' agent='{}'",
+            ctx.team_id,
+            agent_id
+        );
+    }
     let dismissed_at = Utc::now().to_rfc3339();
     Ok(json!({
         "success": true,

--- a/src-tauri/src/team_hub/protocol/tools/info.rs
+++ b/src-tauri/src/team_hub/protocol/tools/info.rs
@@ -14,11 +14,19 @@ pub async fn team_info(hub: &TeamHub, ctx: &CallContext) -> Result<Value, String
     // 自分自身の binding (`myBoundRole`) のみフル表示する。
     // Issue #518: チーム単位の engine_policy を一緒に取得して response に乗せる。
     // HR / Leader / UI が「自分が属する team は ClaudeOnly か?」を確認するために必要。
+    // Issue #637: `agent_role_bindings` は `(team_id, agent_id)` キーになっているので、
+    // 当該 team_id のスコープだけを抽出した `agent_id -> role` マップに reduce してから
+    // 既存の inconsistent 判定ロジックを適用する (cross-team の他 team binding は無視)。
     let state = hub.state.lock().await;
     let team_entry = state.teams.get(&ctx.team_id);
     let name = team_entry.map(|t| t.name.clone()).unwrap_or_default();
     let engine_policy = team_entry.map(|t| t.engine_policy.clone()).unwrap_or_default();
-    let bindings_snapshot: HashMap<String, String> = state.agent_role_bindings.clone();
+    let bindings_snapshot: HashMap<String, String> = state
+        .agent_role_bindings
+        .iter()
+        .filter(|((team_id, _), _)| team_id == &ctx.team_id)
+        .map(|((_, agent_id), role)| (agent_id.clone(), role.clone()))
+        .collect();
     drop(state);
     let members: Vec<_> = hub
         .registry

--- a/src-tauri/src/team_hub/state.rs
+++ b/src-tauri/src/team_hub/state.rs
@@ -41,7 +41,12 @@ pub(crate) struct HubState {
     pub(crate) pending_recruits: HashMap<String, PendingRecruit>,
     /// Issue #183: agent_id を初回 handshake で確定した role に bind する。
     /// 別プロセスが同 agent_id で接続してきても異なる role を主張できなくする。
-    pub(crate) agent_role_bindings: HashMap<String, String>,
+    ///
+    /// Issue #637: key を `(team_id, agent_id)` の tuple に拡張。同一 `agent_id` が
+    /// 別 team で再 handshake された場合に古い team の binding を上書きしないよう、
+    /// team 次元を持たせる (cross-team で role 上書きの race を遮断)。
+    /// in-memory only (Hub 再起動で全 clear)、永続化レイヤーは無いので migration 不要。
+    pub(crate) agent_role_bindings: HashMap<(String, String), String>,
     /// renderer から同期された role profile 一覧 (team_list_role_profiles で返す)
     pub(crate) role_profile_summary: Vec<RoleProfileSummary>,
     /// Leader が team_create_role / team_recruit(role_definition=...) で動的に生成した
@@ -650,6 +655,17 @@ impl TeamHub {
         crate::team_hub::file_locks::release_all_for_agent(&mut s.file_locks, team_id, agent_id)
     }
 
+    /// Issue #637: dismiss された (team_id, agent_id) の role binding を取り除く。
+    /// 取り除かないと「dismiss 済 worker の role 文字列」がメモリに残り続け、
+    /// 同 agent_id を別 role で再 recruit したい時に role mismatch で接続拒否される。
+    /// 別 team の binding は team_id 次元で分離されているので影響しない。
+    pub async fn remove_agent_role_binding(&self, team_id: &str, agent_id: &str) -> bool {
+        let mut s = self.state.lock().await;
+        s.agent_role_bindings
+            .remove(&(team_id.to_string(), agent_id.to_string()))
+            .is_some()
+    }
+
     /// `paths` の現在の lock 保持者一覧 (assign_task の競合検知用、agent_id_filter で自分宛除外可)。
     pub async fn peek_file_locks(
         &self,
@@ -826,8 +842,11 @@ impl TeamHub {
     ///
     /// Issue #342 Phase 2: `team_id` も照合対象に追加。pending の `team_id` と
     /// handshake で送られてきた `team_id` が一致しない場合は false を返して接続を切る
-    /// (cross-team 偽 handshake / 旧 context 残骸の混線を防ぐ)。`agent_role_bindings`
-    /// の構造拡張は行わない (registry が `(agent_id, team_id)` の SSOT のため)。
+    /// (cross-team 偽 handshake / 旧 context 残骸の混線を防ぐ)。
+    ///
+    /// Issue #637: `agent_role_bindings` の key を `(team_id, agent_id)` tuple に拡張。
+    /// 同 agent_id が別 team で handshake してきても old team の binding を上書きしない
+    /// (cross-team race の遮断)。lookup / insert は team_id ペアで行う。
     pub async fn resolve_pending_recruit(
         &self,
         agent_id: &str,
@@ -860,11 +879,15 @@ impl TeamHub {
                 role_profile_id: role_profile_id.to_string(),
             });
         }
-        // 既に bind 済みの agent_id なら role 一致を強制
-        if let Some(bound) = s.agent_role_bindings.get(agent_id) {
+        // 既に bind 済みの (team_id, agent_id) なら role 一致を強制。
+        // Issue #637: team_id 次元で分離しているので、別 team の同 agent_id binding は
+        // この lookup に引っかからず、上書きで old team の role が消えることもない。
+        let binding_key = (team_id.to_string(), agent_id.to_string());
+        if let Some(bound) = s.agent_role_bindings.get(&binding_key) {
             if bound != role_profile_id {
                 tracing::warn!(
-                    "[teamhub] role mismatch on handshake (rebind) agent={} bound={} got={}",
+                    "[teamhub] role mismatch on handshake (rebind) team={} agent={} bound={} got={}",
+                    team_id,
                     agent_id,
                     bound,
                     role_profile_id
@@ -874,7 +897,7 @@ impl TeamHub {
         } else {
             // 初回 handshake で bind
             s.agent_role_bindings
-                .insert(agent_id.to_string(), role_profile_id.to_string());
+                .insert(binding_key, role_profile_id.to_string());
         }
         // Issue #342 Phase 3 (3.3): 初回 handshake / 再接続 handshake いずれも last_handshake_at と
         // last_seen_at を更新する。recruit 経路を通らずに直接 handshake してきた場合 (= 旧 context
@@ -1609,6 +1632,111 @@ async fn load_persisted_dynamic_for_team(
         }
     }
     out
+}
+
+/// Issue #637: `agent_role_bindings` の `(team_id, agent_id)` 複合キー化を検証する単体テスト。
+/// cross-team で同 agent_id が違う role で bind しても old team の binding が保持されること、
+/// dismiss で当該 (team_id, agent_id) のみ消えて other team の binding が残ることを検証する。
+#[cfg(test)]
+mod role_binding_team_id_tests {
+    use super::TeamHub;
+    use crate::pty::SessionRegistry;
+    use std::sync::Arc;
+
+    fn make_hub() -> TeamHub {
+        TeamHub::new(Arc::new(SessionRegistry::new()))
+    }
+
+    /// 同じ `agent_id` を 2 つの team でそれぞれ違う role として handshake させても、
+    /// 各 team の binding は独立に保持される (= cross-team での role 上書きが起きない)。
+    #[tokio::test]
+    async fn cross_team_same_agent_id_does_not_overwrite_role_binding() {
+        let hub = make_hub();
+        // team-a で programmer として handshake
+        assert!(
+            hub.resolve_pending_recruit("agent-1", "team-a", "programmer")
+                .await,
+            "first handshake on team-a should succeed"
+        );
+        // team-b で同 agent_id を reviewer として handshake
+        assert!(
+            hub.resolve_pending_recruit("agent-1", "team-b", "reviewer")
+                .await,
+            "handshake of same agent_id on a different team should succeed (different binding key)"
+        );
+        let s = hub.state.lock().await;
+        assert_eq!(
+            s.agent_role_bindings
+                .get(&("team-a".to_string(), "agent-1".to_string())),
+            Some(&"programmer".to_string()),
+            "team-a binding should keep its original role even after team-b handshake"
+        );
+        assert_eq!(
+            s.agent_role_bindings
+                .get(&("team-b".to_string(), "agent-1".to_string())),
+            Some(&"reviewer".to_string()),
+            "team-b binding should hold the role asserted on team-b handshake"
+        );
+    }
+
+    /// 同じ team で同 agent_id が違う role で再 handshake してきた場合は
+    /// (issue #183 の挙動どおり) false で拒否される。
+    #[tokio::test]
+    async fn same_team_role_mismatch_on_rehandshake_is_rejected() {
+        let hub = make_hub();
+        assert!(
+            hub.resolve_pending_recruit("agent-1", "team-a", "programmer")
+                .await
+        );
+        assert!(
+            !hub.resolve_pending_recruit("agent-1", "team-a", "reviewer")
+                .await,
+            "rehandshake on same team with conflicting role must be rejected"
+        );
+    }
+
+    /// `remove_agent_role_binding` は当該 `(team_id, agent_id)` のみ消し、
+    /// 別 team の同 agent_id の binding は残す。
+    #[tokio::test]
+    async fn remove_agent_role_binding_only_targets_specified_team_scope() {
+        let hub = make_hub();
+        assert!(
+            hub.resolve_pending_recruit("agent-1", "team-a", "programmer")
+                .await
+        );
+        assert!(
+            hub.resolve_pending_recruit("agent-1", "team-b", "reviewer")
+                .await
+        );
+        let removed = hub.remove_agent_role_binding("team-a", "agent-1").await;
+        assert!(removed, "remove should report true when entry existed");
+
+        let s = hub.state.lock().await;
+        assert!(
+            !s.agent_role_bindings
+                .contains_key(&("team-a".to_string(), "agent-1".to_string())),
+            "team-a binding should be removed"
+        );
+        assert_eq!(
+            s.agent_role_bindings
+                .get(&("team-b".to_string(), "agent-1".to_string())),
+            Some(&"reviewer".to_string()),
+            "team-b binding for the same agent_id must remain intact"
+        );
+    }
+
+    /// 存在しない `(team_id, agent_id)` の remove は false を返す (idempotent)。
+    #[tokio::test]
+    async fn remove_agent_role_binding_returns_false_when_absent() {
+        let hub = make_hub();
+        let removed = hub
+            .remove_agent_role_binding("nonexistent-team", "ghost-agent")
+            .await;
+        assert!(
+            !removed,
+            "removing a nonexistent binding should report false without panicking"
+        );
+    }
 }
 
 /// Issue #577: timeout 後 grace 期間中の recruit ack rescue の単体テスト。


### PR DESCRIPTION
Closes #637

## Summary
- `HubState.agent_role_bindings` の key を `agent_id` 単独から `(team_id, agent_id)` の tuple に拡張し、cross-team で同 agent_id が再 handshake された際に old team の binding を上書きしないようにした。
- `resolve_pending_recruit` / `team_info` / `team_diagnostics` の lookup・snapshot 抽出・insert を全て tuple key に揃え、`team_dismiss` で対象 `(team_id, agent_id)` の binding を解放する `remove_agent_role_binding` helper を追加した。
- `agent_role_bindings` は in-memory only (永続化レイヤー無し) のため migration / schema_version bump は不要。

## Key 拡張と migration 方針
- 旧: `HashMap<String, String>` (`agent_id -> role`)
- 新: `HashMap<(String, String), String>` (`(team_id, agent_id) -> role`)
- on-disk persistence は無いので migration コードは追加せず、`HubState` 初期化と既存 callsite の同期書き換えのみで完了。
- `team_info` / `team_diagnostics` は当該 `ctx.team_id` の scope だけを抽出した `agent_id -> role` マップにフィルタしてから既存の inconsistent 判定ロジックに渡しているので、外部 JSON shape は不変。

## 影響範囲
- `src-tauri/src/team_hub/state.rs` (`agent_role_bindings`、`resolve_pending_recruit`、`remove_agent_role_binding` 追加、新規テスト 4 件)
- `src-tauri/src/team_hub/protocol/tools/info.rs` (snapshot 抽出を team_id scope に絞る)
- `src-tauri/src/team_hub/protocol/tools/diagnostics.rs` (同上)
- `src-tauri/src/team_hub/protocol/tools/dismiss.rs` (binding 解放呼び出し)

## Test plan
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib team_hub` 219 tests pass (前回 215 + 新規 4)
- [x] 新規 unit test
  - cross-team で同 agent_id を異なる role で bind しても双方の binding が独立保持される
  - 同 team の role mismatch 再 handshake は拒否される (#183 既存挙動維持)
  - `remove_agent_role_binding` は対象 scope のみ消し他 team の binding は残す
  - 不在 entry の remove は false で idempotent