### PR TITLE
fix(i18n): #729 DensitySection の JP hardcoded desc を i18n.ts に移管

### DIFF
--- a/src/renderer/src/components/settings/DensitySection.tsx
+++ b/src/renderer/src/components/settings/DensitySection.tsx
@@ -27,7 +27,7 @@ export function DensitySection({ draft, update }: Props): JSX.Element {
               onChange={() => update('density', opt.value)}
             />
             <strong>{opt.label}</strong>
-            <span>{opt.desc}</span>
+            <span>{t(`density.desc.${opt.value}`)}</span>
           </label>
         ))}
       </div>

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -403,6 +403,10 @@ const ja: Dict = {
     'cmd.exe / PowerShell 起動時に chcp 65001 を inject して console output を UTF-8 化します。漢字ファイル名や日本語出力が U+FFFD 化するのを防ぎます。OEM コードページを意図的に使いたい場合のみ OFF にしてください。Windows 以外の OS では何もしません。',
   'settings.terminalForceUtf8.nonWindows': 'この設定は Windows でのみ有効です',
   'settings.density': '情報密度',
+  // Issue #729: DensitySection 旧 hardcoded JP desc を i18n.ts に移管 (theme.desc / mascot.desc と同型)
+  'density.desc.compact': '14"以下の画面向け、余白小',
+  'density.desc.normal': '既定',
+  'density.desc.comfortable': '大画面向け、ゆったり',
   'settings.reset': 'デフォルトに戻す',
   'settings.cancel': 'キャンセル',
   'settings.apply': '適用して保存',
@@ -1016,6 +1020,10 @@ const en: Dict = {
     'Inject `chcp 65001` when launching cmd.exe / PowerShell so console output is UTF-8. Prevents Japanese / CJK filenames and output from rendering as U+FFFD. Turn this OFF only if you intentionally want to keep the OEM code page. No-op on non-Windows OSes.',
   'settings.terminalForceUtf8.nonWindows': 'This setting only applies on Windows',
   'settings.density': 'Density',
+  // Issue #729: DensitySection hardcoded JP desc moved to i18n.ts (mirrors theme.desc / mascot.desc)
+  'density.desc.compact': 'For 14" or smaller screens, tighter spacing',
+  'density.desc.normal': 'Default',
+  'density.desc.comfortable': 'For large screens, roomier spacing',
   'settings.reset': 'Reset to defaults',
   'settings.cancel': 'Cancel',
   'settings.apply': 'Apply & save',

--- a/src/renderer/src/lib/settings-options.ts
+++ b/src/renderer/src/lib/settings-options.ts
@@ -137,8 +137,10 @@ export const TERMINAL_FONT_PRESETS: { label: string; value: string }[] = [
   }
 ];
 
-export const DENSITY_OPTIONS: { value: Density; label: string; desc: string }[] = [
-  { value: 'compact', label: 'Compact', desc: '14"以下の画面向け、余白小' },
-  { value: 'normal', label: 'Normal', desc: '既定' },
-  { value: 'comfortable', label: 'Comfortable', desc: '大画面向け、ゆったり' }
+// Issue #729: 旧 `desc` field (JP hardcode) は i18n.ts の `density.desc.{value}` に移管。
+// `label` は Latin 文字列で言語非依存なので保持。
+export const DENSITY_OPTIONS: { value: Density; label: string }[] = [
+  { value: 'compact', label: 'Compact' },
+  { value: 'normal', label: 'Normal' },
+  { value: 'comfortable', label: 'Comfortable' }
 ];


### PR DESCRIPTION
## Summary
- DensitySection の各 density card は `DENSITY_OPTIONS.desc` を直接描画していたが、desc が JP hardcode で EN ユーザーにも JP 説明が出ていた
- PR #760 (theme.desc) / PR #762 (mascot.desc) と同型で i18n.ts へ移管

## 変更
| ファイル | 変更 |
|---|---|
| `i18n.ts` | ja / en に `density.desc.{compact\|normal\|comfortable}` を追加 |
| `settings-options.ts` | DENSITY_OPTIONS から `desc` field 削除 (型も縮小) |
| `DensitySection.tsx` | `opt.desc` → `t(\`density.desc.${opt.value}\`)` |

## Test plan
- [x] `npm run typecheck` クリーン
- [ ] ja: density card に従来通り JP 説明
- [ ] en: density card に英訳説明

🤖 Generated with [Claude Code](https://claude.com/claude-code)