### PR TITLE
fix(i18n): #729 McpSection の isJa 三項を t() に統一

### DIFF
--- a/src/renderer/src/components/settings/McpSection.tsx
+++ b/src/renderer/src/components/settings/McpSection.tsx
@@ -24,7 +24,6 @@ interface HubInfo {
  */
 export function McpSection({ draft, update }: Props): JSX.Element {
   const t = useT();
-  const isJa = draft.language === 'ja';
   const [hub, setHub] = useState<HubInfo | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -142,27 +141,16 @@ VIBE_TEAM_TOKEN = "${token}"`,
           <li>{t('settings.mcp.manualStep3')}</li>
         </ol>
         <p className="modal__note">
-          {isJa
-            ? '~/.claude.json のサンプル (既存の mcpServers と統合してください):'
-            : 'Sample for ~/.claude.json (merge with existing mcpServers):'}
+          {t('settings.mcp.claudeSampleNote')}
         </p>
         <CodeBlock content={manualJson} lang="json" />
         <p className="modal__note">
-          {isJa
-            ? '~/.codex/config.toml のサンプル:'
-            : 'Sample for ~/.codex/config.toml:'}
+          {t('settings.mcp.codexSampleNote')}
         </p>
         <CodeBlock content={manualToml} lang="toml" />
         <p className="modal__note">
-          {isJa ? (
-            <>
-              <b>接続情報 (現在値):</b> socket = <code>{socket}</code> / token = <code>{token}</code> / bridge = <code>{bridgePath}</code>
-            </>
-          ) : (
-            <>
-              <b>Connection info:</b> socket = <code>{socket}</code> / token = <code>{token}</code> / bridge = <code>{bridgePath}</code>
-            </>
-          )}
+          <b>{t('settings.mcp.connInfoLabel')}</b> socket = <code>{socket}</code> / token ={' '}
+          <code>{token}</code> / bridge = <code>{bridgePath}</code>
         </p>
       </section>
     </>

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -663,6 +663,10 @@ const ja: Dict = {
   'settings.mcp.manualStep3': 'Codex を使う場合は ~/.codex/config.toml に同等の [mcp_servers.vibe-team] を追加。',
   'settings.mcp.copy': 'コピー',
   'settings.mcp.copied': 'コピーしました',
+  // Issue #729: McpSection の isJa 三項を i18n.ts に移管
+  'settings.mcp.claudeSampleNote': '~/.claude.json のサンプル (既存の mcpServers と統合してください):',
+  'settings.mcp.codexSampleNote': '~/.codex/config.toml のサンプル:',
+  'settings.mcp.connInfoLabel': '接続情報 (現在値):',
 
   // ---------- Updater (Issue #59) ----------
   'updater.confirm': 'vibe-editor v{version} が利用可能です。今すぐ更新しますか?',
@@ -1384,6 +1388,10 @@ const en: Dict = {
     'For Codex, add the equivalent [mcp_servers.vibe-team] section to ~/.codex/config.toml.',
   'settings.mcp.copy': 'Copy',
   'settings.mcp.copied': 'Copied',
+  // Issue #729: McpSection inline isJa moved into i18n.ts
+  'settings.mcp.claudeSampleNote': 'Sample for ~/.claude.json (merge with existing mcpServers):',
+  'settings.mcp.codexSampleNote': 'Sample for ~/.codex/config.toml:',
+  'settings.mcp.connInfoLabel': 'Connection info:',
 
   // ---------- Updater (Issue #59) ----------
   'updater.confirm': 'vibe-editor v{version} is available. Install it now?',


### PR DESCRIPTION
## Summary
#729 (`isJa ? 'JP' : 'EN'` 三項を `t()` に統一) の最後の未対応箇所だった `McpSection.tsx` を対応。`~/.claude.json` / `~/.codex/config.toml` のサンプル注記 2 箇所と接続情報ラベルの `isJa` 三項を、`i18n.ts` の `settings.mcp.claudeSampleNote` / `codexSampleNote` / `connInfoLabel` キー経由の `t()` に統一。未使用となった `isJa` 変数を撤去。

これで `src/renderer/src` から `isJa` 三項は全廃 (#729 完了)。残る "isJa" 文字列は履歴コメントのみ。

Closes #729

## Test plan
- [x] `npm run typecheck` 通過
- [x] `grep "isJa" McpSection.tsx` — 0 件