### PR TITLE
fix(ipc): #728 app_recruit_ack の tauri-api wrapper と shared 型を追加

### DIFF
--- a/src/renderer/src/lib/recruit-ack.ts
+++ b/src/renderer/src/lib/recruit-ack.ts
@@ -33,10 +33,11 @@
  *   ) -> Result<(), String>
  */
 
-import { invoke } from '@tauri-apps/api/core';
+import type { RecruitAckPhase } from '../../../types/shared';
+import { api } from './tauri-api';
 
 /**
- * ack の失敗理由を表す phase。
+ * ack の失敗理由を表す phase。型定義は `src/types/shared.ts` に集約済み (Issue #728)。
  * - `requester_not_found`: `team:recruit-request` の `requesterAgentId` に一致するカードが
  *   canvas store に無く、200ms grace + leader/hr fallback でも見つからなかった。
  * - `spawn`: `terminal.create` IPC が失敗した (PTY allocation failure 等の汎用エラー)。
@@ -44,11 +45,7 @@ import { invoke } from '@tauri-apps/api/core';
  *   見つからない sub-case (renderer 側で error string ヒューリスティックで分類)。
  * - `instructions_load`: customInstructions 読込が失敗した (将来拡張用、現状未発火)。
  */
-export type RecruitAckPhase =
-  | 'requester_not_found'
-  | 'spawn'
-  | 'engine_binary_missing'
-  | 'instructions_load';
+export type { RecruitAckPhase };
 
 export interface RecruitAckOutcome {
   ok: boolean;
@@ -71,11 +68,11 @@ export async function ackRecruit(
   teamId: string,
   outcome: RecruitAckOutcome
 ): Promise<void> {
-  await invoke('app_recruit_ack', {
+  await api.app.recruitAck({
     newAgentId,
     teamId,
     ok: outcome.ok,
-    reason: outcome.reason ?? null,
-    phase: outcome.phase ?? null
+    reason: outcome.reason,
+    phase: outcome.phase
   });
 }

--- a/src/renderer/src/lib/tauri-api/app.ts
+++ b/src/renderer/src/lib/tauri-api/app.ts
@@ -4,6 +4,7 @@ import { invoke } from '@tauri-apps/api/core';
 import type {
   AppUserInfo,
   ClaudeCheckResult,
+  RecruitAckArgs,
   SetWindowEffectsResult,
   ThemeName,
   UpdaterShouldWarnResult
@@ -93,6 +94,18 @@ export const app = {
   /** recruit を手動キャンセル (timeout 待ち中にユーザーがカードを × で閉じた等) */
   cancelRecruit: (agentId: string): Promise<void> =>
     invoke('app_cancel_recruit', { agentId }),
+  /**
+   * Issue #342 Phase 1 / #728: recruit-request の受領 / 失敗を Hub に通知する。
+   * 引数 5 個 (newAgentId / teamId / ok / reason / phase) を flat camelCase で渡す。
+   */
+  recruitAck: (args: RecruitAckArgs): Promise<void> =>
+    invoke('app_recruit_ack', {
+      newAgentId: args.newAgentId,
+      teamId: args.teamId,
+      ok: args.ok,
+      reason: args.reason ?? null,
+      phase: args.phase ?? null
+    }),
   /**
    * `<projectRoot>/.claude/skills/vibe-team/SKILL.md` を書き出す。
    * setupTeamMcp でも best-effort で実行されるが、Onboarding / 設定 UI から手動で

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1247,6 +1247,26 @@ export interface RecruitRescuedPayload {
   lateByMs: number;
 }
 
+/**
+ * Issue #342 Phase 1: `app_recruit_ack` IPC 引数。
+ * Rust 側 `app_recruit_ack(new_agent_id, team_id, ok, reason, phase)` と camelCase で対応。
+ */
+export type RecruitAckPhase =
+  | 'requester_not_found'
+  | 'spawn'
+  | 'engine_binary_missing'
+  | 'instructions_load';
+
+export interface RecruitAckArgs {
+  newAgentId: string;
+  teamId: string;
+  ok: boolean;
+  /** 失敗理由 (max 256 byte 程度の短文を推奨)。省略時は null を送る。 */
+  reason?: string | null;
+  /** 失敗 phase。Rust 側は enum で受けるため `RecruitAckPhase` の値のみを送る。 */
+  phase?: RecruitAckPhase | null;
+}
+
 // ---------- Window Effects (Issue #260) ----------
 
 /**


### PR DESCRIPTION
## Summary
- `src/types/shared.ts` に `RecruitAckPhase` / `RecruitAckArgs` を追加し、Rust 側 `app_recruit_ack(new_agent_id, team_id, ok, reason, phase)` と camelCase で 1:1 対応する型契約を共通層に集約
- `src/renderer/src/lib/tauri-api/app.ts` に `recruitAck(args)` wrapper を追加 (reason / phase は `?? null` を wrapper 内で正規化)
- `src/renderer/src/lib/recruit-ack.ts` の `RecruitAckPhase` を shared 側からの re-export に置換し、raw `invoke('app_recruit_ack', ...)` を `api.app.recruitAck(...)` に書き換え

IPC 5 点同期 (Rust impl / mod.rs / invoke_handler / shared.ts 型 / tauri-api wrapper) が全層揃った状態に修正。

Closes #728

## Test plan
- [ ] `npx tsc --noEmit` が通ること (確認済)
- [ ] recruit-request → addCard 完了で `recruitAck({ ok: true })` が成功すること
- [ ] requester_not_found / spawn / engine_binary_missing 各 phase の ack 失敗ルートが従来通り動くこと
- [ ] `window.api.app.recruitAck` が renderer から型補完で見えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)