### PR TITLE
fix(i18n): #729 CustomAgentEditor の isJa 三項を t() に統一

### DIFF
--- a/src/renderer/src/components/settings/CustomAgentEditor.tsx
+++ b/src/renderer/src/components/settings/CustomAgentEditor.tsx
@@ -16,7 +16,6 @@ interface Props {
  */
 export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element {
   const t = useT();
-  const isJa = draft.language === 'ja';
   const argsParse = parseShellArgsStrict(agent.args);
 
   const patchAgent = (patch: Partial<AgentConfig>): void => {
@@ -27,14 +26,7 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
   };
 
   const remove = (): void => {
-    if (
-      !window.confirm(
-        isJa
-          ? `カスタムエージェント "${agent.name}" を削除しますか？`
-          : `Delete custom agent "${agent.name}"?`
-      )
-    )
-      return;
+    if (!window.confirm(t('settings.customAgents.confirmDelete', { name: agent.name }))) return;
     update(
       'customAgents',
       (draft.customAgents ?? []).filter((a) => a.id !== agent.id)
@@ -56,7 +48,7 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
           type="text"
           value={agent.name}
           onChange={(e) => patchAgent({ name: e.target.value })}
-          placeholder={isJa ? '例: Aider' : 'e.g. Aider'}
+          placeholder={t('settings.customAgents.namePlaceholder')}
           spellCheck={false}
         />
       </label>
@@ -73,11 +65,7 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
       </label>
 
       <label className="modal__label modal__label--full">
-        <span>
-          {isJa
-            ? '引数（空白区切り、ダブルクォートで空白を含む値）'
-            : 'Arguments (space-separated; use quotes for spaces)'}
-        </span>
+        <span>{t('settings.customAgents.argsLabel')}</span>
         <input
           type="text"
           value={agent.args}
@@ -95,22 +83,18 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
       </label>
 
       <label className="modal__label modal__label--full">
-        <span>
-          {isJa
-            ? '作業ディレクトリ（空なら現在のプロジェクトルート）'
-            : 'Working directory (blank = current project root)'}
-        </span>
+        <span>{t('settings.customAgents.cwdLabel')}</span>
         <input
           type="text"
           value={agent.cwd ?? ''}
           onChange={(e) => patchAgent({ cwd: e.target.value })}
-          placeholder={isJa ? '（未設定）' : '(unset)'}
+          placeholder={t('settings.customAgents.cwdUnset')}
           spellCheck={false}
         />
       </label>
 
       <label className="modal__label modal__label--full">
-        <span>{isJa ? 'アクセントカラー（任意）' : 'Accent color (optional)'}</span>
+        <span>{t('settings.customAgents.accentColor')}</span>
         <input
           type="text"
           value={agent.color ?? ''}
@@ -120,11 +104,7 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
         />
       </label>
 
-      <p className="modal__note">
-        {isJa
-          ? '変更後、Canvas で該当エージェントのカードを作り直すと反映されます。'
-          : 'Recreate the agent card in Canvas to apply changes.'}
-      </p>
+      <p className="modal__note">{t('settings.customAgents.applyNote')}</p>
     </section>
   );
 }

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -557,6 +557,14 @@ const ja: Dict = {
   'settings.customAgents.name': '表示名',
   'settings.customAgents.remove': '削除',
   'settings.customAgents.untitled': '（無名）',
+  // Issue #729: CustomAgentEditor の isJa 三項を i18n.ts に集約
+  'settings.customAgents.confirmDelete': 'カスタムエージェント "{name}" を削除しますか？',
+  'settings.customAgents.namePlaceholder': '例: Aider',
+  'settings.customAgents.argsLabel': '引数（空白区切り、ダブルクォートで空白を含む値）',
+  'settings.customAgents.cwdLabel': '作業ディレクトリ（空なら現在のプロジェクトルート）',
+  'settings.customAgents.cwdUnset': '（未設定）',
+  'settings.customAgents.accentColor': 'アクセントカラー（任意）',
+  'settings.customAgents.applyNote': '変更後、Canvas で該当エージェントのカードを作り直すと反映されます。',
 
   // ---------- MCP tab ----------
   'settings.mcp.autoTitle': '自動セットアップ',
@@ -1186,6 +1194,14 @@ const en: Dict = {
   'settings.customAgents.name': 'Display name',
   'settings.customAgents.remove': 'Remove',
   'settings.customAgents.untitled': '(untitled)',
+  // Issue #729: CustomAgentEditor isJa ternaries consolidated into i18n.ts
+  'settings.customAgents.confirmDelete': 'Delete custom agent "{name}"?',
+  'settings.customAgents.namePlaceholder': 'e.g. Aider',
+  'settings.customAgents.argsLabel': 'Arguments (space-separated; use quotes for spaces)',
+  'settings.customAgents.cwdLabel': 'Working directory (blank = current project root)',
+  'settings.customAgents.cwdUnset': '(unset)',
+  'settings.customAgents.accentColor': 'Accent color (optional)',
+  'settings.customAgents.applyNote': 'Recreate the agent card in Canvas to apply changes.',
 
   // ---------- MCP tab ----------
   'settings.mcp.autoTitle': 'Auto setup',


### PR DESCRIPTION
## Summary
- Issue #729 item 1 の continuation: **CustomAgentEditor.tsx (t()=2 / isJa=8)** を t() ベースに書き換え、`isJa` 変数を完全削除
- 削除 confirm は `t('...confirmDelete', { name })` で interpolation 経由
- i18n.ts に ja/en で 7 キー追加 (`settings.customAgents.confirmDelete` / `.namePlaceholder` / `.argsLabel` / `.cwdLabel` / `.cwdUnset` / `.accentColor` / `.applyNote`)

## #729 連動 PR
- #760 theme.desc 移管
- #761 dead i18n key 63 削除
- #762 MascotSection isJa 統一
- #763 DensitySection desc 移管
- **#764 (this) CustomAgentEditor isJa 統一**

残り isJa 三項 (RoleProfilesSection / McpSection / SettingsModal / WelcomePane 等) は follow-up で。#729 はまだ open。

## Test plan
- [x] `npm run typecheck` クリーン
- [ ] ja: カスタムエージェント追加 / 編集 / 削除 confirm が JP 表示で `{name}` が正しく入る
- [ ] en: 同セクションが英訳表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)