### PR TITLE
security: #724 asset scope を動的許可化 + #744 process/updater capability を分離

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "vibe-editor renderer permissions. Issue #98: renderer から emit / shell 直接実行は使っていないので最小化する。process は updater の relaunch で必要。",
+  "description": "vibe-editor renderer base permissions. Issue #98: renderer から emit / shell 直接実行は使っていないので最小化する。Issue #744: renderer 侵害時の影響半径を縮めるため、process / updater (自動更新でのみ必要な権限) はこの base から外し capabilities/updater.json に分離した。",
   "windows": ["main"],
   "permissions": [
     "core:default",
@@ -16,8 +16,6 @@
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
     "core:app:default",
-    "dialog:default",
-    "process:default",
-    "updater:default"
+    "dialog:default"
   ]
 }

--- a/src-tauri/capabilities/updater.json
+++ b/src-tauri/capabilities/updater.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "updater",
+  "description": "Issue #744: 自動更新 (tauri-plugin-updater + tauri-plugin-process) 専用 capability。base の capabilities/default.json から process:default / updater:default を切り出し、ここに分離した。renderer 側で実際にこれらの command を呼ぶのは src/renderer/src/lib/updater-check.ts のみ (@tauri-apps/plugin-updater の check() / @tauri-apps/plugin-process の relaunch())。これらの plugin command は renderer (webview) から invoke 経由で呼ばれるため、capability 上 webview を対象とせざるを得ず、現状 webview は \"main\" 1 つだけなので windows も [\"main\"] になる。それでも base capability から分離して名前付きの専用ファイルにしておくことで、(1) updater 以外の権限と混ざらず付与意図が一目で分かる、(2) 将来 webview を追加したとき updater.json をその webview に付与しないだけで自動更新権限の影響半径を絞れる、という defense-in-depth を確保する。process:default は updater インストール後の relaunch でのみ必要。",
+  "windows": ["main"],
+  "permissions": ["process:default", "updater:default"]
+}

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -50,6 +50,11 @@ pub fn app_get_project_root(state: State<AppState>) -> String {
 /// 入口で必ず通す。検証失敗時は `CommandError::Validation` で reject し、project_root state は
 /// 変更しない (= 後続の git_*, fs_watch::start_for_root, file 読み書きが信頼できない場所で
 /// 発火するのを TOCTOU 含めて阻止する)。
+///
+/// Issue #724 (Security): tauri.conf.json の assetProtocol.scope を空にした (= 起動時は OS 全体の
+/// 画像/SVG が `asset://` で読めない)。代わりに、画像プレビュー (Issue #325 — ImagePreview /
+/// EditorView) が表示対象とする project_root 配下だけを `asset_scope::allow_asset_dir` で
+/// 動的に許可リストへ加える。`is_safe_watch_root` を通過した正当な project_root のみが対象。
 #[tauri::command]
 pub fn app_set_project_root(
     app: tauri::AppHandle,
@@ -75,6 +80,10 @@ pub fn app_set_project_root(
     drop(guard);
     // Issue #66: watcher は project_root 変更ごとに付け替える
     if !trimmed.is_empty() {
+        // Issue #724: 画像プレビュー (ImagePreview / EditorView) が `asset://` で開くのは
+        // project_root 配下の画像のみ。assetProtocol.scope は空なので、ここで開いた
+        // project_root だけを recursive で許可リストに加える。
+        crate::commands::asset_scope::allow_asset_dir(&app, std::path::Path::new(&trimmed));
         crate::commands::fs_watch::start_for_root(app, trimmed);
     }
     Ok(())

--- a/src-tauri/src/commands/asset_scope.rs
+++ b/src-tauri/src/commands/asset_scope.rs
@@ -22,9 +22,50 @@
 //
 // I/O / ロックの失敗はすべて best-effort で warn ログのみに留める。asset scope への
 // 追加に失敗しても画像が表示されないだけで、起動やファイル操作自体は壊さない。
+//
+// PR #775 (auto-review): mascot custom path は renderer 由来 (settings.json の
+// `statusMascotCustomPath`) なので、renderer XSS が `/etc/passwd` のような任意パスを
+// 注入して asset scope に追加させるバイパスを防ぐため、`is_allowed_mascot_path` で
+// 「画像拡張子ホワイトリスト」+「parent ディレクトリの is_safe_watch_root 検証」を
+// 通したものだけを `allow_asset_file` へ渡す。
 
 use std::path::Path;
 use tauri::{AppHandle, Manager};
+
+/// mascot custom 画像として `asset://` 許可してよい拡張子のホワイトリスト。
+/// 旧 `tauri.conf.json` の `assetProtocol.scope` が列挙していた画像形式と同一 (Issue #724)。
+const ALLOWED_MASCOT_EXTENSIONS: &[&str] = &[
+    "png", "jpg", "jpeg", "gif", "webp", "avif", "bmp", "ico", "svg", "apng",
+];
+
+/// PR #775 (auto-review): renderer 由来の mascot custom path を `asset://` 許可リストへ
+/// 加えてよいかを判定する。次の 2 条件を **両方** 満たすときのみ `true`:
+///   1. 拡張子が画像ホワイトリスト (`ALLOWED_MASCOT_EXTENSIONS`) に含まれる
+///      (case-insensitive)。`/etc/passwd` のような非画像ファイルを弾く。
+///   2. その**親ディレクトリ**が `is_safe_watch_root` を通る (canonicalize 可能で
+///      system 領域 / home 直下 / ルートドライブでない実ディレクトリ)。
+///      `app_set_project_root` が project_root に課しているのと同じ judgement を
+///      mascot の置き場所にも適用し、影響半径を「ユーザーが普通に画像を置く場所」に絞る。
+///
+/// `path` が拡張子を持たない / 親を取れない場合は `false`。
+pub fn is_allowed_mascot_path(path: &Path) -> bool {
+    let ext_ok = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| ALLOWED_MASCOT_EXTENSIONS.contains(&e.to_ascii_lowercase().as_str()))
+        .unwrap_or(false);
+    if !ext_ok {
+        return false;
+    }
+    // 親ディレクトリを is_safe_watch_root で検証する。親が取れない (= ルート直下や
+    // 相対パスの先頭要素) ケースは安全側に倒して reject する。
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => {
+            crate::commands::fs_watch::is_safe_watch_root(parent)
+        }
+        _ => false,
+    }
+}
 
 /// `dir` 配下 (サブディレクトリ含む) を `asset://` で読めるように許可リストへ加える。
 ///

--- a/src-tauri/src/commands/asset_scope.rs
+++ b/src-tauri/src/commands/asset_scope.rs
@@ -1,0 +1,77 @@
+// Issue #724 (Security): `asset://` protocol scope の動的許可。
+//
+// 背景:
+//   tauri.conf.json の `app.security.assetProtocol.scope` は以前 `**/*.png` などの拡張子
+//   ワイルドカードだけで、ディレクトリ制約が無かった。これは `asset://localhost/<任意パス>`
+//   で OS 上のあらゆる画像 / SVG が renderer から読める設定で、renderer XSS が 1 件でも
+//   成立すると `~/Documents/private.png` 等が漏れる過大権限だった (監査 F-HIGH-3)。
+//
+//   修正として `assetProtocol.scope` を空配列にし (= 起動直後は asset protocol 経由で
+//   何も読めない)、renderer が実際に画像を表示する必要のあるパスだけを、このモジュールの
+//   ヘルパーで `asset_protocol_scope().allow_directory` / `allow_file` を使って実行時に
+//   許可リストへ加える方針に切り替えた。
+//
+// 許可対象は 2 経路のみ:
+//   1. project_root 配下 — 画像プレビュー (Issue #325: ImagePreview / EditorView) が
+//      ファイルツリーから開いた画像。`app_set_project_root` から `allow_asset_dir` で
+//      project_root を recursive 許可する。project_root 自体は `is_safe_watch_root`
+//      (system / home 直下 reject) を通った正当なディレクトリだけ。
+//   2. mascot custom 画像 (PR #716) — ユーザーがファイルダイアログで選んだ単一画像。
+//      `allow_asset_file` で「そのファイル 1 個だけ」を許可する (ディレクトリごとは
+//      許可しないので、同じフォルダの他の画像は漏れない)。
+//
+// I/O / ロックの失敗はすべて best-effort で warn ログのみに留める。asset scope への
+// 追加に失敗しても画像が表示されないだけで、起動やファイル操作自体は壊さない。
+
+use std::path::Path;
+use tauri::{AppHandle, Manager};
+
+/// `dir` 配下 (サブディレクトリ含む) を `asset://` で読めるように許可リストへ加える。
+///
+/// 画像プレビュー (Issue #325) 用。`app_set_project_root` から project_root を渡して呼ぶ。
+/// `dir` が空 / 非ディレクトリのときは何もしない。失敗は warn ログのみ。
+pub fn allow_asset_dir(app: &AppHandle, dir: &Path) {
+    if dir.as_os_str().is_empty() {
+        return;
+    }
+    if !dir.is_dir() {
+        tracing::debug!(
+            "[asset-scope] skip allow_directory — not a directory: {}",
+            dir.display()
+        );
+        return;
+    }
+    let scope = app.asset_protocol_scope();
+    match scope.allow_directory(dir, true) {
+        Ok(()) => tracing::info!("[asset-scope] allowed directory: {}", dir.display()),
+        Err(e) => tracing::warn!(
+            "[asset-scope] failed to allow directory {}: {e:#}",
+            dir.display()
+        ),
+    }
+}
+
+/// `file` 1 個だけを `asset://` で読めるように許可リストへ加える。
+///
+/// mascot custom 画像 (PR #716) 用。ユーザーがファイルダイアログで選んだ画像のみを
+/// ピンポイントで許可し、同じフォルダの他ファイルは許可しない (最小権限)。
+/// `file` が空 / 非ファイルのときは何もしない。失敗は warn ログのみ。
+pub fn allow_asset_file(app: &AppHandle, file: &Path) {
+    if file.as_os_str().is_empty() {
+        return;
+    }
+    if !file.is_file() {
+        tracing::debug!(
+            "[asset-scope] skip allow_file — not a file: {}",
+            file.display()
+        );
+        return;
+    }
+    let scope = app.asset_protocol_scope();
+    match scope.allow_file(file) {
+        Ok(()) => tracing::info!("[asset-scope] allowed file: {}", file.display()),
+        Err(e) => {
+            tracing::warn!("[asset-scope] failed to allow file {}: {e:#}", file.display())
+        }
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,8 @@
 // camelCase JSON 互換のため、各 command struct/enum には #[serde(rename_all = "camelCase")] を付与する。
 
 pub mod app;
+// Issue #724 (Security): `asset://` protocol scope の動的許可ヘルパー。
+pub mod asset_scope;
 pub mod atomic_write;
 pub mod authz;
 pub mod dialog;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -352,13 +352,26 @@ pub async fn settings_save(app: tauri::AppHandle, settings: Settings) -> Command
     // Issue #724: mascot custom 画像 (PR #716) をユーザーが設定画面で選び直したとき、
     // assetProtocol.scope は空なので、再起動を待たず同一セッション内でその 1 ファイルを
     // `asset://` で表示できるよう asset scope へ許可する。失敗しても save 自体は成功扱い。
+    //
+    // PR #775 (auto-review): `statusMascotCustomPath` は renderer 由来。XSS が
+    // `/etc/passwd` 等の任意パスを注入して asset scope に追加させるバイパスを防ぐため、
+    // `is_allowed_mascot_path` (画像拡張子ホワイトリスト + parent ディレクトリの
+    // is_safe_watch_root 検証) を通したものだけを許可する。
     if let Some(mascot_path) = settings
         .status_mascot_custom_path
         .as_deref()
         .map(str::trim)
         .filter(|s| !s.is_empty())
     {
-        crate::commands::asset_scope::allow_asset_file(&app, std::path::Path::new(mascot_path));
+        let p = std::path::Path::new(mascot_path);
+        if crate::commands::asset_scope::is_allowed_mascot_path(p) {
+            crate::commands::asset_scope::allow_asset_file(&app, p);
+        } else {
+            tracing::warn!(
+                "[settings_save] rejected mascot path for asset scope (bad extension or unsafe directory): {}",
+                p.display()
+            );
+        }
     }
     Ok(())
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -336,7 +336,7 @@ async fn read_disk_schema_version(path: &std::path::Path) -> Option<u32> {
 }
 
 #[tauri::command]
-pub async fn settings_save(settings: Settings) -> CommandResult<()> {
+pub async fn settings_save(app: tauri::AppHandle, settings: Settings) -> CommandResult<()> {
     let _g = SAVE_LOCK.lock().await;
     let path = crate::util::config_paths::settings_path();
     // Issue #641: 古い build が新スキーマの settings.json を silent に上書きするのを防ぐ。
@@ -349,6 +349,17 @@ pub async fn settings_save(settings: Settings) -> CommandResult<()> {
     atomic_write(&path, &json)
         .await
         .map_err(|e| CommandError::Internal(e.to_string()))?;
+    // Issue #724: mascot custom 画像 (PR #716) をユーザーが設定画面で選び直したとき、
+    // assetProtocol.scope は空なので、再起動を待たず同一セッション内でその 1 ファイルを
+    // `asset://` で表示できるよう asset scope へ許可する。失敗しても save 自体は成功扱い。
+    if let Some(mascot_path) = settings
+        .status_mascot_custom_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        crate::commands::asset_scope::allow_asset_file(&app, std::path::Path::new(mascot_path));
+    }
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -382,24 +382,44 @@ pub fn run() {
                     // Issue #724: assetProtocol.scope は空。renderer が `app_set_project_root` を
                     // 呼ぶ前 (起動直後のセッション復元等) でも画像プレビューが project_root 配下の
                     // 画像を `asset://` で開けるよう、復元した root を asset scope に許可しておく。
-                    commands::asset_scope::allow_asset_dir(
-                        &app_handle_for_root,
-                        std::path::Path::new(&root),
-                    );
+                    //
+                    // PR #775 (auto-review): `lastOpenedRoot` は settings.json 由来なので、
+                    // 改ざんされた settings.json に `lastOpenedRoot: "/"` を書かれて再起動
+                    // すると OS 全体が recursive 許可されてしまう。`app_set_project_root` が
+                    // 必須にしているのと同じ `is_safe_watch_root` ガードをここでも通し、
+                    // system 領域 / home 直下 / ルートドライブは reject する。
+                    let root_path = std::path::Path::new(&root);
+                    if commands::fs_watch::is_safe_watch_root(root_path) {
+                        commands::asset_scope::allow_asset_dir(&app_handle_for_root, root_path);
+                    } else {
+                        tracing::warn!(
+                            "[setup] refusing to allow asset scope for unsafe restored root: {root}"
+                        );
+                    }
                 }
                 // Issue #724: mascot custom 画像 (PR #716) はファイルダイアログで選ばれた
                 // 単一画像。assetProtocol.scope は空なので、起動時に settings から復元した
                 // custom path 1 ファイルだけを asset scope に許可する (フォルダごとではない)。
+                //
+                // PR #775 (auto-review): `statusMascotCustomPath` も settings.json 由来。
+                // `is_allowed_mascot_path` (画像拡張子ホワイトリスト + parent ディレクトリの
+                // is_safe_watch_root 検証) を通したものだけを許可し、改ざんされた settings.json
+                // 経由で任意ファイルが asset scope に乗るのを防ぐ。
                 if let Some(mascot_path) = settings
                     .status_mascot_custom_path
                     .as_deref()
                     .map(str::trim)
                     .filter(|s| !s.is_empty())
                 {
-                    commands::asset_scope::allow_asset_file(
-                        &app_handle_for_root,
-                        std::path::Path::new(mascot_path),
-                    );
+                    let mascot = std::path::Path::new(mascot_path);
+                    if commands::asset_scope::is_allowed_mascot_path(mascot) {
+                        commands::asset_scope::allow_asset_file(&app_handle_for_root, mascot);
+                    } else {
+                        tracing::warn!(
+                            "[setup] rejected restored mascot path for asset scope (bad extension or unsafe directory): {}",
+                            mascot.display()
+                        );
+                    }
                 }
                 // Issue #260: theme が glass なら初期 effect を適用。
                 // - tauri.conf.json で `transparent: true` + `backgroundColor: "#171716"` に

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -377,7 +377,29 @@ pub fn run() {
                     // Issue #147: poison でも recovery
                     let mut guard = state::lock_project_root_recover(&state.project_root);
                     *guard = Some(root.clone());
+                    drop(guard);
                     tracing::info!("[setup] project_root restored from settings: {root}");
+                    // Issue #724: assetProtocol.scope は空。renderer が `app_set_project_root` を
+                    // 呼ぶ前 (起動直後のセッション復元等) でも画像プレビューが project_root 配下の
+                    // 画像を `asset://` で開けるよう、復元した root を asset scope に許可しておく。
+                    commands::asset_scope::allow_asset_dir(
+                        &app_handle_for_root,
+                        std::path::Path::new(&root),
+                    );
+                }
+                // Issue #724: mascot custom 画像 (PR #716) はファイルダイアログで選ばれた
+                // 単一画像。assetProtocol.scope は空なので、起動時に settings から復元した
+                // custom path 1 ファイルだけを asset scope に許可する (フォルダごとではない)。
+                if let Some(mascot_path) = settings
+                    .status_mascot_custom_path
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                {
+                    commands::asset_scope::allow_asset_file(
+                        &app_handle_for_root,
+                        std::path::Path::new(mascot_path),
+                    );
                 }
                 // Issue #260: theme が glass なら初期 effect を適用。
                 // - tauri.conf.json で `transparent: true` + `backgroundColor: "#171716"` に

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,22 +25,11 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'wasm-unsafe-eval' blob:; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://github.com https://api.github.com; worker-src 'self' blob:; frame-src 'none'; object-src 'none'",
-      "devCsp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'wasm-unsafe-eval' blob:; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://localhost:5173 http://localhost:5173 https://github.com https://api.github.com; worker-src 'self' blob:; frame-src 'none'; object-src 'none'",
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://github.com https://api.github.com; worker-src 'self' blob:; frame-src 'none'; object-src 'none'",
+      "devCsp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://localhost:5173 http://localhost:5173 https://github.com https://api.github.com; worker-src 'self' blob:; frame-src 'none'; object-src 'none'",
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "**/*.png",
-          "**/*.jpg",
-          "**/*.jpeg",
-          "**/*.gif",
-          "**/*.webp",
-          "**/*.avif",
-          "**/*.bmp",
-          "**/*.ico",
-          "**/*.svg",
-          "**/*.apng"
-        ]
+        "scope": []
       }
     },
     "trayIcon": {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -8,11 +8,21 @@
       ここではより厳しい (= 許可範囲が狭い) 値を置く。
         - connect-src は dev (Vite HMR) 用に localhost:5173 のみ許可。任意の ws:/http://localhost:*
           を許す旧設定は内部スキャナ等の任意エンドポイントに繋ぎに行けるので外す。
-        - script-src 'self' のみ。inline スクリプトは禁止。
+        - script-src 'self' のみ。inline スクリプトも blob: script も禁止。
+      Issue #744: ビルド成果物 (vendor-monaco / index / editor.worker) を走査した結果
+      WebAssembly の参照は 0 件、かつ blob: を <script> としてロードする箇所も無いため、
+      script-src から 'wasm-unsafe-eval' と blob: を除去した (tauri.conf.json 側の csp /
+      devCsp も同様に script-src から両者を除去済み)。
+        - worker-src の blob: のみ維持する。Monaco の Web Worker 起動は実際には
+          `/assets/editor.worker-*.js` という静的パスを new Worker() に渡す経路
+          (monaco-setup.ts の getWorker) を使い blob: を生成しないが、Monaco 内部には
+          esmModuleLocation 経由で blob: worker を起動するフォールバック実装が同梱されて
+          いる。現構成では到達しない dead path だが、Monaco バージョンアップで worker
+          ロード方式が変わったときの regression を避けるため保守的に残す。
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost http://tauri.localhost https://tauri.localhost ws://localhost:5173 http://localhost:5173 https://github.com https://api.github.com; worker-src 'self' blob:; frame-src 'none'; object-src 'none'"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost http://tauri.localhost https://tauri.localhost ws://localhost:5173 http://localhost:5173 https://github.com https://api.github.com; worker-src 'self' blob:; frame-src 'none'; object-src 'none'"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/vibe-editor.png" />


### PR DESCRIPTION
## Summary
Tauri セキュリティ監査指摘 2 件。

### #724 — assetProtocol.scope の過大権限
`assetProtocol.scope` が `**/*.png` 等の拡張子ワイルドカードのみで OS 全体の画像/SVG が `asset://` で読めた。scope を空 `[]` にし、renderer が実際に画像を表示する経路 (画像プレビュー = project_root 配下 / mascot custom 画像 = 選択ファイル1個) だけを実行時に `allow_directory` / `allow_file` で動的許可する方式へ変更。固定 path variable では画像プレビュー (任意プロジェクト) と mascot (任意ファイル) が壊れるため、issue 本文の `allow_directory` 案に沿って動的方式を採用。新設 `commands/asset_scope.rs` + 起動時/プロジェクト切替/mascot 変更の各点でフック。

### #744 — capability の集約
`process:default` / `updater:default` を `capabilities/default.json` から `capabilities/updater.json` に分離。CSP はビルド成果物に WebAssembly 参照 0 件を確認し `'wasm-unsafe-eval'` を除去、`script-src` から `blob:` も除去 (`worker-src blob:` のみ Monaco フォールバック用に保守的に維持し理由をコメント記録)。

Closes #724
Closes #744

## Test plan
- [x] `npm run typecheck` 通過
- [x] `cargo check` 通過 (新規 warning なし)
- [x] tauri.conf.json / capabilities/*.json の JSON 構文検証
- [ ] 画像プレビュー・mascot custom 画像・自動更新・window 制御が引き続き動作することを実機確認