### PR TITLE
feat(terminal): #662 永続化 PTY size を初回 spawn seed として適用

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1147,6 +1147,8 @@ export function App(): JSX.Element {
                       markSessionPersisted(tab.id);
                     }}
                     onResize={(cols, rows) => reportTerminalSize(tab.id, cols, rows)}
+                    initialCols={tab.initialCols ?? undefined}
+                    initialRows={tab.initialRows ?? undefined}
                   />
                 ) : claudeCheck.state === 'checking' ? (
                   <div className="claude-not-found__body" style={{ padding: 40, textAlign: 'center' }}>

--- a/src/renderer/src/components/TerminalView.tsx
+++ b/src/renderer/src/components/TerminalView.tsx
@@ -71,6 +71,16 @@ interface TerminalViewProps {
    * 全ての size 変化を 1 か所で捕まえる。
    */
   onResize?: (cols: number, rows: number) => void;
+  /**
+   * Issue #662: 永続化復元時の PTY 初回 spawn cols/rows seed。
+   * 指定があると `loadInitialMetrics` の `fit.fit()` より先に `term.resize(seed)` を一度
+   * 適用し、その値を `terminal.create({ cols, rows })` に渡す。font ready 後の
+   * `useFitToContainer.refit` が走るので、persist 値が現在の container 寸法と微妙に
+   * 違っていても自然に補正される (issue 本文で「persist 値は粗くても問題ない」と明記)。
+   * 未指定なら従来通り fit.fit() / computeUnscaledGrid 経路で seed する (regression なし)。
+   */
+  initialCols?: number;
+  initialRows?: number;
   /** ユーザーが xterm 上で入力したキーストロークの sniff (タイトル auto-summary 等の用途) */
   onUserInput?: (data: string) => void;
   /**
@@ -137,6 +147,8 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       onExit,
       onSessionId,
       onResize,
+      initialCols,
+      initialRows,
       onUserInput,
       onSpawnError,
       disableWebgl,
@@ -254,7 +266,10 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       unscaledFit,
       getCellSize,
       containerRef,
-      lastScheduledRef
+      lastScheduledRef,
+      // Issue #662: 永続化復元時の初回 spawn size seed (未指定なら fit 経路に倒す)
+      initialCols,
+      initialRows
     });
 
     // --- Ctrl+C / Ctrl+V / 画像ペースト (不変式 #4) ---

--- a/src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx
@@ -136,6 +136,39 @@ describe('useTerminalTabs', () => {
     );
   });
 
+  // ---- Issue #662: 永続化復元から渡された PTY size seed をタブに焼き付ける ----
+
+  it('seeds initialCols/initialRows on the tab when AddTerminalTabOptions provides them (#662)', () => {
+    const { result } = renderHook(() => useTerminalTabs(options()));
+
+    act(() => {
+      result.current.addTerminalTab({
+        agent: 'claude',
+        cwd: 'C:\\Users\\zooyo\\repo',
+        initialCols: 142,
+        initialRows: 38
+      });
+    });
+
+    expect(result.current.terminalTabs).toHaveLength(1);
+    const tab = result.current.terminalTabs[0]!;
+    expect(tab.cwd).toBe('C:\\Users\\zooyo\\repo');
+    expect(tab.initialCols).toBe(142);
+    expect(tab.initialRows).toBe(38);
+  });
+
+  it('defaults initialCols/initialRows to null on a fresh user-created tab (#662)', () => {
+    const { result } = renderHook(() => useTerminalTabs(options()));
+
+    act(() => {
+      result.current.addTerminalTab({ agent: 'claude' });
+    });
+
+    const tab = result.current.terminalTabs[0]!;
+    expect(tab.initialCols).toBeNull();
+    expect(tab.initialRows).toBeNull();
+  });
+
   it('after the limit is reached, closing one tab allows adding exactly one more (#588)', () => {
     const { result } = renderHook(() => useTerminalTabs(options({ showToast: vi.fn() })));
 

--- a/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
@@ -33,6 +33,24 @@ const SAVE_DEBOUNCE_MS = 500;
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 
+/**
+ * Issue #662: 永続化ファイルから読んだ cols/rows 値が「PTY 起動 seed として安全か」を判定する。
+ * portable-pty は cols/rows に u16 の正の整数を要求し、0 や巨大値で起動すると Windows ConPTY
+ * 側で `E_INVALIDARG` になる。Linux/macOS でも cols=0 はカーネルが拒否する。再起動時に
+ * ファイルが手編集 / 旧 schema 残骸 / 0 値で書かれていてもアプリが死なないよう、以下を満たす
+ * 場合のみ seed として採用する:
+ *   - 整数 (NaN / 小数を弾く)
+ *   - 1..=10000 の範囲 (実用上の最大は ~999、安全マージンで 10000 上限)
+ */
+function isValidPtyDim(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 1 &&
+    value <= 10000
+  );
+}
+
 export interface UseTerminalTabsPersistenceOptions {
   projectRoot: string;
   terminalTabs: TerminalTab[];
@@ -97,7 +115,13 @@ export function useTerminalTabsPersistence(
             teamId: p.teamId ?? null,
             agentId: p.agentId ?? undefined,
             customLabel: p.label ?? null,
-            cwd: p.cwd
+            cwd: p.cwd,
+            // Issue #662: 永続化された PTY size を初回 spawn の seed として渡す。
+            // 値が壊れていても 0 / 負値 / NaN は use-xterm-bind 側で sanitize されるが、
+            // ここでも防御的に妥当範囲だけを seed する (壊れた値で xterm が cells=0 で
+            // 立ち上がる事故を防ぐ)。
+            initialCols: isValidPtyDim(p.cols) ? p.cols : null,
+            initialRows: isValidPtyDim(p.rows) ? p.rows : null
           });
           if (newId !== null) {
             numericByPersistedId.set(p.tabId, newId);

--- a/src/renderer/src/lib/hooks/use-terminal-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs.ts
@@ -34,6 +34,15 @@ export interface TerminalTab {
    * null なら App.tsx 側 fallback (`settings.claudeCwd ?? projectRoot`) を使う。
    */
   cwd: string | null;
+  /**
+   * Issue #662: 永続化復元時に PTY の初回 spawn cols/rows seed として使う値。
+   * fit.fit() より先に term.resize(initialCols, initialRows) を一度呼ぶことで、
+   * 復元直後の terminal.create() が「前回の最終 PTY size」で立ち上がり、
+   * font ready 後の useFitToContainer.refit が走るまでの間に出る再 fit 一瞬の
+   * 表示崩れを抑える。null なら通常の fit 経路 (= 既存挙動)。
+   */
+  initialCols: number | null;
+  initialRows: number | null;
   /** チーム履歴で使う member インデックス。未所属タブは null */
   teamHistoryMemberIdx: number | null;
   /** 自動生成されたデフォルトラベル（"Claude #1" / "Programmer A" など） */
@@ -68,6 +77,12 @@ export interface AddTerminalTabOptions {
    * 未指定なら App.tsx 側 fallback (`settings.claudeCwd ?? projectRoot`) を使う。
    */
   cwd?: string | null;
+  /**
+   * Issue #662: 永続化復元時に PTY の初回 spawn cols/rows seed として渡す値。
+   * 通常の addTerminalTab (新規タブ作成時) では未指定で OK。
+   */
+  initialCols?: number | null;
+  initialRows?: number | null;
 }
 
 type ToastFn = (
@@ -296,6 +311,8 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
           resumeSessionId,
           freshSessionId,
           cwd: addOpts?.cwd ?? null,
+          initialCols: addOpts?.initialCols ?? null,
+          initialRows: addOpts?.initialRows ?? null,
           teamHistoryMemberIdx: addOpts?.teamHistoryMemberIdx ?? null,
           label,
           customLabel: addOpts?.customLabel ?? null

--- a/src/renderer/src/lib/hooks/use-xterm-bind.ts
+++ b/src/renderer/src/lib/hooks/use-xterm-bind.ts
@@ -109,6 +109,16 @@ export interface UseXtermBindOptions {
    * useFitToContainer の visible-effect refit が IPC を二重発火させずに済む。
    */
   lastScheduledRef?: MutableRefObject<{ cols: number; rows: number } | null>;
+  /**
+   * Issue #662: 永続化復元時の PTY 初回 spawn cols/rows seed。
+   * 指定があると `fit.fit()` / `computeUnscaledGrid` より先に `term.resize(seed)` を
+   * 一度適用し、その値を `terminal.create({ cols, rows })` に渡す。font ready 後の
+   * `useFitToContainer.refit` が走るので、persist 値が現在の container 寸法と
+   * 微妙に違っていても自然に補正される。
+   * 未指定なら従来挙動 (fit 経路で seed) に倒す。
+   */
+  initialCols?: number;
+  initialRows?: number;
 }
 
 export function useXtermBind(options: UseXtermBindOptions): void {
@@ -128,7 +138,9 @@ export function useXtermBind(options: UseXtermBindOptions): void {
     unscaledFit = false,
     getCellSize,
     containerRef,
-    lastScheduledRef
+    lastScheduledRef,
+    initialCols: persistedInitialCols,
+    initialRows: persistedInitialRows
   } = options;
   // sessionKey は HMR cleanup / preflight 判定のために effect 内で参照したいので
   // ref に退避しておく (deps から外しても stale にならないため)。
@@ -205,6 +217,39 @@ export function useXtermBind(options: UseXtermBindOptions): void {
     let initialCols = 80;
     let initialRows = 24;
 
+    // Issue #662: 永続化復元由来の seed を持っていればここで一度 term.resize() を当てる。
+    // この時点で xterm の cols/rows が「前回の最終 PTY size」になり、後続の fit 経路が
+    // 失敗 (= container がまだ 0px) しても terminal.create({cols, rows}) に妥当値が渡る。
+    // fit が成功した場合は後段で initialCols/Rows を fit 結果で上書きするので、現在の
+    // container 寸法と一致した PTY が立ち、persist 値が古ければ font ready 後の refit
+    // が補正する。範囲チェックは use-terminal-tabs-persistence で済んでいる前提だが、
+    // 防御的に再チェックする。`seedLastScheduledSize` は本関数より後ろで定義されるが、
+    // この closure を呼び出すのは loadInitialMetrics (async IIFE) 内なので、その時点では
+    // 既に定義済み (closure resolution は呼び出し時)。
+    const seedFromPersistence = (cols?: number, rows?: number): boolean => {
+      if (
+        typeof cols !== 'number' ||
+        typeof rows !== 'number' ||
+        !Number.isInteger(cols) ||
+        !Number.isInteger(rows) ||
+        cols < 1 ||
+        rows < 1 ||
+        cols > 10000 ||
+        rows > 10000
+      ) {
+        return false;
+      }
+      try {
+        term.resize(cols, rows);
+        initialCols = cols;
+        initialRows = rows;
+        seedLastScheduledSize(cols, rows);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
     let offData: (() => void) | null = null;
     let offExit: (() => void) | null = null;
     let offSessionId: (() => void) | null = null;
@@ -276,6 +321,14 @@ export function useXtermBind(options: UseXtermBindOptions): void {
         }
         if (localDisposed || disposedRef.current) return;
       }
+
+      // Issue #662: 永続化復元由来の seed があれば fit より先に baseline として当てる。
+      // これで万一 fit/computeUnscaledGrid が container 未レイアウトで失敗しても
+      // 「前回終了時の最終 PTY size」で terminal.create({cols, rows}) が呼ばれる。
+      // fit が成功した場合は後段で initialCols/Rows を fit 結果で上書きするので
+      // 現在の container 寸法に合った PTY が立ち、persist 値が古ければ font ready 後の
+      // refit が補正する (issue 本文「persist 値は粗くても問題ない」)。
+      seedFromPersistence(persistedInitialCols, persistedInitialRows);
 
       // 初期サイズ算出。Canvas モード (unscaledFit=true) では `transform: scale(zoom)` 下で
       // FitAddon.fit() が getBoundingClientRect 経由で scale 後の視覚矩形を読んでしまうため、


### PR DESCRIPTION
## Summary

PR #663 で `terminal-tabs.json` に cwd / cols / rows を永続化する経路は入ったが、復元時の cols/rows は `xterm.onResize` 経由で集めるだけで初回 spawn の `terminal.create({ cols, rows })` には反映されていなかった。再起動直後は 80x24 (xterm 既定値) で立ち上がり、`useFitToContainer` が font ready 後に re-fit するまでの数十 ms に PTY サイズと container サイズが食い違う症状が残っていた。

本 PR は #662 の最後のピース「復元時の cols/rows を初回 spawn の seed として実際に適用する」を入れる。

Closes #662

## 変更点

| 領域 | 内容 |
|---|---|
| `TerminalTab` / `AddTerminalTabOptions` | `initialCols` / `initialRows` フィールドを追加 (永続化復元用)。新規タブ作成時は null。 |
| `use-terminal-tabs-persistence` | 復元 path で `addTerminalTab` に永続化された `cols/rows` を渡す。`isValidPtyDim` で 0 / NaN / 整数外 / 範囲外を弾く防御的バリデーション。 |
| `TerminalView` -> `usePtySession` -> `use-xterm-bind` | `initialCols` / `initialRows` props を passthrough。 |
| `use-xterm-bind` | `loadInitialMetrics` で `fit.fit()` / `computeUnscaledGrid` より先に `term.resize(seed)` を当て、seed の値を `terminal.create()` に渡す。fit が成功すれば seed は上書きされる (現在の container 寸法優先) が、fit が失敗 (container 未レイアウト) しても妥当値で PTY が立つ。font ready 後の `useFitToContainer.refit` が refit する設計は維持。 |
| vitest | `TerminalTab.initialCols/initialRows` が `AddTerminalTabOptions` 経由で焼き付けられること / 新規タブでは null になることを固定。9 tests pass。 |

## 設計判断

- **fit の上書きは許容**: 現在の container 寸法と persist 値が違う場合は fit 結果を優先するのが正しい。persist 値はあくまで「fit が間に合わない初期 mount での baseline」。Issue 本文「persist 値は粗くても問題ない (font ready 後の useFitToContainer が再 fit する)」と整合。
- **2 段サニタイズ**: `use-terminal-tabs-persistence` 側 (永続化ファイル由来の値を弾く) と `use-xterm-bind` 側 (any caller 由来でも弾く) で 2 段構えにする。永続化ファイル手編集 / 旧 schema 残骸 / 0 値で書かれていてもアプリが死なない。
- **regression なし**: `initialCols` / `initialRows` が未指定なら従来挙動 (fit 経路で seed) に倒すので、新規タブ / Canvas / team-history resume いずれの経路にも影響なし。

## 関連

- #660 (Claude session id `--session-id` 事前注入) — closed
- #661 (IDE タブ永続化) — 永続化経路は #663 で merge 済み
- #662 (cwd / PTY size 復元) — 本 PR で seed 適用が完成

## Test plan

- [x] `npm run typecheck`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `npx vitest run` 全 374 tests pass (use-terminal-tabs に #662 用 2 tests を追加し 9/9)
- [ ] `npm run dev` で IDE タブ作成 -> ターミナル幅を変更 -> 完全終了 -> 再起動でサイズが復元されること
- [ ] `~/.vibe-editor/terminal-tabs.json` を手編集して cols=0 / cols=99999 等にして起動が落ちないこと