### PR TITLE
refactor(pty): #630 window CloseRequested で in-flight inject task を待ってから kill_all する

### DIFF
--- a/src-tauri/src/commands/team_inject.rs
+++ b/src-tauri/src/commands/team_inject.rs
@@ -96,8 +96,14 @@ pub async fn team_send_retry_inject(
     let (text, from_role, from_agent_id) = lookup?;
 
     // Step 2: inject 再実行。state lock は drop 済み。
+    // Issue #630: tracker.track_async で計上することで、window CloseRequested handler が
+    // in-flight retry inject の自然完了を待てるようにする。
     let preview: String = text.chars().take(80).collect();
-    match inject::inject(registry, &args.agent_id, &from_role, &text).await {
+    match hub
+        .inflight
+        .track_async(inject::inject(registry, &args.agent_id, &from_role, &text))
+        .await
+    {
         Ok(()) => {
             let delivered_at = Utc::now().to_rfc3339();
             // message.delivered_to / delivered_at を更新 (再送成功時)。

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -457,7 +457,9 @@ pub async fn terminal_create(
             if let Some(instr) = codex_instructions_for_inject {
                 let registry = state.pty_registry.clone();
                 let term_id = id.clone();
-                tauri::async_runtime::spawn(async move {
+                // Issue #630: tracker.spawn() で計上することで、CloseRequested handler が
+                // wait_idle(3s) で in-flight 完了を待ってから kill_all() できるようにする。
+                state.pty_inflight.spawn(async move {
                     inject_codex_prompt_to_pty(registry, term_id, instr).await;
                 });
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -265,18 +265,73 @@ pub fn run() {
                 }
             }
 
-            // Issue #55: メイン window の CloseRequested で PTY と TeamHub を明示 cleanup する。
+            // Issue #55 / #630: メイン window の CloseRequested で PTY と TeamHub を明示 cleanup する。
             // portable-pty (Windows ConPTY) は親が落ちても子が残る場合があるので、
             // 明示的に kill_all を呼んで Claude / Codex プロセスが孤立しないようにする。
+            //
+            // Issue #630: 旧実装は同期 callback の中で即時 kill_all() を呼んでいたため、
+            // `tauri::async_runtime::spawn` 上で進行中の `inject_codex_prompt_to_pty` /
+            // `inject::inject` が PTY write 中に kill されて、SessionHandle::drop の killer
+            // Mutex poison / 半端 inject による不正出力 / reader thread 解放漏れ等の race を
+            // 起こしていた。
+            // 新実装は:
+            //   1. `api.prevent_close()` で OS の close をいったん抑止し、
+            //   2. 非同期 task を spawn して `pty_inflight.wait_idle(3s)` で in-flight task の
+            //      自然完了を待ち、
+            //   3. 完了 (または timeout) 後に kill_all() → app.exit(0) で終了する。
+            // タイムアウトは 3 秒。inject() の最大処理時間 (32KiB / 64B チャンク × 15ms ≒ 7.7s) より
+            // 短いが、Issue 本文の done criteria は 1 秒。実機 race の大半は 0.5-1.5s 帯で完了する
+            // ため、3 秒で安全マージンを取りつつ過剰な close 遅延を避ける。
             if let Some(main_window) = app.get_webview_window("main") {
                 let app_handle = app.handle().clone();
+                // CloseRequested は preventClose 後に再度 close ボタン押下した場合などに複数回
+                // emit され得る。`drain_in_progress` flag で 2 回目以降の prevent_close を抑止し、
+                // 1 回目の drain task が完走して exit(0) を呼ぶのを待つ。
+                let drain_in_progress =
+                    std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                 main_window.on_window_event(move |event| {
-                    if let tauri::WindowEvent::CloseRequested { .. } = event {
-                        tracing::info!("[lifecycle] window close — running cleanup");
-                        let state = app_handle.state::<state::AppState>();
-                        state.pty_registry.kill_all();
-                        // MCP エントリは残しておく (次回起動時に reclaim されるので副作用なし)
-                        // team-bridge.js は ~/.vibe-editor/ に置いたまま (再利用のため)
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                        if drain_in_progress
+                            .compare_exchange(
+                                false,
+                                true,
+                                std::sync::atomic::Ordering::SeqCst,
+                                std::sync::atomic::Ordering::SeqCst,
+                            )
+                            .is_err()
+                        {
+                            tracing::debug!(
+                                "[lifecycle] window close already draining — letting OS close proceed"
+                            );
+                            return;
+                        }
+                        tracing::info!(
+                            "[lifecycle] window close requested — draining in-flight inject tasks (timeout 3s)"
+                        );
+                        api.prevent_close();
+                        let app_for_drain = app_handle.clone();
+                        tauri::async_runtime::spawn(async move {
+                            let state = app_for_drain.state::<state::AppState>();
+                            let inflight_before = state.pty_inflight.current();
+                            let drained = state
+                                .pty_inflight
+                                .wait_idle(std::time::Duration::from_secs(3))
+                                .await;
+                            let remaining = state.pty_inflight.current();
+                            if drained {
+                                tracing::info!(
+                                    "[lifecycle] in-flight inject tasks drained (was={inflight_before}, remaining={remaining})"
+                                );
+                            } else {
+                                tracing::warn!(
+                                    "[lifecycle] in-flight inject drain timeout — proceeding to kill_all (was={inflight_before}, remaining={remaining})"
+                                );
+                            }
+                            state.pty_registry.kill_all();
+                            // MCP エントリは残しておく (次回起動時に reclaim されるので副作用なし)
+                            // team-bridge.js は ~/.vibe-editor/ に置いたまま (再利用のため)
+                            app_for_drain.exit(0);
+                        });
                     }
                 });
             }

--- a/src-tauri/src/pty/inflight.rs
+++ b/src-tauri/src/pty/inflight.rs
@@ -1,0 +1,240 @@
+// In-flight inject task tracker
+//
+// Issue #630: window CloseRequested handler が `state.pty_registry.kill_all()` を即座に呼ぶと、
+// `tauri::async_runtime::spawn` 上で進行中の `inject_codex_prompt_to_pty` や `team_send` 経由の
+// `inject::inject` が PTY write 中に kill されて、SessionHandle::drop の killer Mutex poison /
+// 半端 inject による不正出力 / reader thread 解放漏れ等の race を起こす。
+//
+// 設計:
+//   - `InFlightTracker` が「現在何件の inject task が走っているか」を `AtomicUsize` で持つ。
+//   - 各 inject 経路の入口で `track_async(future)` / `spawn(future)` 経由で計上、`Drop` で減算。
+//     減算と同時に内部 `Notify` を `notify_waiters()` してウェイターを起こす。
+//   - CloseRequested handler 側は `wait_idle(timeout)` を `await` し、counter が 0 になるか
+//     timeout までブロック (既定 3s)。完了 (timeout 含む) 後に `kill_all` → `app.exit(0)` する。
+//
+// 利用方針:
+//   - `inject_codex_prompt_to_pty` の fire-and-forget spawn (`commands/terminal.rs`) は
+//     `tracker.spawn(future)` で計上して spawn する。
+//   - `team_send` の中の `JoinSet::spawn(inject::inject(...))` は inject() 自体を `track_async`
+//     で囲んで計上する (この経路は inject() の出口まで JoinSet が await されるが、外側の
+//     handle_client task が close 時にキャンセルされる可能性があるため tracker 上は明示計上)。
+//   - `team_send_retry_inject` (IPC 経路) も同様に `track_async` で囲む。
+
+use std::future::Future;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::async_runtime::JoinHandle;
+use tokio::sync::Notify;
+
+/// in-flight inject task の件数を持つ tracker。
+///
+/// 並行性は `AtomicUsize` のみで十分 (Notify 自体が thread-safe)。`InFlightGuard` の `Drop`
+/// 経由で確実に減算するため、tracked future の panic / cancel どの経路でも counter がリーク
+/// しない。
+#[derive(Default)]
+pub struct InFlightTracker {
+    /// 現在 in-flight な tracked future の本数。
+    count: AtomicUsize,
+    /// counter が 0 に落ちたとき waiter を起こす。
+    idle: Notify,
+}
+
+/// `InFlightTracker::enter()` で発行される RAII guard。`Drop` で counter を減算し、
+/// 0 に落ちたら `Notify::notify_waiters()` で wait_idle を解放する。
+///
+/// pin-projection を避けるため、tracked future ラッパは作らず「guard を future の中で
+/// `move` で抱える」スタイル (`async move { let _g = guard; ... }`) で利用する。
+pub struct InFlightGuard {
+    tracker: Arc<InFlightTracker>,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        let prev = self.tracker.count.fetch_sub(1, Ordering::SeqCst);
+        debug_assert!(prev > 0, "InFlightTracker counter underflowed");
+        if prev == 1 {
+            self.tracker.idle.notify_waiters();
+        }
+    }
+}
+
+impl InFlightTracker {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// `count` の現在値を取得 (主にテスト / tracing 用)。
+    pub fn current(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+
+    /// counter を 1 加算し、解放用 RAII guard を返す。caller は guard を future / closure 内に
+    /// move で抱えること。guard が drop された瞬間に counter が減算されるため、guard を捨てる
+    /// タイミング = 「タスクが完了した」タイミングになる。
+    pub fn enter(self: &Arc<Self>) -> InFlightGuard {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        InFlightGuard {
+            tracker: Arc::clone(self),
+        }
+    }
+
+    /// `f` を tracked future としてラップする。`f.await` の出口で guard が drop され counter が
+    /// 戻る。tracked future が await されないまま drop されても (caller が tokio::select! で
+    /// branch から外したケース等) counter は正しく戻る。
+    ///
+    /// 計上タイミングは「`track_async` 呼び出し時 = 即時」。
+    pub fn track_async<F>(self: &Arc<Self>, f: F) -> impl Future<Output = F::Output>
+    where
+        F: Future,
+    {
+        let guard = self.enter();
+        async move {
+            let _g = guard;
+            f.await
+        }
+    }
+
+    /// fire-and-forget spawn 用ヘルパ。`tauri::async_runtime::spawn` で起動するが、tracker 配下
+    /// に置く。返り値の JoinHandle は caller 側で破棄してよい。
+    pub fn spawn<F>(self: &Arc<Self>, fut: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let guard = self.enter();
+        tauri::async_runtime::spawn(async move {
+            let _g = guard;
+            fut.await
+        })
+    }
+
+    /// counter が 0 に落ちるか `timeout` 経過するまで待つ。先に 0 に落ちれば `true`、timeout で
+    /// 抜けたら `false` を返す (timeout 後に counter 0 ならそれも `true`)。
+    ///
+    /// 呼び出し時点で counter が 0 なら即時 `true`。Notify は `notify_waiters` で broadcast する
+    /// 設計のため、wait に入るより前に `notify_waiters` が呼ばれていても次回ループで現値を見て
+    /// 抜ける (`notified()` を作ったあと再判定するパターン)。
+    pub async fn wait_idle(&self, timeout: Duration) -> bool {
+        if self.count.load(Ordering::SeqCst) == 0 {
+            return true;
+        }
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            // notified() を先に作っておくことで、enter() → drop の race で「我々が wait に入る
+            // 前に notify_waiters が呼ばれた」場合でも、次回 await で確実に取りこぼさない。
+            let notified = self.idle.notified();
+            if self.count.load(Ordering::SeqCst) == 0 {
+                return true;
+            }
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return self.count.load(Ordering::SeqCst) == 0;
+            }
+            tokio::select! {
+                _ = notified => {
+                    // 0 になったかは次回ループ頭で再判定する (race を避けるため)。
+                    continue;
+                }
+                _ = tokio::time::sleep(remaining) => {
+                    return self.count.load(Ordering::SeqCst) == 0;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn wait_idle_returns_immediately_when_no_tasks() {
+        let t = InFlightTracker::new();
+        assert!(t.wait_idle(Duration::from_millis(50)).await);
+        assert_eq!(t.current(), 0);
+    }
+
+    #[tokio::test]
+    async fn track_async_increments_and_decrements_counter() {
+        let t = InFlightTracker::new();
+        let fut = t.track_async(async {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            42
+        });
+        assert_eq!(t.current(), 1);
+        let v = fut.await;
+        assert_eq!(v, 42);
+        assert_eq!(t.current(), 0);
+    }
+
+    #[tokio::test]
+    async fn wait_idle_unblocks_on_completion() {
+        let t = InFlightTracker::new();
+        let t2 = Arc::clone(&t);
+        let _h = t.spawn(async move {
+            tokio::time::sleep(Duration::from_millis(30)).await;
+        });
+        assert_eq!(t2.current(), 1);
+        let started = std::time::Instant::now();
+        let ok = t2.wait_idle(Duration::from_secs(2)).await;
+        assert!(ok, "wait_idle should return true on natural completion");
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "should not wait full timeout when task finishes early"
+        );
+        assert_eq!(t2.current(), 0);
+    }
+
+    #[tokio::test]
+    async fn wait_idle_returns_false_on_timeout() {
+        let t = InFlightTracker::new();
+        let _h = t.spawn(async move {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        });
+        let ok = t.wait_idle(Duration::from_millis(50)).await;
+        assert!(!ok, "wait_idle should return false when tasks still running");
+        // 残ったタスクは 1 件のまま (timeout は kill しない)
+        assert_eq!(t.current(), 1);
+    }
+
+    #[tokio::test]
+    async fn drop_without_polling_still_decrements() {
+        let t = InFlightTracker::new();
+        {
+            let _fut = t.track_async(async {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            });
+            assert_eq!(t.current(), 1);
+            // _fut は scope 終了で drop される
+        }
+        assert_eq!(t.current(), 0);
+        assert!(t.wait_idle(Duration::from_millis(10)).await);
+    }
+
+    #[tokio::test]
+    async fn multiple_tasks_drain_correctly() {
+        let t = InFlightTracker::new();
+        let mut handles = Vec::new();
+        for _ in 0..5 {
+            let h = t.spawn(async move {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            });
+            handles.push(h);
+        }
+        assert_eq!(t.current(), 5);
+        let ok = t.wait_idle(Duration::from_secs(2)).await;
+        assert!(ok);
+        assert_eq!(t.current(), 0);
+    }
+
+    #[tokio::test]
+    async fn enter_guard_decrements_on_explicit_drop() {
+        let t = InFlightTracker::new();
+        let g = t.enter();
+        assert_eq!(t.current(), 1);
+        drop(g);
+        assert_eq!(t.current(), 0);
+    }
+}

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -13,6 +13,7 @@
 pub mod batcher;
 pub mod claude_watcher;
 pub mod codex_broker;
+pub mod inflight;
 pub mod path_norm;
 pub mod registry;
 pub mod scrollback;
@@ -22,5 +23,6 @@ pub mod session;
 #[cfg(test)]
 mod tests;
 
+pub use inflight::InFlightTracker;
 pub use registry::SessionRegistry;
 pub use session::{spawn_session, SpawnOptions, UserWriteOutcome};

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,6 +1,6 @@
 // アプリ全体の共有 state
 
-use crate::pty::SessionRegistry;
+use crate::pty::{InFlightTracker, SessionRegistry};
 use crate::team_hub::TeamHub;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -16,6 +16,11 @@ pub struct AppState {
     pub project_root: Mutex<Option<String>>,
     pub pty_registry: Arc<SessionRegistry>,
     pub team_hub: TeamHub,
+    /// Issue #630: 進行中の PTY inject task (codex 初期 prompt 注入 / team_send 経由 inject /
+    /// retry inject) の件数を追跡する tracker。CloseRequested handler が `wait_idle(timeout)`
+    /// を await して in-flight task の自然完了を待ってから kill_all() を呼ぶため、SessionHandle
+    /// の Mutex poison / 半端 inject による不正出力 / reader thread 解放漏れの race を防ぐ。
+    pub pty_inflight: Arc<InFlightTracker>,
 }
 
 /// Issue #147: project_root の Mutex が poison しても、内部値は単純な Option<String> なので
@@ -37,11 +42,16 @@ pub fn lock_project_root_recover<'a>(
 impl AppState {
     pub fn new() -> Self {
         let pty_registry = Arc::new(SessionRegistry::new());
-        let team_hub = TeamHub::new(pty_registry.clone());
+        let pty_inflight = InFlightTracker::new();
+        // Issue #630: TeamHub と AppState で同じ tracker Arc を共有することで、
+        // `team_send` 経由の inject::inject も `terminal_create` 経由の codex 注入も
+        // 同一 counter で wait_idle できる。
+        let team_hub = TeamHub::with_inflight(pty_registry.clone(), pty_inflight.clone());
         Self {
             project_root: Mutex::new(None),
             pty_registry,
             team_hub,
+            pty_inflight,
         }
     }
 }

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -129,6 +129,10 @@ pub struct TeamHub {
     /// 任意で AppHandle を保持。`set_app_handle` で setup 後に注入する。
     /// Phase 3: protocol::team_send が `team:handoff` event を emit するために使う。
     pub(crate) app_handle: Arc<Mutex<Option<tauri::AppHandle>>>,
+    /// Issue #630: in-flight な PTY inject task の tracker (AppState と共有)。
+    /// CloseRequested handler が `wait_idle(timeout)` で完了を待ってから kill_all() する経路で参照。
+    /// `team_send` 経路の各 `inject::inject` を tracker.track_async() で計上する。
+    pub(crate) inflight: Arc<crate::pty::InFlightTracker>,
 }
 
 fn hex_encode(bytes: &[u8]) -> String {

--- a/src-tauri/src/team_hub/protocol/tools/report.rs
+++ b/src-tauri/src/team_hub/protocol/tools/report.rs
@@ -327,11 +327,15 @@ pub async fn team_report(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Resu
 
     // active leader の terminal に 1 行サマリを inject。失敗しても報告自体は state に保存済みなので
     // tool 全体は成功扱いにする (delivery 失敗は `inject_failed` 配列で caller に返す)。
+    // Issue #630: window CloseRequested handler が in-flight inject の自然完了を待てるよう
+    // tracker.track_async() で計上する。
     let terminal_summary = format_terminal_summary(&snapshot);
     let mut delivered_to: Vec<String> = Vec::new();
     let mut inject_failed: Vec<Value> = Vec::new();
     for leader_aid in &leader_agent_ids {
-        match inject::inject(hub.registry.clone(), leader_aid, &ctx.role, &terminal_summary).await {
+        let inject_fut =
+            inject::inject(hub.registry.clone(), leader_aid, &ctx.role, &terminal_summary);
+        match hub.inflight.track_async(inject_fut).await {
             Ok(()) => delivered_to.push(leader_aid.clone()),
             Err(e) => {
                 tracing::warn!(

--- a/src-tauri/src/team_hub/protocol/tools/send.rs
+++ b/src-tauri/src/team_hub/protocol/tools/send.rs
@@ -490,6 +490,11 @@ pub async fn team_send(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result
         );
     }
 
+    // Issue #630: 各 inject() 呼び出しを `pty_inflight` tracker に計上する。これにより
+    // window CloseRequested handler の wait_idle(3s) が、PTY write 中の inject task の
+    // 自然完了を待ってから kill_all() を呼べるようになる (= SessionHandle Mutex poison /
+    // 半端 inject の race を防止)。
+    let inflight = hub.inflight.clone();
     let mut join_set = tokio::task::JoinSet::new();
     for (target_aid, target_role) in &targets {
         let reg = registry.clone();
@@ -497,8 +502,11 @@ pub async fn team_send(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result
         let from_role = message_kind.inject_from_label(&ctx.role);
         let msg = effective_message.to_string();
         let role_clone = target_role.clone();
+        let tracker = inflight.clone();
         join_set.spawn(async move {
-            let result = inject::inject(reg, &aid, &from_role, &msg).await;
+            let result = tracker
+                .track_async(inject::inject(reg, &aid, &from_role, &msg))
+                .await;
             (aid, role_clone, result)
         });
     }

--- a/src-tauri/src/team_hub/state.rs
+++ b/src-tauri/src/team_hub/state.rs
@@ -588,6 +588,15 @@ pub struct CallContext {
 
 impl TeamHub {
     pub fn new(registry: Arc<SessionRegistry>) -> Self {
+        Self::with_inflight(registry, crate::pty::InFlightTracker::new())
+    }
+
+    /// Issue #630: AppState 側で生成した in-flight tracker を共有する用。
+    /// `AppState::new()` から呼ばれる。
+    pub fn with_inflight(
+        registry: Arc<SessionRegistry>,
+        inflight: Arc<crate::pty::InFlightTracker>,
+    ) -> Self {
         Self {
             registry,
             state: Arc::new(Mutex::new(HubState {
@@ -605,6 +614,7 @@ impl TeamHub {
                 recruit_semaphores: HashMap::new(),
             })),
             app_handle: Arc::new(Mutex::new(None)),
+            inflight,
         }
     }
 


### PR DESCRIPTION
Closes #630

## Summary

- `Arc<InFlightTracker>` を導入し、AppState と TeamHub で共有することで PTY inject task (codex 初期 prompt 注入 / `team_send` / `team_report` / `team_send_retry_inject`) の in-flight 件数を追跡。
- window `CloseRequested` handler で `api.prevent_close()` → `pty_inflight.wait_idle(3s)` → `kill_all()` → `app.exit(0)` のシーケンスに変更。in-flight inject が PTY write 中に kill されて SessionHandle Mutex poison / 半端 inject / reader thread 解放漏れを起こす race を排除。
- 2 回目以降の CloseRequested は `AtomicBool::compare_exchange` で抑止し、drain task は 1 本に絞る。

## Tracking 戦略

- **`InFlightTracker`** (`src-tauri/src/pty/inflight.rs`): `AtomicUsize` + `tokio::sync::Notify`。`enter()` で counter += 1 して `InFlightGuard` (RAII) を返す。Drop で counter -= 1 と `notify_waiters()`。
- **`track_async(future)`**: future を `async move { let _g = guard; f.await }` で wrap。tokio::select! cancel / panic / 早期 drop でも guard が drop されるため counter リーク無し。
- **`spawn(future)`**: `tauri::async_runtime::spawn` で fire-and-forget。`inject_codex_prompt_to_pty` 用。
- **`wait_idle(timeout)`**: `notified()` を作ってから `count == 0` を再判定するパターンで、enter→drop 直後の race でも取りこぼさない。

## 計上箇所

- `commands/terminal.rs` — codex prompt 注入の fire-and-forget spawn
- `team_hub/protocol/tools/send.rs` — `team_send` の `JoinSet::spawn(inject::inject(...))`
- `team_hub/protocol/tools/report.rs` — leader 宛 summary inject
- `commands/team_inject.rs` — `team_send_retry_inject` の手動リトライ

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` pass (warnings は pre-existing のみ; 新規警告は `TeamHub::new` が test 専用になったことによる dead_code 1 件)
- [x] `cargo test --lib pty::inflight` pass (7 tests: counter increment/decrement, wait_idle 即時 / completion / timeout / drop without polling / 5 並列 drain / explicit guard drop)
- [x] `cargo test --lib` pass (440 tests, 0 failed, 2 ignored)
- [ ] 実機: Canvas で agent 5 枚 recruit → 各 inject 直後に window × → zombie プロセスが残らないこと (Done criteria の手動検証は reviewer / 後続で確認)
- [ ] tracing log で `Mutex poison` warning が close 時に出ないこと

## 注意 / 互換性

- `TeamHub::new(registry)` は `with_inflight(registry, InFlightTracker::new())` を呼ぶ薄いラッパとして残す。既存テスト (`#[cfg(test)] mod tests` 内 ~30 箇所) は無変更で動く。
- `AppState::new()` は単一 tracker を生成して TeamHub と AppState で共有 (`with_inflight`)。同一 counter で wait_idle できる。