### PR TITLE
refactor(canvas): #707 ヘッダーの「N 枚のカード」を count=0 時に非表示化

### DIFF
--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -485,7 +485,9 @@ export function CanvasLayout(): JSX.Element {
         <span className="canvas-header__brand" data-tauri-drag-region>
           <MonitorSmartphone size={14} strokeWidth={1.75} data-tauri-drag-region />
         </span>
-        <span className="canvas-header__count" data-tauri-drag-region>{formatCardCount(cardCount, settings.language)}</span>
+        {cardCount > 0 && (
+          <span className="canvas-header__count" data-tauri-drag-region>{formatCardCount(cardCount, settings.language)}</span>
+        )}
         <div className="canvas-header__spacer" data-tauri-drag-region />
 
         {cardCount > 0 && (


### PR DESCRIPTION
## Summary
- Canvas ヘッダーの `canvas-header__count` を `cardCount > 0` で条件描画
- 空状態で表示されていた「0 枚のカード」/「0 cards」のノイズを除去
- 隣の clear ボタンが既に同じ `cardCount > 0` ガードで隠れるパターンと揃える

関連 issue: #707

## 変更
- `src/renderer/src/layouts/CanvasLayout.tsx` — `<span className="canvas-header__count">` を `{cardCount > 0 && ...}` で wrap

## Test plan
- [x] `npm run typecheck` (worktree / 現ブランチ両方で OK)
- [x] `npm run dev` 起動中の renderer に HMR 適用 → カード 0 枚で count ラベル消失を確認
- [x] カード 1 枚以上で `N 枚のカード` 表示が維持されることを確認

Closes #707