### PR TITLE
fix(build): #779 [lib] crate-type に rlib を復元し desktop ビルドを修復

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -96,7 +96,10 @@ legacy_message_fallback = []
 
 [lib]
 name = "vibe_editor_lib"
-crate-type = ["staticlib", "cdylib"]
+# rlib は desktop バイナリ (src/main.rs の vibe_editor_lib::run()) が lib を Rust
+# クレートとしてリンクするのに必須 (staticlib/cdylib は mobile 用の C 成果物で
+# Rust クレートとして消費できない)。削除すると desktop ビルドが壊れる (#779)。
+crate-type = ["staticlib", "cdylib", "rlib"]
 
 [[bin]]
 name = "vibe-editor"


### PR DESCRIPTION
## Summary
PR #774 (#723) が `src-tauri/Cargo.toml` の `[lib] crate-type` から `rlib` を削除したが、`src/main.rs` の `vibe-editor` バイナリは `vibe_editor_lib::run()` を呼んでおり、lib を Rust クレートとしてリンクするため `rlib` が必須。`staticlib` / `cdylib` だけでは desktop バイナリビルド (`cargo build` / `cargo tauri build`) が失敗する。

`rlib` を復元し、再削除防止のためコメントで必要性を明記した。

Closes #779

## Test plan
- [x] `["staticlib", "cdylib", "rlib"]` は #723 以前の (正常動作していた) 値の復元
- [ ] CI の cargo build / tauri-action ビルドで desktop バイナリが通ることを確認