### PR TITLE
fix(i18n): #729 StatusBar / canvas-layout-helpers の language 三項を t() に統一

### DIFF
--- a/src/renderer/src/components/shell/StatusBar.tsx
+++ b/src/renderer/src/components/shell/StatusBar.tsx
@@ -68,7 +68,7 @@ export function StatusBar({
       ) : null}
       <span className="status__item">
         <span className="status__label">{t('status.lang')}</span>
-        <span>{settings.language === 'ja' ? 'ja' : 'en'}</span>
+        <span>{settings.language}</span>
       </span>
       <span className="status__item">
         <span className="status__label">{t('status.theme')}</span>

--- a/src/renderer/src/lib/canvas-layout-helpers.ts
+++ b/src/renderer/src/lib/canvas-layout-helpers.ts
@@ -10,19 +10,20 @@ import type {
   TeamRole,
   TerminalAgent
 } from '../../../types/shared';
+import { translate } from './i18n';
+
+// Issue #729: 旧 `formatCardCount` (未参照) は削除。`formatAgentCount` /
+// `formatOrganizationAgentCount` の hardcoded JP/EN テンプレートは i18n.ts の
+// `canvas.agentCount` / `canvas.orgAgentCount` に集約し、translate() 経由で解決する。
 
 export function localeOf(language: Language): string {
+  // BCP47 locale 文字列は Intl.* に渡す用途で、UI 表示テキストではないので
+  // i18n.ts には載せず language 引数からマップする。
   return language === 'ja' ? 'ja-JP' : 'en-US';
 }
 
-export function formatCardCount(count: number, language: Language): string {
-  return language === 'ja'
-    ? `${count} 枚のカード`
-    : `${count} ${count === 1 ? 'card' : 'cards'}`;
-}
-
 export function formatAgentCount(count: number, language: Language): string {
-  return language === 'ja' ? `${count} エージェント` : `${count} agents`;
+  return translate(language, 'canvas.agentCount', { count });
 }
 
 export function formatOrganizationAgentCount(
@@ -31,9 +32,10 @@ export function formatOrganizationAgentCount(
   language: Language
 ): string {
   if (organizationCount <= 1) return formatAgentCount(agentCount, language);
-  return language === 'ja'
-    ? `${organizationCount} 組織 / ${agentCount} エージェント`
-    : `${organizationCount} orgs / ${agentCount} agents`;
+  return translate(language, 'canvas.orgAgentCount', {
+    organizationCount,
+    agentCount
+  });
 }
 
 export function mergeCanvasMembers(

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -404,6 +404,9 @@ const ja: Dict = {
   'welcome.workspaceLabel': 'ワークスペース',
   'welcome.quickStart': 'クイックスタート',
   'welcome.quickStartTitle': 'よく使う操作',
+  // Issue #729: canvas-layout-helpers の language ベース hardcode を i18n.ts に移管
+  'canvas.agentCount': '{count} エージェント',
+  'canvas.orgAgentCount': '{organizationCount} 組織 / {agentCount} エージェント',
   // Issue #729: RoleProfilesSection の isJa 三項を i18n.ts に移管
   'settings.roles.title': 'ロール定義',
   'settings.roles.desc':
@@ -1118,6 +1121,9 @@ const en: Dict = {
   'welcome.workspaceLabel': 'Workspace',
   'welcome.quickStart': 'Quick start',
   'welcome.quickStartTitle': 'What you can do next',
+  // Issue #729: canvas-layout-helpers language-based hardcode moved into i18n.ts
+  'canvas.agentCount': '{count} agents',
+  'canvas.orgAgentCount': '{organizationCount} orgs / {agentCount} agents',
   // Issue #729: RoleProfilesSection inline isJa moved into i18n.ts
   'settings.roles.title': 'Role profiles',
   'settings.roles.desc':


### PR DESCRIPTION
## Summary
- Issue #729 item 1 の clean-up: SettingsModal 周辺以外で残っていた hardcoded 三項を整理
- `isJa` 変数を localStorage 派生 boolean として持ち回すパターンはこれで撲滅完了

## 変更
| ファイル | 変更 |
|---|---|
| `StatusBar.tsx` | `{settings.language === 'ja' ? 'ja' : 'en'}` → `{settings.language}` (settings.language は既に `'ja' \| 'en'` 型) |
| `canvas-layout-helpers.ts` | 未参照 `formatCardCount` 削除 / `formatAgentCount` / `formatOrganizationAgentCount` を `translate()` 経由に / `localeOf` は BCP47 文字列なので残置 |
| `i18n.ts` | ja / en に `canvas.agentCount` (`{count} エージェント` / `{count} agents`) と `canvas.orgAgentCount` を追加 |

## 残置する `language === 'ja'`
以下は **データ選択 / locale 文字列** で UI 表示 hardcode ではないため intentional として残置:
- `role-profiles-context.tsx` の prompt template 選択 (`profile.prompt.templateJa` / `template`)
- `role-profiles-context.tsx` の roster youMarker (` ← あなた` / ` <-- you`) — AI に渡す prompt 文字列の組み立て
- `role-profiles-context.tsx` の globalPreamble.ja / .en 選択
- `role-profiles-builtin.ts` の TOOLS_JA / TOOLS_EN テーブル選択
- `SessionsPanel.tsx` の Intl.DateTimeFormat locale (`ja-JP` / `en-US`)

## #729 完了 PR 全体 (11 連発)
- #760 theme.desc 移管
- #761 dead i18n key 63 削除
- #762 MascotSection isJa 統一
- #763 DensitySection desc 移管
- #764 CustomAgentEditor isJa 統一
- #765 SettingsModal inline isJa 統一
- #766 McpSection isJa 統一
- #767 RoleProfilesSection isJa 統一
- #768 labelOf / useSettingsNav の isJa + FIXED_LABELS を t() に統一
- #769 WelcomePane isJa 統一
- **#770 (this) StatusBar / canvas-layout-helpers cleanup**

これで Issue #729 の (i) isJa 三項 40+ サイト統一 / (ii) theme.desc 欠落 / (iii) dead key 整理 がすべて解消。#729 は close 可能。

## Test plan
- [x] `npm run typecheck` クリーン
- [ ] StatusBar の言語ラベル横の "ja"/"en" 表示が言語切替で変わる
- [ ] Canvas のプリセット一覧 / 最近のチーム一覧で agent count バッジが言語に応じて切替

🤖 Generated with [Claude Code](https://claude.com/claude-code)