### PR TITLE
refactor(themes): #730 monacoTheme の dead 'hc-black' 除去 + useMonacoTheme の undefined ガード

### DIFF
--- a/src/renderer/src/lib/settings-context.tsx
+++ b/src/renderer/src/lib/settings-context.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react';
 import { DEFAULT_SETTINGS, type AppSettings } from '../../../types/shared';
 import { migrateSettings } from './settings-migrate';
-import { applyDensity, applyTheme, THEMES } from './themes';
+import { applyDensity, applyTheme, THEMES, type MonacoThemeName } from './themes';
 import { bridgedToast } from './toast-bridge';
 import { translate } from './i18n';
 
@@ -296,7 +296,11 @@ export function useSettings(): SettingsContextValue {
   );
 }
 
-export function useMonacoTheme(): 'vs-dark' | 'vs' | 'hc-black' | 'claude-dark' | 'claude-light' {
+export function useMonacoTheme(): MonacoThemeName {
   const theme = useSettingsValue('theme');
-  return THEMES[theme].monacoTheme;
+  // Issue #730: settings-migrate.ts は v1 未満のときしか theme 値を validate しないため、
+  // schemaVersion >= 1 の settings.json に未知 theme (旧バージョン名 / 改竄 / 削除済テーマ) が
+  // 残っていると `THEMES[theme]` が undefined になり TypeError で落ちる。Monaco の dark を
+  // 安全な fallback として常に有効な値を返す。
+  return THEMES[theme]?.monacoTheme ?? 'vs-dark';
 }

--- a/src/renderer/src/lib/themes.ts
+++ b/src/renderer/src/lib/themes.ts
@@ -35,8 +35,15 @@ export interface ThemeVars {
   textMute: string;
   surfaceGlass: string;
   focusRing: string;
-  monacoTheme: 'vs-dark' | 'vs' | 'hc-black' | 'claude-dark' | 'claude-light';
+  monacoTheme: MonacoThemeName;
 }
+
+/**
+ * Issue #730: 旧 union に残っていた `'hc-black'` は実 THEMES エントリで使われておらず
+ * consumer 側 switch で dead branch を強制していたため除外。将来 high-contrast を
+ * 戻すときは THEMES エントリ追加とセットで union を拡張する。
+ */
+export type MonacoThemeName = 'vs-dark' | 'vs' | 'claude-dark' | 'claude-light';
 
 export const THEMES: Record<ThemeName, ThemeVars> = {
   'claude-dark': {


### PR DESCRIPTION
## Summary
- `ThemeVars.monacoTheme` を named type `MonacoThemeName` に切り出し、実 THEMES エントリで参照していなかった `'hc-black'` を union から除去 (consumer 側 switch の dead branch を排除)
- `useMonacoTheme()` の戻り型を `MonacoThemeName` で揃え、`THEMES[theme]` 直接アクセスを `THEMES[theme]?.monacoTheme ?? 'vs-dark'` の optional chain + `'vs-dark'` fallback に変更
- `settings-migrate.ts` が v1 未満のときしか theme 値を validate しないため、schemaVersion >= 1 の settings.json に未知 theme が残っていると TypeError で落ちる経路をガード

Closes #730

## Test plan
- [ ] `npx tsc --noEmit` が通る (確認済)
- [ ] 既存の 6 テーマ (claude-dark / claude-light / dark / midnight / glass / light) で Monaco テーマが従来どおり適用される
- [ ] `settings.json` の `theme` を存在しない値 (例: `"nonexistent"`) に手動編集して起動しても TypeError にならず Monaco が dark で立ち上がる

🤖 Generated with [Claude Code](https://claude.com/claude-code)