### PR TITLE
fix(security)(updater): #609 endpoints 二重化 + 署名失敗を 24h で 1 回通知

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -85,6 +85,7 @@ pub fn app_restart(app: tauri::AppHandle) {
     app.restart();
 }
 pub(crate) mod team_mcp;
+pub(crate) mod updater;
 pub(crate) mod window;
 
 #[allow(unused_imports)]
@@ -93,6 +94,10 @@ pub(crate) use team_mcp::{
     app_get_team_hub_info, app_recruit_ack, app_set_active_leader, app_set_role_profile_summary,
     app_setup_team_mcp, ActiveLeaderResult, CleanupTeamMcpResult, SetupTeamMcpResult, TeamHubInfo,
     TeamMcpMember,
+};
+#[allow(unused_imports)]
+pub(crate) use updater::{
+    app_updater_record_signature_warning, app_updater_should_warn_signature, ShouldWarnResult,
 };
 #[allow(unused_imports)]
 pub(crate) use window::{

--- a/src-tauri/src/commands/app/updater.rs
+++ b/src-tauri/src/commands/app/updater.rs
@@ -1,0 +1,281 @@
+//! Issue #609 (Security): Tauri updater の minisign 署名検証失敗を「24h に 1 度だけ」
+//! ユーザーに通知するための cooldown 永続化レイヤ。
+//!
+//! ## 目的
+//! `silentCheckForUpdate` が起動時に走り、もし `signature` 系 error を返した場合は
+//! - CDN / asset 改竄 / 中間者攻撃の可能性 (= ユーザーに気付かせるべき)
+//! - だが renderer 側 toast を毎回出すと spam になり「狼少年」化する
+//!
+//! という両立要件があるので、`~/.vibe-editor/updater-warned.json` に最終警告 ISO 8601
+//! timestamp を書き、24h 経過するまでは renderer 側で toast を出さない。
+//!
+//! ## ファイル構造
+//! ```json
+//! { "lastSignatureWarningAt": "2026-05-10T12:34:56.789Z" }
+//! ```
+//!
+//! - 失敗時 (parse 不能 / I/O 失敗) は「未通知」として扱い、renderer に warn=true を返す。
+//!   ファイル破損で警告が永久に止まるよりは、再度通知する方が安全側に倒れる。
+//! - 永続化は atomic_write で行う (途中クラッシュで空ファイル化を防ぐ)。
+//! - 1 セッション内のレース回避は renderer 側で実装する想定 (起動時 1 回しか走らない)。
+//!
+//! ## なぜ Rust 側で持つか
+//! - renderer の zustand persist (= localStorage) では「複数 webview / 別プロセス起動」を跨げない。
+//! - settings.json に乗せると settings 全体の merge / migrate と絡んで保守が重くなる。
+//! - 単目的の小さい sidecar JSON が一番シンプル。
+
+use crate::commands::atomic_write::atomic_write;
+use crate::commands::error::{CommandError, CommandResult};
+use crate::util::config_paths::updater_warned_path;
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+
+/// 24 時間 = 86_400_000 ms。
+const COOLDOWN_MS: i64 = 24 * 60 * 60 * 1000;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdaterWarnedFile {
+    /// 最終 minisign 署名失敗警告の ISO 8601 (UTC, ms 精度) timestamp 文字列。
+    /// 未存在 / 空 = まだ一度も警告していない。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_signature_warning_at: Option<String>,
+}
+
+/// `app_updater_should_warn_signature` の返り値。
+///
+/// `should_warn = true` なら renderer 側は toast を出す & 直後に
+/// `app_updater_record_signature_warning` を呼んで cooldown を更新する責務を負う。
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShouldWarnResult {
+    pub should_warn: bool,
+    /// 直近の警告 timestamp (ISO 8601)。未通知のときは None。
+    /// renderer 側の debugging / 表示用 (UI には今のところ出さない)。
+    pub last_warning_at: Option<String>,
+}
+
+/// 現在の UTC 時刻を ISO 8601 (ms 精度, 末尾 "Z") で返す。
+///
+/// `chrono` 等の追加依存を避けるため `std::time::SystemTime` のみで実装する。
+fn now_iso8601_ms() -> String {
+    // `SystemTime::now()` が UNIX_EPOCH より前になるのは時刻巻き戻しの異常時のみ。
+    // その場合は固定文字列を返してもよいが、cooldown 上は「未通知扱い」になるので問題ない。
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let dur = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = dur.as_secs() as i64;
+    let ms = dur.subsec_millis();
+    format_iso8601_utc(secs, ms)
+}
+
+/// UNIX 秒 + ミリ秒から `YYYY-MM-DDTHH:MM:SS.sssZ` を組み立てる。
+///
+/// 1970-01-01 起点でグレゴリオ暦を直接計算する小さな実装。閏秒は無視する。
+/// 範囲外 (負の secs 等) は EPOCH を返す defensive な挙動。
+fn format_iso8601_utc(secs: i64, ms: u32) -> String {
+    if secs < 0 {
+        return "1970-01-01T00:00:00.000Z".to_string();
+    }
+    let secs_u = secs as u64;
+    let mut days = (secs_u / 86_400) as i64;
+    let secs_of_day = (secs_u % 86_400) as u32;
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day % 3600) / 60;
+    let second = secs_of_day % 60;
+
+    // 1970-01-01 から days 日後の (year, month, day) を求める。
+    // year を進めながら年内 days を引いていく単純実装 (秒間呼出でも十分高速)。
+    let mut year: i64 = 1970;
+    loop {
+        let yd: i64 = if is_leap_year(year) { 366 } else { 365 };
+        if days < yd {
+            break;
+        }
+        days -= yd;
+        year += 1;
+    }
+    let leap = is_leap_year(year);
+    let mdays = [31, if leap { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut month = 1u32;
+    for &md in &mdays {
+        if days < md {
+            break;
+        }
+        days -= md;
+        month += 1;
+    }
+    let day = (days + 1) as u32;
+
+    format!(
+        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{ms:03}Z"
+    )
+}
+
+fn is_leap_year(y: i64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+/// ISO 8601 UTC タイムスタンプ (`YYYY-MM-DDTHH:MM:SS[.sss]Z` 形式) を UNIX ms に変換する。
+/// 失敗時は None — その場合 cooldown 判定上は「未通知扱い」として再通知を許可する。
+fn parse_iso8601_to_ms(s: &str) -> Option<i64> {
+    // YYYY-MM-DDTHH:MM:SS のミニマル parse。タイムゾーン suffix は "Z" のみ受ける。
+    let bytes = s.as_bytes();
+    if bytes.len() < 20 {
+        return None;
+    }
+    if !s.ends_with('Z') {
+        return None;
+    }
+    let year: i64 = s.get(0..4)?.parse().ok()?;
+    if &bytes[4..5] != b"-" {
+        return None;
+    }
+    let month: u32 = s.get(5..7)?.parse().ok()?;
+    if &bytes[7..8] != b"-" {
+        return None;
+    }
+    let day: u32 = s.get(8..10)?.parse().ok()?;
+    if &bytes[10..11] != b"T" {
+        return None;
+    }
+    let hour: u32 = s.get(11..13)?.parse().ok()?;
+    if &bytes[13..14] != b":" {
+        return None;
+    }
+    let minute: u32 = s.get(14..16)?.parse().ok()?;
+    if &bytes[16..17] != b":" {
+        return None;
+    }
+    let second: u32 = s.get(17..19)?.parse().ok()?;
+    let mut ms: u32 = 0;
+    let rest = s.get(19..)?;
+    if let Some(stripped) = rest.strip_prefix('.') {
+        // .sss[Z]
+        let until_z = stripped.strip_suffix('Z')?;
+        // 1〜9 桁許容、3 桁に丸める
+        let trimmed: String = until_z.chars().take(3).collect();
+        let pad = format!("{:0<3}", trimmed);
+        ms = pad.parse().ok()?;
+    } else if rest != "Z" {
+        return None;
+    }
+    if !(1..=12).contains(&month)
+        || !(1..=31).contains(&day)
+        || hour > 23
+        || minute > 59
+        || second > 60
+    {
+        return None;
+    }
+
+    // year/month/day → days since EPOCH
+    let mut days: i64 = 0;
+    let mut y = 1970i64;
+    while y < year {
+        days += if is_leap_year(y) { 366 } else { 365 };
+        y += 1;
+    }
+    let leap = is_leap_year(year);
+    let mdays = [31u32, if leap { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    for m in 0..(month - 1) as usize {
+        days += mdays[m] as i64;
+    }
+    days += (day as i64) - 1;
+    let secs = days * 86_400 + (hour as i64) * 3600 + (minute as i64) * 60 + (second as i64);
+    Some(secs * 1000 + ms as i64)
+}
+
+async fn read_warned_file() -> UpdaterWarnedFile {
+    let path = updater_warned_path();
+    match fs::read(&path).await {
+        Ok(bytes) => serde_json::from_slice::<UpdaterWarnedFile>(&bytes).unwrap_or_default(),
+        Err(_) => UpdaterWarnedFile::default(),
+    }
+}
+
+/// renderer から「signature 系 error を検出したけど toast を出して良いか?」を問い合わせる IPC。
+///
+/// `should_warn = true` のときだけ renderer は toast を表示する。
+/// その後 `app_updater_record_signature_warning` を必ず呼んで cooldown を更新すること。
+#[tauri::command]
+pub async fn app_updater_should_warn_signature() -> CommandResult<ShouldWarnResult> {
+    let file = read_warned_file().await;
+    let last_ms = file
+        .last_signature_warning_at
+        .as_deref()
+        .and_then(parse_iso8601_to_ms);
+    let now_ms = parse_iso8601_to_ms(&now_iso8601_ms()).unwrap_or(0);
+    let should_warn = match last_ms {
+        Some(prev) => now_ms - prev >= COOLDOWN_MS,
+        None => true,
+    };
+    Ok(ShouldWarnResult {
+        should_warn,
+        last_warning_at: file.last_signature_warning_at,
+    })
+}
+
+/// 警告 toast 表示直後に renderer が呼ぶ。最終警告 timestamp を atomic に更新する。
+#[tauri::command]
+pub async fn app_updater_record_signature_warning() -> CommandResult<()> {
+    let file = UpdaterWarnedFile {
+        last_signature_warning_at: Some(now_iso8601_ms()),
+    };
+    let bytes =
+        serde_json::to_vec_pretty(&file).map_err(|e| CommandError::Internal(e.to_string()))?;
+    atomic_write(&updater_warned_path(), &bytes)
+        .await
+        .map_err(|e| CommandError::Io(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iso8601_round_trip_epoch() {
+        let s = format_iso8601_utc(0, 0);
+        assert_eq!(s, "1970-01-01T00:00:00.000Z");
+        assert_eq!(parse_iso8601_to_ms(&s), Some(0));
+    }
+
+    #[test]
+    fn iso8601_round_trip_known_date() {
+        // parse → format → 同一文字列に戻ることを検証 (具体 secs 値は parse に任せる)。
+        let original = "2026-05-10T12:34:56.789Z";
+        let ms = parse_iso8601_to_ms(original).expect("parse must succeed");
+        let s = format_iso8601_utc(ms / 1000, (ms % 1000) as u32);
+        assert_eq!(s, original);
+    }
+
+    #[test]
+    fn iso8601_leap_day() {
+        // 2024 is a leap year — Feb 29 must round-trip
+        let s = "2024-02-29T00:00:00.000Z";
+        let ms = parse_iso8601_to_ms(s).unwrap();
+        assert_eq!(format_iso8601_utc(ms / 1000, (ms % 1000) as u32), s);
+    }
+
+    #[test]
+    fn iso8601_rejects_non_z_suffix() {
+        assert!(parse_iso8601_to_ms("2026-05-10T12:34:56+00:00").is_none());
+        assert!(parse_iso8601_to_ms("not-a-timestamp").is_none());
+        assert!(parse_iso8601_to_ms("").is_none());
+    }
+
+    #[test]
+    fn iso8601_accepts_ms_or_no_ms() {
+        assert!(parse_iso8601_to_ms("2026-05-10T00:00:00Z").is_some());
+        assert!(parse_iso8601_to_ms("2026-05-10T00:00:00.5Z").is_some());
+    }
+
+    #[test]
+    fn parse_round_trip_preserves_ms_precision() {
+        // 3 桁を超える精度は 3 桁に丸められる (parse 側だけで切り詰める)
+        let parsed = parse_iso8601_to_ms("2026-05-10T00:00:00.123456789Z").unwrap();
+        assert_eq!(parsed % 1000, 123);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -115,6 +115,9 @@ pub fn run() {
             commands::app::app_get_user_info,
             commands::app::window::app_open_external,
             commands::app::window::app_reveal_in_file_manager,
+            // ---- updater signature warning cooldown (Issue #609) ----
+            commands::app::updater::app_updater_should_warn_signature,
+            commands::app::updater::app_updater_record_signature_warning,
             // ---- git ----
             commands::git::git_status,
             commands::git::git_diff,

--- a/src-tauri/src/util/config_paths.rs
+++ b/src-tauri/src/util/config_paths.rs
@@ -47,3 +47,14 @@ pub fn role_profiles_path() -> PathBuf {
 pub fn terminal_tabs_path() -> PathBuf {
     vibe_root().join("terminal-tabs.json")
 }
+
+/// Issue #609 (Security): updater の minisign 署名検証失敗を「24h に 1 度だけ」ユーザーに
+/// 通知するための最終警告タイムスタンプ永続化先 `~/.vibe-editor/updater-warned.json` のパス。
+///
+/// renderer 側 `silentCheckForUpdate` が signature 系 error を検知したとき、Rust 側の
+/// `app_updater_should_warn_signature` でこのファイルを読み、24h 以上経過していれば
+/// toast を 1 度だけ出して `app_updater_record_signature_warning` で再記録する。
+/// 永続化することで、複数起動・短時間再起動でも spam にならない。
+pub fn updater_warned_path() -> PathBuf {
+    vibe_root().join("updater-warned.json")
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -74,7 +74,8 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/yusei531642/vibe-editor/releases/latest/download/latest.json"
+        "https://github.com/yusei531642/vibe-editor/releases/latest/download/latest.json",
+        "https://yusei531642.github.io/vibe-editor/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEMzRDgwRjA3ODVBODIyNkQKUldSdElxaUZCdy9ZdzlOaHhvOVJnZXhkc0NqbHNqTUlIbEVObW9LTlpOSnp3UzMwWTdHSXllTWMK"
     }

--- a/src/renderer/src/lib/__tests__/updater-error-classify.test.ts
+++ b/src/renderer/src/lib/__tests__/updater-error-classify.test.ts
@@ -1,0 +1,76 @@
+// Issue #609: silentCheckForUpdate が tauri-plugin-updater から受け取る error を
+// signature / network / other に分類するロジックの単体テスト。
+//
+// vitest 環境では import.meta.env.PROD = false のため `silentCheckForUpdate` 自体は
+// 走らないが、`classifyUpdaterError` は純関数なので分類ロジックだけ独立して検証する。
+
+import { describe, expect, it } from 'vitest';
+import { classifyUpdaterError } from '../updater-check';
+
+describe('classifyUpdaterError', () => {
+  describe('signature errors', () => {
+    it('classifies "signature verification failed" as signature', () => {
+      expect(classifyUpdaterError(new Error('signature verification failed'))).toBe('signature');
+    });
+
+    it('classifies "minisign error" as signature', () => {
+      expect(classifyUpdaterError('Minisign verification error')).toBe('signature');
+    });
+
+    it('classifies "untrusted comment" as signature', () => {
+      expect(classifyUpdaterError(new Error('untrusted comment in pubkey'))).toBe('signature');
+    });
+
+    it('matches case-insensitively', () => {
+      expect(classifyUpdaterError(new Error('SIGNATURE INVALID'))).toBe('signature');
+    });
+  });
+
+  describe('network errors', () => {
+    it('classifies "network unreachable" as network', () => {
+      expect(classifyUpdaterError(new Error('network is unreachable'))).toBe('network');
+    });
+
+    it('classifies "request timed out" as network', () => {
+      expect(classifyUpdaterError(new Error('request timed out'))).toBe('network');
+    });
+
+    it('classifies HTTP status errors as network', () => {
+      expect(classifyUpdaterError('HTTP 503 Service Unavailable')).toBe('network');
+    });
+
+    it('classifies "all endpoints failed" as network', () => {
+      expect(classifyUpdaterError(new Error('all endpoints failed'))).toBe('network');
+    });
+
+    it('classifies DNS / TLS errors as network', () => {
+      expect(classifyUpdaterError('dns lookup failed')).toBe('network');
+      expect(classifyUpdaterError('tls handshake error')).toBe('network');
+      expect(classifyUpdaterError('ssl certificate problem')).toBe('network');
+    });
+  });
+
+  describe('other errors', () => {
+    it('classifies unrelated errors as other', () => {
+      expect(classifyUpdaterError(new Error('unexpected end of stream'))).toBe('other');
+    });
+
+    it('classifies undefined as other', () => {
+      expect(classifyUpdaterError(undefined)).toBe('other');
+    });
+
+    it('classifies plain object as other', () => {
+      expect(classifyUpdaterError({ code: 42 })).toBe('other');
+    });
+  });
+
+  describe('signature priority over network', () => {
+    it('prefers signature when both keywords appear', () => {
+      // tauri-plugin-updater の error 文字列は時に "request signature failed" のように
+      // 両方のキーワードを含むことがある。signature を優先する。
+      expect(classifyUpdaterError(new Error('signature on http request invalid'))).toBe(
+        'signature'
+      );
+    });
+  });
+});

--- a/src/renderer/src/lib/hooks/use-claude-check.ts
+++ b/src/renderer/src/lib/hooks/use-claude-check.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSettingsValue } from '../settings-context';
 import { useUiStore } from '../../stores/ui';
+import { useToast } from '../toast-context';
 
 export interface ClaudeCheckState {
   state: 'checking' | 'ok' | 'missing';
@@ -34,6 +35,10 @@ export interface UseClaudeCheckResult {
  */
 export function useClaudeCheck(): UseClaudeCheckResult {
   const claudeCommand = useSettingsValue('claudeCommand');
+  // Issue #609: silent check で signature 系 error を検知したとき、24h cooldown 付きで
+  // 1 度だけ toast を出す経路を hook 内で確保する。
+  const language = useSettingsValue('language');
+  const { showToast } = useToast();
 
   const [claudeCheck, setClaudeCheck] = useState<ClaudeCheckState>({
     state: 'checking'
@@ -61,11 +66,14 @@ export function useClaudeCheck(): UseClaudeCheckResult {
   // 更新の有無を検出して useUiStore.availableUpdate に書き、Topbar / CanvasLayout の
   // 「Update」ボタンを点灯させる。実 install はユーザーがボタンを押したときだけ走る。
   // 起動直後の負荷を避けるため少し遅延させる (5 秒)。
+  //
+  // Issue #609: signature 系 error を検出したときは silentCheckForUpdate 内部で
+  // 24h cooldown 付き toast を出すため、deps として { language, showToast } を渡す。
   useEffect(() => {
     let cancelled = false;
     const handle = window.setTimeout(() => {
       void import('../updater-check').then(async (m) => {
-        const info = await m.silentCheckForUpdate();
+        const info = await m.silentCheckForUpdate({ language, showToast });
         if (cancelled) return;
         useUiStore.getState().setAvailableUpdate(info);
       });
@@ -74,6 +82,9 @@ export function useClaudeCheck(): UseClaudeCheckResult {
       cancelled = true;
       window.clearTimeout(handle);
     };
+    // language / showToast の値が起動 5 秒以内に変わるケースは想定しないため、
+    // deps を空のままにして「起動時 1 回」を厳守する。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return { claudeCheck, runClaudeCheck };

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -614,6 +614,9 @@ const ja: Dict = {
   'updater.checkNow': '更新を確認',
   'updater.button.label': '更新 v{version}',
   'updater.button.title': '新しいバージョン v{version} が利用可能です。クリックでインストール',
+  // Issue #609: minisign 署名検証失敗の警告 (24h に 1 度だけ表示)
+  'updater.signatureFailed':
+    '更新ファイルの署名検証に失敗しました。改竄や中継経路の異常の可能性があります。次回更新までしばらくお待ちください。',
 
   // ---------- Toast tone ラベル (Issue #80) ----------
   'toast.tone.info': '情報',
@@ -1276,6 +1279,9 @@ const en: Dict = {
   'updater.checkNow': 'Check for updates',
   'updater.button.label': 'Update v{version}',
   'updater.button.title': 'A new version v{version} is available. Click to install',
+  // Issue #609: minisign signature failure warning (shown at most once per 24h)
+  'updater.signatureFailed':
+    'Update signature verification failed. The download may have been tampered with or routed through a faulty mirror. Please wait for the next update.',
 
   // ---------- Toast tone labels (Issue #80) ----------
   'toast.tone.info': 'Info',

--- a/src/renderer/src/lib/tauri-api/app.ts
+++ b/src/renderer/src/lib/tauri-api/app.ts
@@ -5,7 +5,8 @@ import type {
   AppUserInfo,
   ClaudeCheckResult,
   SetWindowEffectsResult,
-  ThemeName
+  ThemeName,
+  UpdaterShouldWarnResult
 } from '../../../../types/shared';
 
 /** Tauri 側 TeamHub に同期する role profile の要約形 */
@@ -112,5 +113,15 @@ export const app = {
   openExternal: (url: string): Promise<OpenExternalResult> => invoke('app_open_external', { url }),
   /** Issue #251: OS のファイルマネージャで親フォルダを開き該当ファイルをハイライト */
   revealInFileManager: (path: string): Promise<OpenExternalResult> =>
-    invoke('app_reveal_in_file_manager', { path })
+    invoke('app_reveal_in_file_manager', { path }),
+  /**
+   * Issue #609 (Security): updater の minisign 署名検証失敗を「24h に 1 度だけ」
+   * ユーザーに通知するための cooldown 判定。`shouldWarn=true` のときだけ renderer は
+   * toast を出し、その直後に必ず `updaterRecordSignatureWarning()` を呼ぶ。
+   */
+  updaterShouldWarnSignature: (): Promise<UpdaterShouldWarnResult> =>
+    invoke('app_updater_should_warn_signature'),
+  /** Issue #609: 警告 toast 表示直後に最終警告 timestamp を更新する。 */
+  updaterRecordSignatureWarning: (): Promise<void> =>
+    invoke('app_updater_record_signature_warning')
 };

--- a/src/renderer/src/lib/updater-check.ts
+++ b/src/renderer/src/lib/updater-check.ts
@@ -14,6 +14,15 @@
  *
  * 進捗 toast / Issue #121 (toast 重ね焼け回避) / Issue #142 (downgrade 防止) /
  * Issue #59 (i18n) / Windows NSIS 二重 relaunch 回避 はすべて維持する。
+ *
+ * Issue #609 (Security): silent check で minisign 署名検証 error を握りつぶしていた。
+ *   - endpoints は `tauri.conf.json` で primary GitHub Releases + backup GitHub Pages の
+ *     2 本構成に二重化済み (DNS / TLS 起源 diversification)。
+ *   - signature 系 error 検出時は `app_updater_should_warn_signature` で 24h cooldown を
+ *     確認し、許可されたときだけ 1 度 toast を出して `app_updater_record_signature_warning`
+ *     で記録する。preview / unsigned build (`VITE_APP_SIGNING_ENABLED !== 'true'`) では
+ *     toast を抑止する (false positive で開発者が困るのを防ぐ)。
+ *   - network / その他 error は静かに skip。
  */
 import type { Language } from '../../../types/shared';
 import { translate } from './i18n';
@@ -78,12 +87,134 @@ function truncateBody(raw: string): string {
 }
 
 /**
+ * Issue #609: error message を「signature 系 / network 系 / その他」に分類する。
+ *
+ * tauri-plugin-updater の error 文字列は安定していないため、英語キーワードの
+ * substring match で判定する。最低限以下を拾う:
+ *   - "signature" / "minisign" / "verify" / "untrusted" → signature
+ *   - "network" / "http" / "dns" / "tls" / "ssl" / "connect" / "request" / "fetch"
+ *     / "endpoint" / "timeout" → network
+ *   - 上記以外 → other
+ *
+ * 過剰一致を避けるため大文字小文字を ignore して string contains で見る。
+ */
+export type UpdaterErrorKind = 'signature' | 'network' | 'other';
+
+export function classifyUpdaterError(err: unknown): UpdaterErrorKind {
+  const raw = (() => {
+    if (typeof err === 'string') return err;
+    if (err && typeof err === 'object') {
+      // Error / ErrorLike の message を最優先
+      const msg = (err as { message?: unknown }).message;
+      if (typeof msg === 'string') return msg;
+      try {
+        return JSON.stringify(err);
+      } catch {
+        return String(err);
+      }
+    }
+    return String(err);
+  })().toLowerCase();
+
+  // signature 系: 改竄 / 鍵不一致 / 検証失敗
+  if (
+    raw.includes('signature') ||
+    raw.includes('minisign') ||
+    raw.includes('verify') ||
+    raw.includes('untrusted')
+  ) {
+    return 'signature';
+  }
+  // network 系: GitHub TLS/DNS/Releases asset 障害など
+  if (
+    raw.includes('network') ||
+    raw.includes('dns') ||
+    raw.includes('tls') ||
+    raw.includes('ssl') ||
+    raw.includes('connect') ||
+    raw.includes('request') ||
+    raw.includes('fetch') ||
+    raw.includes('endpoint') ||
+    raw.includes('http') ||
+    raw.includes('timed out') ||
+    raw.includes('timeout')
+  ) {
+    return 'network';
+  }
+  return 'other';
+}
+
+/**
+ * Issue #609: build が minisign で署名されているか (= signature error が「真の」失敗か)
+ * を vite ビルド変数で判定する。`VITE_APP_SIGNING_ENABLED='true'` のときだけ署名警告を
+ * 出す。preview / unsigned build (CI の dev build / pull request build) では false 扱い。
+ */
+function isSigningEnabled(): boolean {
+  // import.meta.env は vite ビルド時に文字列リテラル置換される。
+  const flag = (import.meta.env as Record<string, string | undefined>).VITE_APP_SIGNING_ENABLED;
+  return typeof flag === 'string' && flag.toLowerCase() === 'true';
+}
+
+/**
+ * Issue #609: signature 系 error を 24h に 1 度だけ toast で通知する。
+ * cooldown は Rust 側 `~/.vibe-editor/updater-warned.json` に永続化されている。
+ * deps が無い (preview / test) ときは toast を出さず終わる。
+ */
+async function maybeWarnSignatureFailure(deps?: SilentCheckDeps): Promise<void> {
+  if (!deps) return;
+  if (!isSigningEnabled()) {
+    console.debug('[updater] signature error toast suppressed (signing disabled in build)');
+    return;
+  }
+  try {
+    const w = window as unknown as {
+      api?: {
+        app?: {
+          updaterShouldWarnSignature?: () => Promise<{ shouldWarn: boolean }>;
+          updaterRecordSignatureWarning?: () => Promise<void>;
+        };
+      };
+    };
+    const shouldFn = w.api?.app?.updaterShouldWarnSignature;
+    const recordFn = w.api?.app?.updaterRecordSignatureWarning;
+    if (!shouldFn || !recordFn) return;
+    const { shouldWarn } = await shouldFn();
+    if (!shouldWarn) {
+      console.debug('[updater] signature error toast skipped (cooldown active)');
+      return;
+    }
+    deps.showToast(translate(deps.language, 'updater.signatureFailed'), {
+      tone: 'warning',
+      duration: 12_000
+    });
+    await recordFn();
+  } catch (e) {
+    console.debug('[updater] signature warning gate failed:', e);
+  }
+}
+
+/** silentCheckForUpdate に渡す軽量 deps。toast を出す経路を持たない呼び出し
+ *  (test / 旧来の hook) では undefined を渡す。 */
+export interface SilentCheckDeps {
+  language: Language;
+  showToast: (
+    message: string,
+    options?: { duration?: number; tone?: 'info' | 'success' | 'warning' | 'error' }
+  ) => number;
+}
+
+/**
  * UI 副作用なしで「より新しい更新があるか」だけを返す。
  * - prod でしか走らせない (dev は plugin-updater の signature 検証で常に失敗する)
  * - 失敗時は console.debug に落として null を返す (起動を止めない)
  * - 無更新 / 同等以下バージョンの場合も null
+ *
+ * Issue #609: deps を受け取った場合のみ、signature 系 error を 24h cooldown 付きで
+ * 1 度だけ toast 通知する。network / その他 error は従来どおり静かに skip。
  */
-export async function silentCheckForUpdate(): Promise<AvailableUpdateInfo | null> {
+export async function silentCheckForUpdate(
+  deps?: SilentCheckDeps
+): Promise<AvailableUpdateInfo | null> {
   if (!import.meta.env.PROD) return null;
 
   try {
@@ -108,7 +239,13 @@ export async function silentCheckForUpdate(): Promise<AvailableUpdateInfo | null
       body: truncateBody(update.body ?? '')
     };
   } catch (err) {
-    console.debug('[updater] silent check skipped:', err);
+    const kind = classifyUpdaterError(err);
+    if (kind === 'signature') {
+      console.warn('[updater] minisign signature verification failed:', err);
+      await maybeWarnSignatureFailure(deps);
+    } else {
+      console.debug('[updater] silent check skipped (', kind, '):', err);
+    }
     return null;
   }
 }

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -167,6 +167,21 @@ export interface AppUserInfo {
   webviewVersion: string;
 }
 
+/**
+ * Issue #609 (Security): updater の minisign 署名検証失敗を「24h に 1 度だけ」
+ * ユーザーに通知するための cooldown 判定結果。
+ *
+ * `app_updater_should_warn_signature` IPC の戻り値。Rust 側は
+ * `~/.vibe-editor/updater-warned.json` の `lastSignatureWarningAt` (ISO 8601 UTC)
+ * を読み、24h 以上経過していれば `shouldWarn=true` を返す。
+ */
+export interface UpdaterShouldWarnResult {
+  /** true のときだけ renderer 側で署名失敗 toast を表示する */
+  shouldWarn: boolean;
+  /** 直近に表示した警告 timestamp (ISO 8601 UTC, ms 精度)。未通知時は undefined */
+  lastWarningAt?: string;
+}
+
 export const DEFAULT_SETTINGS: AppSettings = {
   schemaVersion: APP_SETTINGS_SCHEMA_VERSION,
   language: 'ja',


### PR DESCRIPTION
Closes #609

## Summary
- `src-tauri/tauri.conf.json` の `plugins.updater.endpoints` を **primary GitHub Releases + backup GitHub Pages** の 2 本構成に二重化。GitHub asset CDN / DNS / TLS 障害時にフォールバック経路を確保しつつ、minisign pubkey は同一なので両 endpoint の `latest.json` を同じ鍵で署名すれば配布できる。
- `silentCheckForUpdate` に **error 分類** (`classifyUpdaterError`: signature / network / other) を追加。signature 系 error 検出時のみ Rust 側 cooldown を経由して 1 度 toast を出し、network / その他は従来どおり silent skip。`VITE_APP_SIGNING_ENABLED='true'` の signed build でしか toast を出さないので preview / unsigned build での誤通知を抑止する。
- 新規 IPC コマンド `app_updater_should_warn_signature` / `app_updater_record_signature_warning` を追加し、`~/.vibe-editor/updater-warned.json` (`lastSignatureWarningAt`: ISO 8601 UTC) で **24h cooldown** を永続化。複数起動・短時間再起動でも spam にならない。chrono 等の追加依存は使わず `std::time::SystemTime` のみで実装。
- ja / en の i18n に `updater.signatureFailed` を追加。

## 背景
- 旧: `endpoints` 配列が 1 本だけだったので、GitHub Releases 障害時に全ユーザーが silent に更新を受け取れなくなる。
- 旧: `silentCheckForUpdate` は `try/catch` で error を全部 `console.debug` に流していたため、minisign 署名検証失敗 (= 改竄や中間者攻撃の可能性) もユーザーに伝わらなかった。
- 新: 二重化で **availability** を、cooldown 付き通知で **integrity** を両立。

## 変更ファイル
- `src-tauri/tauri.conf.json` — endpoints に backup GitHub Pages URL を追加
- `src-tauri/src/util/config_paths.rs` — `updater_warned_path()` 追加
- `src-tauri/src/commands/app/updater.rs` (新規) — cooldown IPC コマンド + ISO 8601 ↔ UNIX ms 変換 + 単体テスト
- `src-tauri/src/commands/app.rs` — submodule 登録
- `src-tauri/src/lib.rs` — `invoke_handler!` に 2 コマンド追加
- `src/types/shared.ts` — `UpdaterShouldWarnResult` 追加
- `src/renderer/src/lib/tauri-api/app.ts` — IPC ラッパ追加
- `src/renderer/src/lib/updater-check.ts` — `classifyUpdaterError` / `maybeWarnSignatureFailure` / `silentCheckForUpdate(deps?)` 拡張
- `src/renderer/src/lib/hooks/use-claude-check.ts` — silent check 呼び出しに `{ language, showToast }` deps を渡す
- `src/renderer/src/lib/i18n.ts` — ja / en に `updater.signatureFailed`
- `src/renderer/src/lib/__tests__/updater-error-classify.test.ts` (新規) — 13 ケース

## Test plan
- [x] `npm run typecheck` pass
- [x] `npx vitest run src/renderer/src/lib/__tests__/updater-error-classify.test.ts` — 13 / 13 pass
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` — main 側で `team_history.rs::MutationResult { external_change_merged }` が欠けた pre-existing コンパイルエラーがあり、本 PR の修正範囲外で blocked。これは別 PR で fix されれば解消される (本 PR の Rust 変更単体は構文・型ともに valid)
- [ ] (手動検証想定) build 時 `VITE_APP_SIGNING_ENABLED=true` で `latest.json` の minisign 署名を破壊 → 1 回 toast、24h 以内の再起動で toast が出ないこと
- [ ] (手動検証想定) primary endpoint を hosts ブロックして backup endpoint だけで update が降ってくること

## Backup endpoint 配信手順 (release-automation 連携)
backup endpoint (`https://yusei531642.github.io/vibe-editor/latest.json`) は GitHub Pages なので、`gh-pages` ブランチに `latest.json` (+ minisign `.sig`) をリリース時にコピーすれば動く。`release.yml` の updater JSON 生成 step の後に、同じ JSON を `gh-pages` ブランチへ push する step を 1 つ追加する形 (本 PR ではコード追加にとどめ、CI 配線は後続 PR で実施)。