### PR TITLE
refactor(canvas): #732 CardData discriminated union 化 + #735 CardFrame 分割

### DIFF
--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -34,7 +34,14 @@ import HandoffEdge from './HandoffEdge';
 import { QuickNav } from './QuickNav';
 import { LeaderGlow } from './LeaderGlow';
 import { StageHud } from './StageHud';
-import { useCanvasStore, NODE_W, NODE_H, type CardData } from '../../stores/canvas';
+import {
+  useCanvasStore,
+  NODE_W,
+  NODE_H,
+  cardTeamId,
+  agentPayloadOf,
+  type CardData
+} from '../../stores/canvas';
 import {
   useCanvasNodes,
   useCanvasEdges,
@@ -49,7 +56,6 @@ import { useConfirmRemoveCard } from '../../lib/use-confirm-remove-card';
 import { useRoleProfiles } from '../../lib/role-profiles-context';
 import { useSettings } from '../../lib/settings-context';
 import { resolveAgentVisual, type AgentVisualPayload } from '../../lib/agent-visual';
-import type { TeamOrganizationMeta } from '../../../../types/shared';
 
 const nodeTypes = {
   terminal: TerminalCard,
@@ -150,10 +156,9 @@ function FlowApp({ actions }: FlowAppProps): JSX.Element {
       //   - pendingPosIds / pendingDimIds: remaining 内に既存の position/dimensions 変更がある id の Set
       //     (旧 remaining.some 二重ループを Set.has の O(1) に置換)
       //   - lockedTeams: teamId → boolean のキャッシュ (isTeamLocked の重複呼び出しを削減)
-      // payload は CardData 内で複数のサブ型を持つため { teamId?: string } で局所キャストする。
-      // 同じキャストが index 構築 + position/dimensions 分岐で計 3 回走るので helper に集約。
-      const teamIdOf = (n: Node<CardData>): string | undefined =>
-        (n.data?.payload as { teamId?: string } | undefined)?.teamId;
+      // Issue #732: teamId 抽出は cardData の判別可能 union を見る共通 helper
+      // `cardTeamId` に集約済み (旧 `payload as { teamId?: string }` 局所キャストを撤去)。
+      const teamIdOf = (n: Node<CardData>): string | undefined => cardTeamId(n.data);
       // store から最新 nodes を直接取り出す (subscribe している `nodes` と等価だが、
       // ここで getState 越しに読むと callback の deps から `nodes` を外せる →
       // ドラッグ中に毎フレーム識別子が変わる onNodesChange を React Flow に再 bind せずに済む)。
@@ -271,7 +276,7 @@ function FlowApp({ actions }: FlowAppProps): JSX.Element {
     (e: React.MouseEvent, node: Node<CardData>) => {
       e.preventDefault();
       e.stopPropagation();
-      const teamId = (node.data?.payload as { teamId?: string } | undefined)?.teamId;
+      const teamId = cardTeamId(node.data);
       const items: ContextMenuItem[] = [];
       if (teamId) {
         const locked = isTeamLocked(teamId);
@@ -338,11 +343,13 @@ function FlowApp({ actions }: FlowAppProps): JSX.Element {
   // Tauri listen は ActivityFeed と共有なので二重登録にならない。
   useTeamHandoff((p) => {
     const currentNodes = useCanvasStore.getState().nodes;
+    // Issue #732: agentPayloadOf が agent カードのみ payload を返すので
+    // 旧 `cardType === 'agent' && (payload as { agentId? }).agentId` の二段判定が 1 本化される。
     const fromNode = currentNodes.find(
-      (n) => n.data?.cardType === 'agent' && (n.data.payload as { agentId?: string } | undefined)?.agentId === p.fromAgentId
+      (n) => agentPayloadOf(n.data)?.agentId === p.fromAgentId
     );
     const toNode = currentNodes.find(
-      (n) => n.data?.cardType === 'agent' && (n.data.payload as { agentId?: string } | undefined)?.agentId === p.toAgentId
+      (n) => agentPayloadOf(n.data)?.agentId === p.toAgentId
     );
     if (!fromNode || !toNode) return;
     pulseEdge({
@@ -356,8 +363,10 @@ function FlowApp({ actions }: FlowAppProps): JSX.Element {
 
   const minimapColor = useCallback((node: Node) => {
     const data = node.data as CardData | undefined;
+    // Issue #732: `cardType === 'agent'` で data が agent カードに narrowing され、
+    // payload は AgentPayload。AgentVisualPayload は AgentPayload の部分集合なので cast 不要。
     if (data?.cardType === 'agent') {
-      return resolveAccent(data.payload as AgentVisualPayload | undefined);
+      return resolveAccent(data.payload);
     }
     return '#7a7afd';
   }, [resolveAccent]);
@@ -529,15 +538,8 @@ function StageListOverlay(): JSX.Element {
           <div className="tc-list-overlay__empty">まだエージェントが配置されていません</div>
         ) : (
           agentNodes.map((n) => {
-            const payload = (n.data as CardData | undefined)?.payload as
-              | {
-                  roleProfileId?: string;
-                  role?: string;
-                  agentId?: string;
-                  agent?: string;
-                  organization?: TeamOrganizationMeta;
-                }
-              | undefined;
+            // Issue #732: 旧 inline 型キャストを agentPayloadOf に置換 (agent カードのみ payload を返す)。
+            const payload = agentPayloadOf(n.data as CardData | undefined);
             const visual = resolveAgentVisual(payload, profilesById, settings.language);
             const rowStyle = {
               ['--agent-accent' as string]: visual.agentAccent,

--- a/src/renderer/src/components/canvas/QuickNav.tsx
+++ b/src/renderer/src/components/canvas/QuickNav.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useReactFlow } from '@xyflow/react';
 import { useCanvasNodes } from '../../stores/canvas-selectors';
+import { cardRoleId } from '../../stores/canvas';
 import { useT } from '../../lib/i18n';
 import { metaOf } from '../../lib/team-roles';
 
@@ -38,16 +39,14 @@ export function QuickNav({ open, onClose }: QuickNavProps): JSX.Element | null {
     const q = query.trim().toLowerCase();
     return nodes
       .map((n) => {
-        const data = n.data ?? {};
-        const title = String(data.title ?? n.id);
-        const cardType = String(data.cardType ?? n.type ?? '');
+        const data = n.data;
+        const title = String(data?.title ?? n.id);
+        const cardType = String(data?.cardType ?? n.type ?? '');
         // Issue #194: canvas store v2 マイグレーションで legacy `role` は基本 undefined になり、
         // 全カードがデフォルト紫 + 汎用 glyph で表示されて QuickNav が機能ほぼ無価値だった。
         // AgentNodeCard と同じく roleProfileId を優先し、無ければ legacy role を fallback。
-        const payload = data.payload as
-          | { roleProfileId?: string; role?: string }
-          | undefined;
-        const roleId = payload?.roleProfileId ?? payload?.role;
+        // Issue #732: 旧 `payload as { roleProfileId?; role? }` を cardRoleId helper に置換。
+        const roleId = cardRoleId(data);
         const meta = metaOf(roleId);
         const subtitle = meta ? meta.label : cardType;
         const haystack = `${title} ${subtitle} ${roleId ?? ''}`.toLowerCase();

--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -18,7 +18,12 @@ import {
 import { useReactFlow } from '@xyflow/react';
 import { useT } from '../../lib/i18n';
 import { useSettings } from '../../lib/settings-context';
-import { useCanvasStore, type StageView, type CardData } from '../../stores/canvas';
+import {
+  useCanvasStore,
+  agentPayloadOf,
+  type StageView,
+  type CardData
+} from '../../stores/canvas';
 import { useCanvasNodes, useCanvasStageView } from '../../stores/canvas-selectors';
 import { useAgentActivityStore } from '../../stores/agent-activity';
 import {
@@ -29,7 +34,6 @@ import { useTeamHealthMulti } from '../../lib/use-team-health';
 import { deriveHealth } from '../../lib/agent-health';
 import { TeamPresetsPanel } from './TeamPresetsPanel';
 import { TeamDashboard } from './TeamDashboard';
-import type { AgentPayload } from './cards/AgentNodeCard/types';
 import type { ArrangeGap } from '../../lib/canvas-arrange';
 
 /**
@@ -188,7 +192,8 @@ export function StageHud(): JSX.Element {
   const aggregatedTeamIds = useMemo<string[]>(() => {
     const seen = new Set<string>();
     for (const node of agentNodes) {
-      const payload = (node.data as CardData | undefined)?.payload as AgentPayload | undefined;
+      // Issue #732: 旧 `(node.data as CardData)?.payload as AgentPayload` を agentPayloadOf に置換。
+      const payload = agentPayloadOf(node.data);
       if (payload?.teamId) seen.add(payload.teamId);
     }
     return Array.from(seen);
@@ -197,7 +202,8 @@ export function StageHud(): JSX.Element {
   const deadCount = useMemo(() => {
     let n = 0;
     for (const node of agentNodes) {
-      const payload = (node.data as CardData | undefined)?.payload as AgentPayload | undefined;
+      // Issue #732: 旧 `(node.data as CardData)?.payload as AgentPayload` を agentPayloadOf に置換。
+      const payload = agentPayloadOf(node.data);
       if (!payload?.agentId) continue;
       const row = healthSnapshot.byAgentId[payload.agentId];
       const h = deriveHealth(row);
@@ -215,7 +221,8 @@ export function StageHud(): JSX.Element {
     const allTeams: string[] = [];
     const seen = new Set<string>();
     for (const node of agentNodes) {
-      const payload = (node.data as CardData | undefined)?.payload as AgentPayload | undefined;
+      // Issue #732: 旧 `(node.data as CardData)?.payload as AgentPayload` を agentPayloadOf に置換。
+      const payload = agentPayloadOf(node.data);
       if (!payload?.teamId) continue;
       if (!seen.has(payload.teamId)) {
         seen.add(payload.teamId);

--- a/src/renderer/src/components/canvas/TeamPresetsPanel.tsx
+++ b/src/renderer/src/components/canvas/TeamPresetsPanel.tsx
@@ -24,9 +24,6 @@ import type {
   TeamPresetLayoutEntry,
   TeamPresetRole
 } from '../../../../types/shared';
-import type {
-  AgentPayload
-} from './cards/AgentNodeCard/types';
 import { spawnTeam, type SpawnTeamMember } from '../../lib/canvas-team-spawn';
 
 interface TeamPresetsPanelProps {
@@ -62,8 +59,10 @@ function buildPresetFromCanvas(
   let agents: Array<'claude' | 'codex' | 'mixed'> = [];
   for (const node of agentNodes) {
     const data = node.data as CardData | undefined;
+    // Issue #732: `cardType !== 'agent'` の continue で data が agent カードに narrowing され、
+    // 続く data.payload は AgentPayload。旧 `data.payload as AgentPayload` キャストは不要。
     if (data?.cardType !== 'agent') continue;
-    const payload = data.payload as AgentPayload | undefined;
+    const payload = data.payload;
     const roleProfileId = payload?.roleProfileId ?? payload?.role ?? '';
     if (!roleProfileId) continue;
     const agent = (payload?.agent ?? 'claude') as 'claude' | 'codex';

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -15,7 +15,13 @@
  * 挙動は元 AgentNodeCard.tsx と完全一致。構造のみ整理。
  */
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Handle, NodeResizer, Position, type NodeProps } from '@xyflow/react';
+import {
+  Handle,
+  NodeResizer,
+  Position,
+  type Node,
+  type NodeProps
+} from '@xyflow/react';
 import {
   AlertTriangle,
   ClipboardCheck,
@@ -38,7 +44,9 @@ import { useSettings } from '../../../../lib/settings-context';
 import {
   useCanvasStore,
   NODE_MIN_W,
-  NODE_MIN_H
+  NODE_MIN_H,
+  agentPayloadOf,
+  type CardDataOf
 } from '../../../../stores/canvas';
 import { useAgentActivityStore } from '../../../../stores/agent-activity';
 import { useConfirmRemoveCard } from '../../../../lib/use-confirm-remove-card';
@@ -183,14 +191,20 @@ function formatHealthLabel(
   });
 }
 
-function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
+// Issue #732: `NodeProps` を `Node<CardDataOf<'agent'>>` で具体化することで
+// `data.payload` が `AgentPayload` として読め、`unknown` からの inline cast が不要になる。
+function AgentNodeCardImpl({
+  id,
+  data
+}: NodeProps<Node<CardDataOf<'agent'>>>): JSX.Element {
   const termRef = useRef<TerminalViewHandle | null>(null);
   const { settings } = useSettings();
   const t = useT();
   const confirmRemoveCard = useConfirmRemoveCard();
   const setCardPayload = useCanvasStore((s) => s.setCardPayload);
   const { showToast } = useToast();
-  const payload = (data?.payload ?? {}) as AgentPayload;
+  // payload 未設定でも落ちないよう空オブジェクトでフォールバック (AgentPayload は全 field optional)。
+  const payload: AgentPayload = data?.payload ?? {};
   // 新スキーマ roleProfileId を優先、無ければ legacy role を読む
   const roleProfiles = useRoleProfiles();
   const profilesById = roleProfiles.byId;
@@ -200,7 +214,7 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
   const profile = visual.profile;
   const accent = visual.agentAccent;
   const organizationAccent = visual.organizationAccent;
-  const title = (data?.title as string) ?? visual.label;
+  const title = data?.title ?? visual.label;
   const [handoffBusy, setHandoffBusy] = useState(false);
   const [status, setStatus] = useState<string>('');
   const [activity, setActivityState] = useState<AgentStatus>('idle');
@@ -248,7 +262,8 @@ function AgentNodeCardImpl({ id, data }: NodeProps): JSX.Element {
     const sigs: string[] = [];
     for (const n of s.nodes) {
       if (n.type !== 'agent') continue;
-      const p = n.data?.payload as AgentPayload | undefined;
+      // Issue #732: 旧 `n.data?.payload as AgentPayload` を agentPayloadOf に置換。
+      const p = agentPayloadOf(n.data);
       const rp = p?.roleProfileId ?? p?.role;
       if (!p || p.teamId !== payload.teamId || !p.agentId || !rp) continue;
       sigs.push(`${p.agentId}:${rp}:${p.agent ?? 'claude'}`);

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -1,16 +1,25 @@
 /**
- * AgentNodeCard / CardFrame
+ * AgentNodeCard / CardFrame (root)
  *
  * Issue #487: AgentNodeCard 単一ファイルから「カード枠 + role visual + handoff UI」
  * を切り出したもの。pty / xterm の配線は隣接の TerminalOverlay.tsx に分けてある。
  *
- * 責務:
+ * Issue #735: ~900 行の god card だった本ファイルを以下の子コンポーネントへ分割した。
+ *   - `CardFrame.tsx`        — root: state/派生の解決 + layout (NodeResizer / Handle /
+ *                              .canvas-agent-card) + 子コンポーネントの合成
+ *   - `CardPresentation.tsx` — ヘッダーの視覚表現 (avatar / title / role / status pill)
+ *   - `CardHandoff.tsx`      — Leader 専用 handoff 作成ボタン + 注入フロー
+ *   - `CardInject.tsx`       — PTY inject 失敗の警告 row + リトライ UI
+ *   - `CardSummary.tsx`      — current task / 経過 / health / 未読 inbox サマリ
+ * さらに、zustand selector callback 内で ref を mutate していた pure 違反を
+ * `useTeamMembersSig` (useSyncExternalStore ベース) へ移して解消した。
+ *
+ * 責務 (この root):
  *   - NodeResizer + 入出力 Handle (xyflow)
  *   - ロール由来の accent / avatar / 表示ラベル (resolveAgentVisual)
- *   - ヘッダー (title / organization / role / StatusBadge / handoff button / close)
- *   - Leader 専用の handoff 作成 → bracketed paste 注入フロー
  *   - 起動引数 (command / args / sysPrompt / codexInstructions) の解決
- *   - TerminalOverlay の mount & 共有 ref / callback の橋渡し
+ *   - agent-activity store への activity / summary の publish
+ *   - 子コンポーネント (Presentation / Handoff / Inject / Summary) と TerminalOverlay の合成
  *
  * 挙動は元 AgentNodeCard.tsx と完全一致。構造のみ整理。
  */
@@ -22,30 +31,17 @@ import {
   type Node,
   type NodeProps
 } from '@xyflow/react';
-import {
-  AlertTriangle,
-  ClipboardCheck,
-  ClipboardList,
-  Clock,
-  Heart,
-  HeartPulse,
-  Inbox,
-  RotateCcw,
-  Skull
-} from 'lucide-react';
 import { useT } from '../../../../lib/i18n';
 import { useTeamHealth } from '../../../../lib/use-team-health';
-import { deriveHealth, type HealthState } from '../../../../lib/agent-health';
-import { useTeamInjectFailed } from '../../../../lib/use-team-inject-failed';
-import { useTeamInboxRead } from '../../../../lib/use-team-inbox-read';
+import { deriveHealth } from '../../../../lib/agent-health';
 import { useTeamHandoff } from '../../../../lib/use-team-handoff';
+import { useTeamInboxRead } from '../../../../lib/use-team-inbox-read';
 import { applyHandoffArrival, applyInboxRead } from './unread-inbox-count';
 import { useSettings } from '../../../../lib/settings-context';
 import {
   useCanvasStore,
   NODE_MIN_W,
   NODE_MIN_H,
-  agentPayloadOf,
   type CardDataOf
 } from '../../../../stores/canvas';
 import { useAgentActivityStore } from '../../../../stores/agent-activity';
@@ -60,136 +56,16 @@ import { resolveAgentConfig } from '../../../../lib/agent-resolver';
 import { useToast } from '../../../../lib/toast-context';
 import {
   deriveCardSummary,
-  type CardSummary
+  type CardSummary as CardSummaryData
 } from '../../../../lib/agent-summary';
 import type { TerminalViewHandle } from '../../../TerminalView';
-import type {
-  HandoffCheckpoint,
-  HandoffReference
-} from '../../../../../../types/shared';
 import type { AgentPayload, AgentStatus } from './types';
 import { TerminalOverlay } from './TerminalOverlay';
-
-/**
- * pty 起動時の status 文字列 ("実行中: claude --append-system-prompt ...long text...") を
- * 最初のフラグ/引数まで切り詰める。チームプロンプトなど巨大な文字列がヘッダに溢れるのを防ぐ。
- */
-function shortStatus(s: string): string {
-  // "実行中: claude --append-system-prompt あなたは..." → "実行中: claude"
-  const m = s.match(/^(\S+:\s*)?([^\s]+)/);
-  if (m) return `${m[1] ?? ''}${m[2]}`;
-  return s.length > 32 ? s.slice(0, 32) + '…' : s;
-}
-
-/**
- * 絶対パスからファイル名だけを返す。Windows (`\`) と POSIX (`/`) の両方に対応するため
- * path モジュールを使わず手元で処理する (renderer 側に node:path は無い)。
- */
-function basenameOf(absPath: string): string {
-  const normalized = absPath.replace(/\\/g, '/');
-  const idx = normalized.lastIndexOf('/');
-  return idx >= 0 ? normalized.slice(idx + 1) : normalized;
-}
-
-function handoffReferenceOf(
-  handoff: HandoffCheckpoint | HandoffReference
-): HandoffReference {
-  return {
-    id: handoff.id,
-    kind: handoff.kind,
-    status: handoff.status,
-    createdAt: handoff.createdAt,
-    updatedAt: handoff.updatedAt,
-    jsonPath: handoff.jsonPath,
-    markdownPath: handoff.markdownPath,
-    fromAgentId: handoff.fromAgentId,
-    toAgentId: handoff.toAgentId,
-    replacementForAgentId: handoff.replacementForAgentId
-  };
-}
-
-/**
- * Issue #423: Leader 自身に「引き継ぎ手順」を伝える PTY 注入用プロンプトを組み立てる。
- * UI 側で handoff document を保存した直後、保存先パスをこのプロンプトに埋めて Leader の
- * PTY に bracketed paste で注入する。Leader は MCP `team_create_leader` → `team_switch_leader`
- * を呼び、自律的に新 Leader へ交代する。
- */
-function buildLeaderHandoffPrompt(markdownPath: string, handoffId: string): string {
-  return [
-    '【引き継ぎ手順】',
-    '',
-    `引き継ぎ書を保存しました: ${markdownPath}`,
-    `Handoff id: ${handoffId}`,
-    '',
-    '次の手順で引き継ぎを完了してください:',
-    '1. 上記 handoff markdown を Read tool で読み、現在の作業状況・未完了タスク・次アクションを確認する。',
-    '2. 必要なら handoff の Notes / Next Actions を補強する追加メモを書き足す。',
-    '3. MCP tool `team_create_leader` を呼び、新しい Leader を採用する:',
-    `     team_create_leader({ handoff_id: "${handoffId}" })`,
-    '   返り値の `agentId` を控えること。',
-    '4. 新 Leader が起動したら、`team_send` で agentId 宛にこの handoff のパスと「お前が新 Leader だ」という旨を伝える:',
-    `     team_send({ to: "<上で得た agentId>", handoff_id: "${handoffId}", message: "あなたが新 Leader です。handoff を読んで team_ack_handoff({ handoff_id: '${handoffId}' }) を呼び、ACK を返してください: ${markdownPath}" })`,
-    '5. 新 Leader が `team_ack_handoff` と ACK を返したら、MCP tool `team_switch_leader` を呼ぶ:',
-    `     team_switch_leader({ new_leader_agent_id: "<上で得た agentId>", handoff_id: "${handoffId}" })`,
-    '   呼び出し成功後、約 2 秒で自分のカードが自動的に閉じられる。',
-    '',
-    '上記を順に実行してください。'
-  ].join('\n');
-}
-
-/** 文字列を bracketed paste マーカーで包む。Claude/Codex TUI に「1 件のペースト」として渡る。 */
-function wrapBracketedPaste(text: string): string {
-  return `\x1b[200~${text}\x1b[201~`;
-}
-
-/**
- * Issue #521: deriveCardSummary が返す `{ unit, value }` を i18n キーに変換する。
- * unit が 'now' の時は値を埋め込まないキー、それ以外は `{value}` パラメータを渡す。
- * lastOutputAgo が null (= 起動直後で未観測) のときは「観測なし」のキーへフォールバック。
- */
-function formatAgoLabel(
-  ago: { unit: 'now' | 'sec' | 'min' | 'hour' | 'day'; value: number } | null,
-  t: (key: string, params?: Record<string, string | number>) => string
-): string {
-  if (ago === null) return t('agentCard.summary.ago.unobserved');
-  if (ago.unit === 'now') return t('agentCard.summary.ago.now');
-  return t(`agentCard.summary.ago.${ago.unit}`, { value: ago.value });
-}
-
-/**
- * Issue #510: 「●alive | ◐stale | ○dead」 + 経過秒/分 + 自己申告ステータスを 1 行に整形する。
- * - alive: status があれば status を出す。なければ 'alive' のみ。
- * - stale / dead: 経過時間を強調 ('沈黙 N 分')。
- */
-function formatHealthLabel(
-  state: HealthState,
-  ageMs: number | null,
-  currentStatus: string | null,
-  t: (key: string, params?: Record<string, string | number>) => string
-): string {
-  const stateLabel = t(`agentCard.summary.health.state.${state}`);
-  if (state === 'alive') {
-    if (currentStatus && currentStatus.trim().length > 0) {
-      const status = currentStatus.length > 32 ? currentStatus.slice(0, 31) + '…' : currentStatus;
-      return `${stateLabel} · ${status}`;
-    }
-    return stateLabel;
-  }
-  if (ageMs === null) return stateLabel;
-  // 沈黙時間: 1 分未満は秒、それ以上は分単位 (停滞は「N 分」が直感的)。
-  const sec = Math.floor(ageMs / 1000);
-  if (sec < 60) {
-    return t('agentCard.summary.health.silent.sec', {
-      state: stateLabel,
-      value: sec
-    });
-  }
-  const min = Math.floor(sec / 60);
-  return t('agentCard.summary.health.silent.min', {
-    state: stateLabel,
-    value: min
-  });
-}
+import { useTeamMembersSig } from './use-team-members-sig';
+import { CardPresentation } from './CardPresentation';
+import { CardHandoff } from './CardHandoff';
+import { CardInject } from './CardInject';
+import { CardSummary, type CardSummaryHealth } from './CardSummary';
 
 // Issue #732: `NodeProps` を `Node<CardDataOf<'agent'>>` で具体化することで
 // `data.payload` が `AgentPayload` として読め、`unknown` からの inline cast が不要になる。
@@ -215,7 +91,6 @@ function AgentNodeCardImpl({
   const accent = visual.agentAccent;
   const organizationAccent = visual.organizationAccent;
   const title = data?.title ?? visual.label;
-  const [handoffBusy, setHandoffBusy] = useState(false);
   const [status, setStatus] = useState<string>('');
   const [activity, setActivityState] = useState<AgentStatus>('idle');
 
@@ -253,25 +128,13 @@ function AgentNodeCardImpl({
   // パフォーマンス: 旧実装は `useCanvasStore((s) => s.nodes)` で全 nodes を購読していたため、
   // ノードを 1 ピクセル動かすだけで全 AgentNodeCard が再レンダーし Canvas が重かった。
   // 対策として primitive な signature 文字列 (agentId|role|agent を ; で連結) を購読し、
-  // 文字列 equality で React がデフォルトで bailout できるようにする。drag/resize では
-  // signature が変わらないので再レンダーが発生しない。
-  const lastTeamMembersSigRef = useRef('');
-  const teamMembersSig = useCanvasStore((s) => {
-    if (!payload.teamId) return '';
-    if (s.isDragging) return lastTeamMembersSigRef.current;
-    const sigs: string[] = [];
-    for (const n of s.nodes) {
-      if (n.type !== 'agent') continue;
-      // Issue #732: 旧 `n.data?.payload as AgentPayload` を agentPayloadOf に置換。
-      const p = agentPayloadOf(n.data);
-      const rp = p?.roleProfileId ?? p?.role;
-      if (!p || p.teamId !== payload.teamId || !p.agentId || !rp) continue;
-      sigs.push(`${p.agentId}:${rp}:${p.agent ?? 'claude'}`);
-    }
-    const sig = sigs.join(';');
-    lastTeamMembersSigRef.current = sig;
-    return sig;
-  });
+  // 文字列 equality で React がデフォルトで bailout できるようにする。
+  //
+  // Issue #735: 旧実装は signature 計算を zustand selector callback 内で行いつつ
+  // `lastTeamMembersSigRef.current = sig` と ref を mutate していた (selector pure 違反)。
+  // signature 計算は useSyncExternalStore ベースの `useTeamMembersSig` へ移し、
+  // selector からの ref mutate を撤廃した。
+  const teamMembersSig = useTeamMembersSig(payload.teamId);
   const teamMembers = useMemo(() => {
     if (!payload.teamId) return null;
     if (teamMembersSig === '')
@@ -388,202 +251,6 @@ function AgentNodeCardImpl({
 
   const codexInstructions = isCodex ? sysPrompt : undefined;
 
-  // Issue #375 / #423: createHandoff は副作用 (handoff の保存 + payload.latestHandoff 更新) のみ
-  // 行い、success toast は呼び出し側 (handleCreateHandoffClick) に任せる。
-  // 呼び出し側で「保存先のパス」を PTY 注入用に取り出すため、戻り値の HandoffCheckpoint は必須。
-  const createHandoff = useCallback(async (): Promise<HandoffCheckpoint | null> => {
-    const projectRoot = cwd || payload.cwd || '';
-    if (!projectRoot) {
-      showToast(t('handoff.error.noProject'), { tone: 'error', duration: 8000 });
-      return null;
-    }
-    const snapshot = termRef.current?.getBufferText(120) ?? '';
-    const kind = roleProfileId === 'leader' ? 'leader' : 'worker';
-    const result = await window.api.handoffs.create({
-      projectRoot,
-      teamId: payload.teamId ?? null,
-      kind,
-      fromAgentId: payload.agentId ?? null,
-      fromRole: roleProfileId,
-      fromAgent: payload.agent ?? 'claude',
-      fromTitle: title,
-      sourceSessionId: payload.resumeSessionId ?? null,
-      replacementForAgentId: payload.agentId ?? null,
-      retireAfterAck: true,
-      trigger: 'manual',
-      content: {
-        summary: `${title} (${visual.label}) の Canvas handoff。保存時点の terminal snapshot と次アクションを含みます。`,
-        decisions: ['この handoff は既存セッションを --resume せず、新しいセッションへ注入するための継続メモとして保存されました。'],
-        filesTouched: [],
-        openTasks: ['handoff markdown を読み、現在の作業目的・未完了タスク・次アクションを確認する。'],
-        risks: ['terminal snapshot は直近の表示内容ベースのため、完全な会話履歴ではありません。必要なら旧 agent / team history を確認してください。'],
-        nextActions: ['handoff を読んだら ack を返し、Next Actions に沿って作業を継続する。'],
-        verification: ['handoff 作成時点では自動検証は未実行です。'],
-        notes: [`Canvas card: ${id}`, payload.teamId ? `Team: ${payload.teamId}` : 'Standalone agent'],
-        terminalSnapshot: snapshot.slice(-16_000) || null
-      }
-    });
-    if (!result.ok || !result.handoff) {
-      throw new Error(result.error ?? 'handoff create failed');
-    }
-    setCardPayload(id, { latestHandoff: handoffReferenceOf(result.handoff) });
-    return result.handoff;
-  }, [
-    cwd,
-    id,
-    visual.label,
-    payload.agent,
-    payload.agentId,
-    payload.cwd,
-    payload.resumeSessionId,
-    payload.teamId,
-    roleProfileId,
-    setCardPayload,
-    showToast,
-    t,
-    title
-  ]);
-
-  // Issue #423: 旧 `startFreshFromHandoff` (UI が直接新カードを生やす) は廃止し、
-  // 「Leader 自身が MCP 経由で交代する」フローへ移行。ボタンは下記 1 本に統合。
-
-  // Issue #423: ボタン押下時のフロー
-  //   1. Rust 側 `handoffs.create` で handoff JSON / Markdown を確実に保存
-  //   2. 保存先パス + MCP 手順を Leader 自身の PTY に bracketed paste で注入
-  //   3. Leader (Claude/Codex) が `team_create_leader` → `team_send` → `team_switch_leader`
-  //      を順に叩き、自律的に新 Leader へ交代する
-  // Leader 以外のカードでは押せない (worker の引き継ぎは将来の別 issue で対応)。
-  const handleCreateHandoffClick = useCallback(() => {
-    if (handoffBusy) return;
-    if (roleProfileId !== 'leader') {
-      showToast(t('handoff.error.notLeader'), { tone: 'error', duration: 6000 });
-      return;
-    }
-    setHandoffBusy(true);
-    void createHandoff()
-      .then((handoff) => {
-        if (!handoff) return; // noProject 等は createHandoff 側で error toast を出している
-        const fileName = basenameOf(handoff.markdownPath);
-        const markdownPath = handoff.markdownPath;
-        // Leader の PTY に「引き継ぎ手順」プロンプトを bracketed paste で注入。
-        // sendCommand(text, submit=true) は末尾に \r を付けて送信するため、
-        // 全文が 1 つの paste として確定 → Claude/Codex が読み取って MCP を叩き始める。
-        try {
-          const prompt = buildLeaderHandoffPrompt(markdownPath, handoff.id);
-          termRef.current?.sendCommand(wrapBracketedPaste(prompt), true);
-        } catch (err) {
-          const detail = err instanceof Error ? err.message : String(err);
-          showToast(t('handoff.error.injectFailed', { detail }), {
-            tone: 'error',
-            duration: 8000
-          });
-          return;
-        }
-        showToast(t('handoff.created', { file: fileName }), {
-          tone: 'success',
-          duration: 8000,
-          action: {
-            label: t('handoff.action.reveal'),
-            onClick: () => {
-              void window.api.app.revealInFileManager(markdownPath).catch((err) => {
-                console.warn('[handoff] reveal failed:', err);
-              });
-            }
-          }
-        });
-      })
-      .catch((err) => {
-        console.warn('[handoff] create failed:', err);
-        const detail = err instanceof Error ? err.message : String(err);
-        showToast(t('handoff.error.createFailed', { detail }), {
-          tone: 'error',
-          duration: 8000
-        });
-      })
-      .finally(() => setHandoffBusy(false));
-  }, [createHandoff, handoffBusy, roleProfileId, showToast, t]);
-
-  // Issue #423: 旧 `startFreshFromHandoff` 経路で使っていた `handoff_ack:` 監視は撤去。
-  // 新フローでは `team_switch_leader` MCP tool が active leader 切替 + 旧カード retire を
-  // 行うため、renderer 側で ack を listen する必要は無い。
-
-  // ---------- Issue #511: inject 失敗の警告表示 + 手動リトライ ----------
-  //
-  // `team_send` (またはリトライ後の `team_send_retry_inject`) が PTY inject に失敗した
-  // 瞬間、Hub から `team:inject_failed` event が emit される。Canvas 側はそれを受けて
-  // 該当 agent の payload.lastInjectFailure に reason を書き込む → CardFrame が warning
-  // row を render する。retry button で `window.api.team.retryInject` を呼び、成功すれば
-  // payload.lastInjectFailure を undefined クリアして warning を消す。
-  const [retryBusy, setRetryBusy] = useState(false);
-  useTeamInjectFailed(
-    useCallback(
-      (evt) => {
-        if (!payload.agentId || evt.toAgentId !== payload.agentId) return;
-        setCardPayload(id, {
-          lastInjectFailure: {
-            messageId: evt.messageId,
-            reason: { code: evt.reasonCode, message: evt.reasonMessage },
-            failedAt: evt.failedAt,
-            fromRole: evt.fromRole
-          }
-        });
-      },
-      [id, payload.agentId, setCardPayload]
-    )
-  );
-  const handleRetryInject = useCallback(() => {
-    if (retryBusy) return;
-    const failure = payload.lastInjectFailure;
-    if (!failure || !payload.teamId || !payload.agentId) return;
-    setRetryBusy(true);
-    void window.api.team
-      .retryInject({
-        teamId: payload.teamId,
-        messageId: failure.messageId,
-        agentId: payload.agentId
-      })
-      .then((result) => {
-        if (result.ok) {
-          // 成功時は warning row を消す。Hub からは team:handoff event が来るので
-          // 配信成功は Canvas 側 ActivityFeed / HandoffEdge が拾う。
-          setCardPayload(id, { lastInjectFailure: undefined });
-          showToast(t('injectFailure.retrySuccess'), {
-            tone: 'success',
-            duration: 5000
-          });
-        } else {
-          // 再失敗。Hub が `team:inject_failed` を再 emit するので useTeamInjectFailed が
-          // 新しい reason を payload に書き込む (= warning row はそのまま、内容だけ更新)。
-          const reason = result.reasonCode ?? result.error ?? 'unknown';
-          showToast(t('injectFailure.retryFailed', { reason }), {
-            tone: 'error',
-            duration: 8000
-          });
-        }
-      })
-      .catch((err) => {
-        // unknown_team / unknown_message / invalid_recipient の構造化エラーはここに来る。
-        const detail = err instanceof Error ? err.message : String(err);
-        showToast(t('injectFailure.retryError', { detail }), {
-          tone: 'error',
-          duration: 8000
-        });
-      })
-      .finally(() => setRetryBusy(false));
-  }, [
-    retryBusy,
-    payload.lastInjectFailure,
-    payload.teamId,
-    payload.agentId,
-    id,
-    setCardPayload,
-    showToast,
-    t
-  ]);
-  const handleDismissInjectWarning = useCallback(() => {
-    setCardPayload(id, { lastInjectFailure: undefined });
-  }, [id, setCardPayload]);
-
   // ---------- Issue #509: 未読 inbox 数の event-driven 集計 ----------
   //
   // `team:handoff` (= delivered = inject 成功) を受けると、自分宛のメッセージは「配信済み
@@ -631,10 +298,10 @@ function AgentNodeCardImpl({
   const publishSummary = useAgentActivityStore((s) => s.setSummary);
   const [nowTick, setNowTick] = useState(() => Date.now());
   useEffect(() => {
-    const t = window.setInterval(() => setNowTick(Date.now()), 15_000);
-    return () => window.clearInterval(t);
+    const timer = window.setInterval(() => setNowTick(Date.now()), 15_000);
+    return () => window.clearInterval(timer);
   }, []);
-  const summary = useMemo<CardSummary>(
+  const summary = useMemo<CardSummaryData>(
     () =>
       deriveCardSummary({
         payload,
@@ -649,7 +316,6 @@ function AgentNodeCardImpl({
   useEffect(() => {
     publishSummary(id, summary);
   }, [id, summary, publishSummary]);
-  const summaryAgoLabel = formatAgoLabel(summary.lastOutputAgo, t);
 
   // Issue #510: TeamHub diagnostics を 5s poll し、自カードの per-agent 行から
   // health (alive / stale / dead) と現在 status / pendingInbox を抽出する。
@@ -663,6 +329,21 @@ function AgentNodeCardImpl({
   const unreadInboxCount = hasHealthRow
     ? health.pendingInboxCount
     : payload.unreadInboxCount ?? 0;
+  // CardSummary に渡す health 派生値。health 行を出すのは teamId / agentId が両方あり
+  // state が 'unknown' でないとき (= standalone カードでは出さない)。
+  const showHealthRow = Boolean(payload.agentId) && Boolean(payload.teamId) && health.state !== 'unknown';
+  const summaryHealth = useMemo<CardSummaryHealth>(
+    () => ({
+      state: health.state,
+      ageMs: health.ageMs,
+      currentStatus: health.currentStatus,
+      stalledInbound: health.stalledInbound,
+      oldestPendingInboxAgeMs: health.oldestPendingInboxAgeMs
+    }),
+    [health]
+  );
+
+  const handleClose = useCallback(() => confirmRemoveCard(id), [confirmRemoveCard, id]);
 
   return (
     <>
@@ -679,197 +360,48 @@ function AgentNodeCardImpl({
         style={{ background: accent, width: 10, height: 10 }}
       />
       <div className="canvas-agent-card" style={cardStyle}>
-        <header className="canvas-agent-card__header">
-          <span className="canvas-agent-card__title-row">
-            <span aria-hidden="true" className="canvas-agent-card__avatar">
-              {profile.visual.glyph}
-            </span>
-            <span className="canvas-agent-card__title">{title}</span>
-            {payload.organization && (
-              <span className="canvas-agent-card__organization">
-                {payload.organization.name}
-              </span>
-            )}
-            <span className="canvas-agent-card__role">{visual.label}</span>
-          </span>
-          <span className="canvas-agent-card__actions">
-            <StatusBadge state={activity} label={t(`agentStatus.${activity}`)} />
-            {status && (
-              <span className="canvas-agent-card__status" title={status}>
-                {shortStatus(status)}
-              </span>
-            )}
-            {roleProfileId === 'leader' && (
-              <button
-                type="button"
-                className="nodrag canvas-agent-card__tool"
-                onClick={handleCreateHandoffClick}
-                disabled={handoffBusy}
-                title={t('handoff.createTooltip')}
-                aria-label={t('handoff.create')}
-              >
-                <ClipboardCheck size={13} strokeWidth={1.9} />
-              </button>
-            )}
-            <button
-              type="button"
-              className="nodrag canvas-agent-card__close"
-              onClick={() => confirmRemoveCard(id)}
-              title={t('agentCard.close')}
-              aria-label={t('agentCard.close')}
-            >
-              ×
-            </button>
-          </span>
-        </header>
-        <div
-          className={
-            'canvas-agent-card__summary' +
-            (summary.needsLeaderInput
-              ? ' canvas-agent-card__summary--alert'
-              : '')
-          }
-          aria-label={t('agentCard.summary.region')}
-        >
-          <div
-            className="canvas-agent-card__summary-row canvas-agent-card__summary-row--task"
-            title={summary.taskTitle || t('agentCard.summary.noTask')}
-          >
-            <ClipboardList size={11} strokeWidth={2} aria-hidden="true" />
-            <span className="canvas-agent-card__summary-text">
-              {summary.taskTitle || t('agentCard.summary.noTask')}
-            </span>
-          </div>
-          <div className="canvas-agent-card__summary-row canvas-agent-card__summary-row--clock">
-            <Clock size={11} strokeWidth={2} aria-hidden="true" />
-            <span className="canvas-agent-card__summary-text">
-              {summaryAgoLabel}
-            </span>
-          </div>
-          {summary.needsLeaderInput ? (
-            <div
-              className="canvas-agent-card__summary-row canvas-agent-card__summary-row--leader"
-              role="status"
-            >
-              <AlertTriangle size={11} strokeWidth={2} aria-hidden="true" />
-              <span className="canvas-agent-card__summary-text">
-                {t('agentCard.summary.needsLeader')}
-              </span>
-            </div>
-          ) : null}
-          {/* Issue #510: 自カードに対応する TeamHub diagnostics 行から health badge を表示する。 */}
-          {/* teamId / agentId が無いスタンドアロンカードでは何も出さない (= state==='unknown' は描画しない)。 */}
-          {payload.agentId && payload.teamId && health.state !== 'unknown' ? (
-            <div
-              className={
-                'canvas-agent-card__summary-row canvas-agent-card__summary-row--health' +
-                ' canvas-agent-card__summary-row--health-' + health.state
-              }
-              role="status"
-              title={
-                t('agentCard.summary.health.tooltip', {
-                  state: t(`agentCard.summary.health.state.${health.state}`),
-                  status: health.currentStatus ?? t('agentCard.summary.health.noStatus')
-                })
-              }
-            >
-              {health.state === 'alive' ? (
-                <Heart size={11} strokeWidth={2.2} aria-hidden="true" />
-              ) : health.state === 'stale' ? (
-                <HeartPulse size={11} strokeWidth={2.2} aria-hidden="true" />
-              ) : (
-                <Skull size={11} strokeWidth={2.2} aria-hidden="true" />
-              )}
-              <span className="canvas-agent-card__summary-text">
-                {formatHealthLabel(health.state, health.ageMs, health.currentStatus, t)}
-              </span>
-            </div>
-          ) : null}
-          {/* Issue #509: 配送済みだが team_read で確認していない message の数。 */}
-          {/* 60s 超過で stalled クラスを追加して警告色に切り替える。 */}
-          {unreadInboxCount > 0 ? (() => {
-            const ageMs = hasHealthRow
-              ? health.oldestPendingInboxAgeMs ?? 0
-              : payload.oldestUnreadDeliveredAt
-                ? Math.max(0, nowTick - new Date(payload.oldestUnreadDeliveredAt).getTime())
-                : 0;
-            const stalled = hasHealthRow ? health.stalledInbound : ageMs >= 60_000;
-            const ageSec = Math.floor(ageMs / 1000);
-            return (
-              <div
-                className={
-                  'canvas-agent-card__summary-row canvas-agent-card__summary-row--unread' +
-                  (stalled
-                    ? ' canvas-agent-card__summary-row--unread-stalled'
-                    : '')
-                }
-                role="status"
-                title={t('inboxUnread.tooltip', {
-                  count: unreadInboxCount,
-                  ageSec
-                })}
-              >
-                <Inbox size={11} strokeWidth={2} aria-hidden="true" />
-                <span className="canvas-agent-card__summary-text">
-                  {t('inboxUnread.label', {
-                    count: unreadInboxCount,
-                    ageSec
-                  })}
-                </span>
-              </div>
-            );
-          })() : null}
-        </div>
-        {/* Issue #511: PTY inject 失敗 warning row。 */}
-        {/* 通常時は何も rendering されず、`team:inject_failed` が来た瞬間に出現する。 */}
-        {/* `__summary` block の sibling として置き、既存 header の flex レイアウトを破壊しない。 */}
-        {payload.lastInjectFailure ? (
-          <div
-            className="canvas-agent-card__inject-warning"
-            role="alert"
-            aria-live="polite"
-          >
-            <AlertTriangle
-              size={12}
-              strokeWidth={2}
-              className="canvas-agent-card__inject-warning__icon"
-              aria-hidden="true"
+        <CardPresentation
+          cardId={id}
+          title={title}
+          roleLabel={visual.label}
+          glyph={profile.visual.glyph}
+          organizationName={payload.organization?.name}
+          activity={activity}
+          status={status}
+          handoff={
+            <CardHandoff
+              cardId={id}
+              payload={payload}
+              roleProfileId={roleProfileId}
+              title={title}
+              visualLabel={visual.label}
+              cwd={cwd}
+              termRef={termRef}
+              setCardPayload={setCardPayload}
+              showToast={showToast}
+              t={t}
             />
-            <span
-              className="canvas-agent-card__inject-warning__text"
-              title={payload.lastInjectFailure.reason.message}
-            >
-              {t('injectFailure.title', {
-                code: payload.lastInjectFailure.reason.code,
-                message: payload.lastInjectFailure.reason.message
-              })}
-            </span>
-            <button
-              type="button"
-              className="nodrag canvas-agent-card__inject-warning__retry"
-              onClick={handleRetryInject}
-              disabled={retryBusy}
-              title={t('injectFailure.retry')}
-              aria-label={t('injectFailure.retry')}
-            >
-              <RotateCcw size={11} strokeWidth={2} aria-hidden="true" />
-              <span>
-                {retryBusy
-                  ? t('injectFailure.retryBusy')
-                  : t('injectFailure.retry')}
-              </span>
-            </button>
-            <button
-              type="button"
-              className="nodrag canvas-agent-card__inject-warning__dismiss"
-              onClick={handleDismissInjectWarning}
-              title={t('injectFailure.dismiss')}
-              aria-label={t('injectFailure.dismiss')}
-            >
-              ×
-            </button>
-          </div>
-        ) : null}
+          }
+          onClose={handleClose}
+          t={t}
+        />
+        <CardSummary
+          summary={summary}
+          health={summaryHealth}
+          showHealthRow={showHealthRow}
+          hasHealthRow={hasHealthRow}
+          unreadInboxCount={unreadInboxCount}
+          oldestUnreadDeliveredAt={payload.oldestUnreadDeliveredAt}
+          nowTick={nowTick}
+          t={t}
+        />
+        <CardInject
+          cardId={id}
+          payload={payload}
+          setCardPayload={setCardPayload}
+          showToast={showToast}
+          t={t}
+        />
         <TerminalOverlay
           cardId={id}
           termRef={termRef}
@@ -891,26 +423,6 @@ function AgentNodeCardImpl({
         style={{ background: accent, width: 10, height: 10 }}
       />
     </>
-  );
-}
-
-/** ヘッダー右の小さなステータスドット (idle=灰, thinking=黄, typing=accent パルス) */
-function StatusBadge({
-  state,
-  label
-}: {
-  state: AgentStatus;
-  label: string;
-}): JSX.Element {
-  return (
-    <span
-      title={label}
-      aria-label={label}
-      className={`canvas-agent-status canvas-agent-status--${state}`}
-    >
-      <span className="canvas-agent-status__dot" />
-      <span>{label}</span>
-    </span>
   );
 }
 

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardHandoff.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardHandoff.tsx
@@ -1,0 +1,259 @@
+/**
+ * AgentNodeCard / CardHandoff
+ *
+ * Issue #735: 旧 `CardFrame.tsx` (~900 行 god card) から「Leader 専用の handoff
+ * 作成ボタン + bracketed-paste 注入フロー」(Issue #423) を切り出した子コンポーネント。
+ *
+ * Leader カードのヘッダーに置く小さなボタン 1 つと、その押下フロー:
+ *   1. Rust 側 `handoffs.create` で handoff JSON / Markdown を確実に保存
+ *   2. 保存先パス + MCP 手順を Leader 自身の PTY に bracketed paste で注入
+ *   3. Leader (Claude/Codex) が `team_create_leader` → `team_send` → `team_switch_leader`
+ *      を順に叩き、自律的に新 Leader へ交代する
+ *
+ * Leader 以外のカードでは描画されない (`null` を返す)。
+ * 挙動・DOM・クラス名・トーストは元 `CardFrame.tsx` の handoff ボタンと完全一致。
+ */
+import { useCallback, useState, type RefObject } from 'react';
+import { ClipboardCheck } from 'lucide-react';
+import type { useToast } from '../../../../lib/toast-context';
+import type { TerminalViewHandle } from '../../../TerminalView';
+import type {
+  HandoffCheckpoint,
+  HandoffReference
+} from '../../../../../../types/shared';
+import type { AgentPayload } from './types';
+
+/** i18n の `t` 関数シグネチャ。 */
+type TFn = (key: string, params?: Record<string, string | number>) => string;
+
+/** CardFrame から渡される `showToast` (useToast の戻り値そのまま)。 */
+type ShowToastFn = ReturnType<typeof useToast>['showToast'];
+
+/**
+ * 絶対パスからファイル名だけを返す。Windows (`\`) と POSIX (`/`) の両方に対応するため
+ * path モジュールを使わず手元で処理する (renderer 側に node:path は無い)。
+ */
+function basenameOf(absPath: string): string {
+  const normalized = absPath.replace(/\\/g, '/');
+  const idx = normalized.lastIndexOf('/');
+  return idx >= 0 ? normalized.slice(idx + 1) : normalized;
+}
+
+function handoffReferenceOf(
+  handoff: HandoffCheckpoint | HandoffReference
+): HandoffReference {
+  return {
+    id: handoff.id,
+    kind: handoff.kind,
+    status: handoff.status,
+    createdAt: handoff.createdAt,
+    updatedAt: handoff.updatedAt,
+    jsonPath: handoff.jsonPath,
+    markdownPath: handoff.markdownPath,
+    fromAgentId: handoff.fromAgentId,
+    toAgentId: handoff.toAgentId,
+    replacementForAgentId: handoff.replacementForAgentId
+  };
+}
+
+/**
+ * Issue #423: Leader 自身に「引き継ぎ手順」を伝える PTY 注入用プロンプトを組み立てる。
+ * UI 側で handoff document を保存した直後、保存先パスをこのプロンプトに埋めて Leader の
+ * PTY に bracketed paste で注入する。Leader は MCP `team_create_leader` → `team_switch_leader`
+ * を呼び、自律的に新 Leader へ交代する。
+ */
+function buildLeaderHandoffPrompt(markdownPath: string, handoffId: string): string {
+  return [
+    '【引き継ぎ手順】',
+    '',
+    `引き継ぎ書を保存しました: ${markdownPath}`,
+    `Handoff id: ${handoffId}`,
+    '',
+    '次の手順で引き継ぎを完了してください:',
+    '1. 上記 handoff markdown を Read tool で読み、現在の作業状況・未完了タスク・次アクションを確認する。',
+    '2. 必要なら handoff の Notes / Next Actions を補強する追加メモを書き足す。',
+    '3. MCP tool `team_create_leader` を呼び、新しい Leader を採用する:',
+    `     team_create_leader({ handoff_id: "${handoffId}" })`,
+    '   返り値の `agentId` を控えること。',
+    '4. 新 Leader が起動したら、`team_send` で agentId 宛にこの handoff のパスと「お前が新 Leader だ」という旨を伝える:',
+    `     team_send({ to: "<上で得た agentId>", handoff_id: "${handoffId}", message: "あなたが新 Leader です。handoff を読んで team_ack_handoff({ handoff_id: '${handoffId}' }) を呼び、ACK を返してください: ${markdownPath}" })`,
+    '5. 新 Leader が `team_ack_handoff` と ACK を返したら、MCP tool `team_switch_leader` を呼ぶ:',
+    `     team_switch_leader({ new_leader_agent_id: "<上で得た agentId>", handoff_id: "${handoffId}" })`,
+    '   呼び出し成功後、約 2 秒で自分のカードが自動的に閉じられる。',
+    '',
+    '上記を順に実行してください。'
+  ].join('\n');
+}
+
+/** 文字列を bracketed paste マーカーで包む。Claude/Codex TUI に「1 件のペースト」として渡る。 */
+function wrapBracketedPaste(text: string): string {
+  return `\x1b[200~${text}\x1b[201~`;
+}
+
+interface CardHandoffProps {
+  /** Canvas ノード id (handoff の notes / setCardPayload 用)。 */
+  cardId: string;
+  /** agent payload (teamId / agentId / agent / cwd / resumeSessionId を読む)。 */
+  payload: AgentPayload;
+  /** 解決済みロール識別子。'leader' のときだけボタンを描画する。 */
+  roleProfileId: string;
+  /** カードタイトル (handoff content の表示用)。 */
+  title: string;
+  /** ロール表示ラベル (handoff summary の表示用)。 */
+  visualLabel: string;
+  /** 解決済み cwd (handoff 保存先 projectRoot の第一候補)。 */
+  cwd: string;
+  /** TerminalOverlay と共有する terminal handle (PTY 注入 / バッファ取得)。 */
+  termRef: RefObject<TerminalViewHandle | null>;
+  /** canvas store の setCardPayload (payload.latestHandoff 更新用)。 */
+  setCardPayload: (id: string, patch: Record<string, unknown>) => void;
+  showToast: ShowToastFn;
+  t: TFn;
+}
+
+/**
+ * Issue #735: 旧 CardFrame の Leader 専用 handoff ボタン。
+ * `roleProfileId !== 'leader'` のカードでは `null` を返す。
+ */
+export function CardHandoff({
+  cardId,
+  payload,
+  roleProfileId,
+  title,
+  visualLabel,
+  cwd,
+  termRef,
+  setCardPayload,
+  showToast,
+  t
+}: CardHandoffProps): JSX.Element | null {
+  const [handoffBusy, setHandoffBusy] = useState(false);
+
+  // Issue #375 / #423: createHandoff は副作用 (handoff の保存 + payload.latestHandoff 更新) のみ
+  // 行い、success toast は呼び出し側 (handleCreateHandoffClick) に任せる。
+  // 呼び出し側で「保存先のパス」を PTY 注入用に取り出すため、戻り値の HandoffCheckpoint は必須。
+  const createHandoff = useCallback(async (): Promise<HandoffCheckpoint | null> => {
+    const projectRoot = cwd || payload.cwd || '';
+    if (!projectRoot) {
+      showToast(t('handoff.error.noProject'), { tone: 'error', duration: 8000 });
+      return null;
+    }
+    const snapshot = termRef.current?.getBufferText(120) ?? '';
+    const kind = roleProfileId === 'leader' ? 'leader' : 'worker';
+    const result = await window.api.handoffs.create({
+      projectRoot,
+      teamId: payload.teamId ?? null,
+      kind,
+      fromAgentId: payload.agentId ?? null,
+      fromRole: roleProfileId,
+      fromAgent: payload.agent ?? 'claude',
+      fromTitle: title,
+      sourceSessionId: payload.resumeSessionId ?? null,
+      replacementForAgentId: payload.agentId ?? null,
+      retireAfterAck: true,
+      trigger: 'manual',
+      content: {
+        summary: `${title} (${visualLabel}) の Canvas handoff。保存時点の terminal snapshot と次アクションを含みます。`,
+        decisions: ['この handoff は既存セッションを --resume せず、新しいセッションへ注入するための継続メモとして保存されました。'],
+        filesTouched: [],
+        openTasks: ['handoff markdown を読み、現在の作業目的・未完了タスク・次アクションを確認する。'],
+        risks: ['terminal snapshot は直近の表示内容ベースのため、完全な会話履歴ではありません。必要なら旧 agent / team history を確認してください。'],
+        nextActions: ['handoff を読んだら ack を返し、Next Actions に沿って作業を継続する。'],
+        verification: ['handoff 作成時点では自動検証は未実行です。'],
+        notes: [`Canvas card: ${cardId}`, payload.teamId ? `Team: ${payload.teamId}` : 'Standalone agent'],
+        terminalSnapshot: snapshot.slice(-16_000) || null
+      }
+    });
+    if (!result.ok || !result.handoff) {
+      throw new Error(result.error ?? 'handoff create failed');
+    }
+    setCardPayload(cardId, { latestHandoff: handoffReferenceOf(result.handoff) });
+    return result.handoff;
+  }, [
+    cwd,
+    cardId,
+    visualLabel,
+    payload.agent,
+    payload.agentId,
+    payload.cwd,
+    payload.resumeSessionId,
+    payload.teamId,
+    roleProfileId,
+    setCardPayload,
+    showToast,
+    t,
+    title,
+    termRef
+  ]);
+
+  // Issue #423: ボタン押下時のフロー
+  //   1. Rust 側 `handoffs.create` で handoff JSON / Markdown を確実に保存
+  //   2. 保存先パス + MCP 手順を Leader 自身の PTY に bracketed paste で注入
+  //   3. Leader (Claude/Codex) が `team_create_leader` → `team_send` → `team_switch_leader`
+  //      を順に叩き、自律的に新 Leader へ交代する
+  // Leader 以外のカードでは押せない (worker の引き継ぎは将来の別 issue で対応)。
+  const handleCreateHandoffClick = useCallback(() => {
+    if (handoffBusy) return;
+    if (roleProfileId !== 'leader') {
+      showToast(t('handoff.error.notLeader'), { tone: 'error', duration: 6000 });
+      return;
+    }
+    setHandoffBusy(true);
+    void createHandoff()
+      .then((handoff) => {
+        if (!handoff) return; // noProject 等は createHandoff 側で error toast を出している
+        const fileName = basenameOf(handoff.markdownPath);
+        const markdownPath = handoff.markdownPath;
+        // Leader の PTY に「引き継ぎ手順」プロンプトを bracketed paste で注入。
+        // sendCommand(text, submit=true) は末尾に \r を付けて送信するため、
+        // 全文が 1 つの paste として確定 → Claude/Codex が読み取って MCP を叩き始める。
+        try {
+          const prompt = buildLeaderHandoffPrompt(markdownPath, handoff.id);
+          termRef.current?.sendCommand(wrapBracketedPaste(prompt), true);
+        } catch (err) {
+          const detail = err instanceof Error ? err.message : String(err);
+          showToast(t('handoff.error.injectFailed', { detail }), {
+            tone: 'error',
+            duration: 8000
+          });
+          return;
+        }
+        showToast(t('handoff.created', { file: fileName }), {
+          tone: 'success',
+          duration: 8000,
+          action: {
+            label: t('handoff.action.reveal'),
+            onClick: () => {
+              void window.api.app.revealInFileManager(markdownPath).catch((err) => {
+                console.warn('[handoff] reveal failed:', err);
+              });
+            }
+          }
+        });
+      })
+      .catch((err) => {
+        console.warn('[handoff] create failed:', err);
+        const detail = err instanceof Error ? err.message : String(err);
+        showToast(t('handoff.error.createFailed', { detail }), {
+          tone: 'error',
+          duration: 8000
+        });
+      })
+      .finally(() => setHandoffBusy(false));
+  }, [createHandoff, handoffBusy, roleProfileId, showToast, t, termRef]);
+
+  if (roleProfileId !== 'leader') return null;
+
+  return (
+    <button
+      type="button"
+      className="nodrag canvas-agent-card__tool"
+      onClick={handleCreateHandoffClick}
+      disabled={handoffBusy}
+      title={t('handoff.createTooltip')}
+      aria-label={t('handoff.create')}
+    >
+      <ClipboardCheck size={13} strokeWidth={1.9} />
+    </button>
+  );
+}

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardInject.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardInject.tsx
@@ -1,0 +1,159 @@
+/**
+ * AgentNodeCard / CardInject
+ *
+ * Issue #735: 旧 `CardFrame.tsx` (~900 行 god card) から「PTY inject 失敗の
+ * 警告 row + 手動リトライ UI」(Issue #511) を切り出した子コンポーネント。
+ *
+ * `team_send` (またはリトライ後の `team_send_retry_inject`) が PTY inject に失敗した
+ * 瞬間、Hub から `team:inject_failed` event が emit される。Canvas 側はそれを受けて
+ * 該当 agent の payload.lastInjectFailure に reason を書き込み、本コンポーネントが
+ * warning row を render する。retry button で `window.api.team.retryInject` を呼び、
+ * 成功すれば payload.lastInjectFailure を undefined クリアして warning を消す。
+ *
+ * 挙動・DOM・クラス名は元 `.canvas-agent-card__inject-warning` ブロックと完全一致。
+ * inject 失敗 event の購読 (useTeamInjectFailed) も含めて本コンポーネントに閉じる
+ * (payload.lastInjectFailure が無いときは何も render しない)。
+ */
+import { useCallback, useState } from 'react';
+import { AlertTriangle, RotateCcw } from 'lucide-react';
+import { useTeamInjectFailed } from '../../../../lib/use-team-inject-failed';
+import type { useToast } from '../../../../lib/toast-context';
+import type { AgentPayload } from './types';
+
+/** i18n の `t` 関数シグネチャ。 */
+type TFn = (key: string, params?: Record<string, string | number>) => string;
+
+/** CardFrame から渡される `showToast` (useToast の戻り値そのまま)。 */
+type ShowToastFn = ReturnType<typeof useToast>['showToast'];
+
+interface CardInjectProps {
+  /** Canvas ノード id。setCardPayload の対象。 */
+  cardId: string;
+  /** agent payload (lastInjectFailure / teamId / agentId を読む)。 */
+  payload: AgentPayload;
+  /** canvas store の setCardPayload (payload 浅マージ)。 */
+  setCardPayload: (id: string, patch: Record<string, unknown>) => void;
+  showToast: ShowToastFn;
+  t: TFn;
+}
+
+/**
+ * Issue #735: 旧 CardFrame の inject 失敗 warning row。
+ *
+ * `team:inject_failed` event の購読・retry IPC・dismiss をすべて内包する。
+ * `payload.lastInjectFailure` が無い間は `null` を返す (= 通常時は不可視)。
+ */
+export function CardInject({
+  cardId,
+  payload,
+  setCardPayload,
+  showToast,
+  t
+}: CardInjectProps): JSX.Element | null {
+  const [retryBusy, setRetryBusy] = useState(false);
+
+  // `team:inject_failed` を受けたら自カード宛のものだけ payload.lastInjectFailure へ書き込む。
+  useTeamInjectFailed(
+    useCallback(
+      (evt) => {
+        if (!payload.agentId || evt.toAgentId !== payload.agentId) return;
+        setCardPayload(cardId, {
+          lastInjectFailure: {
+            messageId: evt.messageId,
+            reason: { code: evt.reasonCode, message: evt.reasonMessage },
+            failedAt: evt.failedAt,
+            fromRole: evt.fromRole
+          }
+        });
+      },
+      [cardId, payload.agentId, setCardPayload]
+    )
+  );
+
+  const handleRetryInject = useCallback(() => {
+    if (retryBusy) return;
+    const failure = payload.lastInjectFailure;
+    if (!failure || !payload.teamId || !payload.agentId) return;
+    setRetryBusy(true);
+    void window.api.team
+      .retryInject({
+        teamId: payload.teamId,
+        messageId: failure.messageId,
+        agentId: payload.agentId
+      })
+      .then((result) => {
+        if (result.ok) {
+          // 成功時は warning row を消す。Hub からは team:handoff event が来るので
+          // 配信成功は Canvas 側 ActivityFeed / HandoffEdge が拾う。
+          setCardPayload(cardId, { lastInjectFailure: undefined });
+          showToast(t('injectFailure.retrySuccess'), { tone: 'success', duration: 5000 });
+        } else {
+          // 再失敗。Hub が `team:inject_failed` を再 emit するので useTeamInjectFailed が
+          // 新しい reason を payload に書き込む (= warning row はそのまま、内容だけ更新)。
+          const reason = result.reasonCode ?? result.error ?? 'unknown';
+          showToast(t('injectFailure.retryFailed', { reason }), {
+            tone: 'error',
+            duration: 8000
+          });
+        }
+      })
+      .catch((err) => {
+        // unknown_team / unknown_message / invalid_recipient の構造化エラーはここに来る。
+        const detail = err instanceof Error ? err.message : String(err);
+        showToast(t('injectFailure.retryError', { detail }), {
+          tone: 'error',
+          duration: 8000
+        });
+      })
+      .finally(() => setRetryBusy(false));
+  }, [retryBusy, payload.lastInjectFailure, payload.teamId, payload.agentId, cardId, setCardPayload, showToast, t]);
+
+  const handleDismissInjectWarning = useCallback(() => {
+    setCardPayload(cardId, { lastInjectFailure: undefined });
+  }, [cardId, setCardPayload]);
+
+  const failure = payload.lastInjectFailure;
+  if (!failure) return null;
+
+  // 通常時は何も rendering されず、`team:inject_failed` が来た瞬間に出現する。
+  // `__summary` block の sibling として置き、既存 header の flex レイアウトを破壊しない。
+  return (
+    <div className="canvas-agent-card__inject-warning" role="alert" aria-live="polite">
+      <AlertTriangle
+        size={12}
+        strokeWidth={2}
+        className="canvas-agent-card__inject-warning__icon"
+        aria-hidden="true"
+      />
+      <span
+        className="canvas-agent-card__inject-warning__text"
+        title={failure.reason.message}
+      >
+        {t('injectFailure.title', {
+          code: failure.reason.code,
+          message: failure.reason.message
+        })}
+      </span>
+      <button
+        type="button"
+        className="nodrag canvas-agent-card__inject-warning__retry"
+        onClick={handleRetryInject}
+        disabled={retryBusy}
+        title={t('injectFailure.retry')}
+        aria-label={t('injectFailure.retry')}
+      >
+        <RotateCcw size={11} strokeWidth={2} aria-hidden="true" />
+        <span>{retryBusy ? t('injectFailure.retryBusy') : t('injectFailure.retry')}</span>
+      </button>
+      <button
+        type="button"
+        className="nodrag canvas-agent-card__inject-warning__dismiss"
+        onClick={handleDismissInjectWarning}
+        title={t('injectFailure.dismiss')}
+        aria-label={t('injectFailure.dismiss')}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardPresentation.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardPresentation.tsx
@@ -1,0 +1,110 @@
+/**
+ * AgentNodeCard / CardPresentation
+ *
+ * Issue #735: 旧 `CardFrame.tsx` (~900 行 god card) から「カードヘッダーの視覚表現」
+ * (avatar / title / organization / role badge / status pill / close ボタン) を
+ * 切り出した子コンポーネント。
+ *
+ * 純粋な表示コンポーネント: 値は親 (CardFrame) が解決して props で渡す。
+ * handoff ボタンは責務分離のため `handoff` slot (ReactNode) で受け取り、本体は
+ * その配置だけを担う (handoff ロジックは CardHandoff.tsx)。
+ * 挙動・DOM・クラス名は元 `.canvas-agent-card__header` と完全一致。
+ */
+import type { ReactNode } from 'react';
+import type { AgentStatus } from './types';
+
+/** i18n の `t` 関数シグネチャ。 */
+type TFn = (key: string, params?: Record<string, string | number>) => string;
+
+/**
+ * pty 起動時の status 文字列 ("実行中: claude --append-system-prompt ...long text...") を
+ * 最初のフラグ/引数まで切り詰める。チームプロンプトなど巨大な文字列がヘッダに溢れるのを防ぐ。
+ */
+export function shortStatus(s: string): string {
+  // "実行中: claude --append-system-prompt あなたは..." → "実行中: claude"
+  const m = s.match(/^(\S+:\s*)?([^\s]+)/);
+  if (m) return `${m[1] ?? ''}${m[2]}`;
+  return s.length > 32 ? s.slice(0, 32) + '…' : s;
+}
+
+/** ヘッダー右の小さなステータスドット (idle=灰, thinking=黄, typing=accent パルス) */
+function StatusBadge({ state, label }: { state: AgentStatus; label: string }): JSX.Element {
+  return (
+    <span
+      title={label}
+      aria-label={label}
+      className={`canvas-agent-status canvas-agent-status--${state}`}
+    >
+      <span className="canvas-agent-status__dot" />
+      <span>{label}</span>
+    </span>
+  );
+}
+
+interface CardPresentationProps {
+  /** Canvas ノード id (close ボタンの対象)。 */
+  cardId: string;
+  /** カードタイトル。 */
+  title: string;
+  /** ロール表示ラベル (リーダー / プログラマー 等)。 */
+  roleLabel: string;
+  /** ロール由来の avatar glyph。 */
+  glyph: string;
+  /** 所属組織名 (複数組織運用時のみ。無ければ非表示)。 */
+  organizationName: string | undefined;
+  /** 現在のアクティビティ状態 (idle / thinking / typing)。 */
+  activity: AgentStatus;
+  /** pty 起動 status 文字列 (空なら status pill 非表示)。 */
+  status: string;
+  /** handoff ボタン slot (Leader 以外では呼び出し側が null を渡す)。 */
+  handoff: ReactNode;
+  /** close ボタン押下時 (チーム cascade confirm 込み)。 */
+  onClose: () => void;
+  t: TFn;
+}
+
+/** Issue #735: 旧 CardFrame の `.canvas-agent-card__header`。 */
+export function CardPresentation({
+  title,
+  roleLabel,
+  glyph,
+  organizationName,
+  activity,
+  status,
+  handoff,
+  onClose,
+  t
+}: CardPresentationProps): JSX.Element {
+  return (
+    <header className="canvas-agent-card__header">
+      <span className="canvas-agent-card__title-row">
+        <span aria-hidden="true" className="canvas-agent-card__avatar">
+          {glyph}
+        </span>
+        <span className="canvas-agent-card__title">{title}</span>
+        {organizationName && (
+          <span className="canvas-agent-card__organization">{organizationName}</span>
+        )}
+        <span className="canvas-agent-card__role">{roleLabel}</span>
+      </span>
+      <span className="canvas-agent-card__actions">
+        <StatusBadge state={activity} label={t(`agentStatus.${activity}`)} />
+        {status && (
+          <span className="canvas-agent-card__status" title={status}>
+            {shortStatus(status)}
+          </span>
+        )}
+        {handoff}
+        <button
+          type="button"
+          className="nodrag canvas-agent-card__close"
+          onClick={onClose}
+          title={t('agentCard.close')}
+          aria-label={t('agentCard.close')}
+        >
+          ×
+        </button>
+      </span>
+    </header>
+  );
+}

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardSummary.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardSummary.tsx
@@ -1,0 +1,192 @@
+/**
+ * AgentNodeCard / CardSummary
+ *
+ * Issue #735: 旧 `CardFrame.tsx` (~900 行 god card) から「カードの状態サマリ」
+ * (current task / 経過時間 / Leader 入力待ち / health / 未読 inbox) のプレゼン
+ * テーションだけを切り出した子コンポーネント。
+ *
+ * 純粋な表示コンポーネント: 値は親 (CardFrame) が `deriveCardSummary` /
+ * `deriveHealth` で算出して props で渡す。本コンポーネントは store も IPC も触らない。
+ * 挙動・DOM・クラス名は元 `.canvas-agent-card__summary` ブロックと完全一致。
+ */
+import { AlertTriangle, Clock, ClipboardList, Heart, HeartPulse, Inbox, Skull } from 'lucide-react';
+import type { HealthState } from '../../../../lib/agent-health';
+import type { CardSummary as CardSummaryData } from '../../../../lib/agent-summary';
+
+/** i18n の `t` 関数シグネチャ (CardFrame から渡される)。 */
+type TFn = (key: string, params?: Record<string, string | number>) => string;
+
+/**
+ * Issue #521: deriveCardSummary が返す `{ unit, value }` を i18n キーに変換する。
+ * unit が 'now' の時は値を埋め込まないキー、それ以外は `{value}` パラメータを渡す。
+ * lastOutputAgo が null (= 起動直後で未観測) のときは「観測なし」のキーへフォールバック。
+ */
+export function formatAgoLabel(
+  ago: { unit: 'now' | 'sec' | 'min' | 'hour' | 'day'; value: number } | null,
+  t: TFn
+): string {
+  if (ago === null) return t('agentCard.summary.ago.unobserved');
+  if (ago.unit === 'now') return t('agentCard.summary.ago.now');
+  return t(`agentCard.summary.ago.${ago.unit}`, { value: ago.value });
+}
+
+/**
+ * Issue #510: 「●alive | ◐stale | ○dead」 + 経過秒/分 + 自己申告ステータスを 1 行に整形する。
+ * - alive: status があれば status を出す。なければ 'alive' のみ。
+ * - stale / dead: 経過時間を強調 ('沈黙 N 分')。
+ */
+export function formatHealthLabel(
+  state: HealthState,
+  ageMs: number | null,
+  currentStatus: string | null,
+  t: TFn
+): string {
+  const stateLabel = t(`agentCard.summary.health.state.${state}`);
+  if (state === 'alive') {
+    if (currentStatus && currentStatus.trim().length > 0) {
+      const status = currentStatus.length > 32 ? currentStatus.slice(0, 31) + '…' : currentStatus;
+      return `${stateLabel} · ${status}`;
+    }
+    return stateLabel;
+  }
+  if (ageMs === null) return stateLabel;
+  // 沈黙時間: 1 分未満は秒、それ以上は分単位 (停滞は「N 分」が直感的)。
+  const sec = Math.floor(ageMs / 1000);
+  if (sec < 60) {
+    return t('agentCard.summary.health.silent.sec', { state: stateLabel, value: sec });
+  }
+  const min = Math.floor(sec / 60);
+  return t('agentCard.summary.health.silent.min', { state: stateLabel, value: min });
+}
+
+/** CardSummary 内の health 行が必要とする health 由来の値。 */
+export interface CardSummaryHealth {
+  state: HealthState;
+  ageMs: number | null;
+  currentStatus: string | null;
+  /** 未読 inbox 行の stalled 判定 (TeamHub diagnostics 由来)。 */
+  stalledInbound: boolean;
+  /** TeamHub diagnostics が観測した「一番古い未読の経過 ms」。 */
+  oldestPendingInboxAgeMs: number | null;
+}
+
+interface CardSummaryProps {
+  /** deriveCardSummary の結果 (task / 経過 / needsLeaderInput)。 */
+  summary: CardSummaryData;
+  /** deriveHealth の結果から CardSummary が使う部分。 */
+  health: CardSummaryHealth;
+  /** health 行を出すか (teamId / agentId が両方揃い、state !== 'unknown' のとき)。 */
+  showHealthRow: boolean;
+  /** TeamHub diagnostics 行が存在するか。未読経過 ms の算出経路を切り替える。 */
+  hasHealthRow: boolean;
+  /** 配信済み未読 message 数。0 のとき未読行は描画しない。 */
+  unreadInboxCount: number;
+  /** payload 由来の「一番古い未読の delivered 時刻」(RFC3339)。fallback 経路で使う。 */
+  oldestUnreadDeliveredAt: string | undefined;
+  /** 経過時間表示用の現在時刻 (15s 間隔で更新される nowTick)。 */
+  nowTick: number;
+  t: TFn;
+}
+
+/** Issue #735: 旧 CardFrame の `.canvas-agent-card__summary` ブロック。 */
+export function CardSummary({
+  summary,
+  health,
+  showHealthRow,
+  hasHealthRow,
+  unreadInboxCount,
+  oldestUnreadDeliveredAt,
+  nowTick,
+  t
+}: CardSummaryProps): JSX.Element {
+  const summaryAgoLabel = formatAgoLabel(summary.lastOutputAgo, t);
+  return (
+    <div
+      className={
+        'canvas-agent-card__summary' +
+        (summary.needsLeaderInput ? ' canvas-agent-card__summary--alert' : '')
+      }
+      aria-label={t('agentCard.summary.region')}
+    >
+      <div
+        className="canvas-agent-card__summary-row canvas-agent-card__summary-row--task"
+        title={summary.taskTitle || t('agentCard.summary.noTask')}
+      >
+        <ClipboardList size={11} strokeWidth={2} aria-hidden="true" />
+        <span className="canvas-agent-card__summary-text">
+          {summary.taskTitle || t('agentCard.summary.noTask')}
+        </span>
+      </div>
+      <div className="canvas-agent-card__summary-row canvas-agent-card__summary-row--clock">
+        <Clock size={11} strokeWidth={2} aria-hidden="true" />
+        <span className="canvas-agent-card__summary-text">{summaryAgoLabel}</span>
+      </div>
+      {summary.needsLeaderInput ? (
+        <div
+          className="canvas-agent-card__summary-row canvas-agent-card__summary-row--leader"
+          role="status"
+        >
+          <AlertTriangle size={11} strokeWidth={2} aria-hidden="true" />
+          <span className="canvas-agent-card__summary-text">
+            {t('agentCard.summary.needsLeader')}
+          </span>
+        </div>
+      ) : null}
+      {/* Issue #510: 自カードに対応する TeamHub diagnostics 行から health badge を表示する。 */}
+      {/* teamId / agentId が無いスタンドアロンカードでは何も出さない (= state==='unknown' は描画しない)。 */}
+      {showHealthRow ? (
+        <div
+          className={
+            'canvas-agent-card__summary-row canvas-agent-card__summary-row--health' +
+            ' canvas-agent-card__summary-row--health-' +
+            health.state
+          }
+          role="status"
+          title={t('agentCard.summary.health.tooltip', {
+            state: t(`agentCard.summary.health.state.${health.state}`),
+            status: health.currentStatus ?? t('agentCard.summary.health.noStatus')
+          })}
+        >
+          {health.state === 'alive' ? (
+            <Heart size={11} strokeWidth={2.2} aria-hidden="true" />
+          ) : health.state === 'stale' ? (
+            <HeartPulse size={11} strokeWidth={2.2} aria-hidden="true" />
+          ) : (
+            <Skull size={11} strokeWidth={2.2} aria-hidden="true" />
+          )}
+          <span className="canvas-agent-card__summary-text">
+            {formatHealthLabel(health.state, health.ageMs, health.currentStatus, t)}
+          </span>
+        </div>
+      ) : null}
+      {/* Issue #509: 配送済みだが team_read で確認していない message の数。 */}
+      {/* 60s 超過で stalled クラスを追加して警告色に切り替える。 */}
+      {unreadInboxCount > 0
+        ? (() => {
+            const ageMs = hasHealthRow
+              ? health.oldestPendingInboxAgeMs ?? 0
+              : oldestUnreadDeliveredAt
+                ? Math.max(0, nowTick - new Date(oldestUnreadDeliveredAt).getTime())
+                : 0;
+            const stalled = hasHealthRow ? health.stalledInbound : ageMs >= 60_000;
+            const ageSec = Math.floor(ageMs / 1000);
+            return (
+              <div
+                className={
+                  'canvas-agent-card__summary-row canvas-agent-card__summary-row--unread' +
+                  (stalled ? ' canvas-agent-card__summary-row--unread-stalled' : '')
+                }
+                role="status"
+                title={t('inboxUnread.tooltip', { count: unreadInboxCount, ageSec })}
+              >
+                <Inbox size={11} strokeWidth={2} aria-hidden="true" />
+                <span className="canvas-agent-card__summary-text">
+                  {t('inboxUnread.label', { count: unreadInboxCount, ageSec })}
+                </span>
+              </div>
+            );
+          })()
+        : null}
+    </div>
+  );
+}

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/unread-inbox-count.ts
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/unread-inbox-count.ts
@@ -17,7 +17,7 @@
 
 import type { HandoffPayload } from '../../../../lib/use-team-handoff';
 import type { TeamInboxReadEvent } from '../../../../../../types/shared';
-import { useCanvasStore } from '../../../../stores/canvas';
+import { useCanvasStore, agentPayloadOf } from '../../../../stores/canvas';
 import type { AgentPayload } from './types';
 
 /** test と本体で `useCanvasStore` を共有するための型 alias。 */
@@ -25,7 +25,8 @@ export type CanvasStoreApi = typeof useCanvasStore;
 
 function readLatestPayload(store: CanvasStoreApi, id: string): AgentPayload {
   const node = store.getState().nodes.find((n) => n.id === id);
-  return ((node?.data?.payload as AgentPayload | undefined) ?? {}) as AgentPayload;
+  // Issue #732: 旧 `node?.data?.payload as AgentPayload` を agentPayloadOf に置換。
+  return agentPayloadOf(node?.data) ?? {};
 }
 
 /**

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/use-team-members-sig.ts
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/use-team-members-sig.ts
@@ -1,0 +1,68 @@
+/**
+ * AgentNodeCard / useTeamMembersSig
+ *
+ * Issue #735: 旧 `CardFrame.tsx` は同 teamId のメンバー roster を
+ * `useCanvasStore((s) => { ...; lastTeamMembersSigRef.current = sig; return sig; })`
+ * という形で購読しており、**zustand selector callback の中で ref を mutate** していた。
+ * selector は pure であることが前提 (zustand が equality bailout のため任意回数呼ぶ /
+ * StrictMode で二重実行する) なので、これは前提違反だった。
+ *
+ * 修正方針: signature 計算を `useSyncExternalStore` に移す。
+ *   - `getSnapshot` は「キャッシュ済みの安定値を返す」のが React 公式の規定動作。
+ *     同じ内容なら同一文字列を返すので useSyncExternalStore は再レンダーを bailout する。
+ *   - drag 中は roster (agentId:role:agent) が変わらないため signature も不変。
+ *     旧実装と同じく drag 中は O(N) ループをスキップしてキャッシュ値を返す
+ *     (これは「未変更なのでキャッシュを返す」= getSnapshot の正しい使い方)。
+ *
+ * これにより zustand に渡る selector は廃止され、pure 違反が解消する。
+ */
+import { useCallback, useRef, useSyncExternalStore } from 'react';
+import { useCanvasStore, agentPayloadOf } from '../../../../stores/canvas';
+
+/**
+ * 同 teamId の agent カード群から `agentId:roleProfileId:agent` を `;` 連結した
+ * primitive signature を計算する。`teamId` が無ければ空文字。
+ *
+ * 旧 `CardFrame.tsx` の selector 内ループと完全に同一ロジック (挙動不変)。
+ */
+function computeTeamMembersSig(
+  nodes: ReturnType<typeof useCanvasStore.getState>['nodes'],
+  teamId: string
+): string {
+  const sigs: string[] = [];
+  for (const n of nodes) {
+    if (n.type !== 'agent') continue;
+    const p = agentPayloadOf(n.data);
+    const rp = p?.roleProfileId ?? p?.role;
+    if (!p || p.teamId !== teamId || !p.agentId || !rp) continue;
+    sigs.push(`${p.agentId}:${rp}:${p.agent ?? 'claude'}`);
+  }
+  return sigs.join(';');
+}
+
+/**
+ * 同 teamId のメンバー roster を表す primitive signature を購読する hook。
+ *
+ * - `teamId` が undefined のときは常に空文字を返す。
+ * - drag 中 (`isDragging`) は roster 不変なので直前の signature をそのまま返し、
+ *   毎フレームの O(N) 走査を避ける (旧 CardFrame のキャッシュ最適化を踏襲)。
+ * - 戻り値は文字列なので、内容が同じなら useSyncExternalStore が再レンダーを bailout する。
+ */
+export function useTeamMembersSig(teamId: string | undefined): string {
+  // getSnapshot が返す「安定値」のキャッシュ。useSyncExternalStore の規定どおり、
+  // 内容が変わらない限り同一文字列を返すことで不要な再レンダーを防ぐ。
+  const cacheRef = useRef('');
+  const getSnapshot = useCallback((): string => {
+    if (!teamId) {
+      cacheRef.current = '';
+      return '';
+    }
+    const s = useCanvasStore.getState();
+    // drag 中は roster 不変。直前 signature をそのまま返す (= 未変更キャッシュ返却)。
+    if (s.isDragging) return cacheRef.current;
+    const sig = computeTeamMembersSig(s.nodes, teamId);
+    cacheRef.current = sig;
+    return sig;
+  }, [teamId]);
+  return useSyncExternalStore(useCanvasStore.subscribe, getSnapshot, getSnapshot);
+}

--- a/src/renderer/src/components/canvas/cards/ChangesCard.tsx
+++ b/src/renderer/src/components/canvas/cards/ChangesCard.tsx
@@ -4,21 +4,25 @@
  * payload: { projectRoot }
  */
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import type { GitStatus } from '../../../../../types/shared';
 import { CardFrame } from '../CardFrame';
 import { ChangesPanel } from '../../ChangesPanel';
 import { useCanvasStore } from '../../../stores/canvas';
+import type { CardDataOf } from '../../../stores/canvas';
 import { useSettings } from '../../../lib/settings-context';
 import { useFilesChanged } from '../../../lib/use-files-changed';
 
-interface ChangesPayload {
-  projectRoot?: string;
-}
-
-function ChangesCardImpl({ id, data, positionAbsoluteX, positionAbsoluteY }: NodeProps): JSX.Element {
+// Issue #732: payload 型は canvas store の判別可能 union に集約。`NodeProps` を
+// `Node<CardDataOf<'changes'>>` で具体化することで `data.payload` が直接読め、inline cast を撤廃。
+function ChangesCardImpl({
+  id,
+  data,
+  positionAbsoluteX,
+  positionAbsoluteY
+}: NodeProps<Node<CardDataOf<'changes'>>>): JSX.Element {
   const { settings } = useSettings();
-  const payload = (data?.payload ?? {}) as ChangesPayload;
+  const payload = data?.payload ?? {};
   // Issue #23: lastOpenedRoot (現在プロジェクト) を最優先、claudeCwd は fallback。
   const projectRoot = settings.lastOpenedRoot || settings.claudeCwd || payload.projectRoot || '';
   const title = (data?.title as string) ?? 'Changes';

--- a/src/renderer/src/components/canvas/cards/DiffCard.tsx
+++ b/src/renderer/src/components/canvas/cards/DiffCard.tsx
@@ -4,21 +4,18 @@
  * payload: { projectRoot, relPath }
  */
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import type { GitDiffResult } from '../../../../../types/shared';
 import { CardFrame } from '../CardFrame';
 import { DiffView } from '../../DiffView';
 import { useFilesChanged } from '../../../lib/use-files-changed';
+import type { CardDataOf, DiffCardPayload } from '../../../stores/canvas';
 
-interface DiffPayload {
-  projectRoot: string;
-  relPath: string;
-  /** Issue #19: rename の HEAD 側パス。CanvasSidebar / ChangesCard が渡す。 */
-  originalRelPath?: string;
-}
-
-function DiffCardImpl({ id, data }: NodeProps): JSX.Element {
-  const payload = (data?.payload ?? {}) as DiffPayload;
+// Issue #732: payload 型は canvas store の判別可能 union に集約。`NodeProps` を
+// `Node<CardDataOf<'diff'>>` で具体化することで `data.payload` の inline cast を撤廃。
+function DiffCardImpl({ id, data }: NodeProps<Node<CardDataOf<'diff'>>>): JSX.Element {
+  // 旧 `(data?.payload ?? {}) as DiffPayload` と同一挙動 (空 payload を許容)。
+  const payload = (data?.payload ?? {}) as DiffCardPayload;
   const { projectRoot, relPath, originalRelPath } = payload;
   const title = (data?.title as string) ?? `diff: ${relPath}`;
 

--- a/src/renderer/src/components/canvas/cards/EditorCard.tsx
+++ b/src/renderer/src/components/canvas/cards/EditorCard.tsx
@@ -10,19 +10,21 @@
  * dirty card 一覧を覗いて confirm dialog を出せる。
  */
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import { CardFrame } from '../CardFrame';
 import { EditorView } from '../../EditorView';
 import { detectLanguage } from '../../../lib/language';
 import { registerEditorCardDirty } from '../../../lib/editor-card-dirty-registry';
+import type { CardDataOf, EditorCardPayload } from '../../../stores/canvas';
 
-interface EditorPayload {
-  projectRoot: string;
-  relPath: string;
-}
-
-function EditorCardImpl({ id, data }: NodeProps): JSX.Element {
-  const payload = (data?.payload ?? {}) as EditorPayload;
+// Issue #732: payload 型は canvas store の判別可能 union に集約。`NodeProps` を
+// `Node<CardDataOf<'editor'>>` で具体化することで `data.payload` が `EditorCardPayload`
+// として読め、`unknown` からの型再構築 (inline cast) が不要になる。
+function EditorCardImpl({ id, data }: NodeProps<Node<CardDataOf<'editor'>>>): JSX.Element {
+  // payload 未設定の「空 EditorCard」もあり得るので空オブジェクトでフォールバックする
+  // (旧 `(data?.payload ?? {}) as EditorPayload` と同一挙動。`{}` 既定なので
+  //  projectRoot / relPath は undefined 扱いになり、既存の null チェックで吸収される)。
+  const payload = (data?.payload ?? {}) as EditorCardPayload;
   const { projectRoot, relPath } = payload;
   const title = (data?.title as string) ?? relPath ?? 'Editor';
   const isImage = useMemo(

--- a/src/renderer/src/components/canvas/cards/FileTreeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/FileTreeCard.tsx
@@ -5,22 +5,25 @@
  * payload: { projectRoot, extraRoots? }
  */
 import { memo, useCallback } from 'react';
-import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import { CardFrame } from '../CardFrame';
 import { FileTreePanel } from '../../FileTreePanel';
 import { useCanvasStore } from '../../../stores/canvas';
+import type { CardDataOf } from '../../../stores/canvas';
 import { useSettings } from '../../../lib/settings-context';
 import { useT } from '../../../lib/i18n';
 
-interface FileTreePayload {
-  projectRoot?: string;
-  extraRoots?: string[];
-}
-
-function FileTreeCardImpl({ id, data, positionAbsoluteX, positionAbsoluteY }: NodeProps): JSX.Element {
+// Issue #732: payload 型は canvas store の判別可能 union に集約。`NodeProps` を
+// `Node<CardDataOf<'fileTree'>>` で具体化することで `data.payload` が直接読め、inline cast を撤廃。
+function FileTreeCardImpl({
+  id,
+  data,
+  positionAbsoluteX,
+  positionAbsoluteY
+}: NodeProps<Node<CardDataOf<'fileTree'>>>): JSX.Element {
   const { settings, update } = useSettings();
   const t = useT();
-  const payload = (data?.payload ?? {}) as FileTreePayload;
+  const payload = data?.payload ?? {};
   // Issue #23: lastOpenedRoot (現在プロジェクト) を最優先、claudeCwd は fallback。
   const projectRoot = settings.lastOpenedRoot || settings.claudeCwd || payload.projectRoot || '';
   const extraRoots = payload.extraRoots ?? settings.workspaceFolders ?? [];

--- a/src/renderer/src/components/canvas/cards/TerminalCard.tsx
+++ b/src/renderer/src/components/canvas/cards/TerminalCard.tsx
@@ -6,39 +6,27 @@
  * TerminalView に伝える。Phase 3 で AgentNodeCard (ロール色) に派生させる。
  */
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
-import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import { CardFrame } from '../CardFrame';
 import { TerminalView, type TerminalViewHandle } from '../../TerminalView';
 import { useSettings } from '../../../lib/settings-context';
 import { useCanvasStore, NODE_MIN_W, NODE_MIN_H } from '../../../stores/canvas';
+import type { CardDataOf } from '../../../stores/canvas';
 import { useUiStore } from '../../../stores/ui';
 import { useCanvasTerminalFit } from '../../../lib/use-canvas-terminal-fit';
 import { useXtermScrollToBottomOnResize } from '../../../lib/use-xterm-scroll-on-resize';
 
-interface TerminalPayload {
-  agent?: 'claude' | 'codex';
-  role?: string;
-  teamId?: string;
-  agentId?: string;
-  command?: string;
-  args?: string[];
-  cwd?: string;
-  /** Issue #22: Canvas から Resume 起動したときの Claude セッション id。
-   *  Claude の場合は args に `--resume <id>` を追加して既存会話を再開する。 */
-  resumeSessionId?: string | null;
-  /** Issue #63: Codex の role system prompt (一時ファイル化されて model_instructions_file へ)。
-   *  Canvas から team 外の Codex を起動するケースでも使えるよう payload 経由で渡せるようにする。 */
-  codexInstructions?: string;
-}
-
-function TerminalCardImpl({ id, data }: NodeProps): JSX.Element {
+// Issue #732: payload 型 (旧ローカル `TerminalPayload`) は canvas store の判別可能 union
+// 側 `TerminalCardPayload` に集約。`NodeProps` を `Node<CardDataOf<'terminal'>>` で具体化し、
+// `data.payload` の inline cast を撤廃する。
+function TerminalCardImpl({ id, data }: NodeProps<Node<CardDataOf<'terminal'>>>): JSX.Element {
   const ref = useRef<TerminalViewHandle | null>(null);
   // Issue #272: NodeResizer でカードをリサイズしたとき、内部 `.xterm-viewport`
   // の scrollTop が古い値で残り最終行が下端で見切れるのを防ぐため、
   // wrapper div の ref を ResizeObserver に渡して末尾追従させる。
   const termContainerRef = useRef<HTMLDivElement | null>(null);
   const { settings } = useSettings();
-  const payload = (data?.payload ?? {}) as TerminalPayload;
+  const payload = data?.payload ?? {};
   const title = (data?.title as string) ?? 'Terminal';
   const [, setStatus] = useState<string>('');
   const setCardPayload = useCanvasStore((s) => s.setCardPayload);

--- a/src/renderer/src/lib/use-confirm-remove-card.ts
+++ b/src/renderer/src/lib/use-confirm-remove-card.ts
@@ -12,7 +12,7 @@
  *   を出す。dirty 検出は editor-card-dirty-registry が一元管理する。
  */
 import { useCallback } from 'react';
-import { useCanvasStore } from '../stores/canvas';
+import { useCanvasStore, cardTeamId, cardTeamName } from '../stores/canvas';
 import { useT } from './i18n';
 import { getDirtyEditorCardSnapshots } from './editor-card-dirty-registry';
 
@@ -22,20 +22,21 @@ export function useConfirmRemoveCard(): (id: string) => void {
     (id: string) => {
       const state = useCanvasStore.getState();
       const target = state.nodes.find((n) => n.id === id);
-      const teamId = (target?.data?.payload as { teamId?: string } | undefined)?.teamId;
+      // Issue #732: teamId / teamName 抽出は判別可能 union を見る共通 helper に集約
+      // (旧 `payload as { teamId? } / { teamName? }` 局所キャストを撤去)。
+      const teamId = cardTeamId(target?.data);
       // store.removeCard と同じ「cascadeTeam=true」の動きで削除対象 id 集合を作る。
       // editor dirty チェックはこの集合全体に対して行う。
       const idsToRemove = new Set<string>([id]);
       if (teamId) {
         for (const n of state.nodes) {
-          const tid = (n.data?.payload as { teamId?: string } | undefined)?.teamId;
+          const tid = cardTeamId(n.data);
           if (tid === teamId) idsToRemove.add(n.id);
         }
       }
       // ---- 1) チーム cascade confirm (既存仕様) ----
       if (teamId && idsToRemove.size > 1) {
-        const teamName =
-          (target?.data?.payload as { teamName?: string } | undefined)?.teamName ?? teamId;
+        const teamName = cardTeamName(target?.data) ?? teamId;
         const ok = window.confirm(
           t('agentCard.confirmCloseTeam', {
             count: idsToRemove.size,

--- a/src/renderer/src/lib/use-recruit-listener.ts
+++ b/src/renderer/src/lib/use-recruit-listener.ts
@@ -16,7 +16,13 @@
  */
 import { useEffect, useRef } from 'react';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-import { useCanvasStore } from '../stores/canvas';
+import {
+  useCanvasStore,
+  cardTeamId,
+  cardAgentId,
+  cardRoleId,
+  agentPayloadOf
+} from '../stores/canvas';
 import type { Node } from '@xyflow/react';
 import type { CardData } from '../stores/canvas';
 import { useRoleProfiles } from './role-profiles-context';
@@ -190,18 +196,15 @@ export function useRecruitListener(): void {
         // ハンドラ側で一元的に removeCard する (チャネル方向の一意化)。
         const findRequester = (): Node<CardData> | undefined => {
           const nodes = useCanvasStore.getState().nodes;
-          const exact = nodes.find((n) => {
-            const data = n.data?.payload as { agentId?: string } | undefined;
-            return data?.agentId === p.requesterAgentId;
-          });
+          // Issue #732: agentId / teamId / role 抽出は判別可能 union 用の共通 helper に置換。
+          const exact = nodes.find(
+            (n) => cardAgentId(n.data) === p.requesterAgentId
+          );
           if (exact) return exact;
           // 同 teamId 内の leader / hr に fallback
           return nodes.find((n) => {
-            const data = n.data?.payload as
-              | { agentId?: string; teamId?: string; roleProfileId?: string; role?: string }
-              | undefined;
-            if (!data || data.teamId !== p.teamId) return false;
-            const r = data.roleProfileId ?? data.role ?? '';
+            if (cardTeamId(n.data) !== p.teamId) return false;
+            const r = cardRoleId(n.data) ?? '';
             return r === 'leader' || r === 'hr';
           });
         };
@@ -239,13 +242,13 @@ export function useRecruitListener(): void {
           });
         }
         const store = useCanvasStore.getState();
-        const requesterPayload = (requester.data?.payload ?? {}) as {
-          organization?: unknown;
-        };
-        const teamNodes = store.nodes.filter((n) => {
-          const data = n.data?.payload as { teamId?: string } | undefined;
-          return data?.teamId === p.teamId;
-        });
+        // Issue #732: requester は recruit を呼んだ agent カード。agentPayloadOf で
+        // payload (AgentPayload) を取り出し、organization を継承させる
+        // (旧 `payload as { organization?: unknown }` の置き換え)。
+        const requesterOrganization = agentPayloadOf(requester.data)?.organization;
+        const teamNodes = store.nodes.filter(
+          (n) => cardTeamId(n.data) === p.teamId
+        );
         const pos = findRecruitPosition(requester, teamNodes);
         const titleHint = p.agentLabelHint?.trim() || p.roleProfileId;
         const newNodeId = store.addCard({
@@ -259,7 +262,7 @@ export function useRecruitListener(): void {
             role: p.roleProfileId,
             teamId: p.teamId,
             agentId: p.newAgentId,
-            organization: requesterPayload.organization,
+            organization: requesterOrganization,
             // Issue #117: AgentNodeCard が拾って Claude(--append-system-prompt) /
             // Codex(model_instructions_file) 両方の経路に注入する正本フィールド。
             customInstructions: mergeCustomInstructions(p.customInstructions, p.waitPolicy),
@@ -291,10 +294,10 @@ export function useRecruitListener(): void {
       if (cancelled) return;
       const p = e.payload;
       const store = useCanvasStore.getState();
-      const target = store.nodes.find((n) => {
-        const data = n.data?.payload as { agentId?: string; teamId?: string } | undefined;
-        return data?.agentId === p.agentId && data?.teamId === p.teamId;
-      });
+      // Issue #732: agentId / teamId 抽出を判別可能 union 用の共通 helper に置換。
+      const target = store.nodes.find(
+        (n) => cardAgentId(n.data) === p.agentId && cardTeamId(n.data) === p.teamId
+      );
       if (target) {
         // team_dismiss は 1 名だけ解雇する MCP 経路。チーム単位カスケードを無効化して、
         // Leader や他メンバーが連鎖的に閉じないようにする。
@@ -312,10 +315,10 @@ export function useRecruitListener(): void {
       if (cancelled) return;
       const p = e.payload;
       const store = useCanvasStore.getState();
-      const target = store.nodes.find((n) => {
-        const data = n.data?.payload as { agentId?: string } | undefined;
-        return data?.agentId === p.newAgentId;
-      });
+      // Issue #732: agentId 抽出を判別可能 union 用の共通 helper に置換。
+      const target = store.nodes.find(
+        (n) => cardAgentId(n.data) === p.newAgentId
+      );
       if (target) {
         console.warn(`[recruit] cancelled: ${p.reason}`);
         // recruit timeout / cancel で出る暫定カードだけを撤収する。

--- a/src/renderer/src/lib/use-team-dashboard.ts
+++ b/src/renderer/src/lib/use-team-dashboard.ts
@@ -22,7 +22,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { Node } from '@xyflow/react';
 import { useCanvasNodes } from '../stores/canvas-selectors';
 import { useAgentActivityStore } from '../stores/agent-activity';
-import type { CardData } from '../stores/canvas';
+import { agentPayloadOf, type CardData } from '../stores/canvas';
 import type {
   TeamOrchestrationState,
   TeamTaskSnapshot
@@ -111,7 +111,7 @@ export function useTeamDashboard(input: {
     () =>
       allNodes.filter((n) => {
         if (n.type !== 'agent') return false;
-        const payload = (n.data as CardData | undefined)?.payload as AgentPayload | undefined;
+        const payload = agentPayloadOf(n.data as CardData | undefined);
         return !teamId || payload?.teamId === teamId;
       }),
     [allNodes, teamId]
@@ -154,7 +154,7 @@ export function useTeamDashboard(input: {
     if (agentNodes.length === 0) return [];
     return agentNodes.map((node) => {
       const data = node.data as CardData | undefined;
-      const payload = data?.payload as AgentPayload | undefined;
+      const payload = agentPayloadOf(data);
       const agentId = payload?.agentId ?? null;
       const roleProfileId = payload?.roleProfileId ?? payload?.role ?? 'unknown';
       const agentKind = payload?.agent ?? 'claude';
@@ -342,7 +342,7 @@ export function useTeamDashboardMulti(input: {
       const state = stateByTeam[teamId] ?? null;
       const rows: TeamDashboardRow[] = nodes.map((node) => {
         const data = node.data as CardData | undefined;
-        const payload = data?.payload as AgentPayload | undefined;
+        const payload = agentPayloadOf(data);
         const agentId = payload?.agentId ?? null;
         const roleProfileId = payload?.roleProfileId ?? payload?.role ?? 'unknown';
         const agentKind = payload?.agent ?? 'claude';

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -20,14 +20,190 @@ import {
   runCanvasMigration,
   normalizeCanvasState
 } from '../lib/canvas-migrations';
+import type { AgentPayload } from '../components/canvas/cards/AgentNodeCard/types';
 
 export type CardType = 'terminal' | 'agent' | 'editor' | 'diff' | 'fileTree' | 'changes';
 
-export interface CardData extends Record<string, unknown> {
-  cardType: CardType;
+/**
+ * Issue #732: カード種別ごとの payload 型。
+ *
+ * 以前は `CardData.payload?: unknown` だったため、消費側 (Canvas / CardFrame /
+ * StageHud / QuickNav 等) が `(card.payload as XxxPayload)` という inline cast を
+ * 20+ 箇所で再構築していた。`cardType` をタグにした判別可能 union (`CardData`) に
+ * することで、`switch (card.cardType)` で TS が payload を自動 narrowing できる。
+ *
+ * agent カードの payload (`AgentPayload`) は AgentNodeCard 配下に既存定義があるので
+ * そこから import して `AgentCardPayload` に合成する。残る 5 種はここで定義し、
+ * 各カードコンポーネント (TerminalCard / EditorCard / ...) はこの型を import して
+ * ローカル重複定義を撤廃する。
+ */
+
+/**
+ * 全カード種別の payload が共通で持てる「チーム所属」フィールド。
+ *
+ * 旧 `payload?: unknown` 時代は teamId / teamName を「種別を問わず」 payload に積めて、
+ * team cascade 削除 (`removeCard` / `useConfirmRemoveCard`) や同期ドラッグがそれを
+ * `payload as { teamId? }` で読み取っていた。判別可能 union 化でこの「どのカードでも
+ * teamId を持てる」性質を失わないよう、共通フィールドを base にまとめて全 payload に
+ * 継承させる (例: editor カードを team locked にして一緒に動かす経路を維持)。
+ */
+export interface CardPayloadBase {
+  /** チーム識別子。同 teamId のカードは team cascade / 同期ドラッグでまとまって動く。 */
+  teamId?: string;
+  /** チーム表示名 (cascade 削除 confirm のメッセージ等で使用)。 */
+  teamName?: string;
+}
+
+/** agent カード payload: 既存 `AgentPayload` に共通 base を合成したもの。 */
+export type AgentCardPayload = AgentPayload & CardPayloadBase;
+
+/** terminal カード: 単発の Claude/Codex/シェル端末を起動するための payload。 */
+export interface TerminalCardPayload extends CardPayloadBase {
+  agent?: 'claude' | 'codex';
+  role?: string;
+  agentId?: string;
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  /** Issue #22: Canvas Resume 起動時の Claude セッション id (`--resume <id>`)。 */
+  resumeSessionId?: string | null;
+  /** Issue #63: Codex の role system prompt (一時ファイル化されて model_instructions_file へ)。 */
+  codexInstructions?: string;
+}
+
+/** editor カード: 1 ファイルを Monaco で編集する payload。 */
+export interface EditorCardPayload extends CardPayloadBase {
+  projectRoot: string;
+  relPath: string;
+}
+
+/** diff カード: 1 ファイルの git diff を表示する payload。 */
+export interface DiffCardPayload extends CardPayloadBase {
+  projectRoot: string;
+  relPath: string;
+  /** Issue #19: rename の HEAD 側パス。 */
+  originalRelPath?: string;
+}
+
+/** fileTree カード: プロジェクトのファイルツリーを表示する payload。 */
+export interface FileTreeCardPayload extends CardPayloadBase {
+  projectRoot?: string;
+  extraRoots?: string[];
+}
+
+/** changes カード: git status 一覧を表示する payload。 */
+export interface ChangesCardPayload extends CardPayloadBase {
+  projectRoot?: string;
+}
+
+/** `CardType` → そのカードの payload 型へのマッピング。 */
+export interface CardPayloadMap {
+  terminal: TerminalCardPayload;
+  agent: AgentCardPayload;
+  editor: EditorCardPayload;
+  diff: DiffCardPayload;
+  fileTree: FileTreeCardPayload;
+  changes: ChangesCardPayload;
+}
+
+/**
+ * `cardType` をタグとする 1 variant 分の card data。
+ * `Record<string, unknown>` を継承するのは @xyflow/react の `Node<T>` 制約
+ * (`T extends Record<string, unknown>`) を満たすため。
+ */
+export type CardDataOf<T extends CardType> = {
+  cardType: T;
   title: string;
-  /** terminal の sessionId / editor の filePath 等 */
-  payload?: unknown;
+  /** カード種別ごとの payload。`cardType` で narrowing される (Issue #732)。 */
+  payload?: CardPayloadMap[T];
+} & Record<string, unknown>;
+
+/**
+ * Issue #732: `cardType` による判別可能 union。
+ * `switch (card.cardType)` で各 case の `card.payload` が対応する payload 型に
+ * 自動 narrowing される。
+ */
+export type CardData =
+  | CardDataOf<'terminal'>
+  | CardDataOf<'agent'>
+  | CardDataOf<'editor'>
+  | CardDataOf<'diff'>
+  | CardDataOf<'fileTree'>
+  | CardDataOf<'changes'>;
+
+/**
+ * Issue #732: `addCards` に渡す 1 件分の card 指定 (`cardType` 判別可能 union)。
+ * `addCard` は generic 引数で同等のことを表現するが、`addCards` は配列なので
+ * 「配列内で type ごとに payload 型が異なる」を表すために専用 union を使う。
+ */
+export type CardSpecOf<T extends CardType> = {
+  type: T;
+  title: string;
+  payload?: CardPayloadMap[T];
+  position: { x: number; y: number };
+};
+export type CardSpec =
+  | CardSpecOf<'terminal'>
+  | CardSpecOf<'agent'>
+  | CardSpecOf<'editor'>
+  | CardSpecOf<'diff'>
+  | CardSpecOf<'fileTree'>
+  | CardSpecOf<'changes'>;
+
+/**
+ * Issue #732: 任意の `CardData` から teamId を取り出すヘルパ。
+ * teamId は `CardPayloadBase` 経由で全カード種別の payload が共通で持てるため、
+ * 種別を問わず `payload?.teamId` を読める (旧 `payload as { teamId? }` の置き換え)。
+ */
+export function cardTeamId(data: CardData | undefined): string | undefined {
+  return data?.payload?.teamId;
+}
+
+/**
+ * Issue #732: 任意の `CardData` から teamName を取り出すヘルパ。
+ * teamName も `CardPayloadBase` 経由で全カード種別の payload が共通で持てる。
+ */
+export function cardTeamName(data: CardData | undefined): string | undefined {
+  return data?.payload?.teamName;
+}
+
+/**
+ * Issue #732: 任意の `CardData` から agentId を取り出すヘルパ。
+ * agentId を持つのは agent / terminal カードのみ (TeamHub の宛先解決に使う)。
+ * 旧コードの `(payload as { agentId?: string }).agentId` 局所 cast を置き換える。
+ */
+export function cardAgentId(data: CardData | undefined): string | undefined {
+  if (!data) return undefined;
+  if (data.cardType === 'agent' || data.cardType === 'terminal') {
+    return data.payload?.agentId;
+  }
+  return undefined;
+}
+
+/**
+ * Issue #732: agent カードなら payload を、それ以外なら undefined を返すヘルパ。
+ * 「agent カードだけ見る」消費側の `switch` narrowing を 1 行に畳む。
+ */
+export function agentPayloadOf(
+  data: CardData | undefined
+): AgentCardPayload | undefined {
+  return data?.cardType === 'agent' ? data.payload : undefined;
+}
+
+/**
+ * Issue #732: 任意の `CardData` から role 識別子 (roleProfileId ?? role) を取り出すヘルパ。
+ * roleProfileId を持つのは agent、role を持つのは agent / terminal カード。
+ * 旧コードの `(payload as { roleProfileId?; role? })` 局所 cast を置き換える。
+ */
+export function cardRoleId(data: CardData | undefined): string | undefined {
+  if (!data) return undefined;
+  if (data.cardType === 'agent') {
+    return data.payload?.roleProfileId ?? data.payload?.role;
+  }
+  if (data.cardType === 'terminal') {
+    return data.payload?.role;
+  }
+  return undefined;
 }
 
 interface CanvasState {
@@ -41,17 +217,20 @@ interface CanvasState {
   setCanvasDragging: (dragging: boolean) => void;
   /** clear() 後に React Flow の内部 viewport も同期リセットするための signal。 */
   viewportResetSeq: number;
-  addCard: (card: {
-    type: CardType;
+  /**
+   * カードを 1 枚配置する。
+   * Issue #732: `type` から payload 型を導出する generic にしたので、呼び出し側で
+   * `payload` がカード種別に合っているか TS が検証する。
+   */
+  addCard: <T extends CardType>(card: {
+    type: T;
     title: string;
-    payload?: unknown;
+    payload?: CardPayloadMap[T];
     /** 明示位置 (preset 用) */
     position?: { x: number; y: number };
   }) => string;
   /** 複数 Card をまとめて配置 (preset 適用用)。1 トランザクションで永続化される */
-  addCards: (
-    cards: { type: CardType; title: string; payload?: unknown; position: { x: number; y: number } }[]
-  ) => string[];
+  addCards: (cards: CardSpec[]) => string[];
   /** カードを 1 枚削除する。
    *  デフォルトは teamId が一致する仲間カードを「チーム単位」で全部閉じる挙動 (× ボタン等の UX)。
    *  `cascadeTeam: false` を渡すと指定 id 1 枚だけを閉じる (`team_dismiss` で 1 名解雇する経路で使う)。 */
@@ -130,6 +309,29 @@ const pulseTimers = new Map<string, number>();
  *  実体は `lib/canvas-migrations.ts` 側に移し、こちらは互換維持のための re-export。 */
 export const __testables = MIGRATION_TESTABLES;
 
+/**
+ * Issue #732: `addCard` / `addCards` 共通の `Node<CardData>` 生成ヘルパ。
+ * `type` と `payload` は呼び出し側 (generic / `CardSpec`) で対応付けて渡されるため、
+ * 構築する `data` は実体として `CardDataOf<T>` (= `CardData` のいずれかの variant)。
+ * generic `T` を union member へ静的に絞れないので `data` 構築の 1 箇所だけ cast する
+ * (構造は変えず、判別 tag `cardType` と payload の対応は呼び出し側の型で保証される)。
+ */
+function makeCardNode<T extends CardType>(
+  id: string,
+  type: T,
+  position: { x: number; y: number },
+  title: string,
+  payload: CardPayloadMap[T] | undefined
+): Node<CardData> {
+  return {
+    id,
+    type,
+    position,
+    data: { cardType: type, title, payload } as CardData,
+    style: { width: NODE_W, height: NODE_H }
+  };
+}
+
 export const useCanvasStore = create<CanvasState>()(
   /**
    * Issue #253 sub: subscribeWithSelector で `subscribe(selector, listener)` API を有効化。
@@ -174,16 +376,7 @@ export const useCanvasStore = create<CanvasState>()(
           };
         }
         set({
-          nodes: [
-            ...existing,
-            {
-              id,
-              type,
-              position: pos,
-              data: { cardType: type, title, payload },
-              style: { width: NODE_W, height: NODE_H }
-            }
-          ]
+          nodes: [...existing, makeCardNode(id, type, pos, title, payload)]
         });
         return id;
       },
@@ -192,13 +385,7 @@ export const useCanvasStore = create<CanvasState>()(
         const newNodes: Node<CardData>[] = cards.map((c) => {
           const id = newId(c.type);
           ids.push(id);
-          return {
-            id,
-            type: c.type,
-            position: c.position,
-            data: { cardType: c.type, title: c.title, payload: c.payload },
-            style: { width: NODE_W, height: NODE_H }
-          };
+          return makeCardNode(id, c.type, c.position, c.title, c.payload);
         });
         set({ nodes: [...get().nodes, ...newNodes] });
         return ids;
@@ -209,12 +396,12 @@ export const useCanvasStore = create<CanvasState>()(
           // cascadeTeam=true (× ボタン等): 同 teamId 全員 + teamLocks も掃除
           // cascadeTeam=false (team_dismiss 1 名解雇): 指定 id だけを閉じ、Leader や他メンバーは残す
           const target = state.nodes.find((n) => n.id === id);
-          const teamId = (target?.data?.payload as { teamId?: string } | undefined)?.teamId;
+          const teamId = cardTeamId(target?.data);
           const ids = new Set<string>([id]);
           let teamLocksNext = state.teamLocks;
           if (cascadeTeam && teamId) {
             for (const n of state.nodes) {
-              const tid = (n.data?.payload as { teamId?: string } | undefined)?.teamId;
+              const tid = cardTeamId(n.data);
               if (tid === teamId) ids.add(n.id);
             }
             // ロック状態も一緒に掃除 (再度同じ teamId を立てる将来のために残骸を残さない)
@@ -242,10 +429,14 @@ export const useCanvasStore = create<CanvasState>()(
         set({
           nodes: get().nodes.map((n) => {
             if (n.id !== id) return n;
-            const prev = (n.data?.payload as Record<string, unknown> | undefined) ?? {};
+            // setCardPayload は意図的に「種別を問わない浅いマージ」のエスケープハッチ。
+            // patch は Record<string, unknown> なので、マージ結果を判別 union の
+            // payload 型へ静的に絞れない。data 構築の 1 箇所だけ cast する
+            // (Issue #732: 旧 `payload as Record<string,unknown>` の置き換え)。
+            const prev = (n.data.payload ?? {}) as Record<string, unknown>;
             return {
               ...n,
-              data: { ...n.data, payload: { ...prev, ...patch } }
+              data: { ...n.data, payload: { ...prev, ...patch } } as CardData
             };
           })
         }),


### PR DESCRIPTION
## Summary
Canvas カードの型システムと CardFrame の保守性改善 (2 件)。

### #732 — CardData を cardType discriminated union 化
`CardData.payload?: unknown` により消費側に 20+ の inline cast が必要だった。`CardType` ごとの payload 型 (`TerminalCardPayload` / `EditorCardPayload` / `DiffCardPayload` / `FileTreeCardPayload` / `ChangesCardPayload` / `AgentCardPayload`) を定義し、`CardData` を `cardType` タグの discriminated union 化。共通 `CardPayloadBase` (teamId/teamName) で「どのカードも team cascade に参加できる」既存挙動を維持。消費側を helper + `switch` narrowing に置換し inline cast を撤廃。`addCard` を generic 化。

### #735 — CardFrame god card 分割 + selector pure 違反修正
CardFrame.tsx (918行→429行) を root + `CardPresentation` / `CardHandoff` / `CardInject` / `CardSummary` に分割。zustand selector callback 内の ref mutate (pure 違反) を `useSyncExternalStore` ベースの `useTeamMembersSig` hook へ移し解消。

いずれも振る舞い不変の純粋リファクタ (DOM 構造・クラス名・イベント・描画順を保持)。

Closes #732
Closes #735

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm test` — canvas 関連 99 テスト (18 ファイル) 全通過。既存無関係 fail 3件 (team-prompts/theme-contrast/workspace-presets) は本変更と無関係
- [ ] Canvas モードで各カード種の描画・team cascade・handoff・inject 警告の実機確認