### PR TITLE
ci: #722 release.yml universal2 化 + #723 Cargo/npm 設定整理

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,12 @@ jobs:
       - name: npm audit signatures
         run: npm audit signatures
 
+      # cargo-audit を毎回 source ビルドすると 1-2 分かかり、Swatinem/rust-cache は
+      # ~/.cargo/bin を共有しないため再利用も効きにくい。pre-built バイナリを取得する。
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
+        with:
+          tool: cargo-audit
 
       - name: Cargo audit
         working-directory: src-tauri

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@
 #
 # 成果物: tauri-apps/tauri-action が GitHub Release を draft で作成し、
 #   - Windows: .exe (NSIS インストーラ)
-#   - macOS:   .dmg (Apple Silicon, aarch64)
+#   - macOS:   .dmg (universal2 — Apple Silicon + Intel)
 #   - Linux:   .AppImage / .deb
 # を upload する。確認後、Releases ページで手動 publish する。
 name: release
@@ -29,11 +29,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # macOS は universal2 dmg (Apple Silicon + Intel) を 1 本ビルドする。
+          # これにより Intel Mac ユーザーへの updater 配信を復活させる (#722)。
           - platform: macos-latest
-            args: '--target aarch64-apple-darwin'
-            bundle_dir: 'src-tauri/target/aarch64-apple-darwin/release/bundle'
-            attest_subjects: 'src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/**/*.dmg'
-            sbom_file: 'sbom-macos-aarch64.cdx.json'
+            args: '--target universal-apple-darwin'
+            bundle_dir: 'src-tauri/target/universal-apple-darwin/release/bundle'
+            attest_subjects: 'src-tauri/target/universal-apple-darwin/release/bundle/dmg/**/*.dmg'
+            sbom_file: 'sbom-macos-universal.cdx.json'
           - platform: ubuntu-22.04
             args: ''
             bundle_dir: 'src-tauri/target/release/bundle'
@@ -62,9 +64,9 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master @ 2026-04-26
         with:
-          # macOS は Apple Silicon (aarch64) のみビルドする
+          # macOS は universal2 (aarch64 + x86_64) ビルドのため両アーキの std を入れる
           toolchain: stable
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || '' }}
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
@@ -100,7 +102,7 @@ jobs:
             自動ビルド成果物。
 
             - Windows: `.exe` (NSIS インストーラ)
-            - macOS:   `.dmg` (Apple Silicon, aarch64)
+            - macOS:   `.dmg` (universal2 — Apple Silicon + Intel)
             - Linux:   `.AppImage` / `.deb`
 
             動作確認後にこの draft を publish してください。

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-process": "^2",
         "@tauri-apps/plugin-updater": "^2",
-        "@types/dompurify": "^3.0.5",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
@@ -34,6 +33,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
+        "@types/dompurify": "^3.0.5",
         "@types/node": "^20.14.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -2110,6 +2110,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
       "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/trusted-types": "*"
@@ -2156,6 +2157,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-process": "^2",
     "@tauri-apps/plugin-updater": "^2",
-    "@types/dompurify": "^3.0.5",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
@@ -43,6 +42,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
+    "@types/dompurify": "^3.0.5",
     "@types/node": "^20.14.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -493,10 +493,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tauri-plugin-process = "2"
 tauri-plugin-opener = "2"
 
 # --- async / serialization ---
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "net", "io-util", "fs", "process"] }
+tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros", "time", "sync", "net", "io-util", "fs", "process"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Issue #79: 以前ここに `toml = "0.8"` / `thiserror = "1"` / `percent-encoding = "2"` が
@@ -44,7 +44,7 @@ tracing-appender = "0.2"
 # --- misc ---
 once_cell = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 dirs = "6"
 which = "8"
 whoami = "2"
@@ -96,7 +96,7 @@ legacy_message_fallback = []
 
 [lib]
 name = "vibe_editor_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["staticlib", "cdylib"]
 
 [[bin]]
 name = "vibe-editor"


### PR DESCRIPTION
## Summary
- **#722**: `release.yml` の macOS ビルドを `aarch64-apple-darwin` 単独から `universal-apple-darwin` (universal2 = Apple Silicon + Intel) に変更。Intel Mac ユーザーへの updater 配信を復活。Rust toolchain の targets に `x86_64-apple-darwin` を追加
- **#723**: Cargo / npm 設定の小規模整理
  - `ci.yml`: cargo-audit を `cargo install` (source ビルド) から `taiki-e/install-action` の pre-built バイナリ取得に変更 (SHA pin)
  - `Cargo.toml`: chrono を `default-features = false` 化 (不要な wasmbind/js-sys を除去)、`[lib] crate-type` から `rlib` を削除、tokio に `default-features = false` を明示
  - `package.json`: `@types/dompurify` を dependencies → devDependencies へ移動

Closes #722
Closes #723

## Test plan
- [x] `npm run typecheck` 通過
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 成功 (既存 dead-code warning のみ)
- [x] `cargo test --locked --no-run` 成功 (lockfile 整合確認)
- [ ] release.yml の universal2 ビルドは次回タグ push 時に実地確認