### PR TITLE
chore(release): bump version to 1.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5261,7 +5261,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.5.5"
+version = "1.5.6"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.5.5"
+version = "1.5.6"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## Summary
- v1.5.5 → v1.5.6 (patch release)
- backend/teamhub の security 強化を複数件バンドル、updater の endpoints 二重化、Canvas / PTY / file tree の信頼性改善が主な内容
- 3 ファイル (`package.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json`) + `Cargo.lock` の version 同期のみ

## v1.5.6 Changelog

### ✨ Features
- feat(filetree): #592 VS Code 互換のファイル/フォルダ操作を追加 (#695)
- feat(terminal): #662 永続化 PTY size を初回 spawn seed として適用 (#697)
- feat(terminal): #660 #661 #662 Claude session 復元を全 OS standalone 化 (#663)
- feat(teamhub): #577 タイムアウト後 grace 期間中の recruit ack を救済 (#584)
- feat(teamhub): #576 同時 recruit を team 単位 semaphore で順番待ち化 (#583)
- feat(canvas): #578 Canvas 非表示中の recruit を可視化時に Toast で警告 (#582)
- feat(team-hub): #572 add team_report MCP tool for structured worker reports (#575)

### 🔒 Security
- fix(security)(updater): #609 endpoints 二重化 + 署名失敗を 24h で 1 回通知 (#699)
- fix(security): backend security 6 件 bundle (#602 #603 #604 #606 #624 #634) (#681)
- fix(security): backend security 7 件 (#622 #623 #631 #635 #636 #639 #605) をバンドル修正 (#675)
- fix(security): #608 atomic_write に mode 引数を追加し機密ファイルを 0o600 強制 (#656)
- fix(team-hub): #599 file_locks に traversal / 絶対 path 検出と team あたり lock 上限 (Tier A-1 security) (#651)
- fix(terminal): #607 args 内の --resume <id> を regex validate して引数注入を防ぐ (#649)
- fix(team-hub): #594 team_update_task に assignee 検証を追加 (Tier S-1 security) (#646)
- fix(backend): #601 team_diagnostics_read を active team set に限定 (Tier A-3 security) (#659)
- fix(backend): #600 team_state_read で active project_root 一致検証 (Tier A-2 security) (#657)

### 🐛 Bug fixes
- fix(team-history): #640 disk write 失敗時に cache が rollback されない問題を修正 (#690)
- fix(canvas): #615 HUD / TeamDashboard を複数 team 集約に対応 (#687)
- fix(pty): #633 attach 経路で listener を create 前に pre-subscribe して欠落を防ぐ (#694)
- fix(team): #638 socket 切断 hook で advisory file lock を一括解放 (#693)
- fix(team-history): #642 save 直前の mtime+sha256 で外部変更を検知して merge (#691)
- fix(teamhub): #619 inject 中の user 入力混入を防ぐ RAII guard を導入 (#685)
- fix(pty): #620 inject_codex_prompt_to_pty を spawn_blocking 経由に揃える (#684)
- fix(canvas): #586 HUD のステータス表示を view 操作と別枠の glass pill に分離 (#683)
- fix(pty): drop テストの Linux 型参照を修正 (#674)
- fix(pty): drop 時の poison でも child kill を試す (#672)
- fix(types): teamReports の共有型を追加 (#671)
- fix(filetree): primary root を外せるようにする (#670)
- fix(canvas): Canvas HUD とヘッダの不具合を修正 (#669)
- fix(pty): #618 Windows ConPTY 起動時に UTF-8 codepage を強制 (CP932 化対策) (#658)
- fix(canvas): #613 #616 #593 keybinding gate + Pane context menu race (#654)
- fix(canvas): #611 #612 spawnTeam helper で team-spawn 3 経路を統一 (#653)
- fix(canvas): #610 Background grid の color を CSS variable + テーマ別 token に切替 (#652)
- fix(canvas): #596 連続 handoff で unreadInboxCount が undercount する race を修正 (#650)
- fix(backend): #597 codex MCP setup/cleanup の rollback を claude と対称化 (#648)
- fix(canvas): #595 EditorCard dirty 内容を ×/Clear で破棄する前に確認 (#647)
- fix: #587 #588 #589 recruit / terminal follow-up 3 件をまとめて修正 (#590)
- fix(teamhub): #574 recruit_ack の timeout 拡大と観測強化 (#580)
- fix(pty): import PathBuf unconditionally for non-Windows builds (#573)
- fix: #568 align IDE readiness check with terminal spawn resolver (#571)
- fix(canvas): #569 拡大した Leader と recruit 子カードが重ならないよう size-aware 配置 (#570)

### ♻️ Refactor / Performance
- refactor(settings): #641 settings_save に schema_version 互換性ガードを追加 (#700)
- refactor(pty): claude_watcher を PTY 寿命に bind して orphan watcher を抑止 (#686)
- refactor(pty): #630 window CloseRequested で in-flight inject task を待ってから kill_all する (#698)
- refactor(logging): #643 vibe-editor.log を日次回転 + 古い世代を自動削除 (#696)
- refactor(settings): #644 settings/role-profiles .bak をタイムスタンプ + 5 世代回転に (#692)
- refactor(team): #637 agent_role_bindings の key を (team_id, agent_id) に拡張 (#689)
- perf(canvas): #665 zoom 単独 refit で xterm 全行 refresh を skip (#688)

### 📝 Docs / Chore
- chore(deps): bump zustand from 5.0.12 to 5.0.13 (#678)
- chore(deps): bump tokio from 1.52.1 to 1.52.3 in /src-tauri (#680)
- docs(roadmap): 2026-05 リファクタリング roadmap を追加 (#682)
- chore(pty): #579 spawn 所要時間を tracing ログで可視化 (#581)

## Test plan
- [ ] tauri-action による Windows / macOS / Linux ビルドがすべて成功する
- [ ] 成果物に Windows `.exe` (NSIS) / macOS `.dmg` (universal) / Linux `.AppImage` `.deb` が attach される
- [ ] updater 用 `latest.json` が attach され、署名検証が通る
- [ ] (publish 後) v1.5.5 から自動アップデート → 再起動 → v1.5.6 起動まで通る