### PR TITLE
fix(i18n): #729 MascotSection の isJa 三項を t() に統一

### DIFF
--- a/src/renderer/src/components/settings/MascotSection.tsx
+++ b/src/renderer/src/components/settings/MascotSection.tsx
@@ -1,4 +1,5 @@
 import { DEFAULT_SETTINGS, type AppSettings } from '../../../../types/shared';
+import { useT } from '../../lib/i18n';
 import { STATUS_MASCOT_OPTIONS } from '../../lib/settings-options';
 import { StatusMascot } from '../shell/StatusMascot';
 import type { UpdateSetting } from './types';
@@ -9,13 +10,12 @@ interface Props {
 }
 
 export function MascotSection({ draft, update }: Props): JSX.Element {
-  const isJa = draft.language === 'ja';
+  const t = useT();
   const selected = draft.statusMascotVariant ?? DEFAULT_SETTINGS.statusMascotVariant;
   const customPath = draft.statusMascotCustomPath ?? '';
 
   const pickCustomImage = async (): Promise<void> => {
-    const title = isJa ? '相棒にする画像を選択' : 'Pick a mascot image';
-    const picked = await window.api.dialog.openFile(title);
+    const picked = await window.api.dialog.openFile(t('settings.mascot.pickTitle'));
     if (!picked) return;
     update('statusMascotCustomPath', picked);
     if (selected !== 'custom') update('statusMascotVariant', 'custom');
@@ -27,7 +27,7 @@ export function MascotSection({ draft, update }: Props): JSX.Element {
 
   return (
     <section className="modal__section">
-      <h3>{isJa ? 'キャラクター' : 'Character'}</h3>
+      <h3>{t('settings.mascot.title')}</h3>
       <div className="mascot-grid">
         {STATUS_MASCOT_OPTIONS.map((opt) => (
           <label
@@ -51,7 +51,7 @@ export function MascotSection({ draft, update }: Props): JSX.Element {
             </span>
             <span className="mascot-card__meta">
               <strong>{opt.label}</strong>
-              <span>{isJa ? opt.descJa : opt.descEn}</span>
+              <span>{t(`mascot.desc.${opt.value}`)}</span>
             </span>
           </label>
         ))}
@@ -65,7 +65,7 @@ export function MascotSection({ draft, update }: Props): JSX.Element {
               className="mascot-custom__pick"
               onClick={() => void pickCustomImage()}
             >
-              {isJa ? '画像を選ぶ…' : 'Choose image…'}
+              {t('settings.mascot.choose')}
             </button>
             {customPath ? (
               <button
@@ -73,7 +73,7 @@ export function MascotSection({ draft, update }: Props): JSX.Element {
                 className="mascot-custom__clear"
                 onClick={clearCustomImage}
               >
-                {isJa ? 'クリア' : 'Clear'}
+                {t('settings.mascot.clear')}
               </button>
             ) : null}
           </div>
@@ -82,11 +82,7 @@ export function MascotSection({ draft, update }: Props): JSX.Element {
               {customPath}
             </p>
           ) : (
-            <p className="mascot-custom__hint">
-              {isJa
-                ? 'PNG / GIF (アニメ可) / APNG / WebP / SVG を選べます。\n小さめ (32〜128px) の正方形が綺麗に出ます。'
-                : 'PNG / GIF (animated) / APNG / WebP / SVG. A small square (32–128 px) renders best.'}
-            </p>
+            <p className="mascot-custom__hint">{t('settings.mascot.hint')}</p>
           )}
         </div>
       )}

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -42,6 +42,20 @@ const ja: Dict = {
   'status.mascot.error': '対応が必要',
   'status.mascot.excited': 'やる気!',
 
+  // ---------- Mascot section (SettingsModal の「キャラクター」セクション) ----------
+  // Issue #729: MascotSection の isJa 三項 / settings-options.ts hardcode を i18n.ts に集約
+  'settings.mascot.title': 'キャラクター',
+  'settings.mascot.pickTitle': '相棒にする画像を選択',
+  'settings.mascot.choose': '画像を選ぶ…',
+  'settings.mascot.clear': 'クリア',
+  'settings.mascot.hint':
+    'PNG / GIF (アニメ可) / APNG / WebP / SVG を選べます。\n小さめ (32〜128px) の正方形が綺麗に出ます。',
+  'mascot.desc.vibe': '既定の小さな相棒',
+  'mascot.desc.spark': '明るめで軽い印象',
+  'mascot.desc.mono': '端末になじむ角ばった見た目',
+  'mascot.desc.coder': 'PCでカタカタ作業する相棒',
+  'mascot.desc.custom': '自分で用意した画像 (PNG/GIF/SVG/WebP) を相棒として使う',
+
   // ---------- Canvas HUD ----------
   'canvas.hud.stage': 'ステージ',
   'canvas.hud.list': 'リスト',
@@ -716,6 +730,20 @@ const en: Dict = {
   'status.mascot.done': 'Done!',
   'status.mascot.error': 'Needs attention',
   'status.mascot.excited': 'Yeah!',
+
+  // ---------- Mascot section (SettingsModal "Character" section) ----------
+  // Issue #729: MascotSection isJa ternaries / settings-options.ts hardcode -> centralised in i18n.ts
+  'settings.mascot.title': 'Character',
+  'settings.mascot.pickTitle': 'Pick a mascot image',
+  'settings.mascot.choose': 'Choose image…',
+  'settings.mascot.clear': 'Clear',
+  'settings.mascot.hint':
+    'PNG / GIF (animated) / APNG / WebP / SVG. A small square (32–128 px) renders best.',
+  'mascot.desc.vibe': 'Default tiny companion',
+  'mascot.desc.spark': 'Brighter and lighter',
+  'mascot.desc.mono': 'A terminal-friendly angular look',
+  'mascot.desc.coder': 'A tiny companion typing at a computer',
+  'mascot.desc.custom': 'Use your own image (PNG/GIF/SVG/WebP) as the companion',
 
   // ---------- Canvas HUD ----------
   'canvas.hud.stage': 'Stage',

--- a/src/renderer/src/lib/settings-options.ts
+++ b/src/renderer/src/lib/settings-options.ts
@@ -13,42 +13,17 @@ export const THEME_OPTIONS: { value: ThemeName; label: string }[] = [
   { value: 'light', label: 'Light' }
 ];
 
+// Issue #729: 旧 `descJa` / `descEn` field は i18n.ts の `mascot.desc.{value}` キーへ移管。
+// `label` は Latin 文字列 (vibe/spark/mono/coder/custom) で言語非依存なのでそのまま保持。
 export const STATUS_MASCOT_OPTIONS: {
   value: StatusMascotVariant;
   label: string;
-  descJa: string;
-  descEn: string;
 }[] = [
-  {
-    value: 'vibe',
-    label: 'Vibe',
-    descJa: '既定の小さな相棒',
-    descEn: 'Default tiny companion'
-  },
-  {
-    value: 'spark',
-    label: 'Spark',
-    descJa: '明るめで軽い印象',
-    descEn: 'Brighter and lighter'
-  },
-  {
-    value: 'mono',
-    label: 'Mono',
-    descJa: '端末になじむ角ばった見た目',
-    descEn: 'A terminal-friendly angular look'
-  },
-  {
-    value: 'coder',
-    label: 'Coder',
-    descJa: 'PCでカタカタ作業する相棒',
-    descEn: 'A tiny companion typing at a computer'
-  },
-  {
-    value: 'custom',
-    label: 'Custom',
-    descJa: '自分で用意した画像 (PNG/GIF/SVG/WebP) を相棒として使う',
-    descEn: 'Use your own image (PNG/GIF/SVG/WebP) as the companion'
-  }
+  { value: 'vibe', label: 'Vibe' },
+  { value: 'spark', label: 'Spark' },
+  { value: 'mono', label: 'Mono' },
+  { value: 'coder', label: 'Coder' },
+  { value: 'custom', label: 'Custom' }
 ];
 
 /* ★ = アプリに同梱 (variable webfont)。OS 未インストールでも常に同じルックで描画される。 */


### PR DESCRIPTION
## Summary
- Issue #729 item 1 (isJa 三項 40+ サイト統一) の最小ターゲット **MascotSection.tsx (t()=0 / isJa=5+)** を t() ベースに書き換え
- PR #760 (theme.desc 移管) と同型のパターンで STATUS_MASCOT_OPTIONS の `descJa/descEn` hardcode も i18n.ts へ移管

## 変更点
| ファイル | 変更 |
|---|---|
| `MascotSection.tsx` | `isJa` 変数を完全削除、6 箇所を `t('settings.mascot.*')` / `t(\`mascot.desc.${opt.value}\`)` に置換 |
| `i18n.ts` | ja/en に `settings.mascot.title/pickTitle/choose/clear/hint` + `mascot.desc.{vibe\|spark\|mono\|coder\|custom}` を追加 |
| `settings-options.ts` | STATUS_MASCOT_OPTIONS から `descJa`/`descEn` 削除 (型も縮小) |

## #729 全体に対する位置づけ
- (i) isJa 三項 40+ サイト統一 ← **本 PR は MascotSection 1 件分のみ** (issue が「最小・最初」と指名)
- (ii) theme.desc 欠落 → 解消済み (#760)
- (iii) dead key 30+ 整理 → 解消済み (#761, 実際は 63 件)

残り isJa 三項 (RoleProfilesSection / CustomAgentEditor / McpSection / SettingsModal / WelcomePane 他、合計 30+) は follow-up で。#729 はまだ open。

## Test plan
- [x] `npm run typecheck` クリーン
- [ ] ja: 「キャラクター」セクションのタイトル / 各 mascot card 説明 / Custom 選択時のボタン・ヒントが従来通り JP 表示
- [ ] en: 同セクションが英訳表示
- [ ] Custom mascot ピッカーの dialog タイトルが言語に応じて切替

🤖 Generated with [Claude Code](https://claude.com/claude-code)