### PR TITLE
refactor(ui): #733 window.confirm を useNativeConfirm (plugin-dialog.ask) に統一

### DIFF
--- a/src/renderer/src/components/FileTreePanel.tsx
+++ b/src/renderer/src/components/FileTreePanel.tsx
@@ -16,6 +16,7 @@ import {
 import type { FileNode } from '../../../types/shared';
 import type { RecentFileEntry } from '../lib/hooks/use-file-tabs';
 import { useT } from '../lib/i18n';
+import { useNativeConfirm } from '../lib/use-native-confirm';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 import { useToast } from '../lib/toast-context';
 import { api } from '../lib/tauri-api';
@@ -63,6 +64,7 @@ export function FileTreePanel({
   onRemoveWorkspaceFolder
 }: FileTreePanelProps): JSX.Element {
   const t = useT();
+  const confirm = useNativeConfirm();
   // Issue #273: 展開状態 / 折り畳み / dir キャッシュは Provider に集約。
   // 同じ Provider を見ている Sidebar / FileTreeCard は同じ参照を持つので、
   // 一方でトグルした結果が他方に即時反映され、`update({ fileTreeExpanded })` の
@@ -297,7 +299,7 @@ export function FileTreePanel({
       const baseKey = node.isDir
         ? 'filetree.confirmDeleteFolder'
         : 'filetree.confirmDeleteFile';
-      if (!window.confirm(t(baseKey, { name: node.name }))) return;
+      if (!(await confirm(t(baseKey, { name: node.name })))) return;
       const res = await api.files.delete(rootPath, node.path, false);
       if (res.ok) {
         showToast(t('toast.fileDeleted', { name: node.name }), { tone: 'success' });
@@ -305,7 +307,7 @@ export function FileTreePanel({
         return;
       }
       // ゴミ箱が使えない環境 (XDG ゴミ箱が無い Linux 等) → 完全削除に fallback
-      if (window.confirm(t('filetree.confirmDeletePermanent', { name: node.name }))) {
+      if (await confirm(t('filetree.confirmDeletePermanent', { name: node.name }))) {
         const r2 = await api.files.delete(rootPath, node.path, true);
         if (r2.ok) {
           showToast(t('toast.fileDeleted', { name: node.name }), { tone: 'success' });
@@ -315,7 +317,7 @@ export function FileTreePanel({
         }
       }
     },
-    [refreshDir, showOpError, showToast, t]
+    [confirm, refreshDir, showOpError, showToast, t]
   );
 
   /** Issue #592: cut / copy で clipboard に積む。paste 時に rename or copy を判定する。 */

--- a/src/renderer/src/components/NotesPanel.tsx
+++ b/src/renderer/src/components/NotesPanel.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Copy, Eraser } from 'lucide-react';
 import { useSettings } from '../lib/settings-context';
 import { useT } from '../lib/i18n';
+import { useNativeConfirm } from '../lib/use-native-confirm';
 import { useToast } from '../lib/toast-context';
 
 const SAVE_DEBOUNCE_MS = 600;
@@ -19,6 +20,7 @@ export function NotesPanel(): JSX.Element {
   const { settings, update } = useSettings();
   const t = useT();
   const toast = useToast();
+  const confirm = useNativeConfirm();
   const [draft, setDraft] = useState<string>(settings.notepad ?? '');
   const debounceRef = useRef<number | null>(null);
   const lastSavedRef = useRef<string>(settings.notepad ?? '');
@@ -69,9 +71,9 @@ export function NotesPanel(): JSX.Element {
     }
   };
 
-  const onClear = (): void => {
+  const onClear = async (): Promise<void> => {
     if (draft.length === 0) return;
-    if (!window.confirm(t('notes.confirmClear'))) return;
+    if (!(await confirm(t('notes.confirmClear')))) return;
     onChange('');
   };
 

--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -135,7 +135,7 @@ function FlowApp({ actions }: FlowAppProps): JSX.Element {
       // (Delete キー / React Flow 内部削除でもチーム全員が一括で閉じるように)
       const removes = changes.filter((c) => c.type === 'remove');
       for (const r of removes) {
-        confirmRemoveCard(r.id);
+        void confirmRemoveCard(r.id);
       }
       const remaining = removes.length > 0
         ? changes.filter((c) => c.type !== 'remove')
@@ -288,7 +288,7 @@ function FlowApp({ actions }: FlowAppProps): JSX.Element {
       }
       items.push({
         label: t('canvasMenu.deleteCard'),
-        action: () => confirmRemoveCard(node.id)
+        action: () => void confirmRemoveCard(node.id)
       });
       setContextMenu({ x: e.clientX, y: e.clientY, items });
     },

--- a/src/renderer/src/components/canvas/CanvasSidebar.tsx
+++ b/src/renderer/src/components/canvas/CanvasSidebar.tsx
@@ -12,6 +12,7 @@ import { Sidebar, type SidebarView } from '../Sidebar';
 import { useCanvasStore } from '../../stores/canvas';
 import { useSettings } from '../../lib/settings-context';
 import { useT } from '../../lib/i18n';
+import { useNativeConfirm } from '../../lib/use-native-confirm';
 import { useUiStore } from '../../stores/ui';
 import { ROLE_META } from '../../lib/team-roles';
 import { useFilesChanged } from '../../lib/use-files-changed';
@@ -35,6 +36,7 @@ export function CanvasSidebar({
 }: CanvasSidebarProps = {}): JSX.Element {
   const { settings, update } = useSettings();
   const t = useT();
+  const confirm = useNativeConfirm();
   // Issue #23: projectRoot は「現在開いているプロジェクト」= lastOpenedRoot を優先。
   // claudeCwd は Claude CLI 起動時の作業ディレクトリ設定 (別用途) としてだけ使う。
   // lastOpenedRoot が空 (初回) のときだけ claudeCwd にフォールバック。
@@ -243,7 +245,7 @@ export function CanvasSidebar({
       const isPrimary = path === projectRoot;
       if (isPrimary) {
         const name = path.split(/[\\/]/).pop() ?? path;
-        if (!window.confirm(t('workspace.removePrimaryConfirm', { name }))) return;
+        if (!(await confirm(t('workspace.removePrimaryConfirm', { name })))) return;
       }
       const nextPrimary = isPrimary ? workspaceFolders.find((p) => p !== path) ?? '' : projectRoot;
       const next = workspaceFolders.filter((p) => p !== path && p !== nextPrimary);
@@ -253,7 +255,7 @@ export function CanvasSidebar({
         ...(isPrimary ? { lastOpenedRoot: nextPrimary } : {})
       });
     },
-    [workspaceFolders, projectRoot, update, t]
+    [workspaceFolders, projectRoot, update, t, confirm]
   );
 
   const handleOpenRecent = useCallback(

--- a/src/renderer/src/components/canvas/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/CardFrame.tsx
@@ -60,7 +60,7 @@ export function CardFrame({
         <button
           type="button"
           className="nodrag canvas-card-frame__close"
-          onClick={() => confirmRemoveCard(id)}
+          onClick={() => void confirmRemoveCard(id)}
           title="Close"
         >
           ×

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -343,7 +343,10 @@ function AgentNodeCardImpl({
     [health]
   );
 
-  const handleClose = useCallback(() => confirmRemoveCard(id), [confirmRemoveCard, id]);
+  const handleClose = useCallback(
+    () => void confirmRemoveCard(id),
+    [confirmRemoveCard, id]
+  );
 
   return (
     <>

--- a/src/renderer/src/components/canvas/cards/FileTreeCard.tsx
+++ b/src/renderer/src/components/canvas/cards/FileTreeCard.tsx
@@ -12,6 +12,7 @@ import { useCanvasStore } from '../../../stores/canvas';
 import type { CardDataOf } from '../../../stores/canvas';
 import { useSettings } from '../../../lib/settings-context';
 import { useT } from '../../../lib/i18n';
+import { useNativeConfirm } from '../../../lib/use-native-confirm';
 
 // Issue #732: payload 型は canvas store の判別可能 union に集約。`NodeProps` を
 // `Node<CardDataOf<'fileTree'>>` で具体化することで `data.payload` が直接読め、inline cast を撤廃。
@@ -23,6 +24,7 @@ function FileTreeCardImpl({
 }: NodeProps<Node<CardDataOf<'fileTree'>>>): JSX.Element {
   const { settings, update } = useSettings();
   const t = useT();
+  const confirm = useNativeConfirm();
   const payload = data?.payload ?? {};
   // Issue #23: lastOpenedRoot (現在プロジェクト) を最優先、claudeCwd は fallback。
   const projectRoot = settings.lastOpenedRoot || settings.claudeCwd || payload.projectRoot || '';
@@ -63,7 +65,7 @@ function FileTreeCardImpl({
       if (!isPrimary && !current.includes(path)) return;
       if (isPrimary) {
         const name = path.split(/[\\/]/).pop() ?? path;
-        if (!window.confirm(t('workspace.removePrimaryConfirm', { name }))) return;
+        if (!(await confirm(t('workspace.removePrimaryConfirm', { name })))) return;
       }
       const nextPrimary = isPrimary ? current.find((p) => p !== path) ?? '' : projectRoot;
       await update({
@@ -71,7 +73,7 @@ function FileTreeCardImpl({
         ...(isPrimary ? { lastOpenedRoot: nextPrimary } : {})
       });
     },
-    [settings.workspaceFolders, projectRoot, update, t]
+    [settings.workspaceFolders, projectRoot, update, t, confirm]
   );
 
   // Issue #273: 展開状態 / 永続化は FileTreeStateProvider に集約済み。FileTreeCard 自身は

--- a/src/renderer/src/components/settings/CustomAgentEditor.tsx
+++ b/src/renderer/src/components/settings/CustomAgentEditor.tsx
@@ -1,5 +1,6 @@
 import type { AgentConfig, AppSettings } from '../../../../types/shared';
 import { useT } from '../../lib/i18n';
+import { useNativeConfirm } from '../../lib/use-native-confirm';
 import { parseShellArgsStrict } from '../../lib/parse-args';
 import type { UpdateSetting } from './types';
 
@@ -16,6 +17,7 @@ interface Props {
  */
 export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element {
   const t = useT();
+  const confirm = useNativeConfirm();
   const argsParse = parseShellArgsStrict(agent.args);
 
   const patchAgent = (patch: Partial<AgentConfig>): void => {
@@ -25,8 +27,8 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
     update('customAgents', next);
   };
 
-  const remove = (): void => {
-    if (!window.confirm(t('settings.customAgents.confirmDelete', { name: agent.name }))) return;
+  const remove = async (): Promise<void> => {
+    if (!(await confirm(t('settings.customAgents.confirmDelete', { name: agent.name })))) return;
     update(
       'customAgents',
       (draft.customAgents ?? []).filter((a) => a.id !== agent.id)

--- a/src/renderer/src/components/settings/RoleProfilesSection.tsx
+++ b/src/renderer/src/components/settings/RoleProfilesSection.tsx
@@ -12,12 +12,14 @@ import { useState } from 'react';
 import { ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
 import type { RoleProfile } from '../../../../types/shared';
 import { useT } from '../../lib/i18n';
+import { useNativeConfirm } from '../../lib/use-native-confirm';
 import { useSettings } from '../../lib/settings-context';
 import { useRoleProfiles } from '../../lib/role-profiles-context';
 import { BUILTIN_BY_ID } from '../../lib/role-profiles-builtin';
 
 export function RoleProfilesSection(): JSX.Element {
   const t = useT();
+  const confirm = useNativeConfirm();
   const { settings } = useSettings();
   const { ordered, file, upsertOverride, addCustom, removeCustom, saveFile } = useRoleProfiles();
   const [expanded, setExpanded] = useState<string | null>(null);
@@ -126,7 +128,7 @@ export function RoleProfilesSection(): JSX.Element {
               BUILTIN_BY_ID[p.id]
                 ? undefined
                 : async () => {
-                    if (window.confirm(t('settings.roles.confirmDelete', { id: p.id }))) {
+                    if (await confirm(t('settings.roles.confirmDelete', { id: p.id }))) {
                       await removeCustom(p.id);
                     }
                   }

--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -39,6 +39,7 @@ import { AppMenuBar } from '../components/shell/AppMenuBar';
 import type { SidebarView } from '../components/Sidebar';
 import { SettingsModal } from '../components/SettingsModal';
 import { useT } from '../lib/i18n';
+import { useNativeConfirm } from '../lib/use-native-confirm';
 import { useUiStore } from '../stores/ui';
 import { useCanvasStore } from '../stores/canvas';
 import { useCanvasViewport } from '../stores/canvas-selectors';
@@ -101,6 +102,7 @@ export function CanvasLayout(): JSX.Element {
   const notifyRecruit = useCanvasStore((s) => s.notifyRecruit);
   const { settings, update: updateSettings, reset: resetSettings } = useSettings();
   const t = useT();
+  const confirm = useNativeConfirm();
   // プロジェクトルート: runtime の lastOpenedRoot を優先。ユーザー設定の
   // claudeCwd (明示指定された作業ディレクトリ) は互換フォールバックとして扱う。
   const projectRoot = settings.lastOpenedRoot || settings.claudeCwd || '';
@@ -362,7 +364,7 @@ export function CanvasLayout(): JSX.Element {
         count: dirty.length,
         paths
       });
-      if (!window.confirm(message)) return;
+      if (!(await confirm(message))) return;
     }
     await window.api.app.restart();
   };
@@ -444,10 +446,10 @@ export function CanvasLayout(): JSX.Element {
     void window.api.app.openExternal('https://github.com/yusei531642/vibe-editor');
   }, []);
 
-  const clearCanvas = (): void => {
+  const clearCanvas = async (): Promise<void> => {
     const dirty = getDirtyEditorCardSnapshots();
     if (dirty.length === 0) {
-      if (window.confirm(t('canvas.clearConfirm'))) clear();
+      if (await confirm(t('canvas.clearConfirm'))) clear();
       return;
     }
     const paths = dirty.map((d) => `• ${d.relPath}`).join('\n');
@@ -455,7 +457,7 @@ export function CanvasLayout(): JSX.Element {
       count: dirty.length,
       paths
     });
-    if (window.confirm(message)) clear();
+    if (await confirm(message)) clear();
   };
 
   const canvasActions = useMemo<CanvasActions>(
@@ -509,7 +511,7 @@ export function CanvasLayout(): JSX.Element {
               <button
                 type="button"
                 className="canvas-btn canvas-btn--ghost"
-                onClick={clearCanvas}
+                onClick={() => void clearCanvas()}
                 title={t('canvas.clear.tooltip')}
                 aria-label={t('canvas.clear.tooltip')}
               >

--- a/src/renderer/src/lib/__tests__/use-confirm-remove-card.test.tsx
+++ b/src/renderer/src/lib/__tests__/use-confirm-remove-card.test.tsx
@@ -1,14 +1,18 @@
 /**
  * useConfirmRemoveCard の confirm 経路テスト (Issue #595)。
  *
- * - dirty な EditorCard が居る場合は window.confirm が呼ばれ、cancel すると removeCard が走らない
+ * - dirty な EditorCard が居る場合は確認ダイアログが出て、cancel すると removeCard が走らない
  * - 確認 OK の場合は removeCard が走る
  * - dirty 無しなら追加 confirm を出さずにそのまま removeCard する
  * - team cascade で dirty editor が巻き込まれる場合も confirm が出る
+ *
+ * Issue #733: window.confirm から useNativeConfirm (@tauri-apps/plugin-dialog の ask)
+ *   へ移行したため、確認ダイアログのモックは ask に対して行い、hook は async になった。
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
+import { ask } from '@tauri-apps/plugin-dialog';
 import { useConfirmRemoveCard } from '../use-confirm-remove-card';
 import { useCanvasStore } from '../../stores/canvas';
 import {
@@ -18,6 +22,12 @@ import {
 import { SettingsProvider } from '../settings-context';
 import { ToastProvider } from '../toast-context';
 import { DEFAULT_SETTINGS } from '../../../../types/shared';
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  ask: vi.fn(async () => true)
+}));
+
+const askMock = vi.mocked(ask);
 
 type TestWindow = Window &
   typeof globalThis & {
@@ -62,12 +72,12 @@ function setupCanvas(
 
 describe('useConfirmRemoveCard (Issue #595)', () => {
   let originalApi: unknown;
-  let confirmSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     originalApi = (window as TestWindow).api;
     installApiStub();
-    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    askMock.mockReset();
+    askMock.mockResolvedValue(true);
     __resetEditorCardDirtyRegistry();
     useCanvasStore.setState({ nodes: [], edges: [], teamLocks: {} } as never);
   });
@@ -80,77 +90,76 @@ describe('useConfirmRemoveCard (Issue #595)', () => {
     }
     __resetEditorCardDirtyRegistry();
     useCanvasStore.setState({ nodes: [], edges: [], teamLocks: {} } as never);
-    confirmSpy.mockRestore();
     vi.restoreAllMocks();
   });
 
-  it('単一 dirty EditorCard を × で閉じようとすると confirm が出る', () => {
+  it('単一 dirty EditorCard を × で閉じようとすると confirm が出る', async () => {
     setupCanvas([{ id: 'editor-1', type: 'editor' }]);
     registerEditorCardDirty('editor-1', () => ({ relPath: 'src/foo.ts', isDirty: true }));
-    confirmSpy.mockReturnValue(true);
+    askMock.mockResolvedValue(true);
 
     const { result } = renderHook(() => useConfirmRemoveCard(), { wrapper: Wrapper });
-    result.current('editor-1');
+    await result.current('editor-1');
 
-    expect(confirmSpy).toHaveBeenCalledTimes(1);
-    expect(confirmSpy.mock.calls[0][0]).toContain('src/foo.ts');
+    expect(askMock).toHaveBeenCalledTimes(1);
+    expect(String(askMock.mock.calls[0][0])).toContain('src/foo.ts');
     expect(useCanvasStore.getState().nodes).toEqual([]);
   });
 
-  it('dirty EditorCard で confirm cancel すると removeCard は呼ばれず content が残る', () => {
+  it('dirty EditorCard で confirm cancel すると removeCard は呼ばれず content が残る', async () => {
     setupCanvas([{ id: 'editor-1', type: 'editor' }]);
     registerEditorCardDirty('editor-1', () => ({ relPath: 'src/foo.ts', isDirty: true }));
-    confirmSpy.mockReturnValue(false);
+    askMock.mockResolvedValue(false);
 
     const { result } = renderHook(() => useConfirmRemoveCard(), { wrapper: Wrapper });
-    result.current('editor-1');
+    await result.current('editor-1');
 
-    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(askMock).toHaveBeenCalledTimes(1);
     expect(useCanvasStore.getState().nodes).toHaveLength(1);
   });
 
-  it('dirty で無い EditorCard は追加 confirm を出さずに即削除する', () => {
+  it('dirty で無い EditorCard は追加 confirm を出さずに即削除する', async () => {
     setupCanvas([{ id: 'editor-1', type: 'editor' }]);
     registerEditorCardDirty('editor-1', () => ({ relPath: 'src/foo.ts', isDirty: false }));
 
     const { result } = renderHook(() => useConfirmRemoveCard(), { wrapper: Wrapper });
-    result.current('editor-1');
+    await result.current('editor-1');
 
-    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(askMock).not.toHaveBeenCalled();
     expect(useCanvasStore.getState().nodes).toEqual([]);
   });
 
-  it('team cascade で dirty EditorCard が巻き込まれるなら editor confirm まで通る', () => {
+  it('team cascade で dirty EditorCard が巻き込まれるなら editor confirm まで通る', async () => {
     setupCanvas([
       { id: 'leader-1', type: 'agent', payload: { teamId: 'team-x', teamName: 'Alpha' } },
       { id: 'worker-1', type: 'agent', payload: { teamId: 'team-x' } },
       { id: 'editor-1', type: 'editor', payload: { teamId: 'team-x' } }
     ]);
     registerEditorCardDirty('editor-1', () => ({ relPath: 'src/foo.ts', isDirty: true }));
-    confirmSpy.mockReturnValue(true);
+    askMock.mockResolvedValue(true);
 
     const { result } = renderHook(() => useConfirmRemoveCard(), { wrapper: Wrapper });
-    result.current('leader-1');
+    await result.current('leader-1');
 
-    expect(confirmSpy).toHaveBeenCalledTimes(2);
-    expect(confirmSpy.mock.calls[0][0]).toMatch(/Alpha|3/);
-    expect(confirmSpy.mock.calls[1][0]).toContain('src/foo.ts');
+    expect(askMock).toHaveBeenCalledTimes(2);
+    expect(String(askMock.mock.calls[0][0])).toMatch(/Alpha|3/);
+    expect(String(askMock.mock.calls[1][0])).toContain('src/foo.ts');
     expect(useCanvasStore.getState().nodes).toEqual([]);
   });
 
-  it('team cascade で 1 回目をキャンセルすれば editor confirm まで進まず何も削除されない', () => {
+  it('team cascade で 1 回目をキャンセルすれば editor confirm まで進まず何も削除されない', async () => {
     setupCanvas([
       { id: 'leader-1', type: 'agent', payload: { teamId: 'team-x' } },
       { id: 'worker-1', type: 'agent', payload: { teamId: 'team-x' } },
       { id: 'editor-1', type: 'editor', payload: { teamId: 'team-x' } }
     ]);
     registerEditorCardDirty('editor-1', () => ({ relPath: 'src/foo.ts', isDirty: true }));
-    confirmSpy.mockReturnValue(false);
+    askMock.mockResolvedValue(false);
 
     const { result } = renderHook(() => useConfirmRemoveCard(), { wrapper: Wrapper });
-    result.current('leader-1');
+    await result.current('leader-1');
 
-    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(askMock).toHaveBeenCalledTimes(1);
     expect(useCanvasStore.getState().nodes).toHaveLength(3);
   });
 });

--- a/src/renderer/src/lib/hooks/use-file-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-file-tabs.ts
@@ -5,6 +5,7 @@ import type {
   GitStatus
 } from '../../../../types/shared';
 import { useT } from '../i18n';
+import { useNativeConfirm } from '../use-native-confirm';
 
 export interface DiffTab {
   id: string;
@@ -86,8 +87,8 @@ export interface UseFileTabsResult {
 
   // ---- 派生値 ----
   dirtyEditorTabs: EditorTab[];
-  /** tabIds 省略時は全 dirty を対象。confirm dialog を出して bool を返す。 */
-  confirmDiscardEditorTabs: (tabIds?: string[]) => boolean;
+  /** tabIds 省略時は全 dirty を対象。ネイティブ確認 dialog を出して bool を resolve する。 */
+  confirmDiscardEditorTabs: (tabIds?: string[]) => Promise<boolean>;
   /**
    * Issue #480: 最近開いたファイルの履歴 (新しい順)。
    * active ファイルも含むが、UI 側で active を優先表示する。
@@ -100,7 +101,7 @@ export interface UseFileTabsResult {
   saveEditorTab: (id: string) => Promise<void>;
   openDiffTab: (file: GitFileChange) => Promise<void>;
   refreshDiffTabsForPath: (relPath: string) => Promise<void>;
-  closeTab: (id: string) => void;
+  closeTab: (id: string) => Promise<void>;
   togglePin: (id: string) => void;
   reopenLastClosed: () => void;
   cycleTab: (direction: 1 | -1) => void;
@@ -126,6 +127,7 @@ export interface UseFileTabsResult {
  */
 export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
   const t = useT();
+  const confirm = useNativeConfirm();
 
   const optsRef = useRef(opts);
   optsRef.current = opts;
@@ -144,18 +146,18 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
   );
 
   const confirmDiscardEditorTabs = useCallback(
-    (tabIds?: string[]): boolean => {
+    async (tabIds?: string[]): Promise<boolean> => {
       const targets =
         tabIds && tabIds.length > 0
           ? dirtyEditorTabs.filter((tab) => tabIds.includes(tab.id))
           : dirtyEditorTabs;
       if (targets.length === 0) return true;
       if (targets.length === 1) {
-        return window.confirm(t('editor.discardSingle', { path: targets[0].relPath }));
+        return confirm(t('editor.discardSingle', { path: targets[0].relPath }));
       }
-      return window.confirm(t('editor.discardMultiple', { count: targets.length }));
+      return confirm(t('editor.discardMultiple', { count: targets.length }));
     },
-    [dirtyEditorTabs, t]
+    [dirtyEditorTabs, t, confirm]
   );
 
   const openDiffTab = useCallback(
@@ -352,7 +354,7 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
         );
         if (res.conflict) {
           // ユーザーに確認 → OK なら再度 mtime/size/hash チェックなしで書き込む
-          const overwrite = window.confirm(
+          const overwrite = await confirm(
             t('editor.externalChangeConfirm', { path: tab.relPath })
           );
           if (!overwrite) {
@@ -395,22 +397,27 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
         showToast(t('editor.saveFailed', { error: String(err) }), { tone: 'error' });
       }
     },
-    [editorTabs, refreshDiffTabsForPath, t]
+    [editorTabs, refreshDiffTabsForPath, t, confirm]
   );
 
   const closeTab = useCallback(
-    (id: string) => {
+    async (id: string) => {
       if (id.startsWith('edit:')) {
+        // confirm がネイティブ dialog (非同期) になったため、setEditorTabs の
+        // updater 内では確認できない。先に対象タブの dirty 判定 → 確認 → その後
+        // setState でフィルタする (旧 updater 内ガードと同じ「pinned/不在/cancel
+        // なら何もしない」挙動を保つ)。
+        const target = editorTabs.find((t) => t.id === id);
+        if (!target || target.pinned) return;
+        if (
+          !target.isBinary &&
+          target.content !== target.originalContent &&
+          !(await confirmDiscardEditorTabs([id]))
+        ) {
+          return;
+        }
         setEditorTabs((prev) => {
-          const target = prev.find((t) => t.id === id);
-          if (!target || target.pinned) return prev;
-          if (
-            !target.isBinary &&
-            target.content !== target.originalContent &&
-            !confirmDiscardEditorTabs([id])
-          ) {
-            return prev;
-          }
+          if (!prev.some((t) => t.id === id)) return prev;
           const next = prev.filter((t) => t.id !== id);
           if (activeTabId === id) {
             // 残ったエディタ or 差分タブのうち末尾を選択

--- a/src/renderer/src/lib/hooks/use-project-loader.ts
+++ b/src/renderer/src/lib/hooks/use-project-loader.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { GitStatus, SessionInfo } from '../../../../types/shared';
 import { useT } from '../i18n';
+import { useNativeConfirm } from '../use-native-confirm';
 import {
   useSettingsActions,
   useSettingsLoading,
@@ -68,6 +69,7 @@ export function useProjectLoader(
   const hasCompletedOnboarding = useSettingsValue('hasCompletedOnboarding');
   const mcpAutoSetup = useSettingsValue('mcpAutoSetup');
   const t = useT();
+  const confirm = useNativeConfirm();
 
   const [projectRoot, setProjectRoot] = useState<string>('');
   const [gitStatus, setGitStatus] = useState<GitStatus | null>(null);
@@ -304,7 +306,7 @@ export function useProjectLoader(
       if (!isPrimary && !current.includes(path)) return;
       const name = path.split(/[\\/]/).pop() ?? path;
 
-      if (isPrimary && !window.confirm(t('workspace.removePrimaryConfirm', { name }))) {
+      if (isPrimary && !(await confirm(t('workspace.removePrimaryConfirm', { name })))) {
         return;
       }
 
@@ -338,7 +340,7 @@ export function useProjectLoader(
       }
       optsRef.current.showToast(t('workspace.removed', { name }), { tone: 'info' });
     },
-    [workspaceFoldersFromSettings, projectRoot, loadProject, updateSettings, t]
+    [workspaceFoldersFromSettings, projectRoot, loadProject, updateSettings, t, confirm]
   );
 
   return {

--- a/src/renderer/src/lib/use-confirm-remove-card.ts
+++ b/src/renderer/src/lib/use-confirm-remove-card.ts
@@ -14,12 +14,14 @@
 import { useCallback } from 'react';
 import { useCanvasStore, cardTeamId, cardTeamName } from '../stores/canvas';
 import { useT } from './i18n';
+import { useNativeConfirm } from './use-native-confirm';
 import { getDirtyEditorCardSnapshots } from './editor-card-dirty-registry';
 
-export function useConfirmRemoveCard(): (id: string) => void {
+export function useConfirmRemoveCard(): (id: string) => Promise<void> {
   const t = useT();
+  const confirm = useNativeConfirm();
   return useCallback(
-    (id: string) => {
+    async (id: string) => {
       const state = useCanvasStore.getState();
       const target = state.nodes.find((n) => n.id === id);
       // Issue #732: teamId / teamName 抽出は判別可能 union を見る共通 helper に集約
@@ -37,7 +39,7 @@ export function useConfirmRemoveCard(): (id: string) => void {
       // ---- 1) チーム cascade confirm (既存仕様) ----
       if (teamId && idsToRemove.size > 1) {
         const teamName = cardTeamName(target?.data) ?? teamId;
-        const ok = window.confirm(
+        const ok = await confirm(
           t('agentCard.confirmCloseTeam', {
             count: idsToRemove.size,
             name: teamName
@@ -48,19 +50,19 @@ export function useConfirmRemoveCard(): (id: string) => void {
       // ---- 2) editor dirty confirm (Issue #595) ----
       const dirty = getDirtyEditorCardSnapshots(idsToRemove);
       if (dirty.length === 1) {
-        const ok = window.confirm(
+        const ok = await confirm(
           t('editor.confirmDiscardChanges', { path: dirty[0].relPath })
         );
         if (!ok) return;
       } else if (dirty.length > 1) {
         const paths = dirty.map((d) => `• ${d.relPath}`).join('\n');
-        const ok = window.confirm(
+        const ok = await confirm(
           t('editor.confirmDiscardChangesPlural', { count: dirty.length, paths })
         );
         if (!ok) return;
       }
       state.removeCard(id);
     },
-    [t]
+    [t, confirm]
   );
 }

--- a/src/renderer/src/lib/use-native-confirm.ts
+++ b/src/renderer/src/lib/use-native-confirm.ts
@@ -1,0 +1,50 @@
+/**
+ * useNativeConfirm — `window.confirm` の代替となる Tauri ネイティブ確認ダイアログ hook。
+ *
+ * 背景 (Issue #733):
+ *   WebView の `window.confirm` はネイティブ感が無く a11y もブラウザ依存。App.tsx /
+ *   AppShell.tsx は既に `@tauri-apps/plugin-dialog` の `ask` に統一済み。本 hook で
+ *   残りの確認ダイアログも同じネイティブ dialog に揃える。
+ *
+ * 使い方:
+ *   const confirm = useNativeConfirm();
+ *   if (await confirm(t('foo.confirmDelete'))) { ... }
+ *
+ *   返り値は `(message, options?) => Promise<boolean>`。OK で `true` / Cancel で
+ *   `false` を resolve するため、`window.confirm` の「OK で実行 / Cancel で中止」
+ *   ロジックをそのまま `await` 付きで置き換えられる。
+ */
+import { useCallback } from 'react';
+
+export interface NativeConfirmOptions {
+  /** ダイアログのタイトル。既定は 'vibe-editor'。 */
+  title?: string;
+  /** ダイアログの種別。既定は確認系として 'warning'。 */
+  kind?: 'info' | 'warning' | 'error';
+  /** OK ボタンのラベル。 */
+  okLabel?: string;
+  /** Cancel ボタンのラベル。 */
+  cancelLabel?: string;
+}
+
+/** ネイティブ確認ダイアログを開く関数。OK で `true` / Cancel で `false`。 */
+export type NativeConfirm = (
+  message: string,
+  options?: NativeConfirmOptions
+) => Promise<boolean>;
+
+/**
+ * Tauri ネイティブ確認ダイアログを返す hook。
+ * `ask` は動的 import する (AppShell / updater-check の既存パターンに合わせる)。
+ */
+export function useNativeConfirm(): NativeConfirm {
+  return useCallback<NativeConfirm>(async (message, options) => {
+    const { ask } = await import('@tauri-apps/plugin-dialog');
+    return ask(message, {
+      title: options?.title ?? 'vibe-editor',
+      kind: options?.kind ?? 'warning',
+      okLabel: options?.okLabel,
+      cancelLabel: options?.cancelLabel
+    });
+  }, []);
+}


### PR DESCRIPTION
## Summary
WebView の `window.confirm` はネイティブ感が無く a11y もブラウザ依存。`useNativeConfirm()` hook (内部で `@tauri-apps/plugin-dialog` の `ask` をラップ) を新設し、プロジェクト全体の `window.confirm` 呼び出し (全 17 サイト) を Tauri ネイティブ確認ダイアログへ統一。呼び出し元は async/await 化。`use-confirm-remove-card` のテストも `ask` モックへ追従。

ESLint で `window.confirm` / `alert` / `prompt` を禁止する案 (#733 修正方針 3) は lint 強化 (#721) と連動のため本 PR では見送り (現状 eslint flat config 未整備)。

Closes #733

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm test` — use-confirm-remove-card 5テスト含め通過 (既存無関係 fail 3件 team-prompts/theme-contrast/workspace-presets は本変更と無関係)
- [x] `grep "window.confirm("` — 実呼び出し 0 件を確認
- [ ] 各種確認ダイアログ (ファイル削除・上書き・workspace folder 削除等) の実機確認