### PR TITLE
refactor(state): #739 AppState を async 安全化 + team_history/schema/小規模整理

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -57,6 +57,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5199,6 +5208,7 @@ name = "vibe-editor"
 version = "1.6.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "assert_matches",
  "base64 0.22.1",
  "bytes",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,10 @@ tracing-appender = "0.2"
 
 # --- misc ---
 once_cell = "1"
+# Issue #739: AppState.project_root を `std::sync::Mutex<Option<String>>` から
+# lock-free な `ArcSwapOption<String>` へ置換し、async コンテキストからの load/store を
+# 構造的に deadlock-free にする (Mutex を async task から lock するアンチパターンを排除)。
+arc-swap = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 dirs = "6"

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -26,9 +26,8 @@ pub struct AppUserInfo {
 
 #[tauri::command]
 pub fn app_get_project_root(state: State<AppState>) -> String {
-    // Issue #147: poison しても recovery して値を返す。
-    crate::state::lock_project_root_recover(&state.project_root)
-        .clone()
+    // Issue #739: ArcSwapOption の lock-free load で現在値を取得する。
+    crate::state::current_project_root(&state.project_root)
         .or_else(|| {
             std::env::current_dir()
                 .ok()
@@ -70,14 +69,15 @@ pub fn app_set_project_root(
             "project_root rejected by safety check (system / home / non-existent dir): {trimmed}"
         )));
     }
-    // Issue #147: poison していても recovery して書き込む。失敗で常時死亡しない。
-    let mut guard = crate::state::lock_project_root_recover(&state.project_root);
-    *guard = if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.clone())
-    };
-    drop(guard);
+    // Issue #739: ArcSwapOption の lock-free store で書き込む。
+    crate::state::set_project_root(
+        &state.project_root,
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.clone())
+        },
+    );
     // Issue #66: watcher は project_root 変更ごとに付け替える
     if !trimmed.is_empty() {
         // Issue #724: 画像プレビュー (ImagePreview / EditorView) が `asset://` で開くのは

--- a/src-tauri/src/commands/app/team_mcp.rs
+++ b/src-tauri/src/commands/app/team_mcp.rs
@@ -172,9 +172,8 @@ pub async fn app_setup_team_mcp(
     // → app_install_vibe_team_skill と同じく req_canon == active_canon を検証してから install する。
     let trimmed = project_root.trim();
     if !trimmed.is_empty() {
-        let active = crate::state::lock_project_root_recover(&state.project_root)
-            .clone()
-            .unwrap_or_default();
+        let active =
+            crate::state::current_project_root(&state.project_root).unwrap_or_default();
         if active.trim().is_empty() {
             tracing::warn!(
                 "[setup_team_mcp] skipping skill install: no active project_root configured"

--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -8,14 +8,19 @@
 //! cross-project leak が成立していた。
 //!
 //! 本 module は `app_install_vibe_team_skill` (#191 で実装済み) と同じ手順
-//! (`lock_project_root_recover` → `canonicalize` 両者比較) を `assert_active_project_root`
+//! (active project_root を読む → `canonicalize` 両者比較) を `assert_active_project_root`
 //! 1 関数に共通化し、A-2 / A-3 / A-8 で同じ防御を横展開できるようにする。
+//!
+//! Issue #739: active project_root の保持を `std::sync::Mutex<Option<String>>` から
+//! lock-free な `ArcSwapOption<String>` へ移したため、本 helper も `ArcSwapOption` を
+//! 受け取る形に追従する (deadlock 経路の構造的排除)。
 
 use std::path::PathBuf;
-use std::sync::Mutex;
+
+use arc_swap::ArcSwapOption;
 
 use crate::commands::error::{CommandError, CommandResult};
-use crate::state::lock_project_root_recover;
+use crate::state::current_project_root;
 use crate::team_hub::TeamHub;
 
 /// 監査ログに raw path を出すときの clamp (制御文字を `?` に置換 + 240 文字で truncate)。
@@ -50,7 +55,7 @@ fn clamp_team_id_for_log(raw: &str) -> String {
 /// reject 時は `tracing::warn!` で active / 試行 path (clamp 済み) を audit log に残す。
 /// 戻り値は **canonicalize 後の active path** (caller が後続処理で使えるよう返す)。
 pub async fn assert_active_project_root(
-    project_root_lock: &Mutex<Option<String>>,
+    project_root_slot: &ArcSwapOption<String>,
     given: &str,
 ) -> CommandResult<PathBuf> {
     let trimmed = given.trim();
@@ -62,9 +67,7 @@ pub async fn assert_active_project_root(
         return Err(CommandError::authz("project_root is empty"));
     }
 
-    let active = lock_project_root_recover(project_root_lock)
-        .clone()
-        .unwrap_or_default();
+    let active = current_project_root(project_root_slot).unwrap_or_default();
     if active.trim().is_empty() {
         tracing::warn!(
             given = %clamp_for_log(given),
@@ -157,11 +160,11 @@ pub async fn assert_active_team(hub: &TeamHub, team_id: &str) -> CommandResult<(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
     use tempfile::tempdir;
 
-    fn make_lock(value: Option<String>) -> Mutex<Option<String>> {
-        Mutex::new(value)
+    /// Issue #739: テスト用の `ArcSwapOption<String>` を作る (旧 `Mutex<Option<String>>` の後継)。
+    fn make_lock(value: Option<String>) -> ArcSwapOption<String> {
+        ArcSwapOption::from(value.map(std::sync::Arc::new))
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -739,7 +739,8 @@ async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
             if file_type.is_symlink() {
                 // Security: planted symlink を経由したプロジェクト外読み出しを防ぐため、
                 // copy 対象から除外する。symlink cycle による無限ループも同時に防止する。
-                eprintln!(
+                // Issue #739: tracing 統一のため eprintln! ではなく tracing::warn! を使う。
+                tracing::warn!(
                     "[files_copy] skipping symlink entry: {}",
                     from_child.display()
                 );
@@ -756,7 +757,8 @@ async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
                     .map_err(|e| e.to_string())?;
             } else {
                 // 通常ファイル / ディレクトリ / symlink 以外 (FIFO 等) は skip する。
-                eprintln!(
+                // Issue #739: tracing 統一のため eprintln! ではなく tracing::warn! を使う。
+                tracing::warn!(
                     "[files_copy] skipping non-regular entry: {}",
                     from_child.display()
                 );

--- a/src-tauri/src/commands/handoffs.rs
+++ b/src-tauri/src/commands/handoffs.rs
@@ -62,6 +62,8 @@ pub struct HandoffCreateRequest {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct HandoffCheckpoint {
+    /// handoff checkpoint JSON の schema version。
+    /// Issue #739: 値は `commands::schema_version::HANDOFF_SCHEMA_VERSION` を SSOT とする。
     pub schema_version: u32,
     pub id: String,
     pub project_root: String,
@@ -320,7 +322,7 @@ pub async fn handoffs_create(
     let json_path = dir.join(format!("{id}.json"));
     let markdown_path = dir.join(format!("{id}.md"));
     let handoff = HandoffCheckpoint {
-        schema_version: 1,
+        schema_version: crate::commands::schema_version::HANDOFF_SCHEMA_VERSION,
         id,
         project_root: req.project_root,
         team_id: req.team_id,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -16,6 +16,8 @@ pub mod git;
 pub mod handoffs;
 pub mod logs;
 pub mod role_profiles;
+// Issue #739: 永続化 schema バージョン定数 + 互換性ガードの集約モジュール。
+pub mod schema_version;
 pub mod sessions;
 pub mod settings;
 pub mod team_diagnostics;

--- a/src-tauri/src/commands/schema_version.rs
+++ b/src-tauri/src/commands/schema_version.rs
@@ -1,0 +1,177 @@
+//! Issue #739: 永続化 schema バージョン定数と互換性チェックの集約モジュール。
+//!
+//! 背景: `settings.json` / `team-state` JSON / `handoffs` checkpoint など複数の永続化
+//! ストアがそれぞれ独自に schema version 定数を持ち、互換性ガード (`disk が新しい build で
+//! 作られていたら save を拒否する` 等) のロジックも `settings.rs` にしか書かれていなかった。
+//! 新しいストアを足す contributor が「どこに version を書き、どう bump 判定するか」を
+//! 都度 settings.rs から発掘する必要があった。
+//!
+//! 本 module は:
+//!   - 各ストアの現行 schema version 定数を 1 箇所 (SSOT) に集約する。
+//!     既存の `commands::settings::APP_SETTINGS_SCHEMA_VERSION` /
+//!     `commands::team_state::TEAM_STATE_SCHEMA_VERSION` は本 module の定数を `pub use`
+//!     で re-export しているので、旧 import パスはそのまま使える。
+//!   - `SchemaVersion::check_compat` で「disk が未来 schema / incoming が未来 schema」を
+//!     拒否する共通互換性ガードを提供する。`settings_save` の #641 ガードはこれ経由になり、
+//!     将来 team-state / handoffs に同種ガードを足すときも横展開できる。
+
+use crate::commands::error::{CommandError, CommandResult};
+
+/// `~/.vibe-editor/settings.json` の現行 schema version。
+/// renderer 側 `src/types/shared.ts` の `APP_SETTINGS_SCHEMA_VERSION` と同期。
+/// Issue #75 / #449 / #618 で bump されてきた。
+pub const SETTINGS_SCHEMA_VERSION: u32 = 11;
+
+/// `~/.vibe-editor/team-state/*.json` (TeamHub orchestration state) の現行 schema version。
+/// Issue #470 で導入。
+pub const TEAM_STATE_SCHEMA_VERSION: u32 = 1;
+
+/// `~/.vibe-editor/handoffs/.../*.json` (leader handoff checkpoint) の現行 schema version。
+/// 旧実装は `handoffs.rs` 内に `schema_version: 1` の直書きリテラルだった。
+pub const HANDOFF_SCHEMA_VERSION: u32 = 1;
+
+/// 永続化ストア 1 つ分の schema version 情報。`current` (= この build がネイティブに扱える
+/// 版数) と、互換性ガードの reject メッセージ / ログに使う `store_label` を束ねる。
+#[derive(Clone, Copy, Debug)]
+pub struct SchemaVersion {
+    /// この build がネイティブに読み書きできる schema version。
+    pub current: u32,
+    /// reject メッセージ / 監査ログに出すストア名 (例: `"settings.json"`)。
+    pub store_label: &'static str,
+}
+
+impl SchemaVersion {
+    /// `settings.json` 用の `SchemaVersion`。
+    pub const SETTINGS: SchemaVersion = SchemaVersion {
+        current: SETTINGS_SCHEMA_VERSION,
+        store_label: "settings.json",
+    };
+
+    /// 永続化前 (= save 直前) の schema version 互換性チェック。
+    ///
+    /// Issue #641 (旧 `settings.rs::check_schema_compat`) のロジックを共通化したもの。
+    /// 以下の 2 ケースで `CommandError::Validation` を返して save を reject する:
+    ///
+    /// 1. **disk が未来 schema** (`disk_version > current`): 新しい build が作った永続化
+    ///    ファイルを、それより古い build が上書きしようとしたケース。古い build の serde は
+    ///    新フィールドを silent drop するため、そのまま書き戻すと新フィールドが永久に失われる。
+    /// 2. **incoming が未来 schema** (`incoming_version > current`): renderer / migration が
+    ///    現行 build の知らない future version を渡してきたケース (改竄ファイル読み込み /
+    ///    複数インスタンス race 等の保険)。
+    ///
+    /// **下回るバージョン (`< current`) は accept する**: renderer 側 migration が現行 schema
+    /// へ前進させてから save するのが正常系で、古い disk からの初回 save もこれに含まれる。
+    ///
+    /// `disk_version` / `incoming_version` が `None` (= ファイル不在 / `schemaVersion` 欠落 /
+    /// parse 失敗) のときはガード対象外として `Ok(())` を返す。
+    pub fn check_compat(
+        &self,
+        disk_version: Option<u32>,
+        incoming_version: Option<u32>,
+    ) -> CommandResult<()> {
+        // case 1: 旧 build が新 schema の disk を上書きしようとしている
+        if let Some(disk_v) = disk_version {
+            if disk_v > self.current {
+                tracing::warn!(
+                    store = self.store_label,
+                    disk_schema_version = disk_v,
+                    current_schema_version = self.current,
+                    "[schema_version] rejected: disk has newer schema than this build",
+                );
+                return Err(CommandError::validation(format!(
+                    "{} was created by a newer vibe-editor (schema v{disk_v}, this build supports v{}). \
+                     Update vibe-editor before saving to avoid losing newer fields.",
+                    self.store_label, self.current
+                )));
+            }
+        }
+        // case 2: renderer から未来バージョンが渡された
+        if let Some(incoming_v) = incoming_version {
+            if incoming_v > self.current {
+                tracing::warn!(
+                    store = self.store_label,
+                    incoming_schema_version = incoming_v,
+                    current_schema_version = self.current,
+                    "[schema_version] rejected: incoming data declares a future schema",
+                );
+                return Err(CommandError::validation(format!(
+                    "Incoming {} declares a future schema (v{incoming_v}, this build supports v{}). \
+                     Refusing to overwrite to avoid silent field loss.",
+                    self.store_label, self.current
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 同一 schema (= 通常運用) は accept される。
+    #[test]
+    fn check_compat_accepts_equal_versions() {
+        let r = SchemaVersion::SETTINGS
+            .check_compat(Some(SETTINGS_SCHEMA_VERSION), Some(SETTINGS_SCHEMA_VERSION));
+        assert!(r.is_ok());
+    }
+
+    /// 旧 schema からの save は accept する (renderer migration が前進中 / 古いファイルの初回 save)。
+    #[test]
+    fn check_compat_accepts_older_versions() {
+        let r = SchemaVersion::SETTINGS.check_compat(Some(2), Some(2));
+        assert!(r.is_ok(), "older equal schemas must be saveable");
+        let r2 = SchemaVersion::SETTINGS.check_compat(Some(5), Some(SETTINGS_SCHEMA_VERSION));
+        assert!(r2.is_ok(), "advancing from older disk must be allowed");
+    }
+
+    /// disk なし / `schemaVersion` 欠落のときはガード対象外として accept。
+    #[test]
+    fn check_compat_accepts_missing_disk_version() {
+        let r = SchemaVersion::SETTINGS.check_compat(None, Some(SETTINGS_SCHEMA_VERSION));
+        assert!(r.is_ok());
+        let r2 = SchemaVersion::SETTINGS.check_compat(None, None);
+        assert!(r2.is_ok());
+    }
+
+    /// disk が新 schema で、incoming が現行 build (= 旧) のとき reject される。
+    #[test]
+    fn check_compat_rejects_when_disk_has_newer_schema() {
+        let future = SETTINGS_SCHEMA_VERSION + 1;
+        let r = SchemaVersion::SETTINGS.check_compat(Some(future), Some(SETTINGS_SCHEMA_VERSION));
+        assert!(r.is_err(), "disk newer than current build must reject");
+        let msg = format!("{}", r.unwrap_err());
+        assert!(
+            msg.contains("newer vibe-editor"),
+            "error message must hint at update: got {msg}"
+        );
+        assert!(msg.contains("settings.json"), "message must name the store: got {msg}");
+    }
+
+    /// renderer から未来バージョンが渡された場合は reject。
+    #[test]
+    fn check_compat_rejects_when_incoming_is_future_version() {
+        let future = SETTINGS_SCHEMA_VERSION + 1;
+        let r = SchemaVersion::SETTINGS.check_compat(None, Some(future));
+        assert!(r.is_err(), "incoming future schema must reject");
+        let msg = format!("{}", r.unwrap_err());
+        assert!(
+            msg.contains("future schema"),
+            "error message must mention future schema: got {msg}"
+        );
+    }
+
+    /// `store_label` が異なる `SchemaVersion` でもガード判定ロジックは同一。
+    #[test]
+    fn check_compat_works_for_arbitrary_store() {
+        let team_state = SchemaVersion {
+            current: TEAM_STATE_SCHEMA_VERSION,
+            store_label: "team-state",
+        };
+        assert!(team_state.check_compat(Some(TEAM_STATE_SCHEMA_VERSION), None).is_ok());
+        let r = team_state.check_compat(Some(TEAM_STATE_SCHEMA_VERSION + 1), None);
+        assert!(r.is_err());
+        assert!(format!("{}", r.unwrap_err()).contains("team-state"));
+    }
+}

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -175,7 +175,10 @@ fn default_terminal_force_utf8() -> bool {
 // renderer 側 `DEFAULT_SETTINGS` と完全一致させる。新フィールド追加時は両方を同時に更新する。
 
 /// Issue #75 / #449 / #618: 現在のスキーマ版数。`shared.ts APP_SETTINGS_SCHEMA_VERSION` と同期。
-pub const APP_SETTINGS_SCHEMA_VERSION: u32 = 11;
+///
+/// Issue #739: 実体は `commands::schema_version` に集約した。本 re-export で旧 import パス
+/// (`commands::settings::APP_SETTINGS_SCHEMA_VERSION`) は維持される。
+pub use crate::commands::schema_version::SETTINGS_SCHEMA_VERSION as APP_SETTINGS_SCHEMA_VERSION;
 
 fn default_language() -> String {
     "ja".to_string()
@@ -291,39 +294,16 @@ pub async fn settings_load() -> Settings {
 ///   現行 schema へ前進させた後に save するので、通常 incoming は current と一致する。仮に
 ///   incoming のほうが古くても、disk のほうも同等以下であれば情報損失リスクは無い (= 同一バイナリ
 ///   の前進 migration として扱える)。
+///
+/// Issue #739: 上記の判定ロジックは `commands::schema_version::SchemaVersion::check_compat`
+/// に集約した。本関数は `settings.json` 用の `SchemaVersion` を渡す薄いラッパで、reject 条件
+/// (どの version 差で弾くか) は完全に共通 helper と一致する。
 pub(crate) fn check_schema_compat(
     disk_schema_version: Option<u32>,
     incoming_schema_version: Option<u32>,
 ) -> Result<(), CommandError> {
-    // case 1: 旧 build が新スキーマの disk を上書きしようとしている
-    if let Some(disk_v) = disk_schema_version {
-        if disk_v > APP_SETTINGS_SCHEMA_VERSION {
-            tracing::warn!(
-                disk_schema_version = disk_v,
-                current_schema_version = APP_SETTINGS_SCHEMA_VERSION,
-                "[settings_save] rejected: disk has newer schema than this build",
-            );
-            return Err(CommandError::validation(format!(
-                "settings.json was created by a newer vibe-editor (schema v{disk_v}, this build supports v{APP_SETTINGS_SCHEMA_VERSION}). \
-                 Update vibe-editor before saving settings to avoid losing newer fields."
-            )));
-        }
-    }
-    // case 2: renderer から未来バージョンが渡された
-    if let Some(incoming_v) = incoming_schema_version {
-        if incoming_v > APP_SETTINGS_SCHEMA_VERSION {
-            tracing::warn!(
-                incoming_schema_version = incoming_v,
-                current_schema_version = APP_SETTINGS_SCHEMA_VERSION,
-                "[settings_save] rejected: incoming settings declare future schema",
-            );
-            return Err(CommandError::validation(format!(
-                "Incoming settings declare a future schema (v{incoming_v}, this build supports v{APP_SETTINGS_SCHEMA_VERSION}). \
-                 Refusing to overwrite to avoid silent field loss."
-            )));
-        }
-    }
-    Ok(())
+    crate::commands::schema_version::SchemaVersion::SETTINGS
+        .check_compat(disk_schema_version, incoming_schema_version)
 }
 
 /// disk から既存 settings.json の `schema_version` だけを軽量に読み取る。

--- a/src-tauri/src/commands/team_history.rs
+++ b/src-tauri/src/commands/team_history.rs
@@ -12,21 +12,58 @@ use std::path::{Path, PathBuf};
 use tokio::fs;
 use tokio::sync::Mutex;
 
-/// Issue #132: in-memory cache。`load_all` が毎回ディスク I/O していたのを解消する。
-/// `None` は「未ロード」、`Some(...)` は「ディスクと同期済み」状態。
-static CACHE: once_cell::sync::Lazy<Mutex<Option<Vec<TeamHistoryEntry>>>> =
-    once_cell::sync::Lazy::new(|| Mutex::new(None));
-
-/// Issue #642: cache を最後に disk と同期したときの fingerprint (`(mtime, size, sha256)`)。
-/// `Outer None` は「fingerprint 未取得」(= `CACHE` も未ロードの初期状態)。
-/// `Outer Some(None)` は「disk 上にファイルが存在しない状態を確認済み」。
-/// `Outer Some(Some(fp))` は「fingerprint=fp の disk と同期済み」。
+/// Issue #642 / #739: cache を最後に disk と同期したときの状態を表す sum type。
 ///
-/// save 直前に `compute_fingerprint(disk)` と比較し、不一致なら手編集 / 別プロセスによる
-/// 外部変更を検知 → `merge_external_disk` で disk 側の独自エントリを cache に取り込んでから
-/// 上書きする (stale-write 防止)。
-static DISK_FINGERPRINT: once_cell::sync::Lazy<Mutex<Option<Option<DiskFingerprint>>>> =
-    once_cell::sync::Lazy::new(|| Mutex::new(None));
+/// 旧実装は `Option<Option<DiskFingerprint>>` という二重 Option で同じ三状態を表していたが、
+/// 「外側 `None` と内側 `None` のどちらが何を意味するか」がコードを読まないと分からなかった。
+/// 三状態を enum で明示することで、`ensure_loaded` の「ロード済みか」判定と
+/// `reconcile_external_changes` の「同期済み fingerprint」取得が意図どおり読めるようにする。
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+enum DiskSyncState {
+    /// fingerprint 未取得 (= cache も未ロードの初期状態)。旧 `Outer None` に対応。
+    #[default]
+    Unknown,
+    /// disk 上に `team-history.json` が存在しない状態を確認済み。旧 `Outer Some(None)` に対応。
+    Absent,
+    /// `fp` の disk と同期済み。旧 `Outer Some(Some(fp))` に対応。
+    Synced(DiskFingerprint),
+}
+
+impl DiskSyncState {
+    /// `ensure_loaded` 用: 既に disk 状態を確認済み (= cache をロード済み) かどうか。
+    fn is_known(&self) -> bool {
+        !matches!(self, DiskSyncState::Unknown)
+    }
+
+    /// `reconcile_external_changes` 用: 最後に同期した fingerprint。
+    /// `Unknown` / `Absent` はいずれも「ファイルが無い / 未取得」なので `None` を返す
+    /// (= 旧 `Option<Option<DiskFingerprint>>::and_then(|f| f.clone())` と同じ畳み込み)。
+    fn synced_fingerprint(&self) -> Option<DiskFingerprint> {
+        match self {
+            DiskSyncState::Synced(fp) => Some(fp.clone()),
+            _ => None,
+        }
+    }
+}
+
+/// Issue #739: 旧 `LOCK` / `CACHE` / `DISK_FINGERPRINT` の 3 つの Mutex を 1 つに統合した
+/// グローバル state。各 command が「LOCK → CACHE → DISK_FINGERPRINT」を 3 段ロックしていた
+/// (= 4 command で同じパターンが 4 回) のを `STORE` 1 ロックに置き換える。
+///
+/// - `cache`: Issue #132 の in-memory cache。`None` は「未ロード」、`Some(...)` は
+///   「ディスクと同期済み」状態 (旧 `CACHE` と同じセマンティクス)。
+/// - `sync_state`: Issue #642 の disk fingerprint 三状態 (旧 `DISK_FINGERPRINT`)。
+///
+/// `cache` と `sync_state` を同一 Mutex 配下に置くことで、両者が原子的に整合した状態でしか
+/// 観測されないことが型レベルで保証される (旧実装は別 Mutex だったため理論上の skew があった)。
+#[derive(Default)]
+struct TeamHistoryStore {
+    cache: Option<Vec<TeamHistoryEntry>>,
+    sync_state: DiskSyncState,
+}
+
+static STORE: once_cell::sync::Lazy<Mutex<TeamHistoryStore>> =
+    once_cell::sync::Lazy::new(|| Mutex::new(TeamHistoryStore::default()));
 
 /// disk 上の `team-history.json` の状態を一意に識別するフィンガープリント。
 /// Issue #119 と同じく `mtime + size + sha256` の三要素で「秒精度しかない FS で同サイズに
@@ -159,23 +196,20 @@ fn is_false(v: &bool) -> bool {
     !*v
 }
 
-static LOCK: once_cell::sync::Lazy<Mutex<()>> = once_cell::sync::Lazy::new(|| Mutex::new(()));
-
 fn store_path() -> PathBuf {
     crate::util::config_paths::vibe_root().join("team-history.json")
 }
 
 /// Issue #132: cache が live なら disk I/O をスキップ。
-/// 初回呼び出し時のみディスクから読む。以後 LOCK 配下で cache を直接更新する。
+/// 初回呼び出し時のみディスクから読む。以後 STORE ロック配下で cache を直接更新する。
 ///
-/// Issue #642: cache を seed するのと同時に `DISK_FINGERPRINT` も同 disk 状態で初期化する。
-/// fingerprint=Some(None) は「disk 上にファイルなしを確認済み」、fingerprint=Some(Some(fp))
+/// Issue #642: cache を seed するのと同時に `sync_state` も同 disk 状態で初期化する。
+/// `DiskSyncState::Absent` は「disk 上にファイルなしを確認済み」、`DiskSyncState::Synced(fp)`
 /// は「fp の disk と同期済み」を表す。以後の save 系で fingerprint を比較し、外部変更を検知する。
-async fn ensure_loaded(
-    cache: &mut Option<Vec<TeamHistoryEntry>>,
-    fingerprint: &mut Option<Option<DiskFingerprint>>,
-) {
-    if cache.is_some() && fingerprint.is_some() {
+async fn ensure_loaded(store: &mut TeamHistoryStore) {
+    // Issue #739: 旧 `cache.is_some() && fingerprint.is_some()` と等価。
+    // `sync_state.is_known()` (= Absent / Synced) は旧 `fingerprint.is_some()` と一致する。
+    if store.cache.is_some() && store.sync_state.is_known() {
         return;
     }
     let path = store_path();
@@ -183,22 +217,22 @@ async fn ensure_loaded(
         Ok(bytes) => {
             let entries =
                 serde_json::from_slice::<Vec<TeamHistoryEntry>>(&bytes).unwrap_or_default();
-            *cache = Some(entries);
+            store.cache = Some(entries);
             // Issue #642: 起動直後の fingerprint を保存。以後の save 直前にこれと現在 disk の
             // fingerprint を比較して「外部変更が起きたか」を判定する。
             let meta = fs::metadata(&path).await.ok();
             let mtime_ms = meta.as_ref().and_then(mtime_ms_of);
             let size = meta.as_ref().map(|m| m.len()).unwrap_or(bytes.len() as u64);
-            *fingerprint = Some(Some(DiskFingerprint {
+            store.sync_state = DiskSyncState::Synced(DiskFingerprint {
                 mtime_ms,
                 size,
                 hash: sha256_hex(&bytes),
-            }));
+            });
         }
         Err(_) => {
-            *cache = Some(Vec::new());
+            store.cache = Some(Vec::new());
             // ファイルが存在しない状態を確認済みとして記録する。
-            *fingerprint = Some(None);
+            store.sync_state = DiskSyncState::Absent;
         }
     }
 }
@@ -309,18 +343,25 @@ fn same_entry(a: &TeamHistoryEntry, b: &TeamHistoryEntry) -> bool {
 async fn reconcile_external_changes(
     path: &Path,
     cache: &mut Vec<TeamHistoryEntry>,
-    fingerprint: &mut Option<Option<DiskFingerprint>>,
+    sync_state: &mut DiskSyncState,
     incoming_ids: &HashSet<String>,
 ) -> bool {
     let current_disk = compute_fingerprint(path).await;
-    let last_synced = fingerprint.as_ref().and_then(|f| f.clone());
+    // Issue #739: 旧 `fingerprint.as_ref().and_then(|f| f.clone())` と等価。
+    // `Unknown` / `Absent` はいずれも `None` に畳まれる。
+    let last_synced = sync_state.synced_fingerprint();
     if current_disk == last_synced {
         return false;
     }
     // 外部変更検知: disk reload + merge
     let (disk_entries, fp) = reload_disk_entries(path).await;
     let merged = merge_external_disk(cache, disk_entries, incoming_ids);
-    *fingerprint = Some(fp);
+    // `fp` が `None` (= reload 時に disk 不在) なら `Absent`、`Some(fp)` なら `Synced(fp)`。
+    // 旧実装の `*fingerprint = Some(fp)` (= `Some(None)` / `Some(Some(fp))`) と一致する。
+    *sync_state = match fp {
+        Some(fp) => DiskSyncState::Synced(fp),
+        None => DiskSyncState::Absent,
+    };
     merged
 }
 
@@ -336,7 +377,7 @@ async fn save_all(
         .await
         .map_err(|e| e.to_string())?;
     // Issue #642: 書き込み直後の fingerprint を計算して呼び出し側に返す。caller は
-    // `DISK_FINGERPRINT` を更新することで「次回 save 時の比較基準」を最新に保つ。
+    // `STORE.sync_state` を更新することで「次回 save 時の比較基準」を最新に保つ。
     let meta = fs::metadata(path).await.ok();
     let mtime_ms = meta.as_ref().and_then(mtime_ms_of);
     let size = meta.as_ref().map(|m| m.len()).unwrap_or(json.len() as u64);
@@ -362,13 +403,13 @@ async fn save_all(
 ///    失敗なら cache / fingerprint はそのまま
 ///
 /// `external_change_merged` は #642 の reconcile が立てたフラグをそのまま返値に乗せて
-/// renderer まで伝える。`fingerprint` を `&mut` で受け取るのは success path で
-/// disk と同期した最新 fingerprint を caller の `DISK_FINGERPRINT` に書き戻すため。
+/// renderer まで伝える。`sync_state` を `&mut` で受け取るのは success path で
+/// disk と同期した最新 fingerprint を caller の `STORE.sync_state` に書き戻すため。
 ///
 /// テスト容易性のため `save_fn` を引数に取り、失敗 mock を差し込めるようにしている。
 async fn apply_with_disk_commit<F, Fut>(
     cache: &mut Vec<TeamHistoryEntry>,
-    fingerprint: &mut Option<Option<DiskFingerprint>>,
+    sync_state: &mut DiskSyncState,
     external_change_merged: bool,
     mutate: impl FnOnce(&mut Vec<TeamHistoryEntry>),
     save_fn: F,
@@ -384,9 +425,9 @@ where
     // 2. disk 書き込み — 失敗したら cache は旧 state のまま (rollback 不要)
     match save_fn(candidate.clone()).await {
         Ok(new_fp) => {
-            // 3. 成功した場合のみ cache + fingerprint に commit
+            // 3. 成功した場合のみ cache + sync_state に commit
             *cache = candidate;
-            *fingerprint = Some(Some(new_fp));
+            *sync_state = DiskSyncState::Synced(new_fp);
             MutationResult {
                 ok: true,
                 error: None,
@@ -403,17 +444,17 @@ where
 
 #[tauri::command]
 pub async fn team_history_list(project_root: String) -> Vec<TeamHistoryEntry> {
-    let _g = LOCK.lock().await;
-    let mut cache = CACHE.lock().await;
-    let mut fingerprint = DISK_FINGERPRINT.lock().await;
-    ensure_loaded(&mut cache, &mut fingerprint).await;
+    // Issue #739: 旧 LOCK / CACHE / DISK_FINGERPRINT の 3 段ロックを STORE 1 ロックに統合。
+    let mut store = STORE.lock().await;
+    ensure_loaded(&mut store).await;
     // Issue #642: list でも fingerprint を見て外部変更があれば disk を再読込。renderer が
     // ユーザー手編集後に list を再取得したときに古い in-memory cache を返さないようにする。
     // list には書き込み対象 id が無いため `incoming_ids` は空集合 (= 全 entry を disk 側で
     // 上書き可能) として扱う。
     let path = store_path();
+    let TeamHistoryStore { cache, sync_state } = &mut *store;
     let all = cache.as_mut().expect("ensured");
-    let _ = reconcile_external_changes(&path, all, &mut fingerprint, &HashSet::new()).await;
+    let _ = reconcile_external_changes(&path, all, sync_state, &HashSet::new()).await;
     // Issue #32: 比較は normalize 後の値で行う
     let target = normalize_project_root(&project_root);
     all.iter()
@@ -478,10 +519,10 @@ pub async fn team_history_save(mut entry: TeamHistoryEntry) -> MutationResult {
         };
     }
     hydrate_orchestration_summary(&mut entry).await;
-    let _g = LOCK.lock().await;
-    let mut cache = CACHE.lock().await;
-    let mut fingerprint = DISK_FINGERPRINT.lock().await;
-    ensure_loaded(&mut cache, &mut fingerprint).await;
+    // Issue #739: 旧 LOCK / CACHE / DISK_FINGERPRINT の 3 段ロックを STORE 1 ロックに統合。
+    let mut store = STORE.lock().await;
+    ensure_loaded(&mut store).await;
+    let TeamHistoryStore { cache, sync_state } = &mut *store;
     let all = cache.as_mut().expect("ensured");
 
     // Issue #642: save 直前に disk を再 stat。手編集 / 別 vibe-editor インスタンスが
@@ -492,14 +533,14 @@ pub async fn team_history_save(mut entry: TeamHistoryEntry) -> MutationResult {
     let mut incoming_ids = HashSet::new();
     incoming_ids.insert(entry.id.clone());
     let external_change_merged =
-        reconcile_external_changes(&path, all, &mut fingerprint, &incoming_ids).await;
+        reconcile_external_changes(&path, all, sync_state, &incoming_ids).await;
 
     // Issue #46 + #640: 新エントリは必ず残す。merge_entry で per-project MAX 件まで圧縮。
-    // write-ahead — disk write 成功時だけ cache + fingerprint に commit する。
+    // write-ahead — disk write 成功時だけ cache + sync_state に commit する。
     let path_for_save = path.clone();
     apply_with_disk_commit(
         all,
-        &mut fingerprint,
+        sync_state,
         external_change_merged,
         |candidate| merge_entry(candidate, entry),
         |entries| async move { save_all(&path_for_save, &entries).await },
@@ -528,17 +569,17 @@ pub async fn team_history_save_batch(entries: Vec<TeamHistoryEntry>) -> Mutation
             };
         }
     }
-    // hydrate は disk I/O を伴うので LOCK の外で行う (cache mutate は行わないので安全)
+    // hydrate は disk I/O を伴うので STORE ロックの外で行う (cache mutate は行わないので安全)
     let mut hydrated: Vec<TeamHistoryEntry> = Vec::with_capacity(entries.len());
     for mut entry in entries {
         hydrate_orchestration_summary(&mut entry).await;
         hydrated.push(entry);
     }
 
-    let _g = LOCK.lock().await;
-    let mut cache = CACHE.lock().await;
-    let mut fingerprint = DISK_FINGERPRINT.lock().await;
-    ensure_loaded(&mut cache, &mut fingerprint).await;
+    // Issue #739: 旧 LOCK / CACHE / DISK_FINGERPRINT の 3 段ロックを STORE 1 ロックに統合。
+    let mut store = STORE.lock().await;
+    ensure_loaded(&mut store).await;
+    let TeamHistoryStore { cache, sync_state } = &mut *store;
     let all = cache.as_mut().expect("ensured");
     let path = store_path();
 
@@ -546,13 +587,13 @@ pub async fn team_history_save_batch(entries: Vec<TeamHistoryEntry>) -> Mutation
     // 読み直したとき、これら以外の id は disk 側を尊重 (= 外部編集を保持) する。
     let incoming_ids: HashSet<String> = hydrated.iter().map(|e| e.id.clone()).collect();
     let external_change_merged =
-        reconcile_external_changes(&path, all, &mut fingerprint, &incoming_ids).await;
+        reconcile_external_changes(&path, all, sync_state, &incoming_ids).await;
 
-    // Issue #640: write-ahead — disk write 成功時だけ cache + fingerprint に commit する。
+    // Issue #640: write-ahead — disk write 成功時だけ cache + sync_state に commit する。
     let path_for_save = path.clone();
     apply_with_disk_commit(
         all,
-        &mut fingerprint,
+        sync_state,
         external_change_merged,
         |candidate| {
             for entry in hydrated {
@@ -566,10 +607,10 @@ pub async fn team_history_save_batch(entries: Vec<TeamHistoryEntry>) -> Mutation
 
 #[tauri::command]
 pub async fn team_history_delete(id: String) -> MutationResult {
-    let _g = LOCK.lock().await;
-    let mut cache = CACHE.lock().await;
-    let mut fingerprint = DISK_FINGERPRINT.lock().await;
-    ensure_loaded(&mut cache, &mut fingerprint).await;
+    // Issue #739: 旧 LOCK / CACHE / DISK_FINGERPRINT の 3 段ロックを STORE 1 ロックに統合。
+    let mut store = STORE.lock().await;
+    ensure_loaded(&mut store).await;
+    let TeamHistoryStore { cache, sync_state } = &mut *store;
     let all = cache.as_mut().expect("ensured");
     let path = store_path();
 
@@ -578,7 +619,7 @@ pub async fn team_history_delete(id: String) -> MutationResult {
     let mut incoming_ids = HashSet::new();
     incoming_ids.insert(id.clone());
     let external_change_merged =
-        reconcile_external_changes(&path, all, &mut fingerprint, &incoming_ids).await;
+        reconcile_external_changes(&path, all, sync_state, &incoming_ids).await;
 
     // 該当 entry が無く、外部変更の merge も無ければ disk write 自体不要 (ok を返す)。
     // ただし外部変更を merge した場合は disk と cache の差分が変わっている可能性があるため
@@ -591,11 +632,11 @@ pub async fn team_history_delete(id: String) -> MutationResult {
         };
     }
 
-    // Issue #640: write-ahead — disk write 成功時だけ cache + fingerprint に commit する。
+    // Issue #640: write-ahead — disk write 成功時だけ cache + sync_state に commit する。
     let path_for_save = path.clone();
     apply_with_disk_commit(
         all,
-        &mut fingerprint,
+        sync_state,
         external_change_merged,
         |candidate| candidate.retain(|e| e.id != id),
         |entries| async move { save_all(&path_for_save, &entries).await },
@@ -667,12 +708,12 @@ mod tests {
     async fn apply_with_disk_commit_does_not_mutate_cache_on_save_failure() {
         use crate::commands::error::CommandError;
         let mut cache = vec![make_entry("a", "/proj/x", "2026-05-09T00:00:00Z")];
-        let mut fingerprint: Option<Option<DiskFingerprint>> = Some(None);
+        let mut sync_state = DiskSyncState::Absent;
         let snapshot_before = cache.clone();
 
         let result = apply_with_disk_commit(
             &mut cache,
-            &mut fingerprint,
+            &mut sync_state,
             false,
             |candidate| {
                 merge_entry(
@@ -691,19 +732,19 @@ mod tests {
         assert_eq!(cache.len(), snapshot_before.len());
         assert_eq!(cache[0].id, "a");
         assert!(cache.iter().all(|e| e.id != "b"));
-        // fingerprint も touch されていない (Some(None) のまま)
-        assert!(matches!(fingerprint, Some(None)));
+        // sync_state も touch されていない (Absent のまま)
+        assert_eq!(sync_state, DiskSyncState::Absent);
     }
 
     /// 成功 path では cache に candidate が commit される + fingerprint が更新される。
     #[tokio::test]
     async fn apply_with_disk_commit_commits_cache_on_save_success() {
         let mut cache = vec![make_entry("a", "/proj/x", "2026-05-09T00:00:00Z")];
-        let mut fingerprint: Option<Option<DiskFingerprint>> = Some(None);
+        let mut sync_state = DiskSyncState::Absent;
 
         let result = apply_with_disk_commit(
             &mut cache,
-            &mut fingerprint,
+            &mut sync_state,
             false,
             |candidate| {
                 merge_entry(
@@ -727,11 +768,10 @@ mod tests {
         assert_eq!(cache.len(), 2);
         assert!(cache.iter().any(|e| e.id == "b"));
         assert!(cache.iter().any(|e| e.id == "a"));
-        // fingerprint も更新されている
-        let fp = fingerprint
-            .as_ref()
-            .and_then(|f| f.as_ref())
-            .expect("fingerprint set");
+        // sync_state も Synced(fp) に更新されている
+        let fp = sync_state
+            .synced_fingerprint()
+            .expect("sync_state must be Synced after success");
         assert_eq!(fp.size, 42);
         assert_eq!(fp.hash, "deadbeef");
     }
@@ -744,12 +784,12 @@ mod tests {
             make_entry("a", "/proj/x", "2026-05-09T00:00:00Z"),
             make_entry("b", "/proj/x", "2026-05-10T00:00:00Z"),
         ];
-        let mut fingerprint: Option<Option<DiskFingerprint>> = Some(None);
+        let mut sync_state = DiskSyncState::Absent;
 
         let target_id = "a".to_string();
         let result = apply_with_disk_commit(
             &mut cache,
-            &mut fingerprint,
+            &mut sync_state,
             false,
             |candidate| candidate.retain(|e| e.id != target_id),
             |_entries| async { Err(CommandError::Io("permission denied".to_string())) },
@@ -767,7 +807,7 @@ mod tests {
     async fn apply_with_disk_commit_batch_save_rolls_back_all_on_failure() {
         use crate::commands::error::CommandError;
         let mut cache = vec![make_entry("a", "/proj/x", "2026-05-09T00:00:00Z")];
-        let mut fingerprint: Option<Option<DiskFingerprint>> = Some(None);
+        let mut sync_state = DiskSyncState::Absent;
         let new_entries = vec![
             make_entry("b", "/proj/x", "2026-05-10T00:00:00Z"),
             make_entry("c", "/proj/x", "2026-05-10T01:00:00Z"),
@@ -775,7 +815,7 @@ mod tests {
 
         let result = apply_with_disk_commit(
             &mut cache,
-            &mut fingerprint,
+            &mut sync_state,
             false,
             |candidate| {
                 for entry in new_entries {
@@ -798,14 +838,14 @@ mod tests {
     #[tokio::test]
     async fn apply_with_disk_commit_passes_candidate_state_to_save_fn() {
         let mut cache = vec![make_entry("a", "/proj/x", "2026-05-09T00:00:00Z")];
-        let mut fingerprint: Option<Option<DiskFingerprint>> = Some(None);
+        let mut sync_state = DiskSyncState::Absent;
         let captured: std::sync::Arc<std::sync::Mutex<Option<Vec<String>>>> =
             std::sync::Arc::new(std::sync::Mutex::new(None));
         let captured_for_fn = captured.clone();
 
         let result = apply_with_disk_commit(
             &mut cache,
-            &mut fingerprint,
+            &mut sync_state,
             false,
             |candidate| {
                 merge_entry(
@@ -841,11 +881,11 @@ mod tests {
     #[tokio::test]
     async fn apply_with_disk_commit_propagates_external_change_merged_flag() {
         let mut cache = vec![make_entry("a", "/proj/x", "2026-05-09T00:00:00Z")];
-        let mut fingerprint: Option<Option<DiskFingerprint>> = Some(None);
+        let mut sync_state = DiskSyncState::Absent;
 
         let result = apply_with_disk_commit(
             &mut cache,
-            &mut fingerprint,
+            &mut sync_state,
             true, // 外部変更を merge 済み
             |_candidate| {},
             |_entries| async {
@@ -1005,11 +1045,11 @@ mod tests {
         let entries = vec![entry("a", "x", "2026-01-03T00:00:00Z")];
         let fp = save_all(&path, &entries).await.unwrap();
         let mut cache = entries.clone();
-        let mut fingerprint: Option<Option<DiskFingerprint>> = Some(Some(fp));
+        let mut sync_state = DiskSyncState::Synced(fp);
         let incoming = HashSet::new();
 
         let merged =
-            reconcile_external_changes(&path, &mut cache, &mut fingerprint, &incoming).await;
+            reconcile_external_changes(&path, &mut cache, &mut sync_state, &incoming).await;
 
         assert!(!merged, "fingerprint match → no merge");
         assert_eq!(cache.len(), 1);
@@ -1031,7 +1071,7 @@ mod tests {
             entry("b", "original-summary", "2026-01-02T00:00:00Z"),
             entry("a", "new-from-app", "2026-01-03T00:00:00Z"),
         ];
-        let mut fingerprint: Option<Option<DiskFingerprint>> = Some(Some(fp));
+        let mut sync_state = DiskSyncState::Synced(fp);
 
         // Step 3: ユーザーが外部 (jq 等) で disk の entry "b" の summary を直接編集
         let externally_edited = vec![entry("b", "user-hand-edited!", "2026-01-02T00:00:00Z")];
@@ -1043,7 +1083,7 @@ mod tests {
         incoming.insert("a".to_string());
 
         let merged =
-            reconcile_external_changes(&path, &mut cache, &mut fingerprint, &incoming).await;
+            reconcile_external_changes(&path, &mut cache, &mut sync_state, &incoming).await;
 
         assert!(merged, "external edit on 'b' must be detected");
         // cache の "b" は disk 側 (手編集) で上書きされている
@@ -1063,22 +1103,25 @@ mod tests {
                 .and_then(|o| o.blocked_reason.as_deref()),
             Some("new-from-app"),
         );
-        // fingerprint は disk 側に更新されている
-        assert!(fingerprint.as_ref().and_then(|f| f.as_ref()).is_some());
+        // sync_state は disk 側に更新されている (= Synced)
+        assert!(
+            sync_state.synced_fingerprint().is_some(),
+            "sync_state must be Synced after external reload"
+        );
     }
 
     /// disk のファイルが存在しない (= 初回 save 前) ケースで、`reconcile_external_changes` が
-    /// fingerprint=None と一致して no-op になる。
+    /// fingerprint なし (= Absent) と一致して no-op になる。
     #[tokio::test]
     async fn reconcile_no_op_when_disk_absent_and_fingerprint_absent() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("team-history.json");
         let mut cache: Vec<TeamHistoryEntry> = vec![];
-        let mut fingerprint: Option<Option<DiskFingerprint>> = Some(None);
+        let mut sync_state = DiskSyncState::Absent;
         let incoming = HashSet::new();
 
         let merged =
-            reconcile_external_changes(&path, &mut cache, &mut fingerprint, &incoming).await;
+            reconcile_external_changes(&path, &mut cache, &mut sync_state, &incoming).await;
         assert!(!merged);
         assert!(cache.is_empty());
     }

--- a/src-tauri/src/commands/team_state.rs
+++ b/src-tauri/src/commands/team_state.rs
@@ -13,7 +13,11 @@ use tokio::fs;
 
 use crate::commands::team_history::HandoffReference;
 
-pub const TEAM_STATE_SCHEMA_VERSION: u32 = 1;
+/// TeamHub orchestration state JSON の現行 schema version。
+///
+/// Issue #739: 実体は `commands::schema_version` に集約した。本 re-export で旧 import パス
+/// (`commands::team_state::TEAM_STATE_SCHEMA_VERSION`) は維持される。
+pub use crate::commands::schema_version::TEAM_STATE_SCHEMA_VERSION;
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -18,6 +18,22 @@ use std::time::Duration;
 use tauri::{AppHandle, State};
 use uuid::Uuid;
 
+/// Issue #739: `inject_codex_prompt_to_pty` が PTY 注入を始める前に待つ初期スリープ (ミリ秒)。
+///
+/// Codex の TUI が起動してから prompt 入力を受け付ける状態になるまでの猶予。旧実装は
+/// `sleep(Duration::from_millis(1800))` の magic number 直書きだった。短すぎると注入文字が
+/// TUI 初期化中に取りこぼされ、長すぎると初手の指示が遅れて UX が悪化するため、この 1 箇所で
+/// 調整できるよう定数化する。
+const CODEX_INITIAL_PROMPT_DELAY_MS: u64 = 1800;
+
+/// Issue #739: `inject_codex_prompt_to_pty` のチャンク間 / 末尾 `\r` 送出前スリープ (ミリ秒)。
+///
+/// ConPTY のリングバッファ事故を避けつつ Codex TUI が paste sequence を 1 件として
+/// バンドルできる時間的余裕を確保するための値。`team_hub::protocol::consts::INJECT_CHUNK_DELAY_MS`
+/// と意図的に同値だが、当該定数は `pub(in crate::team_hub)` で `commands` から不可視のため、
+/// terminal 側のチャンク注入用にローカル定数として持つ (旧実装は `15` の直書きだった)。
+const CODEX_PROMPT_CHUNK_DELAY_MS: u64 = 15;
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TerminalCreateOptions {
@@ -156,7 +172,7 @@ async fn inject_codex_prompt_to_pty(
     instructions: String,
 ) {
     use tokio::time::sleep;
-    sleep(Duration::from_millis(1800)).await;
+    sleep(Duration::from_millis(CODEX_INITIAL_PROMPT_DELAY_MS)).await;
     let Some(session) = registry.get(&term_id) else {
         return;
     };
@@ -191,7 +207,7 @@ async fn inject_codex_prompt_to_pty(
         }
     }
     for chunk in iter {
-        sleep(Duration::from_millis(15)).await;
+        sleep(Duration::from_millis(CODEX_PROMPT_CHUNK_DELAY_MS)).await;
         if registry.get(&term_id).is_none() {
             return;
         }
@@ -214,7 +230,7 @@ async fn inject_codex_prompt_to_pty(
             }
         }
     }
-    sleep(Duration::from_millis(15)).await;
+    sleep(Duration::from_millis(CODEX_PROMPT_CHUNK_DELAY_MS)).await;
     // Issue #620: 末尾の確定 `\r` も spawn_blocking 経由で送る。
     let s = session.clone();
     match tokio::task::spawn_blocking(move || s.write(b"\r")).await {
@@ -515,10 +531,9 @@ pub async fn terminal_create(
             // Claude Code 起動時のみ session watcher を仕掛ける (codex は jsonl を作らない)
             if command.to_lowercase().contains("claude") {
                 let watcher_id = id.clone();
-                // Issue #147: poison でも recovery して読む
-                let watcher_root = crate::state::lock_project_root_recover(&state.project_root)
-                    .clone()
-                    .unwrap_or_default();
+                // Issue #739: ArcSwapOption の lock-free load で現在値を読む。
+                let watcher_root =
+                    crate::state::current_project_root(&state.project_root).unwrap_or_default();
                 let actual_root = if watcher_root.is_empty() {
                     // PTY spawn 時の cwd を流用
                     std::env::current_dir()

--- a/src-tauri/src/commands/vibe_team_skill.rs
+++ b/src-tauri/src/commands/vibe_team_skill.rs
@@ -161,10 +161,8 @@ pub async fn app_install_vibe_team_skill(
     // Issue #135 (Security): renderer から来る project_root が AppState の現在値と一致
     // するか canonicalize 比較する。一致しないとユーザー HOME 等の任意ディレクトリ配下に
     // .claude/skills/vibe-team/SKILL.md を作成できてしまい AI hijack 経路になる。
-    // Issue #147: poison でも recovery して読む
-    let active = crate::state::lock_project_root_recover(&state.project_root)
-        .clone()
-        .unwrap_or_default();
+    // Issue #739: ArcSwapOption の lock-free load で現在値を読む。
+    let active = crate::state::current_project_root(&state.project_root).unwrap_or_default();
     if active.trim().is_empty() {
         return Ok(InstallSkillResult {
             ok: false,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -144,61 +144,12 @@ fn prune_old_log_files(log_dir: &std::path::Path, keep_days: u32) {
     }
 }
 
+// Issue #739: 旧ここに inline 同居していた大規模テスト mod (`log_prune_tests`) は
+// `src-tauri/src/log_prune_tests.rs` へ分離。`prune_old_log_files` / `LOG_KEEP_DAYS` は
+// クレートルート private 項目のため、`super::` でアクセスできる in-crate 子モジュール
+// (= 別ファイルの `mod`) として切り出している。
 #[cfg(test)]
-mod log_prune_tests {
-    use super::{prune_old_log_files, LOG_KEEP_DAYS};
-    use std::fs;
-    use std::time::{Duration, SystemTime};
-
-    /// Issue #643: 14 日より古い `vibe-editor.log*` は削除され、
-    /// 新しいファイルや無関係ファイルは残ることを確認する。
-    #[test]
-    fn prunes_only_old_vibe_editor_log_files() {
-        let dir = tempfile::tempdir().expect("tempdir");
-
-        let old_dated = dir.path().join("vibe-editor.log.2020-01-01");
-        let old_legacy = dir.path().join("vibe-editor.log");
-        let recent_dated = dir.path().join("vibe-editor.log.2099-12-31");
-        let unrelated = dir.path().join("other.log");
-        let unrelated_old = dir.path().join("readme.txt");
-
-        for f in [
-            &old_dated,
-            &old_legacy,
-            &recent_dated,
-            &unrelated,
-            &unrelated_old,
-        ] {
-            fs::write(f, b"x").unwrap();
-        }
-
-        // 古い 2 ファイルと「無関係だが古い」ファイルの mtime を 30 日前に倒す。
-        let way_old = SystemTime::now() - Duration::from_secs(60 * 60 * 24 * 30);
-        for f in [&old_dated, &old_legacy, &unrelated_old] {
-            let file = fs::File::options().write(true).open(f).unwrap();
-            file.set_modified(way_old).unwrap();
-        }
-
-        prune_old_log_files(dir.path(), LOG_KEEP_DAYS);
-
-        assert!(!old_dated.exists(), "old dated log should be pruned");
-        assert!(!old_legacy.exists(), "legacy single log should be pruned");
-        assert!(recent_dated.exists(), "recent log must survive");
-        assert!(unrelated.exists(), "non-log file must survive");
-        assert!(
-            unrelated_old.exists(),
-            "files outside vibe-editor.log* prefix must not be touched"
-        );
-    }
-
-    /// 存在しないディレクトリを渡しても panic しない (起動を失敗させない契約)。
-    #[test]
-    fn prune_is_noop_on_missing_dir() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let missing = dir.path().join("does-not-exist");
-        prune_old_log_files(&missing, LOG_KEEP_DAYS);
-    }
-}
+mod log_prune_tests;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -374,10 +325,8 @@ pub fn run() {
                     .or_else(|| Some(settings.claude_cwd.clone()).filter(|s| !s.trim().is_empty()));
                 if let Some(root) = root {
                     let state = app_handle_for_root.state::<state::AppState>();
-                    // Issue #147: poison でも recovery
-                    let mut guard = state::lock_project_root_recover(&state.project_root);
-                    *guard = Some(root.clone());
-                    drop(guard);
+                    // Issue #739: ArcSwapOption の lock-free store で復元する。
+                    state::set_project_root(&state.project_root, Some(root.clone()));
                     tracing::info!("[setup] project_root restored from settings: {root}");
                     // Issue #724: assetProtocol.scope は空。renderer が `app_set_project_root` を
                     // 呼ぶ前 (起動直後のセッション復元等) でも画像プレビューが project_root 配下の

--- a/src-tauri/src/log_prune_tests.rs
+++ b/src-tauri/src/log_prune_tests.rs
@@ -1,0 +1,62 @@
+//! Issue #739: 旧 `lib.rs` 内に inline 同居していた `log_prune_tests` mod を分離。
+//!
+//! `prune_old_log_files` / `LOG_KEEP_DAYS` は `lib.rs` のクレートルート private 項目なので
+//! `src-tauri/tests/` の integration test (= public API しか触れない) には移せない。
+//! `commands/tests/` / `pty/tests/` と同じく「本体ファイルとは別ファイルの in-crate test mod」
+//! としてクレートルートの子モジュールに置くことで、private 項目への `super::` アクセスを
+//! 保ったまま `lib.rs` 本体から大きなテスト塊を切り離す。
+//!
+//! Issue #643: ログ世代 GC (`prune_old_log_files`) の挙動を検証する。
+
+use super::{prune_old_log_files, LOG_KEEP_DAYS};
+use std::fs;
+use std::time::{Duration, SystemTime};
+
+/// Issue #643: 14 日より古い `vibe-editor.log*` は削除され、
+/// 新しいファイルや無関係ファイルは残ることを確認する。
+#[test]
+fn prunes_only_old_vibe_editor_log_files() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let old_dated = dir.path().join("vibe-editor.log.2020-01-01");
+    let old_legacy = dir.path().join("vibe-editor.log");
+    let recent_dated = dir.path().join("vibe-editor.log.2099-12-31");
+    let unrelated = dir.path().join("other.log");
+    let unrelated_old = dir.path().join("readme.txt");
+
+    for f in [
+        &old_dated,
+        &old_legacy,
+        &recent_dated,
+        &unrelated,
+        &unrelated_old,
+    ] {
+        fs::write(f, b"x").unwrap();
+    }
+
+    // 古い 2 ファイルと「無関係だが古い」ファイルの mtime を 30 日前に倒す。
+    let way_old = SystemTime::now() - Duration::from_secs(60 * 60 * 24 * 30);
+    for f in [&old_dated, &old_legacy, &unrelated_old] {
+        let file = fs::File::options().write(true).open(f).unwrap();
+        file.set_modified(way_old).unwrap();
+    }
+
+    prune_old_log_files(dir.path(), LOG_KEEP_DAYS);
+
+    assert!(!old_dated.exists(), "old dated log should be pruned");
+    assert!(!old_legacy.exists(), "legacy single log should be pruned");
+    assert!(recent_dated.exists(), "recent log must survive");
+    assert!(unrelated.exists(), "non-log file must survive");
+    assert!(
+        unrelated_old.exists(),
+        "files outside vibe-editor.log* prefix must not be touched"
+    );
+}
+
+/// 存在しないディレクトリを渡しても panic しない (起動を失敗させない契約)。
+#[test]
+fn prune_is_noop_on_missing_dir() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("does-not-exist");
+    prune_old_log_files(&missing, LOG_KEEP_DAYS);
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2,18 +2,21 @@
 
 use crate::pty::{InFlightTracker, SessionRegistry};
 use crate::team_hub::TeamHub;
-use std::sync::{Arc, Mutex, MutexGuard};
+use arc_swap::ArcSwapOption;
+use std::sync::Arc;
 
 pub struct AppState {
     /// 現在 UI で開いているプロジェクトルート。
     ///
-    /// Issue #56 / #147 注記:
-    ///   `std::sync::Mutex` を async コンテキスト (tokio task) から `.lock()` するのは
-    ///   通常アンチパターンだが、ここは `lock → clone → unlock` のみで重い処理は入れない。
-    ///   クリティカル区間を絶対に短く保つこと (canonicalize / fs I/O を lock 保持中に
-    ///   行ってはいけない)。lock 保持中に `.await` は絶対禁止。
-    ///   poison が発生しても `lock_project_root_recover` 経由で recovery できる。
-    pub project_root: Mutex<Option<String>>,
+    /// Issue #56 / #147 / #739 注記:
+    ///   旧実装は `std::sync::Mutex<Option<String>>` で、`lock → clone → unlock` のみとはいえ
+    ///   async コンテキスト (tokio task) から `.lock()` するアンチパターンを抱えていた。
+    ///   `arc_swap::ArcSwapOption<String>` に置換したことで lock 自体が存在しなくなり、
+    ///   load / store はいずれも lock-free atomic な操作になる。これにより
+    ///   「async task から lock を保持したまま `.await`」という deadlock 経路が
+    ///   **構造的に発生しえない** 状態になった。poison 概念も無くなる。
+    ///   読み出しは `current_project_root`、書き込みは `set_project_root` ヘルパを使う。
+    pub project_root: ArcSwapOption<String>,
     pub pty_registry: Arc<SessionRegistry>,
     pub team_hub: TeamHub,
     /// Issue #630: 進行中の PTY inject task (codex 初期 prompt 注入 / team_send 経由 inject /
@@ -23,21 +26,21 @@ pub struct AppState {
     pub pty_inflight: Arc<InFlightTracker>,
 }
 
-/// Issue #147: project_root の Mutex が poison しても、内部値は単純な Option<String> なので
-/// safe に取り出せる。poison_error.into_inner() で guard を取り出して使い続ける。
-/// 上位呼び出し側はこのヘルパを使うことで以降の root 切替が永続失敗する状態を避けられる。
-pub fn lock_project_root_recover<'a>(
-    m: &'a Mutex<Option<String>>,
-) -> MutexGuard<'a, Option<String>> {
-    match m.lock() {
-        Ok(g) => g,
-        Err(poisoned) => {
-            tracing::warn!("[state] project_root mutex poisoned — recovering");
-            poisoned.into_inner()
-        }
-    }
+/// Issue #739: `ArcSwapOption<String>` から現在の project_root を `Option<String>` として
+/// 取り出す。lock-free な atomic load なので async コンテキストから呼んでも安全。
+///
+/// 旧 `lock_project_root_recover` (poison recovery 付き `MutexGuard` 返却) の後継。
+/// 呼び出し側が `MutexGuard` ではなく値そのものを欲しがるパターン (`.clone()` /
+/// `.unwrap_or_default()`) しか存在しなかったため、値を直接返す形に簡素化している。
+pub fn current_project_root(slot: &ArcSwapOption<String>) -> Option<String> {
+    slot.load().as_deref().map(|s| s.clone())
 }
 
+/// Issue #739: project_root を更新する。`Some("")` のような空文字はそのまま保持する
+/// (空判定 / trim は呼び出し側の責務 — 旧 Mutex 実装と同じセマンティクス)。
+pub fn set_project_root(slot: &ArcSwapOption<String>, value: Option<String>) {
+    slot.store(value.map(Arc::new));
+}
 
 impl AppState {
     pub fn new() -> Self {
@@ -48,7 +51,7 @@ impl AppState {
         // 同一 counter で wait_idle できる。
         let team_hub = TeamHub::with_inflight(pty_registry.clone(), pty_inflight.clone());
         Self {
-            project_root: Mutex::new(None),
+            project_root: ArcSwapOption::from(None),
             pty_registry,
             team_hub,
             pty_inflight,

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -320,16 +320,6 @@ pub struct TeamHub {
     pub(crate) inflight: Arc<crate::pty::InFlightTracker>,
 }
 
-fn hex_encode(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        out.push(HEX[(b >> 4) as usize] as char);
-        out.push(HEX[(b & 0x0f) as usize] as char);
-    }
-    out
-}
-
 async fn handle_client<S>(hub: TeamHub, sock: S, expected_token: String) -> Result<()>
 where
     S: AsyncRead + AsyncWrite + Unpin,

--- a/src-tauri/src/team_hub/state/file_locks_glue.rs
+++ b/src-tauri/src/team_hub/state/file_locks_glue.rs
@@ -72,8 +72,14 @@ impl TeamHub {
         crate::team_hub::file_locks::peek(&s.file_locks, team_id, agent_id_filter, paths)
     }
 
-    /// team 内の全 lock 一覧 (将来の team_diagnostics 拡張 / UI 表示用)。
-    /// 現在は MCP API 経由の caller が居ないので `#[allow(dead_code)]`。
+    /// team 内の全 lock 一覧を返す。`file_locks::list_for_team` (pure 関数 + 単体テストあり) を
+    /// HubState の Mutex 越しに呼ぶ glue。
+    ///
+    /// Issue #739: 現状 production の呼び出し元は無いが、`#[allow(dead_code)]` を残す:
+    /// 依存先の `file_locks::list_for_team` は `file_locks` モジュールの公開 API 一覧に
+    /// 明記され単体テストも持つ「意図された primitive」であり、この glue が唯一の production
+    /// 配線ポイント。glue ごと削除すると `list_for_team` が連鎖的に dead code 化する。
+    /// team_diagnostics の lock 一覧 UI が実装され次第、本 method を配線して attr を外す。
     #[allow(dead_code)]
     pub async fn list_file_locks_for_team(
         &self,
@@ -110,16 +116,10 @@ impl TeamHub {
             .and_then(|m| m.get(role_id).cloned())
     }
 
-    /// renderer 側に dynamic_roles のスナップショットを渡せるようにする想定の hook。
-    /// 現状は未使用 (未来のチーム履歴永続化で使う)
-    #[allow(dead_code)]
-    pub async fn export_dynamic_roles(&self, team_id: &str) -> Vec<DynamicRole> {
-        self.get_dynamic_roles(team_id).await
-    }
-
     /// canvas 復元時に renderer 側 dynamic_roles をまとめて Hub に流し込むための入口。
     /// 既存をクリアしてから一括 insert する (team_id スコープ単位)。
-    #[allow(dead_code)]
+    /// Issue #513: `dynamic_role::replay_persisted_dynamic_roles_for_team` 経由で実際に
+    /// 呼ばれているため、Issue #739 で stale な `#[allow(dead_code)]` を除去した。
     pub async fn replace_dynamic_roles(&self, team_id: &str, roles: Vec<DynamicRole>) {
         let mut s = self.state.lock().await;
         let entry = s.dynamic_roles.entry(team_id.to_string()).or_default();

--- a/src-tauri/src/team_hub/state/hub_state.rs
+++ b/src-tauri/src/team_hub/state/hub_state.rs
@@ -93,25 +93,6 @@ pub fn set_server_log_path(p: PathBuf) {
     let _ = SERVER_LOG_PATH.set(p);
 }
 
-/// home directory プレフィックスを `~` に reduce する。
-/// home が解決できない / s が home 配下でないときは原文を返す。
-fn reduce_home_prefix(s: &str) -> String {
-    let Some(home) = dirs::home_dir() else {
-        return s.to_string();
-    };
-    let home_s = home.to_string_lossy().to_string();
-    // Windows では `\` と `/` の混在があり得るので両形で試す
-    if let Some(rest) = s.strip_prefix(&home_s) {
-        return format!("~{rest}");
-    }
-    let home_alt = home_s.replace('\\', "/");
-    let s_alt = s.replace('\\', "/");
-    if let Some(rest) = s_alt.strip_prefix(&home_alt) {
-        return format!("~{rest}");
-    }
-    s.to_string()
-}
-
 /// `team_diagnostics` の `serverLogPath` 用に整形済み文字列を返す。
 ///   - env var `VIBE_TEAM_LOG_PATH` が空でなければそれを優先 (絶対パス想定、空白 trim)
 ///   - そうでなければ起動時に記録したファイルパス
@@ -119,6 +100,7 @@ fn reduce_home_prefix(s: &str) -> String {
 ///
 /// 戻り値は home prefix を `~` に reduce 済み (Reviewer D Major 反映)。
 pub fn server_log_path_for_diagnostics() -> String {
+    use crate::util::log_redact::reduce_home_prefix;
     if let Ok(v) = std::env::var("VIBE_TEAM_LOG_PATH") {
         let trimmed = v.trim();
         if !trimmed.is_empty() {
@@ -150,41 +132,11 @@ pub(super) fn extract_no_conversation_session_id(output_tail: &str) -> Option<St
 
 #[cfg(test)]
 mod path_tests {
-    use super::{extract_no_conversation_session_id, reduce_home_prefix};
+    use super::extract_no_conversation_session_id;
 
-    /// home prefix が正しく `~` に置換され、home 配下でないパスは原文のまま。
-    /// home 解決失敗環境を想定した静的テストではないので、CI 環境次第で home が
-    /// 存在しないと一部スキップされる点だけ承知 (Linux CI / Windows CI とも home はある)。
-    #[test]
-    fn reduces_home_prefix_when_under_home() {
-        let Some(home) = dirs::home_dir() else {
-            return; // home 取れない環境ではスキップ (CI 上は通常存在する)
-        };
-        let inside = crate::util::config_paths::vibe_root()
-            .join("logs")
-            .join("vibe-editor.log");
-        let inside_str = inside.to_string_lossy().to_string();
-        let reduced = reduce_home_prefix(&inside_str);
-        // `~/.vibe-editor/logs/vibe-editor.log` 形 (区切り文字は OS 依存だが prefix は `~`)
-        assert!(
-            reduced.starts_with('~'),
-            "expected '~' prefix, got: {reduced}"
-        );
-        assert!(reduced.contains(".vibe-editor"));
-    }
-
-    #[test]
-    fn keeps_path_as_is_when_outside_home() {
-        // home 配下でないパスは reduce されない。
-        // どの OS でも `/tmp/elsewhere.log` は home 配下にならない (Windows でも C:\Users\ 起点なので無関係)。
-        let outside = if cfg!(windows) {
-            r"D:\nowhere\elsewhere.log"
-        } else {
-            "/tmp/elsewhere.log"
-        };
-        let reduced = reduce_home_prefix(outside);
-        assert_eq!(reduced, outside);
-    }
+    // Issue #739: `reduce_home_prefix` は `util::log_redact` へ移設したため、
+    // 関連テストも `util::log_redact` 側に移った。ここでは
+    // `extract_no_conversation_session_id` のみ検証する。
 
     #[test]
     fn extracts_no_conversation_session_id_from_tail() {
@@ -319,13 +271,6 @@ impl EnginePolicy {
                 .clone()
                 .unwrap_or_else(|| role_default.to_string()),
         }
-    }
-
-    /// 「明示的な policy が設定されているか」を bool で返す (将来の info/UI 拡張で扱う)。
-    /// 現在は MCP API 経由の caller が居ないので `#[allow(dead_code)]`。
-    #[allow(dead_code)]
-    pub fn is_explicit(&self) -> bool {
-        !matches!(self.kind, EnginePolicyKind::MixedAllowed) || self.default_engine.is_some()
     }
 }
 
@@ -568,7 +513,8 @@ impl TeamHub {
         use rand::RngCore;
         let mut buf = [0u8; 24];
         rand::thread_rng().fill_bytes(&mut buf);
-        state.token = crate::team_hub::hex_encode(&buf);
+        // Issue #739: 旧 `team_hub::hex_encode` を `util::log_redact` に集約。
+        state.token = crate::util::log_redact::hex_encode(&buf);
 
         // bridge スクリプトを `~/.vibe-editor/team-bridge.js` に書き出し
         // Issue #143 (Security):

--- a/src-tauri/src/team_hub/state/member_diagnostics.rs
+++ b/src-tauri/src/team_hub/state/member_diagnostics.rs
@@ -3,7 +3,6 @@
 //! Issue #736: 旧 `state.rs` から member 診断に関する型・メソッドを切り出し。
 
 use crate::team_hub::TeamHub;
-use std::collections::HashMap;
 
 use super::hub_state::extract_no_conversation_session_id;
 
@@ -115,11 +114,4 @@ impl TeamHub {
         }
     }
 
-    /// Issue #342 Phase 3 (3.3): MemberDiagnostics 全体のスナップショットを返す。
-    /// `team_diagnostics` MCP ツールは protocol.rs 側で state.lock を直接取るため、
-    /// この helper は外部 (テスト / 将来の機能拡張) からの read-only スナップショット用。
-    #[allow(dead_code)]
-    pub async fn snapshot_member_diagnostics(&self) -> HashMap<String, MemberDiagnostics> {
-        self.state.lock().await.member_diagnostics.clone()
-    }
 }

--- a/src-tauri/src/util/log_redact.rs
+++ b/src-tauri/src/util/log_redact.rs
@@ -4,6 +4,12 @@
 // 厳密な PII redaction は別レイヤー (例: Sentry side filter) で行うべきだが、
 // 開発者が `tracing::info!` で何気なく path を出してしまうケースに対する
 // 一次防御として用意する。
+//
+// Issue #739: ログ / 診断系の自前ヘルパ重複を本モジュールに集約する:
+//   - `reduce_home_prefix` — 旧 `team_hub::state::hub_state` 内に `redact_home` とほぼ
+//     同じ実装が重複していたものを移設 (separator 保持の違いがあるため別関数のまま統合)。
+//   - `hex_encode` — 旧 `team_hub::mod` 内の自前 hex 変換 (handshake token を hex 化して
+//     ログ / 診断に出す用途) を移設。
 
 /// `path` 内に含まれるユーザーホームディレクトリを `~` に置き換えた文字列を返す。
 /// home が取れない場合は input をそのまま返す。
@@ -37,14 +43,82 @@ pub fn redact_home(path: &str) -> String {
     path.to_string()
 }
 
+/// home directory プレフィックスを `~` に reduce する。
+/// home が解決できない / `s` が home 配下でないときは原文を返す。
+///
+/// Issue #739: 旧 `team_hub::state::hub_state::reduce_home_prefix` を移設。`redact_home` と
+/// 役割は近いが、こちらは「生のまま prefix 一致したら separator を保持する」「Windows
+/// case-insensitive 一致は見ない」点が異なる (= `team_diagnostics` の `serverLogPath` 表示で
+/// OS ネイティブな区切り文字を保ったまま `~` 化したいケース用)。挙動差を保つため統合しても
+/// `redact_home` には寄せず別関数として残す。
+pub fn reduce_home_prefix(s: &str) -> String {
+    let Some(home) = dirs::home_dir() else {
+        return s.to_string();
+    };
+    let home_s = home.to_string_lossy().to_string();
+    // Windows では `\` と `/` の混在があり得るので両形で試す
+    if let Some(rest) = s.strip_prefix(&home_s) {
+        return format!("~{rest}");
+    }
+    let home_alt = home_s.replace('\\', "/");
+    let s_alt = s.replace('\\', "/");
+    if let Some(rest) = s_alt.strip_prefix(&home_alt) {
+        return format!("~{rest}");
+    }
+    s.to_string()
+}
+
+/// バイト列を小文字 16 進文字列に変換する。
+///
+/// Issue #739: 旧 `team_hub::mod::hex_encode` を移設。TeamHub の handshake token
+/// (24 byte の乱数 → 48 文字の hex) を生成する用途で、生成されたトークンは診断 / ログ
+/// 経路にも露出するため、ログ系ヘルパ集約モジュールである本ファイルに置く。
+pub fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
-    use super::redact_home;
+    use super::{hex_encode, redact_home, reduce_home_prefix};
 
     #[test]
     fn returns_input_when_no_home_match() {
         let s = redact_home("/usr/local/bin/foo");
         // home が一致しないなら原文かつ slash 正規化のみ
         assert!(s.contains("/usr/local/bin/foo") || s == "/usr/local/bin/foo");
+    }
+
+    /// `reduce_home_prefix`: home 配下のパスは `~` に reduce、home 配下でないパスは原文のまま。
+    #[test]
+    fn reduce_home_prefix_reduces_under_home_and_keeps_outside() {
+        if let Some(home) = dirs::home_dir() {
+            let inside = home.join("proj").join("a.txt");
+            let reduced = reduce_home_prefix(&inside.to_string_lossy());
+            assert!(reduced.starts_with('~'), "expected '~' prefix, got: {reduced}");
+        }
+        // どの OS でも home 配下にならないパスは原文のまま。
+        let outside = if cfg!(windows) {
+            r"D:\nowhere\elsewhere.log"
+        } else {
+            "/tmp/elsewhere.log"
+        };
+        assert_eq!(reduce_home_prefix(outside), outside);
+    }
+
+    /// `hex_encode`: 既知バイト列が小文字 hex 文字列になる。長さは入力の 2 倍。
+    #[test]
+    fn hex_encode_produces_lowercase_hex() {
+        assert_eq!(hex_encode(&[0x00, 0x0f, 0xff, 0xab]), "000fffab");
+        assert_eq!(hex_encode(&[]), "");
+        let twenty_four = [0xa5u8; 24];
+        let encoded = hex_encode(&twenty_four);
+        assert_eq!(encoded.len(), 48, "24 bytes → 48 hex chars");
+        assert!(encoded.chars().all(|c| c.is_ascii_hexdigit()));
     }
 }


### PR DESCRIPTION
## Summary
#739 のバンドル issue (AppState async 安全化 + 中小規模整理) を一括対応。

1. **AppState.project_root の async 安全化**: `std::sync::Mutex<Option<String>>` → `arc_swap::ArcSwapOption<String>`。lock-free atomic load/store になり「async task が lock 保持のまま `.await`」する deadlock 経路が構造的に消滅。`lock_project_root_recover` を値返却の `current_project_root` / `set_project_root` helper に置換し全 6 caller を追従。
2. **team_history.rs の Mutex 3 統合**: `LOCK` / `CACHE` / `DISK_FINGERPRINT` の 3 Mutex を `static STORE: Lazy<Mutex<TeamHistoryStore>>` 1 つに統合。disk 同期状態を `enum DiskSyncState { Unknown, Absent, Synced }` の sum type に。
3. **schema version 集約**: `commands/schema_version.rs` を新設し settings/team-state/handoff の schema version 定数を SSOT 化、`SchemaVersion::check_compat` 共通ガードを提供。
4. **小規模整理**: files.rs `eprintln!`→`tracing::warn!`、terminal.rs sleep magic number の定数化、team_hub の不要 `#[allow(dead_code)]` 整理、lib.rs テスト mod 分離、`hex_encode`/`reduce_home_prefix` 重複を `util/log_redact.rs` に集約。

振る舞いは保持 (project_root 読み書きセマンティクス・team_history の write-ahead/merge・schema reject 判定ロジックは byte 一致)。

Closes #739

## Test plan
- [x] `cargo check` (+ `--tests`) 通過、新規 warning 0
- [x] `cargo test --lib` — 554 passed (failed 2 件は clean main でも fail する pre-existing で本変更と無関係)
- [x] 変更モジュールの全テスト 63 件通過 (schema_version 6 新規含む)

## 補足 (レビュー向け)
項目3の schema helper 共通化に伴い、settings の schema reject 時の Toast 文言と `tracing` ログ行のプレフィックスが軽微に変化 (`[settings_save]`→`[schema_version]` 等)。reject 判定ロジック自体は完全不変で、契約を担保する settings ユニット/統合テストは全通過。