### PR TITLE
fix(settings): #726 terminalForceUtf8 の opt-out UI スイッチを TerminalSection に追加

### DIFF
--- a/src/renderer/src/components/settings/TerminalSection.tsx
+++ b/src/renderer/src/components/settings/TerminalSection.tsx
@@ -8,9 +8,14 @@ interface Props {
   update: UpdateSetting;
 }
 
+const IS_WINDOWS = /Win/i.test(
+  (typeof navigator !== 'undefined' && (navigator.platform || navigator.userAgent)) || ''
+);
+
 export function TerminalSection({ draft, update }: Props): JSX.Element {
   const t = useT();
   const currentFamily = draft.terminalFontFamily || draft.editorFontFamily;
+  const forceUtf8 = draft.terminalForceUtf8 !== false;
   return (
     <section className="modal__section">
       <h3>{t('settings.terminal')}</h3>
@@ -50,6 +55,20 @@ export function TerminalSection({ draft, update }: Props): JSX.Element {
         </label>
       </div>
       <p className="modal__note">{t('settings.terminalNote')}</p>
+      <label className="mcp-toggle" style={IS_WINDOWS ? undefined : { opacity: 0.5 }}>
+        <input
+          type="checkbox"
+          checked={forceUtf8}
+          disabled={!IS_WINDOWS}
+          onChange={(e) => update('terminalForceUtf8', e.target.checked)}
+        />
+        <span>{t('settings.terminalForceUtf8.label')}</span>
+      </label>
+      <p className="modal__note">
+        {IS_WINDOWS
+          ? t('settings.terminalForceUtf8.hint')
+          : t('settings.terminalForceUtf8.nonWindows')}
+      </p>
     </section>
   );
 }

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -437,6 +437,10 @@ const ja: Dict = {
   'settings.terminalFontSize': 'フォントサイズ (px)',
   'settings.terminalNote':
     '既定は JetBrains Mono Nerd Font (本体同梱)。Powerline / Devicons / Material Icons の glyph を含み、Starship や oh-my-posh の icon が tofu になりません。★ は本体にバンドルされたフォントで、OS 未インストールでも常に同じルックで描画されます。',
+  'settings.terminalForceUtf8.label': 'Windows ターミナルで UTF-8 を強制 (chcp 65001)',
+  'settings.terminalForceUtf8.hint':
+    'cmd.exe / PowerShell 起動時に chcp 65001 を inject して console output を UTF-8 化します。漢字ファイル名や日本語出力が U+FFFD 化するのを防ぎます。OEM コードページを意図的に使いたい場合のみ OFF にしてください。Windows 以外の OS では何もしません。',
+  'settings.terminalForceUtf8.nonWindows': 'この設定は Windows でのみ有効です',
   'settings.density': '情報密度',
   'settings.density.compact': 'Compact',
   'settings.density.compactDesc': '14"以下の画面向け、余白小',
@@ -1101,6 +1105,10 @@ const en: Dict = {
   'settings.terminalFontSize': 'Font size (px)',
   'settings.terminalNote':
     'Default is JetBrains Mono Nerd Font (bundled). Includes Powerline / Devicons / Material Icons glyphs so Starship and oh-my-posh icons no longer render as tofu. ★ marks bundled fonts that always render the same regardless of OS-installed fonts.',
+  'settings.terminalForceUtf8.label': 'Force UTF-8 in Windows terminals (chcp 65001)',
+  'settings.terminalForceUtf8.hint':
+    'Inject `chcp 65001` when launching cmd.exe / PowerShell so console output is UTF-8. Prevents Japanese / CJK filenames and output from rendering as U+FFFD. Turn this OFF only if you intentionally want to keep the OEM code page. No-op on non-Windows OSes.',
+  'settings.terminalForceUtf8.nonWindows': 'This setting only applies on Windows',
   'settings.density': 'Density',
   'settings.density.compact': 'Compact',
   'settings.density.compactDesc': 'For 14" or smaller screens',


### PR DESCRIPTION
## Summary
- #618 で導入された `terminalForceUtf8` の opt-out UI が SettingsModal に存在しなかった問題を解消
- `TerminalSection.tsx` にチェックボックスを追加し、`shared.ts:152` のコメントが約束していた「設定で false に opt-out できる」を UI 経路で達成
- Windows 以外の OS では disable + opacity 0.5 にして「この設定は Windows でのみ有効」と明示 (commands/terminal の no-op に整合)
- i18n キー `settings.terminalForceUtf8.label` / `.hint` / `.nonWindows` を ja / en 両方に追加

## Closes
- Closes #726

## Test plan
- [x] `npm run typecheck` がクリーン
- [x] 既存の vitest スイートに新規 fail を追加していない (3 件の fail は main にも存在する pre-existing 失敗)
- [ ] Windows 実機で SettingsModal → ターミナル節にトグルが表示され、ON/OFF が `settings.json` の `terminalForceUtf8` と同期する
- [ ] macOS / Linux で同トグルが disable + 半透明、ヒント文が "Windows のみ" の表記に切り替わる
- [ ] OFF にして cmd.exe を開いたとき `chcp 65001` が inject されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)