### PR TITLE
security(team_hub): #742 handshake token を TTL/single-use 化し agent_id binding を強制

### DIFF
--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -584,6 +584,22 @@ mod disconnect_release_tests {
         hub
     }
 
+    /// Issue #742: handshake は Hub が事前発行した recruit grant を要求するようになったため、
+    /// `handle_client` を直接駆動するテストでは事前に pending grant を仕込む。
+    /// `team_recruit` 経路で `try_register_pending_recruit` が登録するのと同じ最小エントリ。
+    async fn seed_pending_grant(hub: &TeamHub, agent_id: &str, team_id: &str, role: &str) {
+        hub.try_register_pending_recruit(
+            agent_id.to_string(),
+            team_id.to_string(),
+            role.to_string(),
+            "leader-seed".to_string(),
+            false,
+            &[],
+        )
+        .await
+        .expect("seed pending recruit should succeed");
+    }
+
     /// agent 用の lock を直接 map に push しておく。
     async fn pre_acquire_lock(hub: &TeamHub, team_id: &str, agent_id: &str, role: &str, path: &str) {
         let mut s = hub.state.lock().await;
@@ -615,6 +631,8 @@ mod disconnect_release_tests {
         let role = "programmer";
         let token = "deadbeef-test-token";
         let hub = setup_hub_for_test(team_id, token).await;
+        // Issue #742: handshake が pending grant を要求するので、recruit 済みを模擬する。
+        seed_pending_grant(&hub, agent_id, team_id, role).await;
         pre_acquire_lock(&hub, team_id, agent_id, role, "src/foo.rs").await;
         assert_eq!(count_team_locks(&hub, team_id).await, 1);
 
@@ -669,6 +687,8 @@ mod disconnect_release_tests {
         let hub = setup_hub_for_test(team_id, token).await;
 
         // 1 回目: lock を取って disconnect。
+        // Issue #742: handshake が pending grant を要求するので recruit 済みを模擬する。
+        seed_pending_grant(&hub, agent_id, team_id, role).await;
         pre_acquire_lock(&hub, team_id, agent_id, role, "src/bar.rs").await;
         let (s1, mut c1) = tokio::io::duplex(8 * 1024);
         let hello = json!({
@@ -709,5 +729,228 @@ mod disconnect_release_tests {
         );
         assert!(!result.has_conflicts());
         assert_eq!(result.locked, vec!["src/bar.rs".to_string()]);
+    }
+}
+
+#[cfg(test)]
+mod handshake_auth_tests {
+    //! Issue #742 (Security): handshake を「Hub が事前発行した recruit grant の照合」に
+    //! 格上げしたことの regression test。
+    //!
+    //! 検証する 3 点:
+    //!   1. **期限切れ token (TTL)**: `issued_at` が TTL を超過した pending grant は reject され、
+    //!      stale な pending entry も掃除される。binding は作られない。
+    //!   2. **未知 agent_id (agent_id binding)**: 正しい global token を持っていても、Hub が
+    //!      発行していない agent_id (pending grant も binding も無い) の handshake は reject される。
+    //!      旧実装はここで binding を新規作成して接続を通していた = 本 issue の主穴。
+    //!   3. **single-use + 正常系維持**: 正しい grant の初回 handshake は成功して grant を消費し、
+    //!      binding を確立する。以後の再接続 (bridge の onClose→connect) は binding 経路で
+    //!      通る (= single-use 化が正常な再接続を壊さない)。
+    use super::*;
+    use crate::pty::SessionRegistry;
+    use serde_json::json;
+    use std::sync::Arc;
+    use std::time::Duration as StdDuration;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::time::{timeout, Duration};
+
+    const TOKEN: &str = "deadbeef-742-token";
+
+    async fn setup_hub(team_id: &str) -> TeamHub {
+        let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+        let mut s = hub.state.lock().await;
+        s.active_teams.insert(team_id.to_string());
+        s.token = TOKEN.to_string();
+        drop(s);
+        hub
+    }
+
+    async fn seed_grant(hub: &TeamHub, agent_id: &str, team_id: &str, role: &str) {
+        hub.try_register_pending_recruit(
+            agent_id.to_string(),
+            team_id.to_string(),
+            role.to_string(),
+            "leader-seed".to_string(),
+            false,
+            &[],
+        )
+        .await
+        .expect("seed pending recruit should succeed");
+    }
+
+    async fn has_binding(hub: &TeamHub, team_id: &str, agent_id: &str) -> bool {
+        hub.state
+            .lock()
+            .await
+            .agent_role_bindings
+            .contains_key(&(team_id.to_string(), agent_id.to_string()))
+    }
+
+    async fn has_pending(hub: &TeamHub, agent_id: &str) -> bool {
+        hub.state
+            .lock()
+            .await
+            .pending_recruits
+            .contains_key(agent_id)
+    }
+
+    fn hello_line(agent_id: &str, team_id: &str, role: &str) -> Vec<u8> {
+        let mut v = serde_json::to_vec(&json!({
+            "token": TOKEN,
+            "teamId": team_id,
+            "role": role,
+            "agentId": agent_id,
+        }))
+        .unwrap();
+        v.push(b'\n');
+        v
+    }
+
+    /// `handle_client` を duplex socket 上で駆動し、handshake 後に `initialize` を 1 本投げて
+    /// 「応答が返るか (= handshake 通過)」「EOF で切られるか (= reject)」を判定する。
+    /// `Some(_)` = handshake 成功して RPC 応答あり、`None` = handshake reject で接続切断。
+    async fn run_handshake_probe(hub: &TeamHub, hello: &[u8]) -> Option<serde_json::Value> {
+        let (server_side, client_side) = tokio::io::duplex(16 * 1024);
+        let hub_clone = hub.clone();
+        let server = tokio::spawn(async move {
+            let _ = handle_client(hub_clone, server_side, TOKEN.to_string()).await;
+        });
+
+        let (rd, mut wr) = tokio::io::split(client_side);
+        let mut reader = BufReader::new(rd);
+        wr.write_all(hello).await.unwrap();
+        wr.flush().await.unwrap();
+        // handshake 通過なら initialize に応答が返る。reject されていれば read_line が 0 を返す。
+        wr.write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}\n")
+            .await
+            .unwrap();
+        wr.flush().await.unwrap();
+
+        let mut line = String::new();
+        let read_res = timeout(Duration::from_secs(5), reader.read_line(&mut line)).await;
+        let outcome = match read_res {
+            Ok(Ok(0)) | Ok(Err(_)) | Err(_) => None,
+            Ok(Ok(_)) => serde_json::from_str::<serde_json::Value>(line.trim()).ok(),
+        };
+
+        // client を畳んで server task を終わらせる。
+        drop(wr);
+        drop(reader);
+        let _ = timeout(Duration::from_secs(5), server).await;
+        outcome
+    }
+
+    /// (1) TTL: `issued_at` が TTL を超過した grant は期限切れ token として reject され、
+    /// stale な pending entry が掃除され、binding も作られない。
+    #[tokio::test]
+    async fn expired_recruit_grant_is_rejected_and_pending_is_cleaned() {
+        let team_id = "team-742-ttl";
+        let agent_id = "vc-worker-742-ttl";
+        let role = "programmer";
+        let hub = setup_hub(team_id).await;
+        seed_grant(&hub, agent_id, team_id, role).await;
+
+        // grant 発行から少し経過させ、TTL を 1ms に絞って確実に期限切れにする。
+        tokio::time::sleep(StdDuration::from_millis(8)).await;
+        let accepted = hub
+            .resolve_pending_recruit_with_ttl(
+                agent_id,
+                team_id,
+                role,
+                StdDuration::from_millis(1),
+            )
+            .await;
+
+        assert!(!accepted, "expired recruit grant must be rejected");
+        assert!(
+            !has_pending(&hub, agent_id).await,
+            "stale (expired) pending grant must be removed on rejection"
+        );
+        assert!(
+            !has_binding(&hub, team_id, agent_id).await,
+            "no role binding may be established for an expired grant"
+        );
+    }
+
+    /// (1b) 同じ grant でも TTL 内なら通る (TTL 検証が正常系を誤爆しないことの対照)。
+    #[tokio::test]
+    async fn fresh_recruit_grant_within_ttl_is_accepted() {
+        let team_id = "team-742-fresh";
+        let agent_id = "vc-worker-742-fresh";
+        let role = "reviewer";
+        let hub = setup_hub(team_id).await;
+        seed_grant(&hub, agent_id, team_id, role).await;
+
+        let accepted = hub
+            .resolve_pending_recruit_with_ttl(agent_id, team_id, role, StdDuration::from_secs(60))
+            .await;
+
+        assert!(accepted, "a fresh grant within TTL must be accepted");
+        assert!(
+            has_binding(&hub, team_id, agent_id).await,
+            "a successful first handshake must establish the role binding"
+        );
+        assert!(
+            !has_pending(&hub, agent_id).await,
+            "single-use: the pending grant must be consumed on success"
+        );
+    }
+
+    /// (2) 未知 agent_id: 正しい global token を持っていても、Hub が事前発行していない
+    /// agent_id の handshake は reject され、binding も作られない (= 主穴の塞ぎ込み確認)。
+    #[tokio::test]
+    async fn handshake_with_unknown_agent_id_is_rejected() {
+        let team_id = "team-742-unknown";
+        let hub = setup_hub(team_id).await;
+        // grant を仕込まずに、正しい token + 登録済み team で偽 agent_id を名乗る。
+        let bogus_agent = "vc-attacker-not-issued";
+        let resp = run_handshake_probe(
+            &hub,
+            &hello_line(bogus_agent, team_id, "programmer"),
+        )
+        .await;
+
+        assert!(
+            resp.is_none(),
+            "handshake with an agent_id the Hub never issued must be rejected (connection closed)"
+        );
+        assert!(
+            !has_binding(&hub, team_id, bogus_agent).await,
+            "rejected unknown agent_id must NOT create a role binding"
+        );
+    }
+
+    /// (3) 正常系 + single-use: 正しい grant の初回 handshake は通り (initialize に応答が返る)、
+    /// grant は消費され binding が確立される。続けて同 agent_id が grant 無しで再接続しても、
+    /// binding 経路で通る (single-use 化が bridge の再接続を壊さないことの担保)。
+    #[tokio::test]
+    async fn valid_grant_handshake_succeeds_then_reconnect_via_binding_works() {
+        let team_id = "team-742-ok";
+        let agent_id = "vc-worker-742-ok";
+        let role = "programmer";
+        let hub = setup_hub(team_id).await;
+        seed_grant(&hub, agent_id, team_id, role).await;
+
+        // 初回 handshake: grant 経由で成功する。
+        let first = run_handshake_probe(&hub, &hello_line(agent_id, team_id, role)).await;
+        assert!(
+            first.is_some(),
+            "first handshake with a valid recruit grant must succeed"
+        );
+        assert!(
+            !has_pending(&hub, agent_id).await,
+            "single-use: grant must be consumed after the first successful handshake"
+        );
+        assert!(
+            has_binding(&hub, team_id, agent_id).await,
+            "first handshake must establish the role binding"
+        );
+
+        // 再接続: grant は既に消費済み。binding 経路で通らなければならない。
+        let second = run_handshake_probe(&hub, &hello_line(agent_id, team_id, role)).await;
+        assert!(
+            second.is_some(),
+            "reconnect of an already-bound agent must still succeed via the binding path"
+        );
     }
 }

--- a/src-tauri/src/team_hub/state.rs
+++ b/src-tauri/src/team_hub/state.rs
@@ -135,6 +135,19 @@ static SERVER_LOG_PATH: OnceCell<PathBuf> = OnceCell::new();
 const RECRUIT_GRACE_DEFAULT_MS: u64 = 2_000;
 const RECRUIT_GRACE_MAX_MS: u64 = 10_000;
 
+/// Issue #742 (Security): recruit grant (= 事前発行された pending recruit) の有効期限。
+/// `try_register_pending_recruit` で agent_id を登録した瞬間から計時し、handshake が
+/// この時間内に来なければ「期限切れ token」として reject する。短い TTL により、
+/// `VIBE_TEAM_TOKEN` を盗んだ別プロセスが「子プロセスが起動に失敗して未 handshake のまま
+/// 放置された grant」を後から悪用できる窓を最小化する。
+/// recruit フロー自体の `RECRUIT_TIMEOUT` (30s) より長めの 60s を既定にして、
+/// recruit-timeout 側 cleanup の belt に対する suspenders として機能させる。
+/// `VIBE_TEAM_HANDSHAKE_TTL_MS` で上書き可能 (parse 失敗 / 範囲外 / 未設定は既定値)。
+const HANDSHAKE_GRANT_TTL_DEFAULT_MS: u64 = 60_000;
+/// TTL の許容上限。これより大きい env 値は無効として既定値に丸める
+/// (TTL を実質無効化するような巨大値の誤設定 / 改ざんを防ぐ)。
+const HANDSHAKE_GRANT_TTL_MAX_MS: u64 = 300_000;
+
 #[cfg(test)]
 static RECRUIT_RESCUED_EVENTS_FOR_TEST: once_cell::sync::Lazy<
     std::sync::Mutex<Vec<RecruitRescuedPayload>>,
@@ -307,6 +320,11 @@ pub struct PendingRecruit {
     pub ack_done: AtomicBool,
     /// Issue #577: ack timeout 済みだが grace window 中で、遅着 ack を rescue できる状態。
     pub timed_out_at: Option<Instant>,
+    /// Issue #742 (Security): この recruit grant を発行した時刻。
+    /// `resolve_pending_recruit` の handshake で `issued_at.elapsed()` が
+    /// `HANDSHAKE_GRANT_TTL` を超えていたら「期限切れ token」として reject する
+    /// (未使用 token を短時間で無効化 = 盗まれた token の有効窓を絞る)。
+    pub issued_at: Instant,
 }
 
 /// Issue #577: timeout 後 grace 期間中に遅着 ack を救済したことを renderer に知らせる event payload。
@@ -873,6 +891,8 @@ impl TeamHub {
                 ack_tx: Some(ack_tx),
                 ack_done: AtomicBool::new(false),
                 timed_out_at: None,
+                // Issue #742: grant 発行時刻。handshake TTL 検証の起点。
+                issued_at: Instant::now(),
             },
         );
         Ok(PendingRecruitChannels {
@@ -896,14 +916,56 @@ impl TeamHub {
     /// Issue #637: `agent_role_bindings` の key を `(team_id, agent_id)` tuple に拡張。
     /// 同 agent_id が別 team で handshake してきても old team の binding を上書きしない
     /// (cross-team race の遮断)。lookup / insert は team_id ペアで行う。
+    ///
+    /// Issue #742 (Security): handshake を「Hub が事前発行した recruit grant の照合」に格上げする。
+    /// 1. **TTL**: pending grant が `HANDSHAKE_GRANT_TTL` を超過していたら期限切れ token として
+    ///    reject し、stale な pending entry をその場で除去する (未使用 token の有効窓を最小化)。
+    /// 2. **single-use**: pending entry は初回 handshake 成功で `remove` される (旧来挙動)。
+    ///    同 grant での 2 回目以降はこの remove 済み状態のため pending 経路には乗らない。
+    /// 3. **agent_id binding**: pending grant も既存 binding も無い「未知 agent_id」は reject する。
+    ///    旧実装は未知 agent_id でも binding を新規作成して `true` を返していたため、正しい
+    ///    global token さえあれば任意の偽 agent_id で接続できた。Hub が `try_register_pending_recruit`
+    ///    で事前発行した agent_id (= pending) か、過去に handshake 済みの agent_id (= binding) の
+    ///    いずれかでなければ通さない。
     pub async fn resolve_pending_recruit(
         &self,
         agent_id: &str,
         team_id: &str,
         role_profile_id: &str,
     ) -> bool {
+        self.resolve_pending_recruit_with_ttl(
+            agent_id,
+            team_id,
+            role_profile_id,
+            handshake_grant_ttl_from_env(),
+        )
+        .await
+    }
+
+    /// Issue #742: TTL を引数で受ける本体。test から短い TTL を注入して期限切れ経路を
+    /// 検証できるようにするため `resolve_pending_recruit` から分離した。
+    pub(crate) async fn resolve_pending_recruit_with_ttl(
+        &self,
+        agent_id: &str,
+        team_id: &str,
+        role_profile_id: &str,
+        grant_ttl: Duration,
+    ) -> bool {
         let mut s = self.state.lock().await;
+        // Issue #742: pending grant が存在するなら TTL / team_id / role を順に検証する。
+        let mut consumed_pending = false;
         if let Some(p) = s.pending_recruits.get(agent_id) {
+            // TTL 超過 = 期限切れ token。stale entry を除去してから reject する
+            // (recruit 側 cancel 経路が拾えなかった残骸を handshake 側でも掃除)。
+            if p.issued_at.elapsed() > grant_ttl {
+                tracing::warn!(
+                    "[teamhub] handshake rejected: recruit grant expired \
+                     (agent={agent_id} team={team_id} age={:?} ttl={grant_ttl:?})",
+                    p.issued_at.elapsed()
+                );
+                s.pending_recruits.remove(agent_id);
+                return false;
+            }
             if p.team_id != team_id {
                 tracing::warn!(
                     "[teamhub] team_id mismatch on handshake (pending) agent={} expected={} got={}",
@@ -922,11 +984,13 @@ impl TeamHub {
                 );
                 return false;
             }
+            // single-use: 成功確定なので grant を消費 (remove) する。
             let p = s.pending_recruits.remove(agent_id).expect("just checked");
             let _ = p.tx.send(RecruitOutcome {
                 agent_id: agent_id.to_string(),
                 role_profile_id: role_profile_id.to_string(),
             });
+            consumed_pending = true;
         }
         // 既に bind 済みの (team_id, agent_id) なら role 一致を強制。
         // Issue #637: team_id 次元で分離しているので、別 team の同 agent_id binding は
@@ -943,10 +1007,19 @@ impl TeamHub {
                 );
                 return false;
             }
-        } else {
-            // 初回 handshake で bind
+        } else if consumed_pending {
+            // 初回 handshake: たった今 grant を消費したので bind を確立する。
+            // 以後の再接続 (bridge の onClose→connect) はこの binding 経路で許可される。
             s.agent_role_bindings
                 .insert(binding_key, role_profile_id.to_string());
+        } else {
+            // Issue #742: pending grant も binding も無い = Hub が発行していない未知 agent_id。
+            // 正しい global token を持っていても、ここで reject して接続を切る。
+            tracing::warn!(
+                "[teamhub] handshake rejected: unknown agent_id (no pending grant, no binding) \
+                 team={team_id} agent={agent_id}"
+            );
+            return false;
         }
         // Issue #342 Phase 3 (3.3): 初回 handshake / 再接続 handshake いずれも last_handshake_at と
         // last_seen_at を更新する。recruit 経路を通らずに直接 handshake してきた場合 (= 旧 context
@@ -1702,6 +1775,18 @@ fn recruit_grace_from_env() -> Duration {
     Duration::from_millis(ms)
 }
 
+/// Issue #742 (Security): recruit grant の TTL。`HANDSHAKE_GRANT_TTL_DEFAULT_MS` 既定。
+/// `VIBE_TEAM_HANDSHAKE_TTL_MS` で上書き可能だが、`1..=HANDSHAKE_GRANT_TTL_MAX_MS` の範囲外
+/// (= 0 で実質即時失効 / 上限超で TTL 無効化) や parse 失敗時は既定値に丸める。
+pub(crate) fn handshake_grant_ttl_from_env() -> Duration {
+    let ms = std::env::var("VIBE_TEAM_HANDSHAKE_TTL_MS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|&n| (1..=HANDSHAKE_GRANT_TTL_MAX_MS).contains(&n))
+        .unwrap_or(HANDSHAKE_GRANT_TTL_DEFAULT_MS);
+    Duration::from_millis(ms)
+}
+
 /// Issue #513: `~/.vibe-editor/role-profiles.json#dynamic[]` から **指定 team_id に紐付く
 /// entry だけ** を抽出して返す内部 helper。`register_team` の前段で呼び、Hub state.lock を
 /// 取らずに async I/O を済ませてから replay する設計。
@@ -1767,18 +1852,36 @@ mod role_binding_team_id_tests {
         TeamHub::new(Arc::new(SessionRegistry::new()))
     }
 
+    /// Issue #742: handshake は「Hub が事前発行した recruit grant」を要求するようになったため、
+    /// 初回 handshake をシミュレートするテストは事前に pending grant を登録する。
+    /// `team_recruit` / `team_create_leader` が裏で行う `try_register_pending_recruit` の最小版。
+    async fn seed_pending(hub: &TeamHub, agent_id: &str, team_id: &str, role: &str) {
+        hub.try_register_pending_recruit(
+            agent_id.to_string(),
+            team_id.to_string(),
+            role.to_string(),
+            "leader-seed".to_string(),
+            false,
+            &[],
+        )
+        .await
+        .expect("seed pending recruit should succeed");
+    }
+
     /// 同じ `agent_id` を 2 つの team でそれぞれ違う role として handshake させても、
     /// 各 team の binding は独立に保持される (= cross-team での role 上書きが起きない)。
     #[tokio::test]
     async fn cross_team_same_agent_id_does_not_overwrite_role_binding() {
         let hub = make_hub();
         // team-a で programmer として handshake
+        seed_pending(&hub, "agent-1", "team-a", "programmer").await;
         assert!(
             hub.resolve_pending_recruit("agent-1", "team-a", "programmer")
                 .await,
             "first handshake on team-a should succeed"
         );
         // team-b で同 agent_id を reviewer として handshake
+        seed_pending(&hub, "agent-1", "team-b", "reviewer").await;
         assert!(
             hub.resolve_pending_recruit("agent-1", "team-b", "reviewer")
                 .await,
@@ -1804,10 +1907,12 @@ mod role_binding_team_id_tests {
     #[tokio::test]
     async fn same_team_role_mismatch_on_rehandshake_is_rejected() {
         let hub = make_hub();
+        seed_pending(&hub, "agent-1", "team-a", "programmer").await;
         assert!(
             hub.resolve_pending_recruit("agent-1", "team-a", "programmer")
                 .await
         );
+        // 2 回目は binding 経由 (Issue #742 の grant は single-use で消費済み) で role 不一致を検出する。
         assert!(
             !hub.resolve_pending_recruit("agent-1", "team-a", "reviewer")
                 .await,
@@ -1820,10 +1925,12 @@ mod role_binding_team_id_tests {
     #[tokio::test]
     async fn remove_agent_role_binding_only_targets_specified_team_scope() {
         let hub = make_hub();
+        seed_pending(&hub, "agent-1", "team-a", "programmer").await;
         assert!(
             hub.resolve_pending_recruit("agent-1", "team-a", "programmer")
                 .await
         );
+        seed_pending(&hub, "agent-1", "team-b", "reviewer").await;
         assert!(
             hub.resolve_pending_recruit("agent-1", "team-b", "reviewer")
                 .await


### PR DESCRIPTION
## Summary
TeamHub のローカル IPC token 認証を強化 (security 監査指摘)。

- **TTL**: recruit grant に発行時刻を持たせ、handshake 時に `HANDSHAKE_GRANT_TTL` (既定 60s、`VIBE_TEAM_HANDSHAKE_TTL_MS` で 1〜300000ms に調整可) 超過なら期限切れとして reject + stale pending entry を掃除
- **single-use**: pending grant は初回 handshake 成功で消費・除去。2 回目以降は pending 経路に乗らない
- **agent_id binding**: 未知 agent_id を reject。旧実装は正しい global token さえあれば任意の偽 agent_id で接続でき binding を新規作成していた (主穴) → Hub が発行した pending grant の agent_id か handshake 済み binding のみ通す
- 正常系 (bind 済み agent の再接続) は維持。IPC / renderer / shared.ts は変更なし、`team_hub/` 内で完結

Closes #742

## Test plan
- [x] `cargo check` 通過
- [x] `cargo test --lib team_hub` — 新規 handshake_auth_tests 4件含め pass (既存無関係の status テスト失敗 1件は pre-existing で main でも fail)
- [ ] Codex/Claude リーダーからの recruit → handshake が引き続き成功することを実機確認