### PR TITLE
chore(release): bump version to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5261,7 +5261,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.5.6"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.5.6"
+version = "1.6.0"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## Summary

v1.6.0 安定版リリースのためのバージョン bump (1.5.6 → 1.6.0)。

`package.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` + `Cargo.lock` を 3 点同期で書き換え。

## v1.6.0 CHANGELOG (Release notes 用草案)

### ✨ Features (feat)
- canvas-header 撤廃 + AppMenuBar 統合 + Glass テーマ刷新 (#709)
- Canvas モードに sidebar 幅変更用 resize handle を追加 (#712 / #713)
- Canvas 右上にチーム起動 split button を absolute 固定で復活 (#712 / #713)

### 🐛 Bug fixes (fix)
- terminal-tabs.json 復元時に jsonl 不在の sessionId を sanitize (#702 / #703)
- Glass テーマで native \`<select>\` dropdown が白背景白文字になる問題 (#712 / #713)
- sidebar body / view padding 二重で生じていた余白 (#712 / #713)

### ♻️ Refactor
- Topbar 右側の Command / Restart / Tweaks / Activity アイコンと付随パネル撤廃 (#711)
- Canvas ヘッダーの「N 枚のカード」を count=0 時に非表示化 (#707 / #708)
- 右下の Canvas モード切替 FAB を削除 (#705 / #706)
- builtin プリセットから HR / dual 組織 6 種を整理 (Leader-only Claude / Codex のみに) (#712 / #713)
- ChangesPanel デザイン刷新 (mono branch chip / count pill / dir 分離 / active accent bar / 空状態アイコン) (#712 / #713)

## Test plan
- [x] bump-version.ps1 で 3 ファイル + Cargo.lock 完全一致
- [ ] bot レビュー approve
- [ ] main マージ後に v1.6.0 タグ push → release.yml 発火