### PR TITLE
fix(i18n): #729 WelcomePane の isJa 三項を t() に統一

### DIFF
--- a/src/renderer/src/components/WelcomePane.tsx
+++ b/src/renderer/src/components/WelcomePane.tsx
@@ -16,7 +16,6 @@ export function WelcomePane({ projectName }: WelcomePaneProps): JSX.Element {
         .slice(0, 4),
     [settings.recentProjects]
   );
-  const isJa = settings.language === 'ja';
   const hintCards = useMemo(
     () => [
       { key: 'hint-right', title: t('welcome.hint1Key'), text: t('welcome.hint1Text') },
@@ -37,9 +36,7 @@ export function WelcomePane({ projectName }: WelcomePaneProps): JSX.Element {
       <div className="welcome__inner">
         <div className="welcome__hero">
           <span className="welcome__eyebrow">vibe-editor</span>
-          <h1 className="welcome__title">
-            {isJa ? '静かな集中で、すばやく進める。' : 'Build with calm momentum.'}
-          </h1>
+          <h1 className="welcome__title">{t('welcome.title')}</h1>
           <p className="welcome__subtitle">{t('welcome.subtitle')}</p>
           <div className="welcome__project-pill">{projectName}</div>
         </div>
@@ -48,12 +45,8 @@ export function WelcomePane({ projectName }: WelcomePaneProps): JSX.Element {
           <section className="welcome__section">
             <div className="welcome__section-head">
               <div>
-                <p className="welcome__section-label">
-                  {isJa ? '最近のプロジェクト' : 'Recent projects'}
-                </p>
-                <h2 className="welcome__section-title">
-                  {isJa ? 'すぐに戻れる作業面' : 'Jump back into your flow'}
-                </h2>
+                <p className="welcome__section-label">{t('welcome.recentProjects')}</p>
+                <h2 className="welcome__section-title">{t('welcome.recentProjectsTitle')}</h2>
               </div>
               <span className="welcome__section-meta">
                 {Math.max(recentProjects.length, 1)}
@@ -62,9 +55,7 @@ export function WelcomePane({ projectName }: WelcomePaneProps): JSX.Element {
             <div className="welcome__cards">
               {(recentProjects.length > 0 ? recentProjects : [projectName]).map((path) => (
                 <article key={path} className="welcome__card">
-                  <span className="welcome__card-label">
-                    {isJa ? 'ワークスペース' : 'Workspace'}
-                  </span>
+                  <span className="welcome__card-label">{t('welcome.workspaceLabel')}</span>
                   <strong className="welcome__card-title">{shortName(path)}</strong>
                   <p className="welcome__card-subtitle">{path}</p>
                 </article>
@@ -75,12 +66,8 @@ export function WelcomePane({ projectName }: WelcomePaneProps): JSX.Element {
           <section className="welcome__section welcome__section--tips">
             <div className="welcome__section-head">
               <div>
-                <p className="welcome__section-label">
-                  {isJa ? 'クイックスタート' : 'Quick start'}
-                </p>
-                <h2 className="welcome__section-title">
-                  {isJa ? 'よく使う操作' : 'What you can do next'}
-                </h2>
+                <p className="welcome__section-label">{t('welcome.quickStart')}</p>
+                <h2 className="welcome__section-title">{t('welcome.quickStartTitle')}</h2>
               </div>
             </div>
             <div className="welcome__cards welcome__cards--tips">

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -397,6 +397,13 @@ const ja: Dict = {
 
   // ---------- Settings ----------
   'settings.title': '設定',
+  // Issue #729: WelcomePane の inline isJa を i18n.ts に移管
+  'welcome.title': '静かな集中で、すばやく進める。',
+  'welcome.recentProjects': '最近のプロジェクト',
+  'welcome.recentProjectsTitle': 'すぐに戻れる作業面',
+  'welcome.workspaceLabel': 'ワークスペース',
+  'welcome.quickStart': 'クイックスタート',
+  'welcome.quickStartTitle': 'よく使う操作',
   // Issue #729: RoleProfilesSection の isJa 三項を i18n.ts に移管
   'settings.roles.title': 'ロール定義',
   'settings.roles.desc':
@@ -1073,6 +1080,13 @@ const en: Dict = {
 
   // ---------- Settings ----------
   'settings.title': 'Settings',
+  // Issue #729: WelcomePane inline isJa moved into i18n.ts
+  'welcome.title': 'Build with calm momentum.',
+  'welcome.recentProjects': 'Recent projects',
+  'welcome.recentProjectsTitle': 'Jump back into your flow',
+  'welcome.workspaceLabel': 'Workspace',
+  'welcome.quickStart': 'Quick start',
+  'welcome.quickStartTitle': 'What you can do next',
   // Issue #729: RoleProfilesSection inline isJa moved into i18n.ts
   'settings.roles.title': 'Role profiles',
   'settings.roles.desc':


### PR DESCRIPTION
## Summary
- Issue #729 item 1 の continuation: **WelcomePane.tsx** (isJa=7) を t() ベースに完全書き換え
- `const isJa` を削除、7 箇所の inline 三項を t() で解決
- i18n.ts に ja / en で 6 キー追加 (welcome.title / .recentProjects / .recentProjectsTitle / .workspaceLabel / .quickStart / .quickStartTitle)

## 連動 PR
#760 #761 #762 #763 #764 #765 #766 #767 #768 + **#769 (this)**

残り: SessionsPanel / StatusBar / role-profiles-context / role-profiles-builtin / canvas-layout-helpers (#729 はまだ open)

## Test plan
- [x] `npm run typecheck` クリーン
- [ ] ja / en で WelcomePane のヒーロー / 最近のプロジェクト / クイックスタート見出し / ワークスペースラベルが言語に応じて切替

🤖 Generated with [Claude Code](https://claude.com/claude-code)