### PR TITLE
fix(i18n): #729 theme description キーを i18n.ts に移管し EN ユーザーへの JP 表示を解消

### DIFF
--- a/src/renderer/src/components/settings/ThemeSection.tsx
+++ b/src/renderer/src/components/settings/ThemeSection.tsx
@@ -34,8 +34,8 @@ export function ThemeSection({ draft, update }: Props): JSX.Element {
               </div>
             </div>
             <div className="theme-card__meta">
-              <strong>{opt.label}</strong>
-              <span>{opt.desc}</span>
+              <strong>{t(`theme.label.${opt.value}`)}</strong>
+              <span>{t(`theme.desc.${opt.value}`)}</span>
             </div>
           </label>
         ))}

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -467,6 +467,15 @@ const ja: Dict = {
   'theme.label.midnight': 'ミッドナイト',
   'theme.label.glass': 'グラス',
 
+  // ---------- Theme descriptions (ThemeSection の theme card 用) ----------
+  // Issue #729: 旧 settings-options.ts の hardcoded JP `desc` を i18n.ts に移管。EN ユーザー向け表示を修正。
+  'theme.desc.claude-dark': 'Anthropic 公式カラー準拠。ウォームダークブラウン + コーラル #D97757（既定）',
+  'theme.desc.claude-light': 'claude.ai のクリーム背景と温かい差し色を再現',
+  'theme.desc.dark': 'VS Code 系のクラシックダーク',
+  'theme.desc.midnight': '深い青紫ベース、紫アクセント',
+  'theme.desc.glass': 'すりガラス風 — 半透明パネル + ブラー',
+  'theme.desc.light': '明るい背景、暗い文字',
+
   // ---------- Language labels (UserMenu / LanguageSection 共有) ----------
   'lang.label.ja': '日本語',
   'lang.label.ja.sub': 'Japanese',
@@ -1135,6 +1144,15 @@ const en: Dict = {
   'theme.label.light': 'Light',
   'theme.label.midnight': 'Midnight',
   'theme.label.glass': 'Glass',
+
+  // ---------- Theme descriptions (ThemeSection theme cards) ----------
+  // Issue #729: previously hardcoded JP in settings-options.ts. Now centralised so EN users see English.
+  'theme.desc.claude-dark': "Anthropic's official palette. Warm dark brown + coral #D97757 (default)",
+  'theme.desc.claude-light': 'Recreates the claude.ai cream background with warm accent colors',
+  'theme.desc.dark': 'Classic VS Code-style dark',
+  'theme.desc.midnight': 'Deep blue-purple base with purple accents',
+  'theme.desc.glass': 'Frosted-glass look — translucent panels + blur',
+  'theme.desc.light': 'Bright background, dark text',
 
   // ---------- Language labels (UserMenu / LanguageSection) ----------
   'lang.label.ja': '日本語',

--- a/src/renderer/src/lib/settings-options.ts
+++ b/src/renderer/src/lib/settings-options.ts
@@ -1,20 +1,16 @@
 import type { Density, StatusMascotVariant, ThemeName } from '../../../types/shared';
 
-export const THEME_OPTIONS: { value: ThemeName; label: string; desc: string }[] = [
-  {
-    value: 'claude-dark',
-    label: 'Claude Dark',
-    desc: 'Anthropic公式カラー準拠。ウォームダークブラウン + コーラル #D97757（既定）'
-  },
-  {
-    value: 'claude-light',
-    label: 'Claude Light',
-    desc: 'claude.ai のクリーム背景と温かい差し色を再現'
-  },
-  { value: 'dark', label: 'Dark', desc: 'VS Code系のクラシックダーク' },
-  { value: 'midnight', label: 'Midnight', desc: '深い青紫ベース、紫アクセント' },
-  { value: 'glass', label: 'Glass', desc: 'すりガラス風 — 半透明パネル + ブラー' },
-  { value: 'light', label: 'Light', desc: '明るい背景、暗い文字' }
+// Issue #729: 旧 `desc` field は JP hardcode で EN ユーザーに JP 説明が出る不具合があり、
+// i18n.ts の `theme.desc.{value}` キーに移管した。ThemeSection は t() 経由で描画する。
+// label は UserMenu / OnboardingWizard 等で `theme.label.{value}` 経由で localize 済み。
+// ここの `label` (Latin 文字列) はテーマ ID と同義の固定ラベルとして残し、表示時は呼び出し側で t() する。
+export const THEME_OPTIONS: { value: ThemeName; label: string }[] = [
+  { value: 'claude-dark', label: 'Claude Dark' },
+  { value: 'claude-light', label: 'Claude Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'midnight', label: 'Midnight' },
+  { value: 'glass', label: 'Glass' },
+  { value: 'light', label: 'Light' }
 ];
 
 export const STATUS_MASCOT_OPTIONS: {


### PR DESCRIPTION
## Summary
- ThemeSection の各 theme card は `THEME_OPTIONS.desc` (settings-options.ts) を直接描画していたが、desc が JP hardcode で EN ユーザーにも JP 説明が出ていた
- i18n.ts に `theme.desc.{value}` を ja / en それぞれ 6 エントリ追加し、ThemeSection は t() 経由で描画
- `label` も既に存在する `theme.label.{value}` を流用するよう統一 (`UserMenu` / `OnboardingWizard` と整合)

## 変更ファイル
| ファイル | 変更 |
|---|---|
| `src/renderer/src/lib/i18n.ts` | ja / en に `theme.desc.{claude-dark\|claude-light\|dark\|light\|midnight\|glass}` を追加 |
| `src/renderer/src/lib/settings-options.ts` | `THEME_OPTIONS` から `desc` field を削除 (型も縮める) |
| `src/renderer/src/components/settings/ThemeSection.tsx` | `opt.label` / `opt.desc` を `t(\`theme.label.${opt.value}\`)` / `t(\`theme.desc.${opt.value}\`)` に置換 |

## #729 全体に対する位置づけ
- Issue #729 全体は 40+ isJa 三項統一 + theme.desc.* 欠落 + dead key 30+ 整理の束
- 本 PR は **theme.desc.* 欠落** のみを解消する partial (cross_layer_consistency_auditor 指摘の 1 件)
- isJa 三項統一 / dead key 整理は follow-up PR で対応する想定 (#729 はまだ open に残す)

## Test plan
- [x] `npm run typecheck` クリーン
- [ ] ja 言語: 各 theme card に従来通り JP 説明が出る (例: Claude Dark → 「Anthropic 公式カラー準拠。…」)
- [ ] en 言語: 各 theme card に英訳説明が出る (例: Claude Dark → "Anthropic's official palette. …")
- [ ] テーマ切替が従来通り動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)