### PR TITLE
refactor(ui): v1.6.0 向け UI ポリッシュバンドル

### DIFF
--- a/src/renderer/src/components/ChangesPanel.tsx
+++ b/src/renderer/src/components/ChangesPanel.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, RefreshCw } from 'lucide-react';
+import { CheckCircle2, GitBranch, RefreshCw } from 'lucide-react';
 import type { GitStatus, GitFileChange } from '../../../types/shared';
 import { useT } from '../lib/i18n';
 
@@ -31,6 +31,13 @@ function shortLabel(file: GitFileChange): string {
   return file.label[0] ?? '?';
 }
 
+/** `src/foo/bar.tsx` → { dir: 'src/foo', name: 'bar.tsx' }. ルート直下は dir 空文字。 */
+function splitPath(path: string): { dir: string; name: string } {
+  const idx = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  if (idx < 0) return { dir: '', name: path };
+  return { dir: path.slice(0, idx), name: path.slice(idx + 1) };
+}
+
 export function ChangesPanel({
   status,
   loading,
@@ -41,24 +48,24 @@ export function ChangesPanel({
 }: ChangesPanelProps): JSX.Element {
   const t = useT();
   return (
-    <div className="sidebar-view">
-      <header className="sidebar-view__header">
-        <div className="sidebar-view__meta">
+    <div className="sidebar-view changes-panel">
+      <header className="changes-panel__header">
+        <div className="changes-panel__meta">
           {status && status.ok && status.branch && (
-            <span className="git-branch">
-              <GitBranch size={11} strokeWidth={2} />
-              {status.branch}
+            <span className="changes-panel__branch" title={status.branch}>
+              <GitBranch size={11} strokeWidth={2.2} />
+              <span className="changes-panel__branch-name">{status.branch}</span>
             </span>
           )}
-          {status && status.ok && (
-            <span className="git-count">
-              {t('sidebar.filesChanged', { count: status.files.length })}
+          {status && status.ok && status.files.length > 0 && (
+            <span className="changes-panel__count" aria-label={t('sidebar.filesChanged', { count: status.files.length })}>
+              {status.files.length}
             </span>
           )}
         </div>
         <button
           type="button"
-          className="sidebar__section-btn"
+          className="changes-panel__refresh"
           onClick={onRefresh}
           title={t('sidebar.refresh')}
           aria-label={t('sidebar.refresh')}
@@ -87,13 +94,17 @@ export function ChangesPanel({
       )}
 
       {!loading && status && status.ok && status.files.length === 0 && (
-        <p className="sidebar__note sidebar__note--dim">{t('sidebar.noChanges')}</p>
+        <div className="changes-panel__empty">
+          <CheckCircle2 size={26} strokeWidth={1.5} className="changes-panel__empty-icon" />
+          <p className="changes-panel__empty-text">{t('sidebar.noChanges')}</p>
+        </div>
       )}
 
       {!loading && status && status.ok && status.files.length > 0 && (
         <ul className="gitfiles">
           {status.files.map((f) => {
             const isActive = activeDiffPath === f.path;
+            const { dir, name } = splitPath(f.path);
             return (
               <li key={f.path}>
                 <button
@@ -102,11 +113,15 @@ export function ChangesPanel({
                   onClick={() => onOpenDiff(f)}
                   onContextMenu={(e) => onFileContextMenu(e, f)}
                   title={`${f.label}: ${f.path}`}
+                  data-status={statusBadgeClass(f).replace('gitfile__badge--', '')}
                 >
                   <span className={`gitfile__badge ${statusBadgeClass(f)}`}>
                     {shortLabel(f)}
                   </span>
-                  <span className="gitfile__path">{f.path}</span>
+                  <span className="gitfile__path">
+                    <span className="gitfile__name">{name}</span>
+                    {dir && <span className="gitfile__dir">{dir}</span>}
+                  </span>
                 </button>
               </li>
             );

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -281,7 +281,6 @@ body.is-resizing * {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  padding: 8px 0 20px;
 }
 
 /* サイドバー切替: アンダーラインスタイルタブ */
@@ -401,6 +400,8 @@ body.is-resizing * {
 .sidebar-view {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
   padding: 8px 0 14px;
 }
 
@@ -1085,64 +1086,190 @@ body.is-resizing * {
 
 /* ---------- Git パネル ---------- */
 
-.git-branch {
-  display: inline-flex;
+/* ---------- ChangesPanel: 差分パネル ---------- */
+/* sidebar-view__header / __meta の汎用スタイルだとブランチ名と件数が
+   斜体 italic で表示されてコード臭が薄かったので、Changes 専用クラスで
+   モノスペース + pill 形式の count badge に置き換える。 */
+.changes-panel__header {
+  display: flex;
   align-items: center;
-  gap: 4px;
-  color: var(--accent);
-  font-weight: 500;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 16px 10px;
 }
 
-.git-count {
+.changes-panel__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.changes-panel__branch {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px 3px 7px;
+  font-family: var(--mono-font);
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border-radius: 999px;
+  letter-spacing: 0.01em;
+  min-width: 0;
+}
+
+.changes-panel__branch > svg {
+  flex-shrink: 0;
+  opacity: 0.9;
+}
+
+.changes-panel__branch-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.changes-panel__count {
+  display: inline-grid;
+  place-items: center;
+  min-width: 22px;
+  height: 18px;
+  padding: 0 6px;
+  font-family: var(--mono-font);
+  font-size: 10.5px;
+  font-weight: 600;
   color: var(--text-mute);
+  background: var(--bg-hover);
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+}
+
+.changes-panel__refresh {
+  display: inline-grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  background: transparent;
+  color: var(--text-mute);
+  border: 0;
+  border-radius: var(--radius-sm, 8px);
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out),
+    transform var(--dur-base) var(--ease-out);
+  flex-shrink: 0;
+}
+
+.changes-panel__refresh:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.changes-panel__refresh:active {
+  transform: rotate(180deg);
+}
+
+/* 空状態: 「変更なし」を控えめなアイコン + メッセージで示す。
+   従来は italic の note 一行だけで「git が動いていない」のか「クリーン」なのか
+   判別しづらかった。CheckCircle で「クリーン」を視覚化する。 */
+.changes-panel__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 28px 16px;
+  color: var(--text-mute);
+  text-align: center;
+}
+
+.changes-panel__empty-icon {
+  color: color-mix(in srgb, var(--accent) 60%, var(--text-mute));
+  opacity: 0.7;
+}
+
+.changes-panel__empty-text {
+  margin: 0;
+  font-size: 12px;
+  font-family: var(--heading-font);
+  letter-spacing: 0.01em;
 }
 
 .gitfiles {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 2px 0;
 }
 
 .gitfile {
+  position: relative;
   display: flex;
   align-items: center;
   width: calc(100% - 16px);
   gap: 10px;
   margin: 1px 8px;
-  padding: 7px 12px;
-  min-height: 32px;
+  padding: 7px 12px 7px 11px;
+  min-height: 34px;
   background: transparent;
   border: none;
   color: var(--text-dim);
   font-family: inherit;
-  font-size: 13px;
+  font-size: 12.5px;
   cursor: pointer;
   text-align: left;
   border-radius: var(--radius-sm);
-  transition: background 0.12s, color 0.12s;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out);
 }
 
+/* hover: 全幅の bg-hover。translateX は文字が滲むので使わない。 */
 .gitfile:hover {
-  background: linear-gradient(90deg, var(--bg-hover) 0%, transparent 100%);
+  background: var(--bg-hover);
   color: var(--text);
-  transform: translateX(2px);
 }
 
+/* active: 左端に status 色の細い accent bar + 全幅 bg-active。
+   ::before の background は data-status 別の override で塗り分ける。 */
 .gitfile.is-active {
   background: var(--bg-active);
   color: var(--text);
   font-weight: 500;
 }
 
+.gitfile.is-active::before {
+  content: '';
+  position: absolute;
+  left: 2px;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  border-radius: 1px;
+  background: var(--accent);
+}
+.gitfile.is-active[data-status='added']::before { background: var(--claude-success, #578a00); }
+.gitfile.is-active[data-status='modified']::before { background: var(--claude-warning, #a86b00); }
+.gitfile.is-active[data-status='deleted']::before { background: var(--claude-danger, #cf3a3a); }
+.gitfile.is-active[data-status='renamed']::before { background: var(--claude-accent-blue, #3886e5); }
+.gitfile.is-active[data-status='conflict']::before { background: var(--claude-accent-violet, #7261e0); }
+
 .gitfile__badge {
-  display: inline-block;
-  width: 16px;
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
   text-align: center;
   font-size: 10px;
   font-weight: 700;
-  padding: 1px 0;
-  border-radius: 3px;
+  border-radius: 5px;
   flex-shrink: 0;
+  letter-spacing: 0;
+  /* badge 自体に subtle border を入れて低 alpha bg でも輪郭を保つ */
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, currentColor 22%, transparent);
 }
 
 /*
@@ -1180,11 +1307,33 @@ body.is-resizing * {
 }
 
 .gitfile__path {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  overflow: hidden;
+  min-width: 0;
+  flex: 1;
+}
+
+/* ファイル名は通常の text 色 + 通常太さで、active 時は font-weight: 500 (親で当たる)。 */
+.gitfile__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+/* ディレクトリは dim color + 小さめ。flex-shrink を大きく取ってまずディレクトリから縮む。 */
+.gitfile__dir {
+  font-size: 11px;
+  color: var(--text-mute);
+  opacity: 0.85;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
-  flex: 1;
+  flex-shrink: 100;
 }
 
 /* ---------- セッション履歴 ---------- */

--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -60,6 +60,7 @@ import {
 } from '../lib/canvas-layout-helpers';
 import { useCanvasTeamRestore } from '../lib/hooks/use-canvas-team-restore';
 import { useCanvasAutoSave } from '../lib/hooks/use-canvas-auto-save';
+import { useLayoutResize } from '../lib/hooks/use-layout-resize';
 import { getDirtyEditorCardSnapshots } from '../lib/editor-card-dirty-registry';
 import {
   spawnTeam,
@@ -188,6 +189,10 @@ export function CanvasLayout(): JSX.Element {
 
   // Phase 4-3: Canvas state を team-history へ自動保存する hook (Issue #167 / #132 / #124)
   useCanvasAutoSave({ projectRoot, nodes, viewport, recent, setRecent });
+
+  // Canvas でも IDE 側と同じ sidebar 幅ハンドラを使う。
+  // `--shell-sidebar-w` を共有しているので、ハンドルだけ Canvas にも生やせばリサイズが効く。
+  const { onSidebarResizeStart, onSidebarResizeDouble } = useLayoutResize();
 
   const applyPreset = async (preset: WorkspacePreset): Promise<void> => {
     const cwd = projectRoot;
@@ -541,8 +546,95 @@ export function CanvasLayout(): JSX.Element {
             onGitOk={setRailHasGitRepo}
           />
         )}
+        {!sidebarCollapsed && (
+          <div
+            className="resize-handle resize-handle--sidebar"
+            onMouseDown={onSidebarResizeStart}
+            onDoubleClick={onSidebarResizeDouble}
+            title="ドラッグでサイドバー幅を調整 / ダブルクリックでリセット"
+            role="separator"
+            aria-orientation="vertical"
+          />
+        )}
         <div className="canvas-layout__stage">
           <Canvas actions={canvasActions} />
+          {/* Canvas 右上に固定で配置するチーム起動 FAB。split button: 本体クリックで
+              既定プリセットを 1-click 起動、caret でプリセット/最近使ったチームの
+              popover を開く。canvas-header 撤廃 (#709) で消えていたのを復活。 */}
+          <div className="canvas-spawn-fab" ref={spawnPopoverRef}>
+            <div className="canvas-btn-split">
+              <button
+                type="button"
+                className="canvas-btn canvas-btn--primary canvas-btn-split__main"
+                onClick={() => void applyPreset(DEFAULT_SPAWN_PRESET)}
+                aria-label={t('canvas.spawnTeam.tooltip')}
+                title={t('canvas.spawnTeam.tooltip')}
+              >
+                <Sparkles size={13} strokeWidth={1.8} />
+                {t('canvas.spawnTeam')}
+              </button>
+              <button
+                type="button"
+                className="canvas-btn canvas-btn--primary canvas-btn-split__caret"
+                onClick={() => setSpawnOpen((v) => !v)}
+                aria-label={t('canvas.spawnTeamMore.tooltip')}
+                title={t('canvas.spawnTeamMore.tooltip')}
+                aria-expanded={spawnOpen}
+              >
+                <ChevronDown size={12} strokeWidth={2} />
+              </button>
+            </div>
+            {spawnOpen && (
+              <div className="canvas-popover canvas-popover--wide">
+                <div className="canvas-popover__tabs">
+                  <TabBtn active={tab === 'preset'} onClick={() => setTab('preset')}>
+                    <Sparkles size={11} /> {t('canvas.preset')}
+                  </TabBtn>
+                  <TabBtn active={tab === 'recent'} onClick={() => setTab('recent')}>
+                    <History size={11} /> {t('canvas.recent')}
+                    {closeRecent.length > 0 && (
+                      <span className="canvas-popover__tab-badge">{closeRecent.length}</span>
+                    )}
+                  </TabBtn>
+                </div>
+                {tab === 'preset' &&
+                  BUILTIN_PRESETS.map((preset) => (
+                    <BuiltinPresetItem
+                      key={preset.id}
+                      preset={preset}
+                      label={t(preset.i18nKey)}
+                      agentCountLabel={formatOrganizationAgentCount(
+                        presetOrganizationCount(preset),
+                        presetMemberCount(preset),
+                        settings.language
+                      )}
+                      onClick={() => void applyPreset(preset)}
+                    />
+                  ))}
+                {tab === 'recent' && (
+                  <>
+                    {closeRecent.length === 0 && (
+                      <div className="canvas-popover__empty">{t('canvas.noRecentTeams')}</div>
+                    )}
+                    {closeRecent.map((entry) => (
+                      <RecentItem
+                        key={entry.id}
+                        entry={entry}
+                        fallbackName={entry.name || entry.id.slice(0, 8)}
+                        agentCountLabel={formatOrganizationAgentCount(
+                          entry.organization ? 1 : 0,
+                          entry.members.length,
+                          settings.language
+                        )}
+                        lastUsedLabel={dateTimeFormatter.format(new Date(entry.lastUsedAt))}
+                        onClick={() => void restoreRecent(entry)}
+                      />
+                    ))}
+                  </>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       </div>
 

--- a/src/renderer/src/lib/workspace-presets.ts
+++ b/src/renderer/src/lib/workspace-presets.ts
@@ -7,7 +7,6 @@
  * 固定ワーカーロール撤廃後は Leader が team_recruit で動的にメンバーを増やすため、
  * builtin プリセットは「起動構成」だけを定義する:
  *   - Leader 1 体 (claude / codex)
- *   - Leader + HR (claude / codex)
  */
 import type { TeamOrganizationMeta, TeamRole, TerminalAgent } from '../../../types/shared';
 import { NODE_H, NODE_W } from '../stores/canvas';
@@ -41,8 +40,6 @@ export interface PresetOrganization {
 
 const CLAUDE_ORG_COLOR = '#d97757';
 const CODEX_ORG_COLOR = '#10b981';
-const CLAUDE_ORG_ALT_COLOR = '#8b7cf6';
-const CODEX_ORG_ALT_COLOR = '#2f80ed';
 
 function defaultOrganizationColor(members: PresetMember[]): string {
   return members[0]?.agent === 'codex' ? CODEX_ORG_COLOR : CLAUDE_ORG_COLOR;
@@ -57,115 +54,11 @@ export const BUILTIN_PRESETS: WorkspacePreset[] = [
     members: [{ role: 'leader', agent: 'claude', col: 0, row: 0 }]
   },
   {
-    id: 'leader-hr-claude',
-    i18nKey: 'canvas.preset.leaderHrClaude',
-    description: 'Leader + HR (Claude Code) で起動。HR が大量採用を補助。',
-    category: 'team',
-    members: [
-      { role: 'leader', agent: 'claude', col: 0, row: 0 },
-      { role: 'hr', agent: 'claude', col: 1, row: 0 }
-    ]
-  },
-  {
     id: 'leader-codex',
     i18nKey: 'canvas.preset.leaderCodex',
     description: 'Leader (Codex) のみで起動。必要なメンバーは Leader が動的に呼び出す。',
     category: 'team',
     members: [{ role: 'leader', agent: 'codex', col: 0, row: 0 }]
-  },
-  {
-    id: 'leader-hr-codex',
-    i18nKey: 'canvas.preset.leaderHrCodex',
-    description: 'Leader + HR (Codex) で起動。HR が大量採用を補助。',
-    category: 'team',
-    members: [
-      { role: 'leader', agent: 'codex', col: 0, row: 0 },
-      { role: 'hr', agent: 'codex', col: 1, row: 0 }
-    ]
-  },
-  {
-    id: 'dual-claude-claude',
-    i18nKey: 'canvas.preset.dualClaudeClaude',
-    description: 'Claude Code の Leader 組織を 2 つ、独立した teamId で同時起動。',
-    category: 'team',
-    members: [],
-    organizations: [
-      {
-        id: 'claude-a',
-        i18nKey: 'canvas.organization.claudeA',
-        color: CLAUDE_ORG_COLOR,
-        members: [{ role: 'leader', agent: 'claude', col: 0, row: 0 }]
-      },
-      {
-        id: 'claude-b',
-        i18nKey: 'canvas.organization.claudeB',
-        color: CLAUDE_ORG_ALT_COLOR,
-        members: [{ role: 'leader', agent: 'claude', col: 1, row: 0 }]
-      }
-    ]
-  },
-  {
-    id: 'dual-claude-codex',
-    i18nKey: 'canvas.preset.dualClaudeCodex',
-    description: 'Claude Code Leader 組織と Codex Leader 組織を別 teamId で同時起動。',
-    category: 'team',
-    members: [],
-    organizations: [
-      {
-        id: 'claude',
-        i18nKey: 'canvas.organization.claude',
-        color: CLAUDE_ORG_COLOR,
-        members: [{ role: 'leader', agent: 'claude', col: 0, row: 0 }]
-      },
-      {
-        id: 'codex',
-        i18nKey: 'canvas.organization.codex',
-        color: CODEX_ORG_COLOR,
-        members: [{ role: 'leader', agent: 'codex', col: 1, row: 0 }]
-      }
-    ]
-  },
-  {
-    id: 'dual-codex-codex',
-    i18nKey: 'canvas.preset.dualCodexCodex',
-    description: 'Codex の Leader 組織を 2 つ、独立した teamId で同時起動。',
-    category: 'team',
-    members: [],
-    organizations: [
-      {
-        id: 'codex-a',
-        i18nKey: 'canvas.organization.codexA',
-        color: CODEX_ORG_COLOR,
-        members: [{ role: 'leader', agent: 'codex', col: 0, row: 0 }]
-      },
-      {
-        id: 'codex-b',
-        i18nKey: 'canvas.organization.codexB',
-        color: CODEX_ORG_ALT_COLOR,
-        members: [{ role: 'leader', agent: 'codex', col: 1, row: 0 }]
-      }
-    ]
-  },
-  {
-    id: 'dual-codex-claude',
-    i18nKey: 'canvas.preset.dualCodexClaude',
-    description: 'Codex Leader 組織と Claude Code Leader 組織を別 teamId で同時起動。',
-    category: 'team',
-    members: [],
-    organizations: [
-      {
-        id: 'codex',
-        i18nKey: 'canvas.organization.codex',
-        color: CODEX_ORG_COLOR,
-        members: [{ role: 'leader', agent: 'codex', col: 0, row: 0 }]
-      },
-      {
-        id: 'claude',
-        i18nKey: 'canvas.organization.claude',
-        color: CLAUDE_ORG_COLOR,
-        members: [{ role: 'leader', agent: 'claude', col: 1, row: 0 }]
-      }
-    ]
   }
 ];
 

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -56,10 +56,28 @@
   max-width: var(--shell-sidebar-w);
 }
 
+/* Canvas モードは flex レイアウトなので、grid 側 (--shell-sidebar-handle) と違って
+   resize-handle 自体に幅を持たせる必要がある。--shell-sidebar-w を共有しているので
+   ハンドルを置くだけで IDE 側と同じ useLayoutResize のハンドラから sidebar 幅が動く。 */
+.canvas-layout__body > .resize-handle--sidebar {
+  flex: 0 0 var(--shell-sidebar-handle);
+  width: var(--shell-sidebar-handle);
+}
+
 .canvas-layout__stage {
   flex: 1;
   position: relative;
   min-width: 0;
+}
+
+/* Canvas 右上の固定 FAB (チーム起動 split button)。canvas-header 撤廃 (#709) で
+   チーム起動の trigger が無くなったため、Canvas ステージ右上に absolute で固定する。
+   stage 自体が position:relative なので、絶対座標は stage を基準にする。 */
+.canvas-spawn-fab {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 10;
 }
 
 /* ---------- React Flow zoom 時の文字ぼやけ対策 ----------

--- a/src/renderer/src/styles/components/glass.css
+++ b/src/renderer/src/styles/components/glass.css
@@ -96,3 +96,22 @@
     0 12px 32px rgba(0, 0, 0, 0.42),
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
+
+/*
+ * Native <select> popup は OS-native widget で CSS でフル制御できない。Glass テーマでは
+ *  - --bg-panel が alpha 0.22 の低不透明 → option の地として伝わると Chromium がデフォルトの
+ *    白 popup chrome に fallback して、白背景 × 白文字で読めなくなる。
+ *  - :root の color-scheme: dark は select 直下まで継承されないケースがある (WebView2 で再現)。
+ *
+ * 対策:
+ *  1. <select> 自身に color-scheme: dark を明示し、Chromium に dark popup chrome を強制。
+ *  2. <option> に opaque な dark 地と text 色を直接指定する。alpha 付き色は Chromium が
+ *     一部混色しきれず白っぽく見えることがあるので、ここは完全不透明値を使う。
+ */
+:root[data-theme='glass'] select {
+  color-scheme: dark;
+}
+:root[data-theme='glass'] select option {
+  background-color: #161a26;
+  color: var(--text);
+}


### PR DESCRIPTION
## Summary

v1.6.0 安定版リリース向けに、未コミットだった UI 改善 6 件をまとめて 1 PR / 1 commit にバンドル。

1. **fix(sidebar)**: `.sidebar__body` (padding: 8px 0 20px) と `.sidebar-view` (padding: 8px 0 14px) の二重 padding を解消。body 側を 0 にし、view に `flex: 1 / min-height: 0` を付与してパネルが body の残余高を埋めるように。
2. **feat(canvas)**: Canvas モードに sidebar 幅変更用 resize handle を追加。`useLayoutResize` フックを IDE と共用、`--shell-sidebar-w` を共有しているのでドラッグで IDE/Canvas 両方が同期する。
3. **fix(settings, glass)**: Glass テーマで native `<select>` の dropdown が白背景 + 白文字で読めなかった問題を修正。`<select>` 自身に `color-scheme: dark` を明示 + `<option>` に opaque dark 地と text 色を指定。
4. **feat(canvas)**: チーム起動 split button を Canvas ステージ右上に absolute 固定で復活。canvas-header 撤廃 (#709) で trigger が完全に消えていたため、Sparkles + 「チーム起動」(既定プリセット 1-click 起動) と caret (プリセット/最近使ったチーム popover) の 2 ボタン構成で再構築。
5. **refactor(canvas)**: builtin プリセットから「Leader + HR」「Claude 組織 + Codex 組織」等の 6 種を削除し、Leader-only (Claude / Codex) の 2 つに絞り込み。HR ロールや dual organization 用の color 定数も整理。
6. **refactor(sidebar)**: ChangesPanel デザイン刷新。
   - branch を mono pill chip 化 (accent 色 + 10% tint 背景, 11.5px mono)
   - 件数を rounded badge 化 (`min-width: 22px`, mono)
   - refresh ボタンに 180° rotate active transform
   - file 行: filename と dir を分離 (dir は dim 11px, flex-shrink 100 で先に縮む)
   - active 状態: 左端に status 別 color の 2px accent bar (added=緑/modified=橙/deleted=赤/renamed=青/conflict=紫)
   - 空状態: `CheckCircle2` アイコン + 中央寄せメッセージで「クリーン」を可視化

Closes #712

## Test plan
- [x] `npm run typecheck` 通過
- [ ] HMR 動作確認 (sidebar 幅 / Canvas 幅 / Glass select / 差分パネル表示)
- [ ] bot レビュー approve