### PR TITLE
refactor(logging): vibe-editor.log を日次回転 + 古い世代を自動削除 (#643)

### DIFF
--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -1,10 +1,10 @@
-// logs.* command — 設定モーダルからログを閲覧する用 (Issue #326)
+// logs.* command — 設定モーダルからログを閲覧する用 (Issue #326 / #643)
 //
-// `~/.vibe-editor/logs/vibe-editor.log` の末尾だけを UTF-8 で読み出して renderer に返す。
-// ログファイル自体は `lib.rs` の `init_logging()` 内で tracing-appender が書き出している。
+// `~/.vibe-editor/logs/vibe-editor.log.YYYY-MM-DD` の末尾だけを UTF-8 で読み出して renderer に返す。
+// ログファイル自体は `lib.rs` の `init_logging()` 内で tracing-appender が日次回転で書き出している。
 
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::fs;
 
 /// `~/.vibe-editor/logs/` ディレクトリ
@@ -12,9 +12,53 @@ pub fn log_dir() -> PathBuf {
     crate::util::config_paths::logs_dir()
 }
 
-/// ログファイル本体のパス
+/// ログファイル本体のパス。
+///
+/// Issue #643: 日次回転に切り替えた後、実ファイルは `vibe-editor.log.YYYY-MM-DD` 形式に
+/// なるため、このパス自体には何も書かれない。`team_diagnostics` の `serverLogPath` 等で
+/// ベース位置の目印として残してある。実ファイルを読むときは `latest_log_file()` を使う。
+///
+/// 現状 in-tree で直接の caller は無いが、外部診断ツール / 将来の IPC コマンドが
+/// 「ログ書き出し先のベースパス」を尋ねるときの公開 API として保持する。
+#[allow(dead_code)]
 pub fn log_file_path() -> PathBuf {
     log_dir().join("vibe-editor.log")
+}
+
+/// Issue #643: ログディレクトリ内の `vibe-editor.log*` のうち mtime 最新のものを返す。
+///
+/// - 候補が無ければベース位置 (`vibe-editor.log`) を返す。呼び出し側は metadata 取得失敗を
+///   `empty=true` として扱うので、存在しない path でも問題なし。
+/// - 旧無回転 `vibe-editor.log` 単体ファイル (Issue #326 互換) も `vibe-editor.log*` に含むので、
+///   起動時 sweep で消えるまでの過渡期にも正しく表示できる。
+fn latest_log_file(dir: &Path) -> PathBuf {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return dir.join("vibe-editor.log");
+    };
+    let mut best: Option<(PathBuf, std::time::SystemTime)> = None;
+    for entry in entries.flatten() {
+        let Ok(ft) = entry.file_type() else {
+            continue;
+        };
+        if !ft.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if !name_str.starts_with("vibe-editor.log") {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        let modified = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        match &best {
+            Some((_, prev)) if *prev >= modified => {}
+            _ => best = Some((entry.path(), modified)),
+        }
+    }
+    best.map(|(p, _)| p)
+        .unwrap_or_else(|| dir.join("vibe-editor.log"))
 }
 
 /// renderer に返す read_log_tail 応答。serde が camelCase に変換する。
@@ -42,7 +86,8 @@ pub async fn logs_read_tail(
 ) -> crate::commands::error::CommandResult<ReadLogTailResponse> {
     const DEFAULT_MAX: u64 = 256 * 1024;
     let cap = max_bytes.filter(|n| *n > 0).unwrap_or(DEFAULT_MAX);
-    let path = log_file_path();
+    // Issue #643: 日次回転後の最新ファイル (`vibe-editor.log.YYYY-MM-DD`) を選んで読む。
+    let path = latest_log_file(&log_dir());
     let path_str = path.to_string_lossy().to_string();
 
     // metadata 取得 (ファイル不在は empty=true で正常終了)
@@ -113,4 +158,58 @@ pub async fn logs_open_dir(app: tauri::AppHandle) -> crate::commands::error::Com
         .opener()
         .open_path(path_str, None::<&str>)
         .map_err(|e| e.to_string())?)
+}
+#[cfg(test)]
+mod tests {
+    use super::latest_log_file;
+    use std::fs;
+    use std::time::{Duration, SystemTime};
+
+    /// Issue #643: 日次回転後の `vibe-editor.log.YYYY-MM-DD` のうち最新世代を選ぶ。
+    #[test]
+    fn latest_log_file_picks_newest_dated_log() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let oldest = dir.path().join("vibe-editor.log.2026-05-01");
+        let newest = dir.path().join("vibe-editor.log.2026-05-09");
+        let middle = dir.path().join("vibe-editor.log.2026-05-05");
+        let unrelated = dir.path().join("audit.log"); // 触らない (prefix 不一致)
+        for f in [&oldest, &newest, &middle, &unrelated] {
+            fs::write(f, b"x").unwrap();
+        }
+
+        // mtime を明示的にずらして「最新 = newest」を保証 (CI のファイル作成順序差を回避)。
+        let now = SystemTime::now();
+        for (f, ago_days) in [(&oldest, 8u64), (&newest, 0), (&middle, 4), (&unrelated, 0)] {
+            let t = now - Duration::from_secs(60 * 60 * 24 * ago_days);
+            fs::File::options()
+                .write(true)
+                .open(f)
+                .unwrap()
+                .set_modified(t)
+                .unwrap();
+        }
+
+        let picked = latest_log_file(dir.path());
+        assert_eq!(picked, newest);
+    }
+
+    /// 候補が空のとき、ベース位置を返す。呼び出し側はそれを metadata 取得失敗 = empty と扱う。
+    #[test]
+    fn latest_log_file_falls_back_to_base_when_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let picked = latest_log_file(dir.path());
+        assert_eq!(picked, dir.path().join("vibe-editor.log"));
+    }
+
+    /// 旧無回転 `vibe-editor.log` 単体ファイル (Issue #326 互換) も候補に含む。
+    #[test]
+    fn latest_log_file_includes_legacy_unrotated_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let legacy = dir.path().join("vibe-editor.log");
+        fs::write(&legacy, b"legacy content").unwrap();
+
+        let picked = latest_log_file(dir.path());
+        assert_eq!(picked, legacy);
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,10 +15,15 @@ use tauri::Manager;
 #[allow(unused_imports)]
 use tracing::info;
 
-/// Issue #326: tracing を stderr + ファイル両方に書き出す。
-/// ファイルは `~/.vibe-editor/logs/vibe-editor.log` (1 ファイル無回転、tracing-appender::never)。
-/// 設定モーダルからこのファイルを読み返してエラーログを GUI 上で確認できる。
+/// Issue #326 → #643: tracing を stderr + ファイル両方に書き出す。
+/// ファイルは `~/.vibe-editor/logs/vibe-editor.log.YYYY-MM-DD` で **日次回転**する
+/// (tracing-appender 0.2 の `rolling::Builder` + `Rotation::DAILY`)。
+/// 古い世代は appender 自身が `max_log_files()` で GC し、加えて起動時に
+/// 14 日を超える残骸 / 旧 `vibe-editor.log` 単体ファイルも `prune_old_log_files()` で
+/// best-effort 削除する。これで長期稼働時に `vibe-editor.log` が肥大化して
+/// disk full → DoS に繋がる経路を塞ぐ。
 fn init_logging() {
+    use tracing_appender::rolling::{Builder as RollingBuilder, Rotation};
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
     use tracing_subscriber::{fmt, EnvFilter};
@@ -28,30 +33,54 @@ fn init_logging() {
 
     let log_dir = commands::logs::log_dir();
     let _ = std::fs::create_dir_all(&log_dir); // best-effort
-    let log_path = log_dir.join("vibe-editor.log");
+
+    // Issue #643: 起動時 sweep。`max_log_files` は appender が新たに rotate した世代しか
+    // 管理しないため、(1) アプリが長期間起動されなかったケースの旧世代、
+    // (2) Issue #326 時代の無回転 `vibe-editor.log` 単体ファイル、
+    // を best-effort で削除する。失敗は無視 (ログ書き込み自体には影響させない)。
+    prune_old_log_files(&log_dir, LOG_KEEP_DAYS);
+
+    // `team_diagnostics` の `serverLogPath` 用に「ベースファイル」のパスを記録する。
+    // 実ファイルは `vibe-editor.log.YYYY-MM-DD` だが、診断 UI 上はディレクトリ位置の
+    // 目印として `vibe-editor.log` を返す形を維持する (renderer の commands::logs 側も
+    // 同ディレクトリの最新世代を解決して表示するため、リテラルが残っていても矛盾しない)。
+    let base_log_path = log_dir.join("vibe-editor.log");
 
     // Issue #342 Phase 3 (3.12): ログファイル ACL を強制する。
     //   - Unix: 0o600 (既存 `bind_local_listener` / `team-bridge.js` 書き出しと同流儀)
     //   - Windows: ~ 配下の user profile default ACL に依存 (新規 ACE は付けない)
     // tracing-appender が append open する前に空ファイルを先行作成しておくことで、
     // 「ログファイル作成された瞬間」にも ACL が掛かっている状態を保証する。
+    // 日次回転後の新ファイル (`vibe-editor.log.YYYY-MM-DD`) には appender が umask で書き
+    // 出すため、Unix で厳格に縛りたい場合は別途 umask を設定する想定。今回はベースファイル
+    // 位置のみ ACL を強制する (regression 回避)。
     {
         let _ = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
-            .open(&log_path);
+            .open(&base_log_path);
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&log_path, std::fs::Permissions::from_mode(0o600));
+            let _ =
+                std::fs::set_permissions(&base_log_path, std::fs::Permissions::from_mode(0o600));
         }
     }
 
     // Issue #342 Phase 3 (3.11): `team_diagnostics` の `serverLogPath` 用に実パスを記録。
     // env var `VIBE_TEAM_LOG_PATH` で override 可能 (server_log_path_for_diagnostics 側で参照)。
-    team_hub::set_server_log_path(log_path);
+    team_hub::set_server_log_path(base_log_path);
 
-    let file_appender = tracing_appender::rolling::never(log_dir, "vibe-editor.log");
+    // Issue #643: 日次回転 + 古い世代を appender 自身が GC。
+    // ファイル名は `vibe-editor.log.YYYY-MM-DD` 形式 (tracing-appender 0.2 の標準形)。
+    // build() 失敗時は best-effort で `rolling::daily()` にフォールバック (max_log_files
+    // GC は失われるが、prune_old_log_files() の起動時 sweep が backstop として残る)。
+    let file_appender = RollingBuilder::new()
+        .rotation(Rotation::DAILY)
+        .filename_prefix("vibe-editor.log")
+        .max_log_files(LOG_KEEP_DAYS as usize)
+        .build(&log_dir)
+        .unwrap_or_else(|_| tracing_appender::rolling::daily(&log_dir, "vibe-editor.log"));
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
     // WorkerGuard はプロセス終了まで保持する必要があるため leak で 'static 化する。
     // 1 度だけの起動コストで、メモリリークも 1 件のみ (許容)。
@@ -65,6 +94,110 @@ fn init_logging() {
         .with(stderr_layer)
         .with(file_layer)
         .init();
+}
+
+/// Issue #643: 保持する日次ログ世代の上限。
+/// `tracing_appender::rolling::Builder::max_log_files()` と
+/// `prune_old_log_files()` の両方で参照する単一の SSOT。
+/// 14 日 = 2 週間分。長期稼働マシンでも 14 ファイル × 数十 MB 程度に収まる想定。
+const LOG_KEEP_DAYS: u32 = 14;
+
+/// Issue #643: ログディレクトリ内の `vibe-editor.log*` のうち、
+/// `keep_days` 日より前に最終更新されたものを best-effort で削除する。
+///
+/// 起動時に 1 度だけ呼ばれる。`max_log_files` だけだと拾えない以下のケースを backstop する:
+///   - アプリを 14 日以上起動しなかった結果として残っている古い世代
+///   - Issue #326 時代の無回転 `vibe-editor.log` 単体ファイル (新形式に移行済み環境用)
+///
+/// 削除対象は `vibe-editor.log` で始まるファイルのみ。サブディレクトリ・別名ファイルは触らない。
+/// I/O エラーはすべて無視 (起動自体を失敗させない)。
+fn prune_old_log_files(log_dir: &std::path::Path, keep_days: u32) {
+    use std::time::{Duration, SystemTime};
+
+    let cutoff = SystemTime::now()
+        .checked_sub(Duration::from_secs(60 * 60 * 24 * keep_days as u64))
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+
+    let Ok(entries) = std::fs::read_dir(log_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        // 我々が書いたログファイル以外は触らない (誤削除防止)。
+        if !name_str.starts_with("vibe-editor.log") {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        let modified = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+        if modified < cutoff {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+#[cfg(test)]
+mod log_prune_tests {
+    use super::{prune_old_log_files, LOG_KEEP_DAYS};
+    use std::fs;
+    use std::time::{Duration, SystemTime};
+
+    /// Issue #643: 14 日より古い `vibe-editor.log*` は削除され、
+    /// 新しいファイルや無関係ファイルは残ることを確認する。
+    #[test]
+    fn prunes_only_old_vibe_editor_log_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let old_dated = dir.path().join("vibe-editor.log.2020-01-01");
+        let old_legacy = dir.path().join("vibe-editor.log");
+        let recent_dated = dir.path().join("vibe-editor.log.2099-12-31");
+        let unrelated = dir.path().join("other.log");
+        let unrelated_old = dir.path().join("readme.txt");
+
+        for f in [
+            &old_dated,
+            &old_legacy,
+            &recent_dated,
+            &unrelated,
+            &unrelated_old,
+        ] {
+            fs::write(f, b"x").unwrap();
+        }
+
+        // 古い 2 ファイルと「無関係だが古い」ファイルの mtime を 30 日前に倒す。
+        let way_old = SystemTime::now() - Duration::from_secs(60 * 60 * 24 * 30);
+        for f in [&old_dated, &old_legacy, &unrelated_old] {
+            let file = fs::File::options().write(true).open(f).unwrap();
+            file.set_modified(way_old).unwrap();
+        }
+
+        prune_old_log_files(dir.path(), LOG_KEEP_DAYS);
+
+        assert!(!old_dated.exists(), "old dated log should be pruned");
+        assert!(!old_legacy.exists(), "legacy single log should be pruned");
+        assert!(recent_dated.exists(), "recent log must survive");
+        assert!(unrelated.exists(), "non-log file must survive");
+        assert!(
+            unrelated_old.exists(),
+            "files outside vibe-editor.log* prefix must not be touched"
+        );
+    }
+
+    /// 存在しないディレクトリを渡しても panic しない (起動を失敗させない契約)。
+    #[test]
+    fn prune_is_noop_on_missing_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("does-not-exist");
+        prune_old_log_files(&missing, LOG_KEEP_DAYS);
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]


### PR DESCRIPTION
## Summary

`tracing-appender::rolling::never` で `vibe-editor.log` に無回転で追記する旧設計を、日次回転 + 14 世代保持に切り替える。長期稼働で `vibe-editor.log` が肥大化して disk full → DoS を成立させる経路を塞ぐ refactor。

## 採用方針

- **library**: `tracing-appender 0.2` の `rolling::Builder` + `Rotation::DAILY` + `max_log_files(14)` (= 14 世代)
- **ファイル名**: `vibe-editor.log.YYYY-MM-DD` (tracing-appender 標準形式)
- **保持世代**: `LOG_KEEP_DAYS = 14` (2 週間。`Builder` と起動時 sweep の SSOT)
- **多層 GC**:
  1. tracing-appender 自身が日次 rotation 時に古い世代を削除 (`max_log_files`)
  2. 起動時 `prune_old_log_files()` が backstop として 14 日経過した `vibe-editor.log*` を best-effort 削除
     - アプリを長期間起動しなかったケースで残った旧世代を回収
     - Issue #326 時代の無回転 `vibe-editor.log` 単体ファイルもこの sweep で消える

## 主な変更

- `src-tauri/src/lib.rs`
  - `init_logging()` を `RollingBuilder::new().rotation(DAILY).filename_prefix("vibe-editor.log").max_log_files(14).build(&log_dir)` に置換
  - `LOG_KEEP_DAYS` 定数 (= 14) と `prune_old_log_files()` 関数を追加
  - 起動時に sweep を 1 度実行 (失敗はログ書き込みに影響させない)
  - `Builder::build()` 失敗時は `rolling::daily()` にフォールバック (max_log_files GC は失われるが起動時 sweep が backstop)
- `src-tauri/src/commands/logs.rs`
  - `latest_log_file()` を追加: ディレクトリ内の `vibe-editor.log*` のうち mtime 最新を選ぶ
  - `logs_read_tail` が `latest_log_file(&log_dir())` を読むように変更 (= 設定モーダルのログ閲覧で最新世代を表示)
  - `log_file_path()` は外部診断用に残す (`#[allow(dead_code)]`)

## Backwards compatibility

- `team_diagnostics` の `serverLogPath` は従来通りベース位置 (`vibe-editor.log`) を返す。実ファイルは `vibe-editor.log.YYYY-MM-DD` だが、ディレクトリ位置の目印として renderer / MCP 互換性を保つ
- 旧無回転 `vibe-editor.log` 単体ファイル (Issue #326 時代の環境) も `latest_log_file()` の候補に含むので過渡期の表示維持。起動時 sweep で 14 日後に消える
- ACL 強制 (Unix 0o600) は引き続きベースファイル位置で実施 (Issue #342 Phase 3 (3.12) を維持)

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` pass (Issue #643 関連の warning 0)
- [x] `cargo test --lib log_prune` pass (2 tests: 14 日経過削除 / missing dir 安全性)
- [x] `cargo test --lib commands::logs` pass (3 tests: 最新世代選択 / 空ディレクトリ fallback / 旧形式互換)
- [x] `cargo test --lib` 全体 pass (438 passed; 0 failed)
- [ ] 実機: `npm run dev` で起動 → `~/.vibe-editor/logs/vibe-editor.log.YYYY-MM-DD` が生成されることを確認
- [ ] 実機: 設定モーダル → ログセクションで最新ログが表示されることを確認
- [ ] 短期動作確認: テストで `vibe-editor.log.2020-01-01` 形式の古いファイルを作成 → 起動 → 削除されることを確認 (`prunes_only_old_vibe_editor_log_files` で代替検証済み)

Closes #643