### PR TITLE
fix(canvas): #755 カード未読数を team_diagnostics の実値で表示

### DIFF
--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -650,6 +650,10 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
     ? healthSnapshot.byAgentId[payload.agentId] ?? null
     : null;
   const health = useMemo(() => deriveHealth(healthRow), [healthRow]);
+  const hasHealthRow = healthRow !== null;
+  const unreadInboxCount = hasHealthRow
+    ? health.pendingInboxCount
+    : payload.unreadInboxCount ?? 0;
 
   return (
     <>
@@ -774,11 +778,13 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
           ) : null}
           {/* Issue #509: 配送済みだが team_read で確認していない message の数。 */}
           {/* 60s 超過で stalled クラスを追加して警告色に切り替える。 */}
-          {(payload.unreadInboxCount ?? 0) > 0 ? (() => {
-            const ageMs = payload.oldestUnreadDeliveredAt
-              ? Math.max(0, nowTick - new Date(payload.oldestUnreadDeliveredAt).getTime())
-              : 0;
-            const stalled = ageMs >= 60_000;
+          {unreadInboxCount > 0 ? (() => {
+            const ageMs = hasHealthRow
+              ? health.oldestPendingInboxAgeMs ?? 0
+              : payload.oldestUnreadDeliveredAt
+                ? Math.max(0, nowTick - new Date(payload.oldestUnreadDeliveredAt).getTime())
+                : 0;
+            const stalled = hasHealthRow ? health.stalledInbound : ageMs >= 60_000;
             const ageSec = Math.floor(ageMs / 1000);
             return (
               <div
@@ -790,14 +796,14 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
                 }
                 role="status"
                 title={t('inboxUnread.tooltip', {
-                  count: payload.unreadInboxCount ?? 0,
+                  count: unreadInboxCount,
                   ageSec
                 })}
               >
                 <Inbox size={11} strokeWidth={2} aria-hidden="true" />
                 <span className="canvas-agent-card__summary-text">
                   {t('inboxUnread.label', {
-                    count: payload.unreadInboxCount ?? 0,
+                    count: unreadInboxCount,
                     ageSec
                   })}
                 </span>

--- a/src/renderer/src/lib/__tests__/agent-health.test.ts
+++ b/src/renderer/src/lib/__tests__/agent-health.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { TeamDiagnosticsMemberRow } from '../../../../types/shared';
+import { deriveHealth } from '../agent-health';
+
+function row(overrides: Partial<TeamDiagnosticsMemberRow> = {}): TeamDiagnosticsMemberRow {
+  return {
+    agentId: 'worker-1',
+    role: 'programmer',
+    online: true,
+    inconsistent: false,
+    recruitedAt: '2026-05-16T00:00:00Z',
+    lastHandshakeAt: null,
+    lastSeenAt: null,
+    lastAgentActivityAt: null,
+    lastMessageInAt: null,
+    lastMessageOutAt: null,
+    messagesInCount: 0,
+    messagesOutCount: 0,
+    tasksClaimedCount: 0,
+    pendingInbox: [],
+    pendingInboxCount: 0,
+    oldestPendingInboxAgeMs: null,
+    stalledInbound: false,
+    currentStatus: null,
+    lastStatusAt: null,
+    lastPtyOutputAt: null,
+    lastStatusAgeMs: null,
+    lastPtyActivityAgeMs: null,
+    autoStale: false,
+    stalenessThresholdMs: 300_000,
+    ...overrides
+  };
+}
+
+describe('deriveHealth', () => {
+  it('passes through pending inbox diagnostics for unread badge rendering', () => {
+    const health = deriveHealth(
+      row({
+        pendingInbox: [101, 102],
+        pendingInboxCount: 2,
+        oldestPendingInboxAgeMs: 65_000,
+        stalledInbound: true
+      })
+    );
+
+    expect(health.pendingInboxCount).toBe(2);
+    expect(health.oldestPendingInboxAgeMs).toBe(65_000);
+    expect(health.stalledInbound).toBe(true);
+  });
+
+  it('uses clean pending inbox defaults when diagnostics are unavailable', () => {
+    const health = deriveHealth(null);
+
+    expect(health.pendingInboxCount).toBe(0);
+    expect(health.oldestPendingInboxAgeMs).toBeNull();
+    expect(health.stalledInbound).toBe(false);
+  });
+});

--- a/src/renderer/src/lib/agent-health.ts
+++ b/src/renderer/src/lib/agent-health.ts
@@ -30,6 +30,10 @@ export interface HealthDerived {
   currentStatus: string | null;
   /** pendingInbox 数 (UI で badge 表示) */
   pendingInboxCount: number;
+  /** 一番古い pending inbox の経過時間。未読なし / 不明なら null。 */
+  oldestPendingInboxAgeMs: number | null;
+  /** Hub 側が「未読が長く残っている」と判定したか。 */
+  stalledInbound: boolean;
 }
 
 export function deriveHealth(
@@ -40,7 +44,9 @@ export function deriveHealth(
       state: 'unknown',
       ageMs: null,
       currentStatus: null,
-      pendingInboxCount: 0
+      pendingInboxCount: 0,
+      oldestPendingInboxAgeMs: null,
+      stalledInbound: false
     };
   }
 
@@ -66,6 +72,8 @@ export function deriveHealth(
     state,
     ageMs: ageMs ?? null,
     currentStatus: row.currentStatus,
-    pendingInboxCount: row.pendingInboxCount
+    pendingInboxCount: row.pendingInboxCount,
+    oldestPendingInboxAgeMs: row.oldestPendingInboxAgeMs,
+    stalledInbound: row.stalledInbound
   };
 }


### PR DESCRIPTION
## Summary
- Canvas カードヘッダの未読バッジがローカルの `payload.unreadInboxCount` のみを参照し、TeamHub が保持する実未読状態 (`team_diagnostics.pendingInboxCount`) を表示に反映していなかった
- イベント取りこぼしや状態復元後に、実際の未読数と表示がずれていた
- diagnostics がある場合は `pendingInboxCount` / `oldestPendingInboxAgeMs` / `stalledInbound` を未読バッジ表示に使うよう修正
- `deriveHealth` に未読診断値を派生値として公開し、回帰テストを追加

関連 issue: #755

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm test` — agent-health / unread-inbox-count 関連 13 tests passed
- [ ] Canvas モードでリーダー/ワーカー間の対話後に未読バッジが更新されることを手動確認