### PR TITLE
fix(i18n): #727 TerminalSection を useT() 化して EN ユーザーへの日本語混入を解消

### DIFF
--- a/src/renderer/src/components/settings/TerminalSection.tsx
+++ b/src/renderer/src/components/settings/TerminalSection.tsx
@@ -1,4 +1,5 @@
 import type { AppSettings } from '../../../../types/shared';
+import { useT } from '../../lib/i18n';
 import { TERMINAL_FONT_PRESETS } from '../../lib/settings-options';
 import type { UpdateSetting } from './types';
 
@@ -8,13 +9,14 @@ interface Props {
 }
 
 export function TerminalSection({ draft, update }: Props): JSX.Element {
+  const t = useT();
   const currentFamily = draft.terminalFontFamily || draft.editorFontFamily;
   return (
     <section className="modal__section">
-      <h3>ターミナル</h3>
+      <h3>{t('settings.terminal')}</h3>
       <div className="modal__row">
         <label className="modal__label">
-          <span>フォント</span>
+          <span>{t('settings.terminalFontFamily')}</span>
           <select
             value={currentFamily}
             onChange={(e) => {
@@ -37,7 +39,7 @@ export function TerminalSection({ draft, update }: Props): JSX.Element {
           </select>
         </label>
         <label className="modal__label">
-          <span>フォントサイズ (px)</span>
+          <span>{t('settings.terminalFontSize')}</span>
           <input
             type="number"
             min={10}
@@ -47,11 +49,7 @@ export function TerminalSection({ draft, update }: Props): JSX.Element {
           />
         </label>
       </div>
-      <p className="modal__note">
-        既定は <strong>JetBrains Mono Nerd Font</strong> (本体同梱)。Powerline / Devicons /
-        Material Icons の glyph を含み、Starship や oh-my-posh の icon が tofu になりません。
-        ★ は本体にバンドルされたフォントで、OS 未インストールでも常に同じルックで描画されます。
-      </p>
+      <p className="modal__note">{t('settings.terminalNote')}</p>
     </section>
   );
 }

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -433,9 +433,10 @@ const ja: Dict = {
   'settings.editorFontSize': 'サイズ (px)',
   'settings.editorFontCustom': 'カスタム CSS font-family',
   'settings.terminal': 'ターミナル',
+  'settings.terminalFontFamily': 'フォント',
   'settings.terminalFontSize': 'フォントサイズ (px)',
   'settings.terminalNote':
-    'ターミナルフォントファミリはエディタフォントと同じものを使用します。',
+    '既定は JetBrains Mono Nerd Font (本体同梱)。Powerline / Devicons / Material Icons の glyph を含み、Starship や oh-my-posh の icon が tofu になりません。★ は本体にバンドルされたフォントで、OS 未インストールでも常に同じルックで描画されます。',
   'settings.density': '情報密度',
   'settings.density.compact': 'Compact',
   'settings.density.compactDesc': '14"以下の画面向け、余白小',
@@ -1096,9 +1097,10 @@ const en: Dict = {
   'settings.editorFontSize': 'Size (px)',
   'settings.editorFontCustom': 'Custom CSS font-family',
   'settings.terminal': 'Terminal',
+  'settings.terminalFontFamily': 'Font',
   'settings.terminalFontSize': 'Font size (px)',
   'settings.terminalNote':
-    'Terminal font family uses the same value as the editor font.',
+    'Default is JetBrains Mono Nerd Font (bundled). Includes Powerline / Devicons / Material Icons glyphs so Starship and oh-my-posh icons no longer render as tofu. ★ marks bundled fonts that always render the same regardless of OS-installed fonts.',
   'settings.density': 'Density',
   'settings.density.compact': 'Compact',
   'settings.density.compactDesc': 'For 14" or smaller screens',


### PR DESCRIPTION
## Summary
- `TerminalSection.tsx` の 4 箇所の日本語ハードコードを `useT()` 経由に置換
- 既存の dead key `settings.terminal` / `settings.terminalFontSize` / `settings.terminalNote` を有効化
- `settings.terminalFontFamily` を ja/en 双方に新規追加
- `settings.terminalNote` の古い記述 (旧設計: terminal font family = editor font) を現状のハードコード文 (JetBrains Mono Nerd Font の説明) に合わせて書き換え

Closes #727

## Test plan
- [ ] Settings を開き Terminal セクションのラベルが言語設定に追従することを確認 (ja / en 切替)
- [ ] フォント・フォントサイズの操作が従来通り動くことを確認
- [ ] modal__note の文言が JetBrains Mono Nerd Font の説明として表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)