### PR TITLE
fix(i18n): #729 McpSection の isJa 三項を t() に統一

### DIFF
--- a/src/renderer/src/components/settings/McpSection.tsx
+++ b/src/renderer/src/components/settings/McpSection.tsx
@@ -24,7 +24,6 @@ interface HubInfo {
  */
 export function McpSection({ draft, update }: Props): JSX.Element {
   const t = useT();
-  const isJa = draft.language === 'ja';
   const [hub, setHub] = useState<HubInfo | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -141,28 +140,13 @@ VIBE_TEAM_TOKEN = "${token}"`,
           <li>{t('settings.mcp.manualStep2')}</li>
           <li>{t('settings.mcp.manualStep3')}</li>
         </ol>
-        <p className="modal__note">
-          {isJa
-            ? '~/.claude.json のサンプル (既存の mcpServers と統合してください):'
-            : 'Sample for ~/.claude.json (merge with existing mcpServers):'}
-        </p>
+        <p className="modal__note">{t('settings.mcp.claudeJsonSample')}</p>
         <CodeBlock content={manualJson} lang="json" />
-        <p className="modal__note">
-          {isJa
-            ? '~/.codex/config.toml のサンプル:'
-            : 'Sample for ~/.codex/config.toml:'}
-        </p>
+        <p className="modal__note">{t('settings.mcp.codexTomlSample')}</p>
         <CodeBlock content={manualToml} lang="toml" />
         <p className="modal__note">
-          {isJa ? (
-            <>
-              <b>接続情報 (現在値):</b> socket = <code>{socket}</code> / token = <code>{token}</code> / bridge = <code>{bridgePath}</code>
-            </>
-          ) : (
-            <>
-              <b>Connection info:</b> socket = <code>{socket}</code> / token = <code>{token}</code> / bridge = <code>{bridgePath}</code>
-            </>
-          )}
+          <b>{t('settings.mcp.connectionInfo')}</b> socket = <code>{socket}</code> / token ={' '}
+          <code>{token}</code> / bridge = <code>{bridgePath}</code>
         </p>
       </section>
     </>

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -397,6 +397,10 @@ const ja: Dict = {
 
   // ---------- Settings ----------
   'settings.title': '設定',
+  // Issue #729: McpSection の inline isJa を i18n.ts に移管
+  'settings.mcp.claudeJsonSample': '~/.claude.json のサンプル (既存の mcpServers と統合してください):',
+  'settings.mcp.codexTomlSample': '~/.codex/config.toml のサンプル:',
+  'settings.mcp.connectionInfo': '接続情報 (現在値):',
   'settings.language': '言語',
   'settings.language.desc':
     'UI 表示言語を切り替え。Claude Code 自体の応答言語には影響しません。',
@@ -1036,6 +1040,10 @@ const en: Dict = {
 
   // ---------- Settings ----------
   'settings.title': 'Settings',
+  // Issue #729: McpSection inline isJa moved into i18n.ts
+  'settings.mcp.claudeJsonSample': 'Sample for ~/.claude.json (merge with existing mcpServers):',
+  'settings.mcp.codexTomlSample': 'Sample for ~/.codex/config.toml:',
+  'settings.mcp.connectionInfo': 'Connection info:',
   'settings.language': 'Language',
   'settings.language.desc':
     'Switch the UI language. Does not affect the language Claude Code responds in.',


### PR DESCRIPTION
## Summary
- Issue #729 item 1 の continuation: **McpSection.tsx** (t()=多数, isJa=3) の inline isJa を完全削除
- 3 箇所の三項表現 (Claude JSON sample header / Codex TOML sample header / Connection info bold label) を t() に統一
- JSX フラグメント (`<>...</>`) で言語ごとに丸ごと分岐していた Connection info 行も、t() で bold ラベルだけ翻訳して値部分は共通化

## 連動 PR
- #760 #761 #762 #763 #764 #765 (#729 連動)
- **#766 (this) McpSection isJa 統一**

残り isJa 三項: labelOf (settings-section-meta.tsx) / RoleProfilesSection / WelcomePane 他 (#729 はまだ open)

## Test plan
- [x] `npm run typecheck` クリーン
- [ ] ja / en で MCP セクションの 3 サンプル見出し + 接続情報 bold ラベルが言語に応じて切替

🤖 Generated with [Claude Code](https://claude.com/claude-code)