### PR TITLE
ci(security): #745 trufflehog secrets scan を CI に追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,25 @@ jobs:
       - name: Cargo audit
         working-directory: src-tauri
         run: cargo audit
+
+  # Issue #745: 既存の `npm audit` / `cargo audit` は advisory DB ベースの依存脆弱性検査で、
+  # 「うっかり API key / token / 暗号鍵をコミットした」を検知できない。
+  # trufflehog を CI に乗せて entropy + verified 検証ベースの secrets scan を行い、
+  # PR push 時は差分 (base..head)、main / tag push 時は full repo を対象にする。
+  # `--only-verified` で credential が実在エンドポイントで通用するもののみ報告 (false positive 抑制)。
+  secrets-scan:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # full history が無いと PR の base..head 差分 scan / push の before..after 差分 scan が
+          # commit を取得できず "fatal: bad revision" になる。trufflehog の git driver 要件。
+          fetch-depth: 0
+
+      - name: Secrets scan (trufflehog, verified-only)
+        uses: trufflesecurity/trufflehog@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab # v3.95.3
+        with:
+          extra_args: --only-verified


### PR DESCRIPTION
## Summary
- `npm audit` / `cargo audit` の依存脆弱性検査では拾えない「API key / token / 暗号鍵の誤コミット」を検知するため、trufflehog を別 job として CI に追加
- `--only-verified` で credential が実エンドポイントで通用するもののみ報告 (false positive 抑制)
- `actions/checkout` は既存 verify job と同じ pinned SHA (`de0fac2e` / v6.0.2) を再利用、trufflehog は v3.95.3 (`37b77001d`) を full SHA pin
- PR push: base..head 差分 scan / main / tag push: before..after 差分 scan (trufflehog の git driver が event 種別から自動判別)

## なぜ別 job か
- verify job をブロックしない (typecheck / cargo test の結果は独立して見える)
- 並列実行で wall-clock を短縮
- `permissions: contents: read` のみで完結

## Closes
- Closes #745

## Test plan
- [ ] CI で `secrets-scan` job が `succeeded` で完了する (verified credential が無い前提)
- [ ] PR への push で `secrets-scan` がトリガーされる
- [ ] main / tag への push でも実行される
- [ ] テスト用に意図的にダミー credential (verified にならない弱い形式) を含む branch を一度回して、true positive と false positive の境界を確認 (任意)

🤖 Generated with [Claude Code](https://claude.com/claude-code)