### PR TITLE
fix(i18n): #729 SettingsModal の inline isJa 三項を t() に統一

### DIFF
--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -134,13 +134,7 @@ export function SettingsModal({
     // unhandled rejection を起こさないよう Promise.resolve でラップしてから .catch する (レビュー指摘)。
     const reportFailure = (err: unknown): void => {
       console.error('[settings] apply failed:', err);
-      const isJaNow = draft.language === 'ja';
-      showToast(
-        isJaNow
-          ? '設定の保存に失敗しました。詳細は開発者ツールのコンソールを確認してください。'
-          : 'Failed to save settings. See the developer console for details.',
-        { tone: 'error', duration: 6000 }
-      );
+      showToast(t('settings.saveFailedSeeConsole'), { tone: 'error', duration: 6000 });
     };
     let result: unknown;
     try {
@@ -186,7 +180,7 @@ export function SettingsModal({
     const id = `ca_${Math.random().toString(36).slice(2, 10)}`;
     const agent: AgentConfig = {
       id,
-      name: isJa ? '新しいエージェント' : 'New agent',
+      name: t('settings.customAgents.newName'),
       command: '',
       args: '',
       cwd: ''
@@ -234,7 +228,7 @@ export function SettingsModal({
         return (
           <>
             <FontFamilySection
-              title={isJa ? 'UI フォント' : 'UI Font'}
+              title={t('settings.fonts.uiFontTitle')}
               familyKey="uiFontFamily"
               sizeKey="uiFontSize"
               presets={UI_FONT_PRESETS}
@@ -242,7 +236,7 @@ export function SettingsModal({
               update={update}
             />
             <FontFamilySection
-              title={isJa ? 'エディタフォント (Monaco)' : 'Editor Font (Monaco)'}
+              title={t('settings.fonts.editorFontTitle')}
               familyKey="editorFontFamily"
               sizeKey="editorFontSize"
               presets={EDITOR_FONT_PRESETS}
@@ -255,20 +249,16 @@ export function SettingsModal({
       case 'claude':
         return (
           <CommandOptionsSection
-            title={isJa ? '起動オプション' : 'Launch options'}
+            title={t('settings.launch.title')}
             commandKey="claudeCommand"
             commandPlaceholder="claude"
             argsKey="claudeArgs"
-            argsLabel={isJa ? '引数（空白区切り、ダブルクォートで空白を含む値）' : 'Arguments'}
+            argsLabel={t('settings.launch.argsLabel')}
             argsPlaceholder='--model opus --add-dir "D:/other project"'
             cwdKey="claudeCwd"
-            cwdLabel={isJa ? '作業ディレクトリ（空なら現在のプロジェクトルート）' : 'Working directory'}
-            cwdPlaceholder={isJa ? '（未設定）' : '(unset)'}
-            note={
-              isJa
-                ? '変更後は再起動でターミナルに反映されます。'
-                : 'Restart terminals to apply changes.'
-            }
+            cwdLabel={t('settings.launch.cwdLabel')}
+            cwdPlaceholder={t('settings.launch.cwdUnset')}
+            note={t('settings.launch.applyNote')}
             draft={draft}
             update={update}
           />
@@ -276,11 +266,11 @@ export function SettingsModal({
       case 'codex':
         return (
           <CommandOptionsSection
-            title={isJa ? '起動オプション' : 'Launch options'}
+            title={t('settings.launch.title')}
             commandKey="codexCommand"
             commandPlaceholder="codex"
             argsKey="codexArgs"
-            argsLabel={isJa ? '引数（空白区切り）' : 'Arguments'}
+            argsLabel={t('settings.launch.argsLabelSimple')}
             argsPlaceholder="--model o3"
             draft={draft}
             update={update}
@@ -319,7 +309,7 @@ export function SettingsModal({
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
-        aria-label={isJa ? '設定' : 'Settings'}
+        aria-label={t('settings.dialog.label')}
         // Issue #195: dialog root を programmatic focus ターゲットにするため tabindex=-1。
         // Escape を入力フィールドから受けたとき、まず root に focus を退避してから次の
         // Escape で閉じる UX (vscode / macOS native と同じ) を実現する。
@@ -332,8 +322,8 @@ export function SettingsModal({
               type="button"
               className="settings-back-btn"
               onClick={onClose}
-              aria-label={isJa ? '戻る' : 'Back'}
-              title={isJa ? '戻る' : 'Back'}
+              aria-label={t('settings.back')}
+              title={t('settings.back')}
             >
               <ArrowLeft size={16} strokeWidth={2} />
             </button>
@@ -348,17 +338,17 @@ export function SettingsModal({
               <input
                 type="text"
                 className="settings-shell__search-input"
-                placeholder={isJa ? '設定を検索…' : 'Search settings…'}
+                placeholder={t('settings.search.placeholder')}
                 value={navQuery}
                 onChange={(e) => setNavQuery(e.target.value)}
-                aria-label={isJa ? '設定を検索' : 'Search settings'}
+                aria-label={t('settings.search.ariaLabel')}
               />
               {navQuery && (
                 <button
                   type="button"
                   className="settings-shell__search-clear"
                   onClick={() => setNavQuery('')}
-                  aria-label={isJa ? 'クリア' : 'Clear'}
+                  aria-label={t('settings.search.clear')}
                 >
                   <X size={12} strokeWidth={2.2} />
                 </button>
@@ -367,7 +357,7 @@ export function SettingsModal({
             <div className="settings-shell__nav-list">
               {groups.length === 0 ? (
                 <div className="settings-shell__nav-empty">
-                  {isJa ? '一致する項目がありません' : 'No matches'}
+                  {t('settings.search.noMatches')}
                 </div>
               ) : (
                 groups.map((g, gi) => (

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -397,6 +397,23 @@ const ja: Dict = {
 
   // ---------- Settings ----------
   'settings.title': '設定',
+  // Issue #729: SettingsModal の inline isJa を i18n.ts に移管
+  'settings.dialog.label': '設定',
+  'settings.back': '戻る',
+  'settings.saveFailedSeeConsole': '設定の保存に失敗しました。詳細は開発者ツールのコンソールを確認してください。',
+  'settings.search.placeholder': '設定を検索…',
+  'settings.search.ariaLabel': '設定を検索',
+  'settings.search.clear': 'クリア',
+  'settings.search.noMatches': '一致する項目がありません',
+  'settings.fonts.uiFontTitle': 'UI フォント',
+  'settings.fonts.editorFontTitle': 'エディタフォント (Monaco)',
+  'settings.launch.title': '起動オプション',
+  'settings.launch.argsLabel': '引数（空白区切り、ダブルクォートで空白を含む値）',
+  'settings.launch.argsLabelSimple': '引数（空白区切り）',
+  'settings.launch.cwdLabel': '作業ディレクトリ（空なら現在のプロジェクトルート）',
+  'settings.launch.cwdUnset': '（未設定）',
+  'settings.launch.applyNote': '変更後は再起動でターミナルに反映されます。',
+  'settings.customAgents.newName': '新しいエージェント',
   'settings.language': '言語',
   'settings.language.desc':
     'UI 表示言語を切り替え。Claude Code 自体の応答言語には影響しません。',
@@ -1028,6 +1045,23 @@ const en: Dict = {
 
   // ---------- Settings ----------
   'settings.title': 'Settings',
+  // Issue #729: SettingsModal inline isJa moved into i18n.ts
+  'settings.dialog.label': 'Settings',
+  'settings.back': 'Back',
+  'settings.saveFailedSeeConsole': 'Failed to save settings. See the developer console for details.',
+  'settings.search.placeholder': 'Search settings…',
+  'settings.search.ariaLabel': 'Search settings',
+  'settings.search.clear': 'Clear',
+  'settings.search.noMatches': 'No matches',
+  'settings.fonts.uiFontTitle': 'UI Font',
+  'settings.fonts.editorFontTitle': 'Editor Font (Monaco)',
+  'settings.launch.title': 'Launch options',
+  'settings.launch.argsLabel': 'Arguments',
+  'settings.launch.argsLabelSimple': 'Arguments',
+  'settings.launch.cwdLabel': 'Working directory',
+  'settings.launch.cwdUnset': '(unset)',
+  'settings.launch.applyNote': 'Restart terminals to apply changes.',
+  'settings.customAgents.newName': 'New agent',
   'settings.language': 'Language',
   'settings.language.desc':
     'Switch the UI language. Does not affect the language Claude Code responds in.',


### PR DESCRIPTION
## Summary
- Issue #729 item 1 の continuation: **SettingsModal.tsx** の inline isJa 三項 11 箇所を t() ベースに書き換え
- labelOf 経由の isJa (settings-section-meta.tsx の FIXED_LABELS_JA/EN を参照) は本 PR では現状維持、follow-up で対応

## 置換した isJa 箇所 (11)
| 箇所 | i18n キー |
|---|---|
| 保存失敗 toast | `settings.saveFailedSeeConsole` |
| addCustomAgent default name | `settings.customAgents.newName` |
| UI フォントタイトル | `settings.fonts.uiFontTitle` |
| エディタフォントタイトル | `settings.fonts.editorFontTitle` |
| Claude CommandOptions title | `settings.launch.title` |
| Claude argsLabel | `settings.launch.argsLabel` |
| Claude cwdLabel | `settings.launch.cwdLabel` |
| Claude cwdPlaceholder | `settings.launch.cwdUnset` |
| Claude applyNote | `settings.launch.applyNote` |
| Codex CommandOptions title | `settings.launch.title` |
| Codex argsLabel | `settings.launch.argsLabelSimple` |
| Dialog aria-label | `settings.dialog.label` |
| Back button | `settings.back` |
| Search placeholder/ariaLabel/clear | `settings.search.*` |
| Empty state | `settings.search.noMatches` |

## #729 連動 PR 6 連発
- #760 theme.desc 移管
- #761 dead i18n key 63 削除
- #762 MascotSection isJa 統一
- #763 DensitySection desc 移管
- #764 CustomAgentEditor isJa 統一
- **#765 (this) SettingsModal inline isJa 統一**

残り: labelOf (settings-section-meta.tsx) / RoleProfilesSection / McpSection / WelcomePane などの isJa は follow-up で。#729 はまだ open。

## Test plan
- [x] `npm run typecheck` クリーン
- [ ] ja: SettingsModal の全セクション (general/appearance/fonts/claude/codex/roles/mcp/logs/custom) で文言が従来通り JP
- [ ] en: 同セクションが英訳
- [ ] 検索バーで「一致する項目がない」状態を出して "No matches" 表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)