### PR TITLE
fix(team_hub): #752/#753/#754 recruit セッション起動の信頼性を修正

### DIFF
--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -1453,12 +1453,28 @@ pub fn spawn_session(
                 .unwrap_or(-1),
             signal: None,
         };
-        if let Err(e) = app_for_exit.emit(&exit_event_clone, info) {
+        if let Err(e) = app_for_exit.emit(&exit_event_clone, info.clone()) {
             tracing::warn!("emit {exit_event_clone} failed: {e}");
         }
         // child.wait() が返った時点で kill 不要だが、registry::remove は handle.kill() を呼ぶ。
         // SessionHandle::kill() は何度呼んでも安全 (ChildKiller 内部で no-op)。
-        let _ = registry_for_exit.remove(&id_for_exit);
+        let removed = registry_for_exit.remove(&id_for_exit);
+        if let Some(handle) = removed {
+            if let (Some(team_id), Some(agent_id)) =
+                (handle.team_id.clone(), handle.agent_id.clone())
+            {
+                let output_tail = handle.scrollback_snapshot();
+                let app = app_for_exit.clone();
+                tauri::async_runtime::spawn(async move {
+                    let Some(state) = app.try_state::<crate::state::AppState>() else {
+                        return;
+                    };
+                    let hub = state.team_hub.clone();
+                    hub.record_agent_process_exit(&team_id, &agent_id, info.exit_code, output_tail)
+                        .await;
+                });
+            }
+        }
     });
 
     Ok(SessionHandle {

--- a/src-tauri/src/team_hub/protocol/consts.rs
+++ b/src-tauri/src/team_hub/protocol/consts.rs
@@ -17,11 +17,15 @@ pub(crate) const RECRUIT_TIMEOUT: Duration = Duration::from_secs(30);
 ///
 /// 実行時値は環境変数 `VIBE_TEAM_RECRUIT_CONCURRENCY` で `1..=RECRUIT_MAX_CONCURRENCY`
 /// の範囲に上書き可能 (範囲外 / parse 失敗時は本既定値にフォールバック)。
-pub(crate) const RECRUIT_DEFAULT_CONCURRENCY: usize = 2;
+pub(crate) const RECRUIT_DEFAULT_CONCURRENCY: usize = 1;
 /// Issue #576: `VIBE_TEAM_RECRUIT_CONCURRENCY` で受け付ける permit 数の上限。
 /// 上限 8 は Phase 1 ログ (`[teamhub] recruit_ack received elapsed_ms=...`) で観測される
 /// 「同時 recruit 6 体」が WebView 側で破綻しない範囲を多少上回る程度に絞った安全弁。
 pub(crate) const RECRUIT_MAX_CONCURRENCY: usize = 8;
+/// Issue #752 / #753: handshake が返った直後に Claude CLI が
+/// `No conversation found with session ID` 等で終了するケースを success 扱いしないため、
+/// `team_recruit` が成功を返す前にこの時間だけ roster 上の生存を再確認する。
+pub(crate) const RECRUIT_POST_HANDSHAKE_LIVENESS_GRACE: Duration = Duration::from_millis(1_500);
 /// Issue #342 Phase 1: renderer 側 `app_recruit_ack` invoke 受領を待つ短期タイムアウトの
 /// デフォルト値。「addCard / spawn 開始の受領通知」を待つ (handshake 完了までは待たない)。
 ///

--- a/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
+++ b/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
@@ -128,6 +128,10 @@ fn build_member_diagnostics_row(
         "lastStatusAt": diagnostics.last_status_at,
         // Issue #524: PTY 出力アクティビティ + staleness 自動判定
         "lastPtyOutputAt": diagnostics.last_pty_output_at,
+        "lastExitAt": diagnostics.last_exit_at,
+        "lastExitCode": diagnostics.last_exit_code,
+        "lastExitReason": diagnostics.last_exit_reason,
+        "lastExitSessionId": diagnostics.last_exit_session_id,
         "lastStatusAgeMs": last_status_age_ms,
         "lastPtyActivityAgeMs": last_pty_activity_age_ms,
         "autoStale": auto_stale,

--- a/src-tauri/src/team_hub/protocol/tools/recruit.rs
+++ b/src-tauri/src/team_hub/protocol/tools/recruit.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use super::super::consts::RECRUIT_ACK_TIMEOUT;
 use super::super::consts::RECRUIT_ACK_TIMEOUT_MAX_SECS;
+use super::super::consts::RECRUIT_POST_HANDSHAKE_LIVENESS_GRACE;
 use super::super::consts::RECRUIT_TIMEOUT;
 use super::super::dynamic_role::{validate_and_register_dynamic_role, DynamicRoleOutcome};
 use super::super::instruction_lint::{lint_all, LintReport};
@@ -76,6 +77,94 @@ fn parse_wait_policy(args: &Value) -> Result<String, String> {
         .with_phase("args")
         .into_err_string()),
     }
+}
+
+fn recruit_liveness_error(
+    code: &str,
+    message: String,
+    agent_id: &str,
+    role_profile_id: &str,
+    elapsed_ms: u64,
+    diag: Option<crate::team_hub::MemberDiagnostics>,
+) -> String {
+    let (session_id, exit_code, exit_reason) = match diag {
+        Some(d) => (d.last_exit_session_id, d.last_exit_code, d.last_exit_reason),
+        None => (None, None, None),
+    };
+    serde_json::to_string(&json!({
+        "code": code,
+        "message": message,
+        "phase": "post_handshake_liveness",
+        "elapsed_ms": elapsed_ms,
+        "agentId": agent_id,
+        "roleProfileId": role_profile_id,
+        "sessionId": session_id,
+        "exitCode": exit_code,
+        "exitReason": exit_reason,
+        "logPath": crate::team_hub::server_log_path_for_diagnostics(),
+    }))
+    .unwrap_or_else(|_| message)
+}
+
+async fn verify_recruit_liveness(
+    hub: &TeamHub,
+    team_id: &str,
+    agent_id: &str,
+    role_profile_id: &str,
+    started: Instant,
+) -> Result<(), String> {
+    tokio::time::sleep(RECRUIT_POST_HANDSHAKE_LIVENESS_GRACE).await;
+
+    let members = hub.registry.list_team_members(team_id);
+    if members
+        .iter()
+        .any(|(aid, role)| aid == agent_id && role == role_profile_id)
+    {
+        return Ok(());
+    }
+
+    let diag = hub.get_member_diagnostics(agent_id).await;
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    let code = if diag
+        .as_ref()
+        .and_then(|d| d.last_exit_session_id.as_deref())
+        .is_some()
+    {
+        "recruit_session_not_found"
+    } else if diag.as_ref().and_then(|d| d.last_exit_code).is_some() {
+        "child_process_exited"
+    } else {
+        "recruit_roster_inconsistent"
+    };
+    let message = match code {
+        "recruit_session_not_found" => {
+            let sid = diag
+                .as_ref()
+                .and_then(|d| d.last_exit_session_id.as_deref())
+                .unwrap_or("unknown");
+            format!("recruited agent exited because Claude session was not found: {sid}")
+        }
+        "child_process_exited" => {
+            let exit_code = diag
+                .as_ref()
+                .and_then(|d| d.last_exit_code)
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            format!("recruited agent exited before it became assignable (exitCode={exit_code})")
+        }
+        _ => format!(
+            "recruited agent did not remain in team roster after handshake (agentId={agent_id})"
+        ),
+    };
+
+    Err(recruit_liveness_error(
+        code,
+        message,
+        agent_id,
+        role_profile_id,
+        elapsed_ms,
+        diag,
+    ))
 }
 
 /// team_recruit: 新メンバーをチームに追加する。Renderer に event::emit でカード生成を依頼し、
@@ -473,6 +562,15 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
     // handshake 完了を待つ (Issue #342 Phase 1: ack 成功後のみ到達。disable_ack=1 では従来通り即座に到達)
     match tokio::time::timeout(RECRUIT_TIMEOUT, rx).await {
         Ok(Ok(outcome)) => {
+            verify_recruit_liveness(
+                hub,
+                &ctx.team_id,
+                &outcome.agent_id,
+                &outcome.role_profile_id,
+                started,
+            )
+            .await?;
+
             // Issue #342 Phase 3 (3.6): 成功時に recruitedAt / handshakeAt を返す。
             // recruited_at は registry 登録時刻、handshakeAt は handshake 完了時刻。
             // どちらも `resolve_pending_recruit` で member_diagnostics に書き込み済み。

--- a/src-tauri/src/team_hub/state.rs
+++ b/src-tauri/src/team_hub/state.rs
@@ -111,6 +111,15 @@ pub struct MemberDiagnostics {
     /// に diagnostics 側で `autoStale: true` を立てる元データ。
     /// 大量出力で hub の lock 競合を避けるため、PTY batcher が 1 秒間隔で dedup して update する。
     pub last_pty_output_at: Option<String>,
+    /// 子プロセスが終了した最終時刻。`team_recruit` が handshake 直後の即終了を成功扱い
+    /// しないための診断情報として保持する。
+    pub last_exit_at: Option<String>,
+    /// 子プロセスの終了コード。OS から取れない場合は -1。
+    pub last_exit_code: Option<i64>,
+    /// 終了直前の出力から推定した短い理由。
+    pub last_exit_reason: Option<String>,
+    /// Claude CLI が出した `No conversation found with session ID: ...` から抽出した session id。
+    pub last_exit_session_id: Option<String>,
 }
 
 /// Issue #342 Phase 3 (3.11): tracing-appender が書き出すログファイルの絶対パスを
@@ -174,9 +183,24 @@ pub fn server_log_path_for_diagnostics() -> String {
     }
 }
 
+fn extract_no_conversation_session_id(output_tail: &str) -> Option<String> {
+    const MARKER: &str = "No conversation found with session ID:";
+    let idx = output_tail.rfind(MARKER)?;
+    let rest = output_tail[idx + MARKER.len()..].trim_start();
+    let session_id: String = rest
+        .chars()
+        .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '-' || *ch == '_')
+        .collect();
+    if session_id.is_empty() {
+        None
+    } else {
+        Some(session_id)
+    }
+}
+
 #[cfg(test)]
 mod path_tests {
-    use super::reduce_home_prefix;
+    use super::{extract_no_conversation_session_id, reduce_home_prefix};
 
     /// home prefix が正しく `~` に置換され、home 配下でないパスは原文のまま。
     /// home 解決失敗環境を想定した静的テストではないので、CI 環境次第で home が
@@ -210,6 +234,15 @@ mod path_tests {
         };
         let reduced = reduce_home_prefix(outside);
         assert_eq!(reduced, outside);
+    }
+
+    #[test]
+    fn extracts_no_conversation_session_id_from_tail() {
+        let tail = "\r\nNo conversation found with session ID: f45f9cf8-eddc-4e70-a5a9-d4d2e6aa0ef9\r\n[process exited]";
+        assert_eq!(
+            extract_no_conversation_session_id(tail).as_deref(),
+            Some("f45f9cf8-eddc-4e70-a5a9-d4d2e6aa0ef9")
+        );
     }
 }
 
@@ -1070,6 +1103,59 @@ impl TeamHub {
             .member_diagnostics
             .get(agent_id)
             .cloned()
+    }
+
+    /// PTY の子プロセス終了を TeamHub 側の診断・整合性情報へ反映する。
+    ///
+    /// registry からは exit watcher が先に remove するため、roster 自体はそこで消える。
+    /// ここでは role binding / file lock / 終了診断を掃除し、`team_recruit` が handshake
+    /// 直後の即終了を検出して構造化エラーにできるようにする。
+    pub async fn record_agent_process_exit(
+        &self,
+        team_id: &str,
+        agent_id: &str,
+        exit_code: i64,
+        output_tail: Option<String>,
+    ) {
+        let now_iso = chrono::Utc::now().to_rfc3339();
+        let session_id = output_tail
+            .as_deref()
+            .and_then(extract_no_conversation_session_id);
+        let reason = if let Some(session_id) = &session_id {
+            Some(format!(
+                "No conversation found with session ID: {session_id}"
+            ))
+        } else {
+            Some(format!("child process exited with exitCode={exit_code}"))
+        };
+        {
+            let mut s = self.state.lock().await;
+            let diag = s
+                .member_diagnostics
+                .entry(agent_id.to_string())
+                .or_default();
+            if diag.recruited_at.is_empty() {
+                diag.recruited_at = now_iso.clone();
+            }
+            diag.last_exit_at = Some(now_iso);
+            diag.last_exit_code = Some(exit_code);
+            diag.last_exit_reason = reason;
+            diag.last_exit_session_id = session_id;
+            s.agent_role_bindings
+                .remove(&(team_id.to_string(), agent_id.to_string()));
+        }
+
+        let released_lock_count = self
+            .release_all_file_locks_for_agent(team_id, agent_id)
+            .await;
+        if released_lock_count > 0 {
+            tracing::info!(
+                "[teamhub] released {released_lock_count} advisory file lock(s) on process exit \
+                 (team={} agent={})",
+                team_id,
+                agent_id
+            );
+        }
     }
 
     /// Issue #342 Phase 3 (3.3): MemberDiagnostics 全体のスナップショットを返す。

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -319,22 +319,16 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   const isClaude = payload.agent === 'claude' || !payload.agent;
   const isCodex = payload.agent === 'codex';
 
-  // Issue #660: client-side UUID 事前注入。
+  // Issue #660 / #752 / #753: client-side UUID 事前注入。
   // payload.resumeSessionId が無い (= 新規 mount) なら UUID v4 を採番して
-  // `--session-id <uuid>` で起動 → 新規 jsonl が確定する。次回以降は payload に
-  // 焼き付いた id を `--resume <uuid>` で読み戻す経路に切替わる。
+  // `--session-id <uuid>` で起動する。ここで Canvas store へ先に書き戻すと、
+  // TerminalView の初回 spawn が走る前の再描画で `--resume <まだ存在しないuuid>` に
+  // 切り替わり、Claude CLI が "No conversation found with session ID" で終了する。
+  // そのため永続化は TerminalOverlay の onSessionId (jsonl 検出後) にだけ任せる。
   const ensuredSessionId = useMemo<string | null>(() => {
     if (!isClaude) return null;
     return payload.resumeSessionId ?? crypto.randomUUID();
   }, [isClaude, payload.resumeSessionId]);
-
-  useEffect(() => {
-    // 採番した UUID を Canvas store に書き戻して永続化する。
-    // payload に既に値があれば書き込まない (zustand 側で同値検出)。
-    if (isClaude && ensuredSessionId && !payload.resumeSessionId) {
-      setCardPayload(id, { resumeSessionId: ensuredSessionId });
-    }
-  }, [id, isClaude, ensuredSessionId, payload.resumeSessionId, setCardPayload]);
 
   const args = useMemo<string[] | undefined>(() => {
     const rawArgs = isClaude
@@ -352,11 +346,11 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
         base.push('-c', 'disable_paste_burst=true');
       }
     }
-    // Issue #660: Claude のみ session 制御フラグを付与 (Codex は両方とも非対応)。
+    // Issue #660 / #752 / #753: Claude のみ session 制御フラグを付与 (Codex は両方とも非対応)。
     //   - payload.resumeSessionId 既存 → 永続化済みなので `--resume` で前回会話を継続
     //   - payload.resumeSessionId 空 → 採番した UUID を `--session-id` で強制注入
-    // useEffect 側で payload に書き戻すと次 render で `--resume` 経路に切り替わる。
-    // 初回 spawn の args は本 render の値が snapRef に固定されるので問題ない。
+    // 新規 UUID は jsonl 検出後にだけ payload へ保存する。初回 spawn 前に保存すると
+    // まだ存在しない会話を resume してしまうため。
     if (isClaude && ensuredSessionId) {
       if (payload.resumeSessionId) {
         base.push('--resume', ensuredSessionId);

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1204,6 +1204,14 @@ export interface TeamDiagnosticsMemberRow {
    * 続いた場合は実際にプロセスが動いていない可能性が高い。
    */
   lastPtyOutputAt: string | null;
+  /** 子プロセスが最後に終了した時刻。online row では通常 null。 */
+  lastExitAt?: string | null;
+  /** 子プロセスの終了コード。 */
+  lastExitCode?: number | null;
+  /** 終了直前の出力から推定した短い理由。 */
+  lastExitReason?: string | null;
+  /** `No conversation found with session ID` から抽出した session id。 */
+  lastExitSessionId?: string | null;
   /** `lastStatusAt` から現在までの経過 ms (`null` なら一度も自己申告がない)。 */
   lastStatusAgeMs: number | null;
   /** `lastPtyOutputAt` から現在までの経過 ms (`null` なら一度も PTY 出力が観測されていない)。 */


### PR DESCRIPTION
## Summary
- Canvas の Claude カードが初回 spawn 前に採番 UUID を `resumeSessionId` として Canvas store へ書き戻していたため、spawn 直前の再描画で起動引数が `--session-id` から `--resume <未作成 UUID>` に切り替わり、Claude CLI が `No conversation found with session ID` で即終了していた (#752)
- `team_recruit` が handshake 完了直後の子プロセス即終了を success 扱いし、roster に残らないまま成功を返していた (#753)
- 連続採用 (4名目) が spawn 競合で失敗していた (#754)

### 修正
- **CardFrame**: 初回 spawn 前の `resumeSessionId` 書き戻し `useEffect` を削除。永続化は jsonl 検出後の `TerminalOverlay.onSessionId` にのみ委ね、初回は必ず `--session-id` で起動
- **team_recruit**: handshake 後 1.5s の roster 生存再確認を追加。子が即終了したら success を返さず構造化エラー (`recruit_session_not_found` / `child_process_exited` / `recruit_roster_inconsistent`) を返す。子終了時に role binding / advisory file lock を掃除し、exitCode/sessionId/logPath を診断へ反映
- **#754**: recruit 既定並行数を 2→1 に下げ連続採用を安全側に
- `MemberDiagnostics` / `TeamDiagnosticsMemberRow` に `lastExit*` フィールドを追加

## Test plan
- [x] `npm run typecheck` 通過
- [x] `cargo check` 通過
- [x] `cargo test extracts_no_conversation_session_id_from_tail` — session id 抽出の回帰テスト追加・通過
- [ ] Canvas モードで Claude カードを開いてプロセスが即終了しないこと、Codex リーダーから4名連続採用できることを手動確認

Closes #752
Closes #753
Closes #754