### PR TITLE
fix(settings): #726 terminalForceUtf8 の opt-out checkbox を追加

### DIFF
--- a/src/renderer/src/components/settings/TerminalSection.tsx
+++ b/src/renderer/src/components/settings/TerminalSection.tsx
@@ -8,9 +8,14 @@ interface Props {
   update: UpdateSetting;
 }
 
+// Issue #726 / #618: terminalForceUtf8 は Windows + cmd.exe / PowerShell でのみ機能する。
+// 他 OS では Rust 側が no-op なので、UI もグレーアウトして「触っても何も起きない」ことを示す。
+const IS_WINDOWS = typeof navigator !== 'undefined' && /Windows/i.test(navigator.userAgent);
+
 export function TerminalSection({ draft, update }: Props): JSX.Element {
   const t = useT();
   const currentFamily = draft.terminalFontFamily || draft.editorFontFamily;
+  const forceUtf8 = draft.terminalForceUtf8 !== false;
   return (
     <section className="modal__section">
       <h3>{t('settings.terminal')}</h3>
@@ -50,6 +55,24 @@ export function TerminalSection({ draft, update }: Props): JSX.Element {
         </label>
       </div>
       <p className="modal__note">{t('settings.terminalNote')}</p>
+      <label
+        className="modal__toggle"
+        style={IS_WINDOWS ? undefined : { opacity: 0.55 }}
+        title={IS_WINDOWS ? undefined : t('settings.terminalForceUtf8.nonWindowsNote')}
+      >
+        <input
+          type="checkbox"
+          checked={forceUtf8}
+          disabled={!IS_WINDOWS}
+          onChange={(e) => update('terminalForceUtf8', e.target.checked)}
+        />
+        <span>{t('settings.terminalForceUtf8.label')}</span>
+      </label>
+      <p className="modal__note">
+        {IS_WINDOWS
+          ? t('settings.terminalForceUtf8.hint')
+          : t('settings.terminalForceUtf8.nonWindowsNote')}
+      </p>
     </section>
   );
 }

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -437,6 +437,11 @@ const ja: Dict = {
   'settings.terminalFontSize': 'フォントサイズ (px)',
   'settings.terminalNote':
     '既定は JetBrains Mono Nerd Font (本体同梱)。Powerline / Devicons / Material Icons の glyph を含み、Starship や oh-my-posh の icon が tofu になりません。★ は本体にバンドルされたフォントで、OS 未インストールでも常に同じルックで描画されます。',
+  'settings.terminalForceUtf8.label': 'UTF-8 を強制 (Windows のみ)',
+  'settings.terminalForceUtf8.hint':
+    'cmd.exe / PowerShell 起動時に chcp 65001 を inject し、CP932 化による漢字ファイル名や日本語出力の U+FFFD 化を防ぎます。OEM コードページ (chcp 932) のままにしたいときだけ off にしてください。',
+  'settings.terminalForceUtf8.nonWindowsNote':
+    'この設定は Windows + cmd.exe / PowerShell でのみ意味があります。他のシェル・OS では何もしません。',
   'settings.density': '情報密度',
   'settings.density.compact': 'Compact',
   'settings.density.compactDesc': '14"以下の画面向け、余白小',
@@ -1101,6 +1106,11 @@ const en: Dict = {
   'settings.terminalFontSize': 'Font size (px)',
   'settings.terminalNote':
     'Default is JetBrains Mono Nerd Font (bundled). Includes Powerline / Devicons / Material Icons glyphs so Starship and oh-my-posh icons no longer render as tofu. ★ marks bundled fonts that always render the same regardless of OS-installed fonts.',
+  'settings.terminalForceUtf8.label': 'Force UTF-8 (Windows only)',
+  'settings.terminalForceUtf8.hint':
+    'Injects chcp 65001 when launching cmd.exe / PowerShell so kanji filenames and non-ASCII output do not get garbled into U+FFFD on CP932 consoles. Turn off only if you want to keep the OEM code page (chcp 932).',
+  'settings.terminalForceUtf8.nonWindowsNote':
+    'This setting only takes effect on Windows + cmd.exe / PowerShell. It is a no-op on other shells and OSes.',
   'settings.density': 'Density',
   'settings.density.compact': 'Compact',
   'settings.density.compactDesc': 'For 14" or smaller screens',

--- a/src/renderer/src/styles/components/modal.css
+++ b/src/renderer/src/styles/components/modal.css
@@ -416,6 +416,31 @@
   accent-color: var(--accent);
 }
 
+/* ---------- 汎用 modal toggle (Issue #726) ---------- */
+.modal__toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  padding: 10px 12px;
+  background: var(--bg-active);
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--border));
+  border-radius: 10px;
+  font-size: 13.5px;
+  color: var(--text);
+  width: fit-content;
+  margin-top: 12px;
+}
+.modal__toggle input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: var(--accent);
+}
+.modal__toggle input[type='checkbox']:disabled {
+  cursor: not-allowed;
+}
+
 .mcp-steps {
   margin: 8px 0 16px;
   padding-left: 22px;


### PR DESCRIPTION
## Summary
- `TerminalSection.tsx` に checkbox を追加し `update('terminalForceUtf8', ...)` を呼ぶ
- Windows 以外では `disabled` + 半透明化し、ホバー title と modal__note で no-op であることを明示 (Rust 側 commands/terminal の挙動と整合)
- `settings.terminalForceUtf8.label` / `.hint` / `.nonWindowsNote` を ja/en に追加
- 汎用の `.modal__toggle` クラスを `modal.css` に追加 (`.mcp-toggle` と同等スタイル、disabled cursor 対応)

Closes #726

## Note
このブランチは **#746 (fix/727) を base** にしています。#746 が main にマージされたら base を main に切り替えます。

## Test plan
- [ ] Settings → Terminal セクションに「UTF-8 を強制」checkbox が表示される
- [ ] (Windows) on/off で `settings.json` の `terminalForceUtf8` が反転する
- [ ] (Windows) off で再起動後、cmd.exe / PowerShell に `chcp 65001` が inject されない
- [ ] (macOS / Linux) checkbox がグレーアウトされ操作不可。hint に「Windows でのみ意味がある」旨が出る
- [ ] `npx tsc --noEmit` が通ること (確認済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)