### PR TITLE
refactor(commands): #737 command の error 型を CommandResult / ToolError に統一

### DIFF
--- a/src-tauri/src/commands/handoffs.rs
+++ b/src-tauri/src/commands/handoffs.rs
@@ -285,7 +285,7 @@ async fn write_handoff(
 pub async fn handoffs_create(
     state: tauri::State<'_, crate::state::AppState>,
     req: HandoffCreateRequest,
-) -> Result<HandoffCreateResult, String> {
+) -> crate::commands::error::CommandResult<HandoffCreateResult> {
     if req.project_root.trim().is_empty() {
         return Ok(HandoffCreateResult {
             ok: false,
@@ -295,9 +295,9 @@ pub async fn handoffs_create(
     }
     // Issue #606 (Security): renderer 由来の project_root が active project_root と一致するか検証。
     // 不一致なら handoff body (= 引き継ぎ context / 機微テキスト) の cross-project write を阻止。
-    // 既存 caller の signature を壊さないため、Authz reject は `Ok(error 入り result)` で返す
-    // (Tauri 2 の `tauri::State<'_>` async command は戻り値が `Result<T, E>` であることを要求するため
-    //  外側を `Result<HandoffCreateResult, String>` に格上げするが、reject 経路は内部 error フィールド)。
+    // 既存 caller の挙動を壊さないため、Authz reject は `Ok(error 入り result)` で返す
+    // (Issue #737: 外側は `CommandResult<HandoffCreateResult>` だが、失敗は一貫して内部
+    //  error フィールドで表現し、外側 `Err` 経路は使わない)。
     if let Err(e) =
         crate::commands::authz::assert_active_project_root(&state.project_root, &req.project_root)
             .await
@@ -362,10 +362,11 @@ pub async fn handoffs_list(
     state: tauri::State<'_, crate::state::AppState>,
     project_root: String,
     team_id: Option<String>,
-) -> Result<Vec<HandoffCheckpoint>, String> {
+) -> crate::commands::error::CommandResult<Vec<HandoffCheckpoint>> {
     // Issue #606 (Security): cross-project read を阻止するため active project_root 一致を検証。
     // reject 時は空 Vec を `Ok` で返し既存 caller (renderer) の挙動を維持する
-    // (Tauri 2 の async command + ref input は戻り値 `Result<T, E>` 必須のため外側を Result 化)。
+    // (Issue #737: 外側は `CommandResult` だが、この command は失敗を `Err` ではなく
+    //  「空 Vec を Ok」で表現する設計を維持する)。
     if crate::commands::authz::assert_active_project_root(&state.project_root, &project_root)
         .await
         .is_err()
@@ -400,9 +401,10 @@ pub async fn handoffs_read(
     project_root: String,
     team_id: Option<String>,
     handoff_id: String,
-) -> Result<Option<HandoffCheckpoint>, String> {
+) -> crate::commands::error::CommandResult<Option<HandoffCheckpoint>> {
     // Issue #606 (Security): cross-project read を阻止。reject 時は `Ok(None)` で返し
-    // 既存の「該当なし」挙動を維持する (Tauri 2 の async command 制約のため Result 外殻化)。
+    // 既存の「該当なし」挙動を維持する (Issue #737: 外側は `CommandResult` だが、失敗は
+    //  `Err` ではなく `Ok(None)` で表現する設計を維持する)。
     if crate::commands::authz::assert_active_project_root(&state.project_root, &project_root)
         .await
         .is_err()
@@ -425,10 +427,10 @@ pub async fn handoffs_update_status(
     handoff_id: String,
     status: String,
     to_agent_id: Option<String>,
-) -> Result<HandoffMutationResult, String> {
+) -> crate::commands::error::CommandResult<HandoffMutationResult> {
     // Issue #606 (Security): cross-project write を阻止。Authz reject は内部 error フィールド
-    // で表現し、外側の `Result` は Tauri 2 の async command 制約 (ref input → Result 必須) を満たす
-    // ためのもの。renderer 側は従来通り `result.ok` で分岐する。
+    // で表現し、renderer 側は従来通り `result.ok` で分岐する (Issue #737: 外側 `Err` 経路は
+    // 使わず、失敗は常に内部 error フィールドで返す)。
     if let Err(e) =
         crate::commands::authz::assert_active_project_root(&state.project_root, &project_root)
             .await

--- a/src-tauri/src/commands/team_diagnostics.rs
+++ b/src-tauri/src/commands/team_diagnostics.rs
@@ -33,12 +33,11 @@ use tauri::State;
 pub async fn team_diagnostics_read(
     state: State<'_, AppState>,
     team_id: String,
-) -> Result<Value, String> {
+) -> crate::commands::error::CommandResult<Value> {
     // Issue #601: active な team_id でなければ reject。
     // empty / unknown / dismissed は同じ generic message にして recon 抑止。
-    crate::commands::authz::assert_active_team(&state.team_hub, &team_id)
-        .await
-        .map_err(String::from)?;
+    // Issue #737: `assert_active_team` は既に `CommandResult` を返すため、そのまま `?` で伝播する。
+    crate::commands::authz::assert_active_team(&state.team_hub, &team_id).await?;
 
     let hub = state.team_hub.clone();
     let ctx = CallContext {
@@ -53,5 +52,11 @@ pub async fn team_diagnostics_read(
         // フィルタで誤って team message を除外しないよう、いずれの agent_id とも被らない名前。
         agent_id: "vibe-editor.renderer".to_string(),
     };
-    team_diagnostics(&hub, &ctx).await
+    // Issue #737: MCP tool は `Result<Value, ToolError>` を返す。`team_diagnostics_read` は
+    // Tauri command なので `CommandResult<Value>` に揃える。`ToolError` の構造化情報
+    // (`code` / `message`) を失わないよう、flat JSON 文字列のまま `CommandError` に載せて
+    // renderer へ届ける (= renderer 側は従来どおり JSON 文字列として error を受け取れる)。
+    team_diagnostics(&hub, &ctx)
+        .await
+        .map_err(|e| crate::commands::error::CommandError::internal(e.to_json_value().to_string()))
 }

--- a/src-tauri/src/commands/team_inject.rs
+++ b/src-tauri/src/commands/team_inject.rs
@@ -48,34 +48,48 @@ pub struct RetryInjectResult {
     pub failed_at: Option<String>,
 }
 
+/// `team_send_retry_inject` が `Err` で返す構造化エラー (JSON object) を組み立てる。
+///
+/// Issue #737: 戻り値を `CommandResult<RetryInjectResult>` に統一した後も、renderer に届く
+/// payload は従来どおり `{"code":"retry_*","message":"..."}` の JSON 文字列を保つ。
+/// `CommandError` の `Serialize` は message をそのまま文字列化するため、`CommandError::internal`
+/// に JSON 文字列を載せれば旧 `Err(String)` と完全同一の wire 出力になる。
+fn retry_err(code: &str, message: String) -> crate::commands::error::CommandError {
+    let payload = json!({ "code": code, "message": message });
+    crate::commands::error::CommandError::internal(payload.to_string())
+}
+
 /// `team_send` の partial failure に対する手動リトライ。同じ team / message / agent を 1 件単位で再 inject する。
 #[tauri::command]
 pub async fn team_send_retry_inject(
     app: AppHandle,
     state: State<'_, AppState>,
     args: RetryInjectArgs,
-) -> Result<RetryInjectResult, String> {
+) -> crate::commands::error::CommandResult<RetryInjectResult> {
     let hub = state.team_hub.clone();
     let registry = hub.registry.clone();
 
     // Step 1: message を lookup。lock は短く保持し、inject の long PTY write 中は離す。
-    let lookup: Result<(String, String, String), String> = {
+    let lookup: crate::commands::error::CommandResult<(String, String, String)> = {
         let s = hub.state.lock().await;
         let team = match s.teams.get(&args.team_id) {
             Some(t) => t,
             None => {
-                return Err(format!(
-                    "{{\"code\":\"retry_unknown_team\",\"message\":\"unknown team_id '{}'\"}}",
-                    args.team_id
+                return Err(retry_err(
+                    "retry_unknown_team",
+                    format!("unknown team_id '{}'", args.team_id),
                 ))
             }
         };
         let msg = match team.messages.iter().find(|m| m.id == args.message_id) {
             Some(m) => m,
             None => {
-                return Err(format!(
-                    "{{\"code\":\"retry_unknown_message\",\"message\":\"message {} not found in team '{}' (history may have been evicted)\"}}",
-                    args.message_id, args.team_id
+                return Err(retry_err(
+                    "retry_unknown_message",
+                    format!(
+                        "message {} not found in team '{}' (history may have been evicted)",
+                        args.message_id, args.team_id
+                    ),
                 ))
             }
         };
@@ -86,9 +100,12 @@ pub async fn team_send_retry_inject(
             .iter()
             .any(|id| id == &args.agent_id)
         {
-            return Err(format!(
-                "{{\"code\":\"retry_invalid_recipient\",\"message\":\"agent '{}' was not a recipient of message {} (resolved_recipient_ids does not contain it)\"}}",
-                args.agent_id, args.message_id
+            return Err(retry_err(
+                "retry_invalid_recipient",
+                format!(
+                    "agent '{}' was not a recipient of message {} (resolved_recipient_ids does not contain it)",
+                    args.agent_id, args.message_id
+                ),
             ));
         }
         Ok((msg.message.clone(), msg.from.clone(), msg.from_agent_id.clone()))

--- a/src-tauri/src/commands/team_state.rs
+++ b/src-tauri/src/commands/team_state.rs
@@ -420,14 +420,12 @@ pub struct RecruitObservedWhileHiddenArgs {
 #[tauri::command]
 pub async fn recruit_observed_while_hidden(
     args: RecruitObservedWhileHiddenArgs,
-) -> Result<(), String> {
+) -> crate::commands::error::CommandResult<()> {
     // Issue #624 (Security): renderer 由来 string が tracing 行に直接乗るため、
     // (1) [A-Za-z0-9_-]{1,64} の id segment 検証で改行 / 制御文字 / shell metachar を弾き、
     // (2) sanitize_for_log で出力直前にも追加防御する (defense-in-depth)。
-    crate::commands::validation::validate_id_segment("team_id", &args.team_id)
-        .map_err(|e| e.to_string())?;
-    crate::commands::validation::validate_id_segment("agent_id", &args.agent_id)
-        .map_err(|e| e.to_string())?;
+    crate::commands::validation::validate_id_segment("team_id", &args.team_id)?;
+    crate::commands::validation::validate_id_segment("agent_id", &args.agent_id)?;
     tracing::info!(
         target: "teamhub",
         team_id = %crate::commands::validation::sanitize_for_log(&args.team_id, 64),

--- a/src-tauri/src/team_hub/protocol/dynamic_role.rs
+++ b/src-tauri/src/team_hub/protocol/dynamic_role.rs
@@ -44,45 +44,58 @@ pub(super) async fn validate_and_register_dynamic_role(
     description: &str,
     instructions: &str,
     instructions_ja: Option<&str>,
-) -> Result<DynamicRoleOutcome, String> {
+) -> Result<DynamicRoleOutcome, RecruitError> {
     // 権限チェック (Leader だけが動的ロールを作れる)
     check_permission(&ctx.role, Permission::CreateRoleProfile)
-        .map_err(|e| e.into_message("create role profiles"))?;
+        .map_err(|e| RecruitError::permission_denied("recruit", &e.role, "create role profiles"))?;
     // バリデーション: id
     let role_id = role_id.trim();
     if role_id.is_empty() {
-        return Err("role_id is required".into());
+        return Err(RecruitError::invalid_args("recruit", "role_id is required"));
     }
     if role_id.len() > 80 {
-        return Err("role_id is too long (max 80)".into());
+        return Err(RecruitError::invalid_args(
+            "recruit",
+            "role_id is too long (max 80)",
+        ));
     }
     // ASCII alnum + _ - のみ許可 (`vc-` などのプレフィックスとの混同を避ける)
     if !role_id
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
     {
-        return Err("role_id must contain only ASCII letters, digits, '_' or '-'".into());
+        return Err(RecruitError::invalid_args(
+            "recruit",
+            "role_id must contain only ASCII letters, digits, '_' or '-'",
+        ));
     }
     // builtin との衝突 (summary に id が居れば builtin or override)
     let summary = hub.get_role_profile_summary().await;
     if summary.iter().any(|p| p.id == role_id) {
-        return Err(format!(
-            "role_id '{role_id}' is reserved by a built-in / existing role profile"
+        return Err(RecruitError::new(
+            "recruit_role_id_reserved",
+            format!("role_id '{role_id}' is reserved by a built-in / existing role profile"),
         ));
     }
     // 長さ上限
     if label.len() > MAX_DYNAMIC_LABEL_LEN {
-        return Err(format!(
-            "label too long: {} bytes (limit {})",
-            label.len(),
-            MAX_DYNAMIC_LABEL_LEN
+        return Err(RecruitError::new(
+            "recruit_role_label_too_long",
+            format!(
+                "label too long: {} bytes (limit {})",
+                label.len(),
+                MAX_DYNAMIC_LABEL_LEN
+            ),
         ));
     }
     if description.len() > MAX_DYNAMIC_DESCRIPTION_LEN {
-        return Err(format!(
-            "description too long: {} bytes (limit {})",
-            description.len(),
-            MAX_DYNAMIC_DESCRIPTION_LEN
+        return Err(RecruitError::new(
+            "recruit_role_description_too_long",
+            format!(
+                "description too long: {} bytes (limit {})",
+                description.len(),
+                MAX_DYNAMIC_DESCRIPTION_LEN
+            ),
         ));
     }
     // Issue #512: instructions は recruit の prompt 本体になる重要 payload。`team_send` /
@@ -100,8 +113,7 @@ pub(super) async fn validate_and_register_dynamic_role(
                 MAX_DYNAMIC_INSTRUCTIONS_LEN
             ),
         )
-        .with_phase("validate")
-        .into_err_string());
+        .with_phase("validate"));
     }
     if let Some(ja) = instructions_ja {
         if ja.len() > MAX_DYNAMIC_INSTRUCTIONS_LEN {
@@ -115,8 +127,7 @@ pub(super) async fn validate_and_register_dynamic_role(
                     MAX_DYNAMIC_INSTRUCTIONS_LEN
                 ),
             )
-            .with_phase("validate")
-            .into_err_string());
+            .with_phase("validate"));
         }
     }
     // Issue #508: 必須テンプレ / 曖昧名 / Worktree Isolation Rule の validation。
@@ -127,8 +138,7 @@ pub(super) async fn validate_and_register_dynamic_role(
             "recruit_role_too_vague",
             template_report.deny_message(),
         )
-        .with_phase("template_validation")
-        .into_err_string());
+        .with_phase("template_validation"));
     }
     let template_warnings: Vec<TemplateFinding> = template_report
         .findings
@@ -141,10 +151,13 @@ pub(super) async fn validate_and_register_dynamic_role(
     if existing.len() >= MAX_DYNAMIC_ROLES_PER_TEAM
         && !existing.iter().any(|r| r.id == role_id)
     {
-        return Err(format!(
-            "too many dynamic roles in this team ({}/{} max)",
-            existing.len(),
-            MAX_DYNAMIC_ROLES_PER_TEAM
+        return Err(RecruitError::new(
+            "recruit_too_many_dynamic_roles",
+            format!(
+                "too many dynamic roles in this team ({}/{} max)",
+                existing.len(),
+                MAX_DYNAMIC_ROLES_PER_TEAM
+            ),
         ));
     }
     let role = DynamicRole {

--- a/src-tauri/src/team_hub/protocol/mod.rs
+++ b/src-tauri/src/team_hub/protocol/mod.rs
@@ -40,6 +40,7 @@ pub(crate) mod tools;
 use crate::team_hub::{CallContext, TeamHub};
 use schema::tool_defs;
 use serde_json::{json, Value};
+use tools::error::ToolError;
 use tools::{
     team_ack_handoff, team_assign_task, team_create_leader, team_diagnostics, team_dismiss,
     team_get_tasks, team_info, team_list_role_profiles, team_lock_files, team_read, team_recruit,
@@ -88,16 +89,13 @@ pub async fn handle(hub: &TeamHub, ctx: &CallContext, req: &Value) -> Option<Val
                         ]
                     }
                 })),
-                Err(msg) => {
-                    // Issue #342 Phase 1 (1.7b): 構造化 JSON 文字列を Err に詰めるツール
-                    // (現在は team_recruit のみ) が、`json!({"error": msg})` で文字列値として
-                    // 二重エスケープされてクライアントが 2 回 parse する必要がある問題を回避。
-                    // msg が JSON object として parse できれば object のまま `error` キーに乗せ、
-                    // そうでなければ従来どおり文字列値として包む。
-                    let text = match serde_json::from_str::<Value>(&msg) {
-                        Ok(v) if v.is_object() => json!({ "error": v }).to_string(),
-                        _ => json!({ "error": msg }).to_string(),
-                    };
+                Err(err) => {
+                    // Issue #737: 各 tool は `Result<Value, ToolError>` を返すようになったため、
+                    // JSON 化はここ (dispatcher) で 1 度だけ行う。旧実装は各 tool が
+                    // `ToolError::into_err_string()` で String 化 → ここで再 parse する二度手間
+                    // (flavor #3: ToolError(JSON-in-String)) だったのを解消する。
+                    // `result.content[0].text` の shape は従来どおり `{"error": {code, message, ...}}`。
+                    let text = json!({ "error": err.to_json_value() }).to_string();
                     Some(json!({
                         "jsonrpc": "2.0",
                         "id": id,
@@ -130,7 +128,7 @@ async fn dispatch_tool(
     ctx: &CallContext,
     name: &str,
     args: &Value,
-) -> Result<Value, String> {
+) -> Result<Value, ToolError> {
     match name {
         "team_send" => team_send(hub, ctx, args).await,
         "team_read" => team_read(hub, ctx, args).await,
@@ -151,6 +149,9 @@ async fn dispatch_tool(
         // Issue #526: vibe-team の advisory file lock。
         "team_lock_files" => team_lock_files(hub, ctx, args).await,
         "team_unlock_files" => team_unlock_files(hub, ctx, args).await,
-        other => Err(format!("Unknown tool: {other}")),
+        other => Err(ToolError::new(
+            "unknown_tool",
+            format!("Unknown tool: {other}"),
+        )),
     }
 }

--- a/src-tauri/src/team_hub/protocol/permissions.rs
+++ b/src-tauri/src/team_hub/protocol/permissions.rs
@@ -52,22 +52,13 @@ impl Permission {
     }
 }
 
-/// `check_permission` の失敗値。`into_message(action)` で各 tool 固有の
-/// "permission denied: role 'X' cannot {action}" エラー文を組み立てる。
+/// `check_permission` の失敗値。各 tool は `role` を使って
+/// `ToolError::permission_denied(code_prefix, &e.role, action)` で構造化エラーを組み立てる
+/// (Issue #737: 旧 `into_message` による生 String 化は廃止し、flat JSON の `ToolError` に統一)。
 #[derive(Clone, Debug)]
 pub(in crate::team_hub) struct PermissionError {
     pub role: String,
     pub permission: Permission,
-}
-
-impl PermissionError {
-    /// 既存の各 tool が出していた "permission denied: role 'X' cannot Y" 形へ整形。
-    /// `action` は tool ごとに違う (例: "recruit" / "dismiss" / "assign tasks" /
-    /// "create role profiles" / "view diagnostics" / "ack handoff" / "create leader" /
-    /// "switch leader") ので呼び出し側で指定する。
-    pub(in crate::team_hub) fn into_message(self, action: &str) -> String {
-        format!("permission denied: role '{}' cannot {action}", self.role)
-    }
 }
 
 impl fmt::Display for PermissionError {
@@ -176,15 +167,22 @@ mod tests {
         }
     }
 
+    /// Issue #737: `PermissionError` から各 tool が `ToolError::permission_denied` で構造化
+    /// エラーを組み立てる経路 (旧 `into_message` による生 String 化の置き換え) を検証する。
     #[test]
-    fn permission_error_into_message_uses_caller_action_verb() {
+    fn permission_error_role_drives_structured_tool_error() {
+        use super::super::tools::error::ToolError;
         let err = check_permission("planner", Permission::Recruit).unwrap_err();
+        let recruit = ToolError::permission_denied("recruit", &err.role, "recruit");
+        assert_eq!(recruit.code, "recruit_permission_denied");
         assert_eq!(
-            err.clone().into_message("recruit"),
+            recruit.message,
             "permission denied: role 'planner' cannot recruit"
         );
+        let ack = ToolError::permission_denied("ack_handoff", &err.role, "ack handoff");
+        assert_eq!(ack.code, "ack_handoff_permission_denied");
         assert_eq!(
-            err.into_message("ack handoff"),
+            ack.message,
             "permission denied: role 'planner' cannot ack handoff"
         );
     }

--- a/src-tauri/src/team_hub/protocol/tools/ack_handoff.rs
+++ b/src-tauri/src/team_hub/protocol/tools/ack_handoff.rs
@@ -10,11 +10,13 @@ pub async fn team_ack_handoff(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
-) -> Result<Value, String> {
+) -> Result<Value, ToolError> {
     if let Err(e) = check_permission(&ctx.role, Permission::Recruit) {
-        return Err(
-            ToolError::permission_denied("ack_handoff", &e.role, "ack handoff").into_err_string(),
-        );
+        return Err(ToolError::permission_denied(
+            "ack_handoff",
+            &e.role,
+            "ack handoff",
+        ));
     }
 
     let handoff_id = args
@@ -23,7 +25,7 @@ pub async fn team_ack_handoff(
         .and_then(|v| v.as_str())
         .map(str::trim)
         .filter(|v| !v.is_empty())
-        .ok_or_else(|| "handoff_id is required".to_string())?;
+        .ok_or_else(|| ToolError::invalid_args("ack_handoff", "handoff_id is required"))?;
     let note = args
         .get("note")
         .and_then(|v| v.as_str())

--- a/src-tauri/src/team_hub/protocol/tools/assign_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/assign_task.rs
@@ -54,6 +54,7 @@ fn assign_invalid_done_criteria(message: impl Into<String>) -> AssignError {
         message: message.into(),
         phase: None,
         elapsed_ms: None,
+        details: None,
     }
 }
 
@@ -106,6 +107,7 @@ fn assign_invalid_pre_approval(message: impl Into<String>) -> AssignError {
         message: message.into(),
         phase: None,
         elapsed_ms: None,
+        details: None,
     }
 }
 
@@ -216,6 +218,7 @@ pub async fn team_assign_task(
             message: "assignee and description are required".into(),
             phase: None,
             elapsed_ms: None,
+            details: None,
         });
     }
     // Issue #526: `target_paths: string[]` (任意) — このタスクで触る予定のファイル / dir 宣言。
@@ -262,6 +265,7 @@ pub async fn team_assign_task(
             ),
             phase: None,
             elapsed_ms: None,
+            details: None,
         });
     }
     // Issue #525: #526 の advisory lock を task state へ接続する。
@@ -328,6 +332,7 @@ pub async fn team_assign_task(
                     ),
                     phase: None,
                     elapsed_ms: None,
+                    details: None,
                 });
             }
         };
@@ -364,6 +369,7 @@ pub async fn team_assign_task(
                     ),
                     phase: None,
                     elapsed_ms: None,
+                    details: None,
                 });
             }
         }

--- a/src-tauri/src/team_hub/protocol/tools/assign_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/assign_task.rs
@@ -48,17 +48,16 @@ fn parse_target_paths(args: &Value) -> Vec<String> {
     out
 }
 
-fn assign_invalid_done_criteria(message: impl Into<String>) -> String {
+fn assign_invalid_done_criteria(message: impl Into<String>) -> AssignError {
     AssignError {
         code: "assign_done_criteria_required".into(),
         message: message.into(),
         phase: None,
         elapsed_ms: None,
     }
-    .into_err_string()
 }
 
-fn parse_done_criteria(args: &Value) -> Result<Vec<String>, String> {
+fn parse_done_criteria(args: &Value) -> Result<Vec<String>, AssignError> {
     let arr = args
         .get("done_criteria")
         .or_else(|| args.get("doneCriteria"))
@@ -101,17 +100,16 @@ fn optional_text_field(
         .map(ToOwned::to_owned)
 }
 
-fn assign_invalid_pre_approval(message: impl Into<String>) -> String {
+fn assign_invalid_pre_approval(message: impl Into<String>) -> AssignError {
     AssignError {
         code: "assign_invalid_pre_approval".into(),
         message: message.into(),
         phase: None,
         elapsed_ms: None,
     }
-    .into_err_string()
 }
 
-fn parse_pre_approval(args: &Value) -> Result<Option<TaskPreApprovalSnapshot>, String> {
+fn parse_pre_approval(args: &Value) -> Result<Option<TaskPreApprovalSnapshot>, AssignError> {
     let Some(raw) = args.get("pre_approval").or_else(|| args.get("preApproval")) else {
         return Ok(None);
     };
@@ -196,13 +194,15 @@ pub async fn team_assign_task(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
-) -> Result<Value, String> {
+) -> Result<Value, AssignError> {
     // Issue #114: 旧実装は assignee / description の空チェックだけで権限を見ておらず、
     // canAssignTasks=false のロールでも task を作成できてしまっていた。先頭で必ず権限検証する。
     if let Err(e) = check_permission(&ctx.role, Permission::AssignTasks) {
-        return Err(
-            AssignError::permission_denied("assign", &e.role, "assign tasks").into_err_string(),
-        );
+        return Err(AssignError::permission_denied(
+            "assign",
+            &e.role,
+            "assign tasks",
+        ));
     }
     let assignee_raw = args.get("assignee").and_then(|v| v.as_str()).unwrap_or("");
     let assignee = assignee_raw.trim();
@@ -216,8 +216,7 @@ pub async fn team_assign_task(
             message: "assignee and description are required".into(),
             phase: None,
             elapsed_ms: None,
-        }
-        .into_err_string());
+        });
     }
     // Issue #526: `target_paths: string[]` (任意) — このタスクで触る予定のファイル / dir 宣言。
     // Hub は assign_task 時点で同 path を別 agent が握っていないか peek し、
@@ -263,8 +262,7 @@ pub async fn team_assign_task(
             ),
             phase: None,
             elapsed_ms: None,
-        }
-        .into_err_string());
+        });
     }
     // Issue #525: #526 の advisory lock を task state へ接続する。
     // target_paths がある時点で既存 lock と peek し、response だけでなく TeamTaskSnapshot にも
@@ -330,8 +328,7 @@ pub async fn team_assign_task(
                     ),
                     phase: None,
                     elapsed_ms: None,
-                }
-                .into_err_string());
+                });
             }
         };
         match crate::team_hub::spool::spool_long_payload(&project_root, description, "assign").await
@@ -367,8 +364,7 @@ pub async fn team_assign_task(
                     ),
                     phase: None,
                     elapsed_ms: None,
-                }
-                .into_err_string());
+                });
             }
         }
     }
@@ -764,8 +760,8 @@ mod tests {
         let missing = parse_done_criteria(&json!({})).unwrap_err();
         let empty = parse_done_criteria(&json!({ "done_criteria": [" "] })).unwrap_err();
 
-        assert!(missing.contains("assign_done_criteria_required"));
-        assert!(empty.contains("at least one non-empty criterion"));
+        assert_eq!(missing.code, "assign_done_criteria_required");
+        assert!(empty.message.contains("at least one non-empty criterion"));
     }
 
     #[test]
@@ -793,8 +789,8 @@ mod tests {
         }))
         .unwrap_err();
 
-        assert!(err.contains("assign_invalid_pre_approval"));
-        assert!(err.contains("at least one non-empty action"));
+        assert_eq!(err.code, "assign_invalid_pre_approval");
+        assert!(err.message.contains("at least one non-empty action"));
     }
 
     #[test]

--- a/src-tauri/src/team_hub/protocol/tools/create_leader.rs
+++ b/src-tauri/src/team_hub/protocol/tools/create_leader.rs
@@ -192,6 +192,7 @@ pub async fn team_create_leader(
                 message,
                 phase: Some(phase_str),
                 elapsed_ms: Some(started.elapsed().as_millis() as u64),
+                details: None,
             });
         }
         Ok(Err(_)) => {
@@ -207,6 +208,7 @@ pub async fn team_create_leader(
                 message: "renderer ack channel was dropped before reply".into(),
                 phase: Some("ack".into()),
                 elapsed_ms: Some(started.elapsed().as_millis() as u64),
+                details: None,
             });
         }
         Err(_) => {
@@ -231,6 +233,7 @@ pub async fn team_create_leader(
                 ),
                 phase: Some("ack".into()),
                 elapsed_ms: Some(elapsed_ms),
+                details: None,
             });
         }
     }
@@ -274,6 +277,7 @@ pub async fn team_create_leader(
                 message: "create_leader cancelled before handshake".into(),
                 phase: Some("handshake".into()),
                 elapsed_ms: Some(started.elapsed().as_millis() as u64),
+                details: None,
             })
         }
         Err(_) => {
@@ -292,6 +296,7 @@ pub async fn team_create_leader(
                 ),
                 phase: Some("handshake".into()),
                 elapsed_ms: Some(started.elapsed().as_millis() as u64),
+                details: None,
             })
         }
     }

--- a/src-tauri/src/team_hub/protocol/tools/create_leader.rs
+++ b/src-tauri/src/team_hub/protocol/tools/create_leader.rs
@@ -127,8 +127,13 @@ pub async fn team_create_leader(
     {
         Ok(c) => c,
         // Issue #737: `try_register_pending_recruit` は hub 内部関数で `Result<_, String>` を
-        // 返す。generic な `tool_error` code で包んで RecruitError へ持ち上げる。
-        Err(e) => return Err(e.into()),
+        // 返す。create_leader 名前空間の専用 code を付けて RecruitError へ持ち上げる。
+        Err(e) => {
+            return Err(RecruitError::new(
+                "create_leader_pending_registration_failed",
+                e,
+            ))
+        }
     };
     let rx = channels.handshake;
     let ack_rx = channels.ack;
@@ -154,7 +159,10 @@ pub async fn team_create_leader(
         }
     } else {
         hub.cancel_pending_recruit(&new_agent_id).await;
-        return Err("renderer not available (canvas mode required)".into());
+        return Err(RecruitError::new(
+            "create_leader_renderer_unavailable",
+            "renderer not available (canvas mode required)",
+        ));
     }
 
     // ack 待機 (renderer が `team:recruit-request` を受領 → addCard 開始)

--- a/src-tauri/src/team_hub/protocol/tools/create_leader.rs
+++ b/src-tauri/src/team_hub/protocol/tools/create_leader.rs
@@ -34,12 +34,13 @@ pub async fn team_create_leader(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
-) -> Result<Value, String> {
+) -> Result<Value, RecruitError> {
     if let Err(e) = check_permission(&ctx.role, Permission::Recruit) {
-        return Err(
-            RecruitError::permission_denied("create_leader", &e.role, "create leader")
-                .into_err_string(),
-        );
+        return Err(RecruitError::permission_denied(
+            "create_leader",
+            &e.role,
+            "create leader",
+        ));
     }
 
     // Issue #576: 同チーム内の同時 recruit / create_leader を team_id 単位 semaphore で
@@ -50,9 +51,7 @@ pub async fn team_create_leader(
         Ok(p) => p,
         Err(msg) => {
             return Err(
-                RecruitError::new("create_leader_permit_timeout", msg)
-                    .with_phase("permit")
-                    .into_err_string(),
+                RecruitError::new("create_leader_permit_timeout", msg).with_phase("permit"),
             );
         }
     };
@@ -85,8 +84,7 @@ pub async fn team_create_leader(
         let parsed_policy = parse_engine_policy_value(policy_value)?;
         if let Err(e) = parsed_policy.validate(&engine) {
             return Err(RecruitError::new("create_leader_engine_policy_violation", e)
-                .with_phase("engine_policy")
-                .into_err_string());
+                .with_phase("engine_policy"));
         }
         hub.set_engine_policy(&ctx.team_id, parsed_policy).await;
     }
@@ -107,8 +105,7 @@ pub async fn team_create_leader(
     // engine 引数が policy 違反になっていないかも改めて検証する (set 後の policy 基準)。
     if let Err(e) = engine_policy.validate(&resolved_engine) {
         return Err(RecruitError::new("create_leader_engine_policy_violation", e)
-            .with_phase("engine_policy")
-            .into_err_string());
+            .with_phase("engine_policy"));
     }
 
     let new_agent_id = format!("vc-{}", Uuid::new_v4());
@@ -129,7 +126,9 @@ pub async fn team_create_leader(
         .await
     {
         Ok(c) => c,
-        Err(e) => return Err(e),
+        // Issue #737: `try_register_pending_recruit` は hub 内部関数で `Result<_, String>` を
+        // 返す。generic な `tool_error` code で包んで RecruitError へ持ち上げる。
+        Err(e) => return Err(e.into()),
     };
     let rx = channels.handshake;
     let ack_rx = channels.ack;
@@ -148,7 +147,10 @@ pub async fn team_create_leader(
         });
         if let Err(e) = app.emit("team:recruit-request", payload) {
             hub.cancel_pending_recruit(&new_agent_id).await;
-            return Err(format!("failed to emit recruit-request: {e}"));
+            return Err(RecruitError::new(
+                "create_leader_emit_failed",
+                format!("failed to emit recruit-request: {e}"),
+            ));
         }
     } else {
         hub.cancel_pending_recruit(&new_agent_id).await;
@@ -190,8 +192,7 @@ pub async fn team_create_leader(
                 message,
                 phase: Some(phase_str),
                 elapsed_ms: Some(started.elapsed().as_millis() as u64),
-            }
-            .into_err_string());
+            });
         }
         Ok(Err(_)) => {
             hub.cancel_pending_recruit(&new_agent_id).await;
@@ -206,8 +207,7 @@ pub async fn team_create_leader(
                 message: "renderer ack channel was dropped before reply".into(),
                 phase: Some("ack".into()),
                 elapsed_ms: Some(started.elapsed().as_millis() as u64),
-            }
-            .into_err_string());
+            });
         }
         Err(_) => {
             let elapsed_ms = started.elapsed().as_millis() as u64;
@@ -231,8 +231,7 @@ pub async fn team_create_leader(
                 ),
                 phase: Some("ack".into()),
                 elapsed_ms: Some(elapsed_ms),
-            }
-            .into_err_string());
+            });
         }
     }
 
@@ -275,8 +274,7 @@ pub async fn team_create_leader(
                 message: "create_leader cancelled before handshake".into(),
                 phase: Some("handshake".into()),
                 elapsed_ms: Some(started.elapsed().as_millis() as u64),
-            }
-            .into_err_string())
+            })
         }
         Err(_) => {
             hub.cancel_pending_recruit(&new_agent_id).await;
@@ -294,8 +292,7 @@ pub async fn team_create_leader(
                 ),
                 phase: Some("handshake".into()),
                 elapsed_ms: Some(started.elapsed().as_millis() as u64),
-            }
-            .into_err_string())
+            })
         }
     }
 }
@@ -304,13 +301,12 @@ pub async fn team_create_leader(
 /// パースする。値が object でない / `kind` が不正なら `create_leader_invalid_engine_policy`
 /// エラー。`defaultEngine` は省略可 (ClaudeOnly / CodexOnly のときは自動で対応する engine が
 /// resolve される)、明示する場合は "claude" / "codex" のみ許可。
-fn parse_engine_policy_value(v: &Value) -> Result<EnginePolicy, String> {
+fn parse_engine_policy_value(v: &Value) -> Result<EnginePolicy, RecruitError> {
     let obj = v.as_object().ok_or_else(|| {
         RecruitError::invalid_args(
             "create_leader",
             "engine_policy must be an object: { kind, defaultEngine? }",
         )
-        .into_err_string()
     })?;
     let kind_str = obj
         .get("kind")
@@ -321,7 +317,6 @@ fn parse_engine_policy_value(v: &Value) -> Result<EnginePolicy, String> {
                 "create_leader",
                 "engine_policy.kind is required (claude_only / codex_only / mixed_allowed)",
             )
-            .into_err_string()
         })?;
     let kind = match kind_str.as_str() {
         "claude_only" | "claudeonly" => EnginePolicyKind::ClaudeOnly,
@@ -334,8 +329,7 @@ fn parse_engine_policy_value(v: &Value) -> Result<EnginePolicy, String> {
                     "unknown engine_policy.kind '{other}' \
                      (expected: claude_only / codex_only / mixed_allowed)"
                 ),
-            )
-            .into_err_string());
+            ));
         }
     };
     // `defaultEngine` (camelCase / 正) と `default_engine` (snake_case / alias) の両 case を accept する。
@@ -356,8 +350,7 @@ fn parse_engine_policy_value(v: &Value) -> Result<EnginePolicy, String> {
                 format!(
                     "engine_policy.defaultEngine must be 'claude' or 'codex' (or omit the field), got '{de}'"
                 ),
-            )
-            .into_err_string());
+            ));
         }
     }
     Ok(EnginePolicy {
@@ -411,29 +404,29 @@ mod tests {
     fn parse_rejects_unknown_kind() {
         let v = json!({ "kind": "claude_or_codex" });
         let err = parse_engine_policy_value(&v).unwrap_err();
-        assert!(err.contains("create_leader_invalid_args"));
-        assert!(err.contains("unknown engine_policy.kind"));
+        assert_eq!(err.code, "create_leader_invalid_args");
+        assert!(err.message.contains("unknown engine_policy.kind"));
     }
 
     #[test]
     fn parse_rejects_missing_kind() {
         let v = json!({ "defaultEngine": "claude" });
         let err = parse_engine_policy_value(&v).unwrap_err();
-        assert!(err.contains("engine_policy.kind is required"));
+        assert!(err.message.contains("engine_policy.kind is required"));
     }
 
     #[test]
     fn parse_rejects_invalid_default_engine() {
         let v = json!({ "kind": "mixed_allowed", "defaultEngine": "gpt" });
         let err = parse_engine_policy_value(&v).unwrap_err();
-        assert!(err.contains("must be 'claude' or 'codex'"));
+        assert!(err.message.contains("must be 'claude' or 'codex'"));
     }
 
     #[test]
     fn parse_rejects_non_object() {
         let v = json!("claude_only");
         let err = parse_engine_policy_value(&v).unwrap_err();
-        assert!(err.contains("must be an object"));
+        assert!(err.message.contains("must be an object"));
     }
 
     #[test]

--- a/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
+++ b/src-tauri/src/team_hub/protocol/tools/diagnostics.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use super::super::consts::STATUS_STALE_THRESHOLD_SECS;
 use super::super::helpers::message_is_for_me;
 use super::super::permissions::{check_permission, Permission};
+use super::error::ToolError;
 
 const STALLED_INBOUND_THRESHOLD_MS: i64 = 60_000;
 
@@ -139,9 +140,9 @@ fn build_member_diagnostics_row(
     })
 }
 
-pub async fn team_diagnostics(hub: &TeamHub, ctx: &CallContext) -> Result<Value, String> {
+pub async fn team_diagnostics(hub: &TeamHub, ctx: &CallContext) -> Result<Value, ToolError> {
     check_permission(&ctx.role, Permission::ViewDiagnostics)
-        .map_err(|e| e.into_message("view diagnostics"))?;
+        .map_err(|e| ToolError::permission_denied("diagnostics", &e.role, "view diagnostics"))?;
 
     let bindings_snapshot: HashMap<String, String>;
     let diag_snapshot: HashMap<String, MemberDiagnostics>;

--- a/src-tauri/src/team_hub/protocol/tools/dismiss.rs
+++ b/src-tauri/src/team_hub/protocol/tools/dismiss.rs
@@ -14,10 +14,9 @@ pub async fn team_dismiss(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
-) -> Result<Value, String> {
+) -> Result<Value, DismissError> {
     if let Err(e) = check_permission(&ctx.role, Permission::Dismiss) {
-        return Err(DismissError::permission_denied("dismiss", &e.role, "dismiss")
-            .into_err_string());
+        return Err(DismissError::permission_denied("dismiss", &e.role, "dismiss"));
     }
     let agent_id = args
         .get("agent_id")
@@ -25,7 +24,7 @@ pub async fn team_dismiss(
         .unwrap_or("")
         .to_string();
     if agent_id.is_empty() {
-        return Err(DismissError::invalid_args("dismiss", "agent_id is required").into_err_string());
+        return Err(DismissError::invalid_args("dismiss", "agent_id is required"));
     }
     if agent_id == ctx.agent_id {
         return Err(DismissError {
@@ -33,8 +32,7 @@ pub async fn team_dismiss(
             message: "cannot dismiss yourself".into(),
             phase: None,
             elapsed_ms: None,
-        }
-        .into_err_string());
+        });
     }
     // チーム所属チェック
     let members = hub.registry.list_team_members(&ctx.team_id);
@@ -44,8 +42,7 @@ pub async fn team_dismiss(
             message: format!("agent '{agent_id}' is not in this team"),
             phase: None,
             elapsed_ms: None,
-        }
-        .into_err_string());
+        });
     }
     // Issue #342 Phase 3 (3.6): dismiss 直前に被 dismiss 側の last_seen_at / 既存 recruited_at を
     // スナップしておき、戻り値に `lastSeenAt` を載せる (= 最後の生存時刻)。

--- a/src-tauri/src/team_hub/protocol/tools/dismiss.rs
+++ b/src-tauri/src/team_hub/protocol/tools/dismiss.rs
@@ -32,6 +32,7 @@ pub async fn team_dismiss(
             message: "cannot dismiss yourself".into(),
             phase: None,
             elapsed_ms: None,
+            details: None,
         });
     }
     // チーム所属チェック
@@ -42,6 +43,7 @@ pub async fn team_dismiss(
             message: format!("agent '{agent_id}' is not in this team"),
             phase: None,
             elapsed_ms: None,
+            details: None,
         });
     }
     // Issue #342 Phase 3 (3.6): dismiss 直前に被 dismiss 側の last_seen_at / 既存 recruited_at を

--- a/src-tauri/src/team_hub/protocol/tools/error.rs
+++ b/src-tauri/src/team_hub/protocol/tools/error.rs
@@ -72,13 +72,29 @@ impl ToolError {
         self
     }
 
-    /// JSON 文字列化して `Err(String)` に詰めるヘルパ。
-    /// to_string() に失敗したら message だけを返す (生 String fallback)。
-    pub fn into_err_string(self) -> String {
-        match serde_json::to_string(&self) {
-            Ok(s) => s,
-            Err(_) => self.message,
-        }
+    /// Issue #737: dispatcher が `{"error": ...}` に詰めるための JSON 値化。
+    /// flat object へのシリアライズに失敗した場合は message 文字列値へ degrade する
+    /// (旧 `into_err_string` の生 String fallback と等価の安全策)。
+    pub fn to_json_value(&self) -> serde_json::Value {
+        serde_json::to_value(self)
+            .unwrap_or_else(|_| serde_json::Value::String(self.message.clone()))
+    }
+}
+
+/// Issue #737: MCP tool を `Result<Value, ToolError>` に統一したことで、`?` で
+/// 伝播してくる `String` エラー (例: `record_handoff_lifecycle` / `acquire_recruit_permit`
+/// 等、tool ではない hub 内部関数が返す `Result<_, String>`) を `ToolError` に持ち上げる。
+/// tool 固有の code 名前空間を持たない内部エラーなので、generic な `tool_error` code で包む。
+/// message 文字列はそのまま保持するため、呼び出し側が受け取る情報量は従来と変わらない。
+impl From<String> for ToolError {
+    fn from(message: String) -> Self {
+        Self::new("tool_error", message)
+    }
+}
+
+impl From<&str> for ToolError {
+    fn from(message: &str) -> Self {
+        Self::new("tool_error", message.to_string())
     }
 }
 
@@ -105,13 +121,28 @@ mod tests {
     #[test]
     fn flat_json_payload_is_preserved() {
         let err = ToolError::new("dismiss_permission_denied", "permission denied: role 'planner' cannot dismiss");
-        let json = err.into_err_string();
+        // Issue #737: dispatcher は `to_json_value()` で flat object を取り出す。
+        let value = err.to_json_value();
         // 旧 RecruitError / ToolError と同じ flat shape (`{"code":"...","message":"..."}`)。
-        assert!(json.contains("\"code\":\"dismiss_permission_denied\""));
-        assert!(json.contains("\"message\":\"permission denied: role 'planner' cannot dismiss\""));
-        // optional フィールドは skip_serializing_if で省略
-        assert!(!json.contains("\"phase\""));
-        assert!(!json.contains("\"elapsed_ms\""));
+        assert_eq!(value["code"], "dismiss_permission_denied");
+        assert_eq!(
+            value["message"],
+            "permission denied: role 'planner' cannot dismiss"
+        );
+        // optional フィールドは skip_serializing_if で省略 (object に key 自体が無い)。
+        let obj = value.as_object().expect("flat object");
+        assert!(!obj.contains_key("phase"));
+        assert!(!obj.contains_key("elapsed_ms"));
+    }
+
+    /// Issue #737: tool ではない hub 内部関数が返す `String` エラーは generic な
+    /// `tool_error` code で包まれる。message 文字列はそのまま保持される。
+    #[test]
+    fn from_string_wraps_with_generic_code() {
+        let err: ToolError = "project_root is not registered for this team".to_string().into();
+        assert_eq!(err.code, "tool_error");
+        assert_eq!(err.message, "project_root is not registered for this team");
+        assert!(err.phase.is_none());
     }
 
     #[test]

--- a/src-tauri/src/team_hub/protocol/tools/error.rs
+++ b/src-tauri/src/team_hub/protocol/tools/error.rs
@@ -32,16 +32,25 @@ pub struct ToolError {
     pub phase: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub elapsed_ms: Option<u64>,
+    /// Issue #737 (PR #787 二次レビュー): tool 固有の追加構造化フィールドを **トップレベルに
+    /// flatten** して載せるための拡張ポイント。`Some(object)` ならその object の各キーが
+    /// `{code, message, phase, elapsed_ms}` と同階層に展開される (例: `team_update_task` の
+    /// `task_done_evidence_missing` が返す `missingCriteria` 配列の wire 後方互換)。
+    /// `None` なら `skip_serializing_if` で完全に省略され、従来の flat shape と一致する。
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
 }
 
 impl ToolError {
-    /// 任意 code / message でインスタンス化。`with_phase` / `with_elapsed_ms` で追加情報を載せる。
+    /// 任意 code / message でインスタンス化。`with_phase` / `with_elapsed_ms` / `with_details`
+    /// で追加情報を載せる。
     pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             code: code.into(),
             message: message.into(),
             phase: None,
             elapsed_ms: None,
+            details: None,
         }
     }
 
@@ -69,6 +78,15 @@ impl ToolError {
     /// 経過ミリ秒を後付けする builder (timeout 等の調査に使う)。
     pub fn with_elapsed_ms(mut self, ms: u64) -> Self {
         self.elapsed_ms = Some(ms);
+        self
+    }
+
+    /// Issue #737 (PR #787 二次レビュー): tool 固有の追加構造化フィールドを後付けする builder。
+    /// 渡す `details` は **object** であることを想定する (`#[serde(flatten)]` でトップレベルに
+    /// 展開されるため)。object 以外 (配列 / scalar) を渡すと serde のシリアライズが失敗するが、
+    /// その場合 `to_json_value()` の fallback で message 文字列値へ degrade する。
+    pub fn with_details(mut self, details: serde_json::Value) -> Self {
+        self.details = Some(details);
         self
     }
 
@@ -133,6 +151,33 @@ mod tests {
         let obj = value.as_object().expect("flat object");
         assert!(!obj.contains_key("phase"));
         assert!(!obj.contains_key("elapsed_ms"));
+        // PR #787 二次レビュー: `details` が None なら追加 key は一切 flatten されない。
+        assert_eq!(obj.len(), 2);
+    }
+
+    /// PR #787 二次レビュー (API Contract): `with_details` で渡した object のキーは
+    /// `{code, message}` と **同階層** にトップレベル展開される (`#[serde(flatten)]`)。
+    /// `task_done_evidence_missing` の `missingCriteria` 配列の wire 後方互換を担保する。
+    #[test]
+    fn with_details_flattens_extra_fields_to_top_level() {
+        let err = ToolError::new(
+            "task_done_evidence_missing",
+            "done_evidence must cover every done_criteria item",
+        )
+        .with_details(serde_json::json!({
+            "missingCriteria": ["focused test passes", "security reviewed"]
+        }));
+        let value = err.to_json_value();
+        let obj = value.as_object().expect("flat object");
+        // code / message は従来どおり。
+        assert_eq!(obj["code"], "task_done_evidence_missing");
+        // `missingCriteria` はネストではなくトップレベルに展開されている。
+        assert_eq!(
+            obj["missingCriteria"],
+            serde_json::json!(["focused test passes", "security reviewed"])
+        );
+        // `details` という中間 key は wire に現れない (flatten のため)。
+        assert!(!obj.contains_key("details"));
     }
 
     /// Issue #737: tool ではない hub 内部関数が返す `String` エラーは generic な

--- a/src-tauri/src/team_hub/protocol/tools/file_lock.rs
+++ b/src-tauri/src/team_hub/protocol/tools/file_lock.rs
@@ -43,7 +43,7 @@ fn validate_and_normalize_paths(
     ctx: &CallContext,
     raw_paths: &[String],
     code_prefix: &str,
-) -> Result<Vec<String>, String> {
+) -> Result<Vec<String>, ToolError> {
     let mut out = Vec::with_capacity(raw_paths.len());
     for raw in raw_paths {
         match normalize_path(raw) {
@@ -61,22 +61,22 @@ fn validate_and_normalize_paths(
                 return Err(ToolError::new(
                     format!("{code_prefix}_invalid_path"),
                     format!("invalid path '{}': {e}", clamp_for_log(raw)),
-                )
-                .into_err_string());
+                ));
             }
         }
     }
     Ok(out)
 }
 
-fn parse_paths_arg(args: &Value, code_prefix: &str) -> Result<Vec<String>, String> {
+fn parse_paths_arg(args: &Value, code_prefix: &str) -> Result<Vec<String>, ToolError> {
     let arr = args.get("paths").and_then(|v| v.as_array()).ok_or_else(|| {
         ToolError::invalid_args(code_prefix, "`paths` must be a non-empty string array")
-            .into_err_string()
     })?;
     if arr.is_empty() {
-        return Err(ToolError::invalid_args(code_prefix, "`paths` must be a non-empty string array")
-            .into_err_string());
+        return Err(ToolError::invalid_args(
+            code_prefix,
+            "`paths` must be a non-empty string array",
+        ));
     }
     if arr.len() > MAX_LOCK_PATHS_PER_CALL {
         return Err(ToolError::invalid_args(
@@ -86,14 +86,12 @@ fn parse_paths_arg(args: &Value, code_prefix: &str) -> Result<Vec<String>, Strin
                 arr.len(),
                 MAX_LOCK_PATHS_PER_CALL
             ),
-        )
-        .into_err_string());
+        ));
     }
     let mut out = Vec::with_capacity(arr.len());
     for v in arr {
         let s = v.as_str().ok_or_else(|| {
             ToolError::invalid_args(code_prefix, "`paths` must be an array of strings")
-                .into_err_string()
         })?;
         if s.len() > MAX_LOCK_PATH_LEN {
             return Err(ToolError::invalid_args(
@@ -103,8 +101,7 @@ fn parse_paths_arg(args: &Value, code_prefix: &str) -> Result<Vec<String>, Strin
                     s.len(),
                     MAX_LOCK_PATH_LEN
                 ),
-            )
-            .into_err_string());
+            ));
         }
         out.push(s.to_string());
     }
@@ -120,7 +117,7 @@ pub async fn team_lock_files(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
-) -> Result<Value, String> {
+) -> Result<Value, ToolError> {
     let raw_paths = parse_paths_arg(args, "lock_files")?;
     let paths = validate_and_normalize_paths(ctx, &raw_paths, "lock_files")?;
     let result = match hub
@@ -150,8 +147,7 @@ pub async fn team_lock_files(
                     "team lock cap exceeded: {} existing + {} requested > {} (limit per team)",
                     cap_exceeded.current, cap_exceeded.requested, cap_exceeded.cap,
                 ),
-            )
-            .into_err_string());
+            ));
         }
     };
     Ok(json!({
@@ -170,7 +166,7 @@ pub async fn team_unlock_files(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
-) -> Result<Value, String> {
+) -> Result<Value, ToolError> {
     let raw_paths = parse_paths_arg(args, "unlock_files")?;
     let paths = validate_and_normalize_paths(ctx, &raw_paths, "unlock_files")?;
     let result = hub
@@ -190,22 +186,22 @@ mod tests {
     fn parse_paths_rejects_missing_paths() {
         let args = json!({});
         let err = parse_paths_arg(&args, "lock_files").unwrap_err();
-        assert!(err.contains("lock_files_invalid_args"));
-        assert!(err.contains("non-empty string array"));
+        assert_eq!(err.code, "lock_files_invalid_args");
+        assert!(err.message.contains("non-empty string array"));
     }
 
     #[test]
     fn parse_paths_rejects_empty_array() {
         let args = json!({ "paths": [] });
         let err = parse_paths_arg(&args, "lock_files").unwrap_err();
-        assert!(err.contains("non-empty string array"));
+        assert!(err.message.contains("non-empty string array"));
     }
 
     #[test]
     fn parse_paths_rejects_non_string_element() {
         let args = json!({ "paths": ["ok.rs", 42, "ok2.rs"] });
         let err = parse_paths_arg(&args, "lock_files").unwrap_err();
-        assert!(err.contains("array of strings"));
+        assert!(err.message.contains("array of strings"));
     }
 
     #[test]
@@ -222,7 +218,7 @@ mod tests {
             .collect();
         let args = json!({ "paths": huge });
         let err = parse_paths_arg(&args, "lock_files").unwrap_err();
-        assert!(err.contains("too many paths"));
+        assert!(err.message.contains("too many paths"));
     }
 
     #[test]
@@ -230,7 +226,7 @@ mod tests {
         let big = "a".repeat(MAX_LOCK_PATH_LEN + 1);
         let args = json!({ "paths": [big] });
         let err = parse_paths_arg(&args, "lock_files").unwrap_err();
-        assert!(err.contains("path too long"));
+        assert!(err.message.contains("path too long"));
     }
 
     /// Issue #599 (Tier A-1): `team_lock_files` IPC は traversal / 絶対 / 制御文字 / 過大長を
@@ -268,9 +264,9 @@ mod tests {
             )
             .await
             .unwrap_err();
-            assert!(
-                err.contains("lock_files_invalid_path"),
-                "expected invalid_path code, got: {err}"
+            assert_eq!(
+                err.code, "lock_files_invalid_path",
+                "expected invalid_path code, got: {err:?}"
             );
             // even the legitimate "src/foo.rs" must NOT be locked when the request is rejected.
             assert_eq!(team_locks_count(&hub, "team-599-pd").await, 0);
@@ -289,9 +285,9 @@ mod tests {
                 let err = team_lock_files(&hub, &ctx, &json!({ "paths": [evil] }))
                     .await
                     .unwrap_err();
-                assert!(
-                    err.contains("lock_files_invalid_path"),
-                    "[{evil}] expected invalid_path, got: {err}"
+                assert_eq!(
+                    err.code, "lock_files_invalid_path",
+                    "[{evil}] expected invalid_path, got: {err:?}"
                 );
             }
             assert_eq!(team_locks_count(&hub, "team-599-abs").await, 0);
@@ -309,7 +305,7 @@ mod tests {
             )
             .await
             .unwrap_err();
-            assert!(err.contains("lock_files_invalid_path"));
+            assert_eq!(err.code, "lock_files_invalid_path");
             assert_eq!(team_locks_count(&hub, "team-599-ctrl").await, 0);
         }
 
@@ -339,9 +335,9 @@ mod tests {
             )
             .await
             .unwrap_err();
-            assert!(
-                err.contains("lock_files_too_many_locks"),
-                "expected too_many_locks, got: {err}"
+            assert_eq!(
+                err.code, "lock_files_too_many_locks",
+                "expected too_many_locks, got: {err:?}"
             );
             // map は 128 のまま (atomic に reject されているので追加されない)。
             assert_eq!(team_locks_count(&hub, "team-599-cap").await, MAX_LOCKS_PER_TEAM);
@@ -354,9 +350,9 @@ mod tests {
             let err = team_unlock_files(&hub, &ctx, &json!({ "paths": ["../../etc/passwd"] }))
                 .await
                 .unwrap_err();
-            assert!(
-                err.contains("unlock_files_invalid_path"),
-                "expected unlock_files_invalid_path, got: {err}"
+            assert_eq!(
+                err.code, "unlock_files_invalid_path",
+                "expected unlock_files_invalid_path, got: {err:?}"
             );
         }
     }

--- a/src-tauri/src/team_hub/protocol/tools/get_tasks.rs
+++ b/src-tauri/src/team_hub/protocol/tools/get_tasks.rs
@@ -6,7 +6,9 @@
 use crate::team_hub::{CallContext, TeamHub};
 use serde_json::{json, Value};
 
-pub async fn team_get_tasks(hub: &TeamHub, ctx: &CallContext) -> Result<Value, String> {
+use super::error::ToolError;
+
+pub async fn team_get_tasks(hub: &TeamHub, ctx: &CallContext) -> Result<Value, ToolError> {
     let state = hub.state.lock().await;
     let team = match state.teams.get(&ctx.team_id) {
         Some(t) => t,

--- a/src-tauri/src/team_hub/protocol/tools/info.rs
+++ b/src-tauri/src/team_hub/protocol/tools/info.rs
@@ -6,7 +6,9 @@ use crate::team_hub::{CallContext, TeamHub};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
-pub async fn team_info(hub: &TeamHub, ctx: &CallContext) -> Result<Value, String> {
+use super::error::ToolError;
+
+pub async fn team_info(hub: &TeamHub, ctx: &CallContext) -> Result<Value, ToolError> {
     // Issue #342 Phase 2: identity 分離検出のため `agent_role_bindings` を一緒に取る。
     // member の registry 上 role と handshake 時に bind した role が乖離している (= 別
     // プロセスが同 agent_id で違う role を主張した / context が古い) なら

--- a/src-tauri/src/team_hub/protocol/tools/list_role_profiles.rs
+++ b/src-tauri/src/team_hub/protocol/tools/list_role_profiles.rs
@@ -5,10 +5,12 @@
 use crate::team_hub::{CallContext, TeamHub};
 use serde_json::{json, Value};
 
+use super::error::ToolError;
+
 pub async fn team_list_role_profiles(
     hub: &TeamHub,
     ctx: &CallContext,
-) -> Result<Value, String> {
+) -> Result<Value, ToolError> {
     let summary = hub.get_role_profile_summary().await;
     let dynamic = hub.get_dynamic_roles(&ctx.team_id).await;
     let mut profiles: Vec<Value> = summary

--- a/src-tauri/src/team_hub/protocol/tools/read.rs
+++ b/src-tauri/src/team_hub/protocol/tools/read.rs
@@ -8,8 +8,13 @@ use serde_json::{json, Value};
 use tauri::Emitter;
 
 use super::super::helpers::message_is_for_me;
+use super::error::ToolError;
 
-pub async fn team_read(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<Value, String> {
+pub async fn team_read(
+    hub: &TeamHub,
+    ctx: &CallContext,
+    args: &Value,
+) -> Result<Value, ToolError> {
     let unread_only = args
         .get("unread_only")
         .and_then(|v| v.as_bool())

--- a/src-tauri/src/team_hub/protocol/tools/recruit.rs
+++ b/src-tauri/src/team_hub/protocol/tools/recruit.rs
@@ -99,26 +99,27 @@ fn recruit_liveness_error(
     let log_path = crate::team_hub::server_log_path_for_diagnostics();
     let mut detail =
         format!(" (agentId={agent_id}, roleProfileId={role_profile_id}, logPath={log_path})");
-    // Issue #737: 構造化フィールドを wire のトップレベルへ復元する details object。
-    // message 末尾の人間可読 detail と併存させ、後方互換と可読性を両立する
-    // (done_evidence_missing の missingCriteria と同じ with_details 経路)。
-    let mut details = serde_json::json!({
-        "agentId": agent_id,
-        "roleProfileId": role_profile_id,
-        "logPath": log_path,
-    });
     if let Some(sid) = &session_id {
         detail.push_str(&format!(", sessionId={sid}"));
-        details["sessionId"] = serde_json::Value::String(sid.clone());
     }
     if let Some(ec) = exit_code {
         detail.push_str(&format!(", exitCode={ec}"));
-        details["exitCode"] = serde_json::Value::from(ec);
     }
     if let Some(er) = &exit_reason {
         detail.push_str(&format!(", exitReason={er}"));
-        details["exitReason"] = serde_json::Value::String(er.clone());
     }
+    // Issue #737: 構造化フィールドを wire のトップレベルへ復元する details object。
+    // optional 診断値 (sessionId / exitCode / exitReason) は旧 wire と互換にするため、
+    // absent でもキーを残し `null` を出す (json! は Option::None を null に展開する)。
+    // message 末尾の人間可読 detail とも併存。
+    let details = serde_json::json!({
+        "agentId": agent_id,
+        "roleProfileId": role_profile_id,
+        "logPath": log_path,
+        "sessionId": session_id,
+        "exitCode": exit_code,
+        "exitReason": exit_reason,
+    });
     RecruitError::new(code, format!("{message}{detail}"))
         .with_phase("post_handshake_liveness")
         .with_elapsed_ms(elapsed_ms)

--- a/src-tauri/src/team_hub/protocol/tools/recruit.rs
+++ b/src-tauri/src/team_hub/protocol/tools/recruit.rs
@@ -60,7 +60,7 @@ pub(super) fn recruit_ack_timeout() -> Duration {
     }
 }
 
-fn parse_wait_policy(args: &Value) -> Result<String, String> {
+fn parse_wait_policy(args: &Value) -> Result<String, RecruitError> {
     let raw = args
         .get("wait_policy")
         .or_else(|| args.get("waitPolicy"))
@@ -74,11 +74,16 @@ fn parse_wait_policy(args: &Value) -> Result<String, String> {
             "recruit_invalid_wait_policy",
             format!("wait_policy must be strict, standard, or proactive (got {other:?})"),
         )
-        .with_phase("args")
-        .into_err_string()),
+        .with_phase("args")),
     }
 }
 
+/// post-handshake liveness 失敗用の構造化エラーを組み立てる。
+///
+/// Issue #737: 旧実装は `agentId` / `sessionId` / `exitCode` / `exitReason` / `logPath` /
+/// `roleProfileId` を JSON 文字列の追加フィールドとして返していた。`ToolError` の flat shape
+/// (`code` / `message` / `phase` / `elapsed_ms`) に揃えるため、これらの診断情報は message 末尾に
+/// 畳み込んで保持する (= renderer / Leader が exit 原因 / session / log path を引き続き読める)。
 fn recruit_liveness_error(
     code: &str,
     message: String,
@@ -86,24 +91,27 @@ fn recruit_liveness_error(
     role_profile_id: &str,
     elapsed_ms: u64,
     diag: Option<crate::team_hub::MemberDiagnostics>,
-) -> String {
+) -> RecruitError {
     let (session_id, exit_code, exit_reason) = match diag {
         Some(d) => (d.last_exit_session_id, d.last_exit_code, d.last_exit_reason),
         None => (None, None, None),
     };
-    serde_json::to_string(&json!({
-        "code": code,
-        "message": message,
-        "phase": "post_handshake_liveness",
-        "elapsed_ms": elapsed_ms,
-        "agentId": agent_id,
-        "roleProfileId": role_profile_id,
-        "sessionId": session_id,
-        "exitCode": exit_code,
-        "exitReason": exit_reason,
-        "logPath": crate::team_hub::server_log_path_for_diagnostics(),
-    }))
-    .unwrap_or_else(|_| message)
+    let mut detail = format!(
+        " (agentId={agent_id}, roleProfileId={role_profile_id}, logPath={})",
+        crate::team_hub::server_log_path_for_diagnostics()
+    );
+    if let Some(sid) = session_id {
+        detail.push_str(&format!(", sessionId={sid}"));
+    }
+    if let Some(ec) = exit_code {
+        detail.push_str(&format!(", exitCode={ec}"));
+    }
+    if let Some(er) = exit_reason {
+        detail.push_str(&format!(", exitReason={er}"));
+    }
+    RecruitError::new(code, format!("{message}{detail}"))
+        .with_phase("post_handshake_liveness")
+        .with_elapsed_ms(elapsed_ms)
 }
 
 async fn verify_recruit_liveness(
@@ -112,7 +120,7 @@ async fn verify_recruit_liveness(
     agent_id: &str,
     role_profile_id: &str,
     started: Instant,
-) -> Result<(), String> {
+) -> Result<(), RecruitError> {
     tokio::time::sleep(RECRUIT_POST_HANDSHAKE_LIVENESS_GRACE).await;
 
     let members = hub.registry.list_team_members(team_id);
@@ -177,8 +185,13 @@ async fn verify_recruit_liveness(
 ///     既存 role_id と被る場合は「既に存在する」エラーになる。
 ///   - instructions_ja: 任意の日本語版 instructions。
 ///   - agent_label_hint: 任意。canvas カードのタイトル上書き。
-pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<Value, String> {
-    check_permission(&ctx.role, Permission::Recruit).map_err(|e| e.into_message("recruit"))?;
+pub async fn team_recruit(
+    hub: &TeamHub,
+    ctx: &CallContext,
+    args: &Value,
+) -> Result<Value, RecruitError> {
+    check_permission(&ctx.role, Permission::Recruit)
+        .map_err(|e| RecruitError::permission_denied("recruit", &e.role, "recruit"))?;
 
     // Issue #576: 同チーム内の同時 recruit を team_id 単位 semaphore で順番待ち化する。
     // permit 保持のまま emit → ack 受領 (or timeout) → cancel_pending_recruit までを
@@ -188,9 +201,7 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
     let _permit = match hub.acquire_recruit_permit(&ctx.team_id).await {
         Ok(p) => p,
         Err(msg) => {
-            return Err(RecruitError::new("recruit_permit_timeout", msg)
-                .with_phase("permit")
-                .into_err_string());
+            return Err(RecruitError::new("recruit_permit_timeout", msg).with_phase("permit"));
         }
     };
 
@@ -257,8 +268,7 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
         if report.has_deny() {
             return Err(
                 RecruitError::new("recruit_lint_denied", report.deny_message())
-                    .with_phase("lint")
-                    .into_err_string(),
+                    .with_phase("lint"),
             );
         }
         report
@@ -353,8 +363,11 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
         None
     };
     if summary_match.is_none() && dynamic_match.is_none() {
-        return Err(format!(
-            "unknown role_profile_id: {role_profile_id} (call team_create_role first, or pass role_definition to team_recruit)"
+        return Err(RecruitError::new(
+            "recruit_unknown_role",
+            format!(
+                "unknown role_profile_id: {role_profile_id} (call team_create_role first, or pass role_definition to team_recruit)"
+            ),
         ));
     }
 
@@ -384,8 +397,7 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
     // ハード拒否し、HR / Leader が誤って混合してしまう経路を構造的に潰す。
     if let Err(msg) = engine_policy.validate(&resolved_engine) {
         return Err(RecruitError::new("recruit_engine_policy_violation", msg)
-            .with_phase("engine_policy")
-            .into_err_string());
+            .with_phase("engine_policy"));
     }
 
     // 動的ロールの場合は agent_label_hint をロール label で補完する (renderer 側カード表示が綺麗になる)
@@ -426,7 +438,10 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
         .await
     {
         Ok(c) => c,
-        Err(e) => return Err(e),
+        // Issue #737: `try_register_pending_recruit` は hub 内部関数で `Result<_, String>` を
+        // 返す。generic な `tool_error` code で包んで RecruitError へ持ち上げる
+        // (`From<String>` impl と同じ扱い。message 文字列はそのまま保持される)。
+        Err(e) => return Err(e.into()),
     };
     let rx = channels.handshake;
     let ack_rx = channels.ack;
@@ -461,7 +476,10 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
         });
         if let Err(e) = app.emit("team:recruit-request", payload) {
             hub.cancel_pending_recruit(&new_agent_id).await;
-            return Err(format!("failed to emit recruit-request: {e}"));
+            return Err(RecruitError::new(
+                "recruit_emit_failed",
+                format!("failed to emit recruit-request: {e}"),
+            ));
         }
     } else {
         hub.cancel_pending_recruit(&new_agent_id).await;
@@ -510,8 +528,7 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
                 };
                 return Err(RecruitError::new("recruit_failed", message)
                     .with_phase(phase_str)
-                    .with_elapsed_ms(started.elapsed().as_millis() as u64)
-                    .into_err_string());
+                    .with_elapsed_ms(started.elapsed().as_millis() as u64));
             }
             Ok(Err(_)) => {
                 // ack_tx が drop された (renderer 側が pending を resolve せずに崩壊) — 緊急 cancel 扱い
@@ -527,8 +544,7 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
                     "renderer ack channel was dropped before reply",
                 )
                 .with_phase("ack")
-                .with_elapsed_ms(started.elapsed().as_millis() as u64)
-                .into_err_string());
+                .with_elapsed_ms(started.elapsed().as_millis() as u64));
             }
             Err(_) => {
                 // ack timeout。renderer が `team:recruit-request` を受け取れていない可能性。
@@ -553,8 +569,7 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
                     ),
                 )
                 .with_phase("ack")
-                .with_elapsed_ms(elapsed_ms)
-                .into_err_string());
+                .with_elapsed_ms(elapsed_ms));
             }
         }
     }
@@ -630,8 +645,7 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
             Err(
                 RecruitError::new("recruit_cancelled", "recruit cancelled before handshake")
                     .with_phase("handshake")
-                    .with_elapsed_ms(started.elapsed().as_millis() as u64)
-                    .into_err_string(),
+                    .with_elapsed_ms(started.elapsed().as_millis() as u64),
             )
         }
         Err(_) => {
@@ -653,8 +667,7 @@ pub async fn team_recruit(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Res
                 ),
             )
             .with_phase("handshake")
-            .with_elapsed_ms(started.elapsed().as_millis() as u64)
-            .into_err_string())
+            .with_elapsed_ms(started.elapsed().as_millis() as u64))
         }
     }
 }
@@ -705,8 +718,8 @@ mod tests {
     fn parse_wait_policy_rejects_unknown_value() {
         let err = parse_wait_policy(&json!({ "wait_policy": "autonomous" })).unwrap_err();
 
-        assert!(err.contains("recruit_invalid_wait_policy"));
-        assert!(err.contains("strict, standard, or proactive"));
+        assert_eq!(err.code, "recruit_invalid_wait_policy");
+        assert!(err.message.contains("strict, standard, or proactive"));
     }
 
     /// Issue #587: `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS=0` は default にフォールバック。

--- a/src-tauri/src/team_hub/protocol/tools/recruit.rs
+++ b/src-tauri/src/team_hub/protocol/tools/recruit.rs
@@ -96,22 +96,33 @@ fn recruit_liveness_error(
         Some(d) => (d.last_exit_session_id, d.last_exit_code, d.last_exit_reason),
         None => (None, None, None),
     };
-    let mut detail = format!(
-        " (agentId={agent_id}, roleProfileId={role_profile_id}, logPath={})",
-        crate::team_hub::server_log_path_for_diagnostics()
-    );
-    if let Some(sid) = session_id {
+    let log_path = crate::team_hub::server_log_path_for_diagnostics();
+    let mut detail =
+        format!(" (agentId={agent_id}, roleProfileId={role_profile_id}, logPath={log_path})");
+    // Issue #737: 構造化フィールドを wire のトップレベルへ復元する details object。
+    // message 末尾の人間可読 detail と併存させ、後方互換と可読性を両立する
+    // (done_evidence_missing の missingCriteria と同じ with_details 経路)。
+    let mut details = serde_json::json!({
+        "agentId": agent_id,
+        "roleProfileId": role_profile_id,
+        "logPath": log_path,
+    });
+    if let Some(sid) = &session_id {
         detail.push_str(&format!(", sessionId={sid}"));
+        details["sessionId"] = serde_json::Value::String(sid.clone());
     }
     if let Some(ec) = exit_code {
         detail.push_str(&format!(", exitCode={ec}"));
+        details["exitCode"] = serde_json::Value::from(ec);
     }
-    if let Some(er) = exit_reason {
+    if let Some(er) = &exit_reason {
         detail.push_str(&format!(", exitReason={er}"));
+        details["exitReason"] = serde_json::Value::String(er.clone());
     }
     RecruitError::new(code, format!("{message}{detail}"))
         .with_phase("post_handshake_liveness")
         .with_elapsed_ms(elapsed_ms)
+        .with_details(details)
 }
 
 async fn verify_recruit_liveness(

--- a/src-tauri/src/team_hub/protocol/tools/recruit.rs
+++ b/src-tauri/src/team_hub/protocol/tools/recruit.rs
@@ -225,7 +225,7 @@ pub async fn team_recruit(
         .unwrap_or("")
         .to_string();
     if role_profile_id.is_empty() {
-        return Err("role_id is required".into());
+        return Err(RecruitError::invalid_args("recruit", "role_id is required"));
     }
     let engine = args
         .get("engine")
@@ -451,9 +451,11 @@ pub async fn team_recruit(
     {
         Ok(c) => c,
         // Issue #737: `try_register_pending_recruit` は hub 内部関数で `Result<_, String>` を
-        // 返す。generic な `tool_error` code で包んで RecruitError へ持ち上げる
-        // (`From<String>` impl と同じ扱い。message 文字列はそのまま保持される)。
-        Err(e) => return Err(e.into()),
+        // 返す。recruit 名前空間の専用 code を付けて RecruitError へ持ち上げる
+        // (message 文字列はそのまま保持される)。
+        Err(e) => {
+            return Err(RecruitError::new("recruit_pending_registration_failed", e))
+        }
     };
     let rx = channels.handshake;
     let ack_rx = channels.ack;
@@ -495,7 +497,10 @@ pub async fn team_recruit(
         }
     } else {
         hub.cancel_pending_recruit(&new_agent_id).await;
-        return Err("renderer not available (canvas mode required)".into());
+        return Err(RecruitError::new(
+            "recruit_renderer_unavailable",
+            "renderer not available (canvas mode required)",
+        ));
     }
 
     // Issue #342 Phase 1 (1.11): 環境変数 `VIBE_TEAM_DISABLE_RECRUIT_ACK=1` で旧 fire-and-forget

--- a/src-tauri/src/team_hub/protocol/tools/report.rs
+++ b/src-tauri/src/team_hub/protocol/tools/report.rs
@@ -24,11 +24,11 @@ const MAX_FINDINGS_PER_REPORT: usize = 200;
 /// 1 レポートあたりの changed_files / artifact_refs / next_actions 上限。
 const MAX_LIST_ENTRIES: usize = 200;
 
-fn invalid_args(message: impl Into<String>) -> String {
-    ToolError::invalid_args("report", message).into_err_string()
+fn invalid_args(message: impl Into<String>) -> ToolError {
+    ToolError::invalid_args("report", message)
 }
 
-fn parse_string_list(args: &Value, snake: &str, camel: &str) -> Result<Vec<String>, String> {
+fn parse_string_list(args: &Value, snake: &str, camel: &str) -> Result<Vec<String>, ToolError> {
     let raw = match args.get(snake).or_else(|| args.get(camel)) {
         Some(v) => v,
         None => return Ok(Vec::new()),
@@ -58,7 +58,7 @@ fn parse_string_list(args: &Value, snake: &str, camel: &str) -> Result<Vec<Strin
     Ok(out)
 }
 
-fn parse_findings(args: &Value) -> Result<Vec<TeamReportFinding>, String> {
+fn parse_findings(args: &Value) -> Result<Vec<TeamReportFinding>, ToolError> {
     let raw = match args.get("findings") {
         Some(v) => v,
         None => return Ok(Vec::new()),
@@ -121,7 +121,7 @@ fn parse_findings(args: &Value) -> Result<Vec<TeamReportFinding>, String> {
     Ok(out)
 }
 
-fn parse_status(args: &Value) -> Result<String, String> {
+fn parse_status(args: &Value) -> Result<String, ToolError> {
     let raw = args
         .get("status")
         .and_then(|v| v.as_str())
@@ -136,7 +136,7 @@ fn parse_status(args: &Value) -> Result<String, String> {
     Ok(lower)
 }
 
-fn parse_task_id(args: &Value) -> Result<(String, Option<u32>), String> {
+fn parse_task_id(args: &Value) -> Result<(String, Option<u32>), ToolError> {
     let value = args
         .get("task_id")
         .or_else(|| args.get("taskId"))
@@ -174,7 +174,7 @@ fn parse_task_id(args: &Value) -> Result<(String, Option<u32>), String> {
     Ok((raw, numeric))
 }
 
-fn parse_summary(args: &Value) -> Result<String, String> {
+fn parse_summary(args: &Value) -> Result<String, ToolError> {
     let summary = args
         .get("summary")
         .and_then(|v| v.as_str())
@@ -229,7 +229,11 @@ fn format_terminal_summary(snapshot: &TeamReportSnapshot) -> String {
     )
 }
 
-pub async fn team_report(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<Value, String> {
+pub async fn team_report(
+    hub: &TeamHub,
+    ctx: &CallContext,
+    args: &Value,
+) -> Result<Value, ToolError> {
     let (task_id_raw, task_id_num) = parse_task_id(args)?;
     let status = parse_status(args)?;
     let summary = parse_summary(args)?;
@@ -395,8 +399,8 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(err.contains("report_invalid_args"));
-        assert!(err.contains("task_id"));
+        assert_eq!(err.code, "report_invalid_args");
+        assert!(err.message.contains("task_id"));
     }
 
     #[tokio::test]
@@ -410,8 +414,8 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(err.contains("report_invalid_args"));
-        assert!(err.contains("status"));
+        assert_eq!(err.code, "report_invalid_args");
+        assert!(err.message.contains("status"));
     }
 
     #[tokio::test]
@@ -431,9 +435,9 @@ mod tests {
             )
             .await
             .unwrap_err();
-            assert!(err.contains("report_invalid_args"), "raw err: {err}");
-            assert!(err.contains("task_id"), "raw err: {err}");
-            assert!(err.contains("control"), "raw err: {err}");
+            assert_eq!(err.code, "report_invalid_args", "raw err: {err:?}");
+            assert!(err.message.contains("task_id"), "raw err: {err:?}");
+            assert!(err.message.contains("control"), "raw err: {err:?}");
         }
     }
 
@@ -450,7 +454,7 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(err.contains("≤ 256 bytes"), "got: {err}");
+        assert!(err.message.contains("≤ 256 bytes"), "got: {err:?}");
     }
 
     /// PR #575 review (defense-in-depth): persisted snapshot 経由で改行 / ESC を含む task_id を
@@ -492,7 +496,7 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(err.contains("summary"));
+        assert!(err.message.contains("summary"));
     }
 
     #[tokio::test]
@@ -515,7 +519,7 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(err.contains("severity"));
+        assert!(err.message.contains("severity"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/team_hub/protocol/tools/send.rs
+++ b/src-tauri/src/team_hub/protocol/tools/send.rs
@@ -68,7 +68,7 @@ impl MessageKind {
     }
 }
 
-fn parse_message_kind(args: &Value) -> Result<MessageKind, String> {
+fn parse_message_kind(args: &Value) -> Result<MessageKind, SendError> {
     let raw = args
         .get("kind")
         .and_then(|v| v.as_str())
@@ -79,20 +79,17 @@ fn parse_message_kind(args: &Value) -> Result<MessageKind, String> {
         "advisory" => Ok(MessageKind::Advisory),
         "request" => Ok(MessageKind::Request),
         "report" => Ok(MessageKind::Report),
-        other => Err(SendError {
-            code: "send_invalid_args".into(),
-            message: format!("kind must be advisory, request, or report (got {other:?})"),
-            phase: None,
-            elapsed_ms: None,
-        }
-        .into_err_string()),
+        other => Err(SendError::invalid_args(
+            "send",
+            format!("kind must be advisory, request, or report (got {other:?})"),
+        )),
     }
 }
 
 fn non_empty_optional_field(
     obj: &serde_json::Map<String, Value>,
     field: &str,
-) -> Result<Option<String>, String> {
+) -> Result<Option<String>, SendError> {
     match obj.get(field) {
         None | Some(Value::Null) => Ok(None),
         Some(Value::String(s)) => {
@@ -103,17 +100,14 @@ fn non_empty_optional_field(
                 Ok(Some(trimmed.to_string()))
             }
         }
-        Some(_) => Err(SendError {
-            code: "send_invalid_args".into(),
-            message: format!("message.{field} must be a string when provided"),
-            phase: None,
-            elapsed_ms: None,
-        }
-        .into_err_string()),
+        Some(_) => Err(SendError::invalid_args(
+            "send",
+            format!("message.{field} must be a string when provided"),
+        )),
     }
 }
 
-fn parse_message_body(args: &Value) -> Result<(String, MessageBodyKind), String> {
+fn parse_message_body(args: &Value) -> Result<(String, MessageBodyKind), SendError> {
     let Some(message_value) = args.get("message") else {
         return Ok((String::new(), MessageBodyKind::Plain));
     };
@@ -123,25 +117,18 @@ fn parse_message_body(args: &Value) -> Result<(String, MessageBodyKind), String>
     }
 
     let Some(obj) = message_value.as_object() else {
-        return Err(SendError {
-            code: "send_invalid_args".into(),
-            message: "message must be a string or an object with instructions/context/data fields"
-                .into(),
-            phase: None,
-            elapsed_ms: None,
-        }
-        .into_err_string());
+        return Err(SendError::invalid_args(
+            "send",
+            "message must be a string or an object with instructions/context/data fields",
+        ));
     };
 
     for field in obj.keys() {
         if !matches!(field.as_str(), "instructions" | "context" | "data") {
-            return Err(SendError {
-                code: "send_invalid_args".into(),
-                message: format!("message.{field} is not allowed"),
-                phase: None,
-                elapsed_ms: None,
-            }
-            .into_err_string());
+            return Err(SendError::invalid_args(
+                "send",
+                format!("message.{field} is not allowed"),
+            ));
         }
     }
 
@@ -265,7 +252,7 @@ struct SendArgs {
 ///   - `to` / `message` (+body kind) / `kind` / `handoff_id` を取り出す
 ///   - `to` 空 or `message` 空 → `send_invalid_args`
 ///   - `message` が `MAX_MESSAGE_LEN` 超過 → `send_message_too_large`
-fn parse_send_args(args: &Value) -> Result<SendArgs, String> {
+fn parse_send_args(args: &Value) -> Result<SendArgs, SendError> {
     // trim は resolve_targets 内で行うので、ここでは生文字列を保持して履歴 / 検証に使う。
     let to = args
         .get("to")
@@ -276,27 +263,21 @@ fn parse_send_args(args: &Value) -> Result<SendArgs, String> {
     let message_kind = parse_message_kind(args)?;
     let handoff_id = optional_string(args, "handoff_id", "handoffId");
     if to.trim().is_empty() || message.is_empty() {
-        return Err(SendError {
-            code: "send_invalid_args".into(),
-            message: "to and a non-empty message are required".into(),
-            phase: None,
-            elapsed_ms: None,
-        }
-        .into_err_string());
+        return Err(SendError::invalid_args(
+            "send",
+            "to and a non-empty message are required",
+        ));
     }
     // Issue #107: 1 メッセージのハードリミット超過は拒否 (途中で truncate すると意味が壊れる)
     if message.len() > MAX_MESSAGE_LEN {
-        return Err(SendError {
-            code: "send_message_too_large".into(),
-            message: format!(
+        return Err(SendError::new(
+            "send_message_too_large",
+            format!(
                 "message too large: {} bytes (limit {} bytes)",
                 message.len(),
                 MAX_MESSAGE_LEN
             ),
-            phase: None,
-            elapsed_ms: None,
-        }
-        .into_err_string());
+        ));
     }
     Ok(SendArgs {
         to,
@@ -327,7 +308,7 @@ async fn spool_oversized_message(
     ctx: &CallContext,
     to: &str,
     message: &str,
-) -> Result<Option<String>, String> {
+) -> Result<Option<String>, SendError> {
     if message.len() <= SOFT_PAYLOAD_LIMIT {
         return Ok(None);
     }
@@ -344,14 +325,14 @@ async fn spool_oversized_message(
     {
         Some(p) => p.to_string(),
         None => {
-            return Err(SendError {
-                // Issue #512 ↔ #545 review: error code は旧名 `send_payload_threshold`
-                // を維持して後方互換を保つ。新実装で挙動が変わったのは「成功時に reject せず
-                // spool 化する」path であり、reject 時の error code は旧来の SOFT_PAYLOAD_LIMIT
-                // 超過と同じ意味で扱える。caller (Leader / HR / worker) が code 判定で
-                // fallback handler を持っていても、本 PR で挙動が壊れない。
-                code: "send_payload_threshold".into(),
-                message: format!(
+            // Issue #512 ↔ #545 review: error code は旧名 `send_payload_threshold`
+            // を維持して後方互換を保つ。新実装で挙動が変わったのは「成功時に reject せず
+            // spool 化する」path であり、reject 時の error code は旧来の SOFT_PAYLOAD_LIMIT
+            // 超過と同じ意味で扱える。caller (Leader / HR / worker) が code 判定で
+            // fallback handler を持っていても、本 PR で挙動が壊れない。
+            return Err(SendError::new(
+                "send_payload_threshold",
+                format!(
                     "message exceeds the long-payload threshold ({} > {} bytes) and \
                      this team has no project_root configured for auto-spool. \
                      Setup the team via Canvas (setupTeamMcp) or write the full content to \
@@ -359,10 +340,7 @@ async fn spool_oversized_message(
                     message.len(),
                     SOFT_PAYLOAD_LIMIT
                 ),
-                phase: None,
-                elapsed_ms: None,
-            }
-            .into_err_string());
+            ));
         }
     };
     match crate::team_hub::spool::spool_long_payload(&project_root, message, "send").await {
@@ -382,14 +360,14 @@ async fn spool_oversized_message(
                 "[team_send] auto-spool failed for team={}: {e:#}; falling back to reject",
                 ctx.team_id
             );
-            Err(SendError {
-                // Issue #512 ↔ #545 review: error code は旧名 `send_payload_threshold`
-                // を維持して後方互換を保つ。新実装で挙動が変わったのは「成功時に reject せず
-                // spool 化する」path であり、reject 時の error code は旧来の SOFT_PAYLOAD_LIMIT
-                // 超過と同じ意味で扱える。caller (Leader / HR / worker) が code 判定で
-                // fallback handler を持っていても、本 PR で挙動が壊れない。
-                code: "send_payload_threshold".into(),
-                message: format!(
+            // Issue #512 ↔ #545 review: error code は旧名 `send_payload_threshold`
+            // を維持して後方互換を保つ。新実装で挙動が変わったのは「成功時に reject せず
+            // spool 化する」path であり、reject 時の error code は旧来の SOFT_PAYLOAD_LIMIT
+            // 超過と同じ意味で扱える。caller (Leader / HR / worker) が code 判定で
+            // fallback handler を持っていても、本 PR で挙動が壊れない。
+            Err(SendError::new(
+                "send_payload_threshold",
+                format!(
                     "message exceeds the long-payload threshold ({} > {} bytes) and \
                      auto-spool to `.vibe-team/tmp/` failed: {e}. \
                      Write the full content to a file with the Write tool, then call team_send \
@@ -397,10 +375,7 @@ async fn spool_oversized_message(
                     message.len(),
                     SOFT_PAYLOAD_LIMIT
                 ),
-                phase: None,
-                elapsed_ms: None,
-            }
-            .into_err_string())
+            ))
         }
     }
 }
@@ -914,7 +889,7 @@ fn build_send_response(
     })
 }
 
-pub async fn team_send(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<Value, String> {
+pub async fn team_send(hub: &TeamHub, ctx: &CallContext, args: &Value) -> Result<Value, SendError> {
     // 段階 1: 引数 parse / 検証。
     let sargs = parse_send_args(args)?;
 
@@ -1052,8 +1027,10 @@ mod tests {
     fn parse_message_kind_rejects_unknown_kind() {
         let err = parse_message_kind(&json!({ "kind": "delegate" })).unwrap_err();
 
-        assert!(err.contains("send_invalid_args"));
-        assert!(err.contains("kind must be advisory, request, or report"));
+        assert_eq!(err.code, "send_invalid_args");
+        assert!(err
+            .message
+            .contains("kind must be advisory, request, or report"));
     }
 
     #[test]
@@ -1170,8 +1147,8 @@ mod tests {
         }))
         .unwrap_err();
 
-        assert!(err.contains("send_invalid_args"));
-        assert!(err.contains("message.data must be a string"));
+        assert_eq!(err.code, "send_invalid_args");
+        assert!(err.message.contains("message.data must be a string"));
     }
 
     #[test]
@@ -1184,7 +1161,7 @@ mod tests {
         }))
         .unwrap_err();
 
-        assert!(err.contains("send_invalid_args"));
-        assert!(err.contains("message.system is not allowed"));
+        assert_eq!(err.code, "send_invalid_args");
+        assert!(err.message.contains("message.system is not allowed"));
     }
 }

--- a/src-tauri/src/team_hub/protocol/tools/status.rs
+++ b/src-tauri/src/team_hub/protocol/tools/status.rs
@@ -14,6 +14,8 @@ use chrono::Utc;
 use serde_json::{json, Value};
 use std::time::{Duration, Instant};
 
+use super::error::ToolError;
+
 /// Issue #634: `current_status` の最大長 (UTF-8 バイト数)。超過分は `… (truncated)` を末尾に付けて切る。
 /// renderer 側 chat row はそもそも 1 行の現況メモなので 256 byte で十分。
 const MAX_STATUS_LEN: usize = 256;
@@ -98,11 +100,14 @@ pub async fn team_status(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
-) -> Result<Value, String> {
+) -> Result<Value, ToolError> {
     let status_raw = args.get("status").and_then(|v| v.as_str()).unwrap_or("");
     let status = status_raw.trim();
     if status.is_empty() {
-        return Err("status is required and must be a non-empty string".to_string());
+        return Err(ToolError::invalid_args(
+            "status",
+            "status is required and must be a non-empty string",
+        ));
     }
     // Issue #634: control char strip → length cap (byte 単位)。
     // truncate は UTF-8 文字境界で行わないと panic するため、char_indices で安全に切る。

--- a/src-tauri/src/team_hub/protocol/tools/status.rs
+++ b/src-tauri/src/team_hub/protocol/tools/status.rs
@@ -282,8 +282,11 @@ mod tests {
             .await
             .expect("ok");
         let saved = result["currentStatus"].as_str().unwrap().to_string();
+        // 入力の非制御文字は "running" + "tests" + "still" + "going"。
+        // sanitize_status_text は制御文字 (ESC seq / BEL / 改行 / NUL) のみ除去し、
+        // 通常文字はそのまま残すため期待値は "runningtestsstillgoing"。
         assert_eq!(
-            saved, "runningteststillgoing",
+            saved, "runningtestsstillgoing",
             "control chars must be stripped (got: {saved:?})"
         );
     }

--- a/src-tauri/src/team_hub/protocol/tools/switch_leader.rs
+++ b/src-tauri/src/team_hub/protocol/tools/switch_leader.rs
@@ -42,6 +42,7 @@ pub async fn team_switch_leader(
             message: "new_leader_agent_id is required".into(),
             phase: None,
             elapsed_ms: None,
+            details: None,
         });
     }
     if new_leader_agent_id == ctx.agent_id {
@@ -50,6 +51,7 @@ pub async fn team_switch_leader(
             message: "new_leader_agent_id must differ from the caller".into(),
             phase: None,
             elapsed_ms: None,
+            details: None,
         });
     }
 
@@ -79,6 +81,7 @@ pub async fn team_switch_leader(
             ),
             phase: None,
             elapsed_ms: None,
+            details: None,
         });
     };
     if new_role != "leader" {
@@ -89,6 +92,7 @@ pub async fn team_switch_leader(
             ),
             phase: None,
             elapsed_ms: None,
+            details: None,
         });
     }
 

--- a/src-tauri/src/team_hub/protocol/tools/switch_leader.rs
+++ b/src-tauri/src/team_hub/protocol/tools/switch_leader.rs
@@ -21,12 +21,13 @@ pub async fn team_switch_leader(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
-) -> Result<Value, String> {
+) -> Result<Value, ToolError> {
     if let Err(e) = check_permission(&ctx.role, Permission::Recruit) {
-        return Err(
-            ToolError::permission_denied("switch_leader", &e.role, "switch leader")
-                .into_err_string(),
-        );
+        return Err(ToolError::permission_denied(
+            "switch_leader",
+            &e.role,
+            "switch leader",
+        ));
     }
 
     let new_leader_agent_id = args
@@ -41,8 +42,7 @@ pub async fn team_switch_leader(
             message: "new_leader_agent_id is required".into(),
             phase: None,
             elapsed_ms: None,
-        }
-        .into_err_string());
+        });
     }
     if new_leader_agent_id == ctx.agent_id {
         return Err(ToolError {
@@ -50,8 +50,7 @@ pub async fn team_switch_leader(
             message: "new_leader_agent_id must differ from the caller".into(),
             phase: None,
             elapsed_ms: None,
-        }
-        .into_err_string());
+        });
     }
 
     let close_old_card = args
@@ -80,8 +79,7 @@ pub async fn team_switch_leader(
             ),
             phase: None,
             elapsed_ms: None,
-        }
-        .into_err_string());
+        });
     };
     if new_role != "leader" {
         return Err(ToolError {
@@ -91,8 +89,7 @@ pub async fn team_switch_leader(
             ),
             phase: None,
             elapsed_ms: None,
-        }
-        .into_err_string());
+        });
     }
 
     // active leader を切替え

--- a/src-tauri/src/team_hub/protocol/tools/update_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/update_task.rs
@@ -43,9 +43,11 @@ fn done_evidence_invalid(message: impl Into<String>) -> ToolError {
     ToolError::new("task_done_evidence_invalid", message)
 }
 
-/// Issue #737: 旧実装は `missingCriteria` 配列を JSON 文字列で別フィールドとして返していた。
-/// `ToolError` の flat shape に合わせ、未充足の criteria を message 末尾に畳み込んで保持する
-/// (= caller / LLM が「どの criterion が足りないか」を引き続き読み取れる)。
+/// Issue #737 (PR #787 二次レビュー): `task_done_evidence_missing` エラーは旧来
+/// `missingCriteria` 配列を **トップレベル JSON フィールド**で返していた。flat ToolError 化で
+/// 一度 message 末尾への畳み込みだけにしたが、wire 後方互換のため `with_details` で
+/// `missingCriteria` をトップレベルフィールドとして復元する (`#[serde(flatten)]` 経由)。
+/// message 末尾の `missing criteria: {missing:?}` 畳み込みは併存させる (情報冗長化、害なし)。
 fn done_evidence_missing(missing: Vec<String>) -> ToolError {
     ToolError::new(
         "task_done_evidence_missing",
@@ -54,6 +56,7 @@ fn done_evidence_missing(missing: Vec<String>) -> ToolError {
              missing criteria: {missing:?}"
         ),
     )
+    .with_details(json!({ "missingCriteria": missing }))
 }
 
 fn parse_done_evidence(args: &Value) -> Result<Vec<TaskDoneEvidenceSnapshot>, ToolError> {

--- a/src-tauri/src/team_hub/protocol/tools/update_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/update_task.rs
@@ -39,24 +39,24 @@ fn is_done_status(status: &str) -> bool {
     )
 }
 
-fn done_evidence_invalid(message: impl Into<String>) -> String {
-    json!({
-        "code": "task_done_evidence_invalid",
-        "message": message.into(),
-    })
-    .to_string()
+fn done_evidence_invalid(message: impl Into<String>) -> ToolError {
+    ToolError::new("task_done_evidence_invalid", message)
 }
 
-fn done_evidence_missing(missing: Vec<String>) -> String {
-    json!({
-        "code": "task_done_evidence_missing",
-        "message": "done_evidence must cover every done_criteria item before marking the task done",
-        "missingCriteria": missing,
-    })
-    .to_string()
+/// Issue #737: 旧実装は `missingCriteria` 配列を JSON 文字列で別フィールドとして返していた。
+/// `ToolError` の flat shape に合わせ、未充足の criteria を message 末尾に畳み込んで保持する
+/// (= caller / LLM が「どの criterion が足りないか」を引き続き読み取れる)。
+fn done_evidence_missing(missing: Vec<String>) -> ToolError {
+    ToolError::new(
+        "task_done_evidence_missing",
+        format!(
+            "done_evidence must cover every done_criteria item before marking the task done; \
+             missing criteria: {missing:?}"
+        ),
+    )
 }
 
-fn parse_done_evidence(args: &Value) -> Result<Vec<TaskDoneEvidenceSnapshot>, String> {
+fn parse_done_evidence(args: &Value) -> Result<Vec<TaskDoneEvidenceSnapshot>, ToolError> {
     let Some(raw) = args
         .get("done_evidence")
         .or_else(|| args.get("doneEvidence"))
@@ -160,7 +160,7 @@ pub async fn team_update_task(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
-) -> Result<Value, String> {
+) -> Result<Value, ToolError> {
     let task_id = args.get("task_id").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
     let status = args.get("status").and_then(|v| v.as_str()).unwrap_or("");
     let done_evidence = parse_done_evidence(args)?;
@@ -192,12 +192,17 @@ pub async fn team_update_task(
         let team = state
             .teams
             .get_mut(&ctx.team_id)
-            .ok_or_else(|| "Team not found".to_string())?;
+            .ok_or_else(|| ToolError::new("update_task_team_not_found", "Team not found"))?;
         let task = team
             .tasks
             .iter_mut()
             .find(|t| t.id == task_id)
-            .ok_or_else(|| format!("Task #{task_id} not found"))?;
+            .ok_or_else(|| {
+                ToolError::new(
+                    "update_task_task_not_found",
+                    format!("Task #{task_id} not found"),
+                )
+            })?;
         // Issue #594 (Tier S-1): assignee / leader 検証。
         // `team_report` (report.rs:285) で同等のガードを入れた対称穴の補完。
         // これが無いと、同 team の任意 worker が他者 task を `done` 化 + `done_evidence` 捏造して
@@ -219,8 +224,7 @@ pub async fn team_update_task(
                 "update_task",
                 &ctx.role,
                 "update task assigned to another agent",
-            )
-            .into_err_string());
+            ));
         }
         if is_done_status(status) && !task.done_criteria.is_empty() {
             let missing = task
@@ -655,8 +659,8 @@ mod tests {
         .await
         .unwrap_err();
 
-        assert!(err.contains("task_done_evidence_missing"));
-        assert!(err.contains("security reviewed"));
+        assert_eq!(err.code, "task_done_evidence_missing");
+        assert!(err.message.contains("security reviewed"));
         let state = hub.state.lock().await;
         let task = state
             .teams
@@ -726,9 +730,9 @@ mod tests {
         .await
         .unwrap_err();
 
-        assert!(
-            err.contains("update_task_permission_denied"),
-            "expected permission_denied code, got: {err}"
+        assert_eq!(
+            err.code, "update_task_permission_denied",
+            "expected permission_denied code, got: {err:?}"
         );
 
         let state = hub.state.lock().await;

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardInject.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardInject.tsx
@@ -99,6 +99,9 @@ export function CardInject({
       })
       .catch((err) => {
         // unknown_team / unknown_message / invalid_recipient の構造化エラーはここに来る。
+        // Issue #737: retryInject の reject は CommandError (Error サブクラス) に統一済み。
+        // `err instanceof Error` 分岐が clean な message を取り出す (旧来の raw JSON 文字列
+        // reject も invokeCommand wrapper が CommandError へ正規化するため契約は不変)。
         const detail = err instanceof Error ? err.message : String(err);
         showToast(t('injectFailure.retryError', { detail }), {
           tone: 'error',

--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -33,6 +33,11 @@ import { terminalTabs } from './tauri-api/terminal-tabs';
 // Tauri 側 TeamHub に同期する role profile の要約形。
 export type { RoleProfileSummary } from './tauri-api/app';
 
+// Issue #737: IPC コマンド失敗の共通 Error subclass。`Result<T, CommandError>` を返す
+// Rust command の wrapper は reject を `CommandError` に正規化するため、caller は
+// `err instanceof CommandError` で構造化エラー (`.code` / `.message`) を扱える。
+export { CommandError } from './tauri-api/command-error';
+
 // Issue #294: `subscribeEvent` / `subscribeEventReady` は `./subscribe-event.ts` に
 // 切り出し、`subscribeEvent` は `subscribeEventReady` の sync ラッパとして再実装。
 // terminal.* event ハンドラ (onData / onExit / ...) からのみ参照される。

--- a/src/renderer/src/lib/tauri-api/app.ts
+++ b/src/renderer/src/lib/tauri-api/app.ts
@@ -9,6 +9,7 @@ import type {
   ThemeName,
   UpdaterShouldWarnResult
 } from '../../../../types/shared';
+import { invokeCommand } from './command-error';
 
 /** Tauri 側 TeamHub に同期する role profile の要約形 */
 export interface RoleProfileSummary {
@@ -110,6 +111,9 @@ export const app = {
    * `<projectRoot>/.claude/skills/vibe-team/SKILL.md` を書き出す。
    * setupTeamMcp でも best-effort で実行されるが、Onboarding / 設定 UI から手動で
    * 強制再配置 (forceOverwrite=true) したい場合のために露出する。
+   *
+   * Issue #737: Rust 側 `app_install_vibe_team_skill` は `CommandResult<T>` を返すため、
+   * reject を共通 `CommandError` に正規化する `invokeCommand` 経由で呼ぶ。
    */
   installVibeTeamSkill: (
     projectRoot: string,
@@ -121,7 +125,10 @@ export const app = {
     overwritten?: boolean;
     error?: string;
   }> =>
-    invoke('app_install_vibe_team_skill', { projectRoot, forceOverwrite: !!forceOverwrite }),
+    invokeCommand('app_install_vibe_team_skill', {
+      projectRoot,
+      forceOverwrite: !!forceOverwrite
+    }),
   getUserInfo: (): Promise<AppUserInfo> => invoke('app_get_user_info'),
   openExternal: (url: string): Promise<OpenExternalResult> => invoke('app_open_external', { url }),
   /** Issue #251: OS のファイルマネージャで親フォルダを開き該当ファイルをハイライト */

--- a/src/renderer/src/lib/tauri-api/command-error.ts
+++ b/src/renderer/src/lib/tauri-api/command-error.ts
@@ -1,0 +1,97 @@
+/**
+ * tauri-api/command-error.ts — IPC エラーの共通正規化層 (Issue #737)
+ *
+ * Rust 側は `commands/error.rs` の `CommandError` を `Serialize` で **message 文字列のみ**
+ * シリアライズして返す (variant tag は含めない後方互換契約)。一部の command (例:
+ * `team_send_retry_inject` / `team_diagnostics_read`) は `CommandError::internal` に
+ * `{"code":"...","message":"..."}` の JSON 文字列を載せて構造化情報を運ぶ。
+ *
+ * `@tauri-apps/api` の `invoke()` は Rust 側 `Err` を「シリアライズされた値そのもの」で
+ * reject するため、これまで renderer 各所が「string で来るときと object で来るとき」を
+ * 場当たり的に処理していた。本モジュールは:
+ *   - `CommandError` … 全 IPC 失敗を表す共通 Error subclass。`code` (構造化されていれば)
+ *     と `message` を必ず持つ。
+ *   - `invokeCommand()` … `invoke()` の薄いラッパ。reject を `CommandError` に正規化して
+ *     再 throw する。成功時の戻り値・引数は `invoke()` と完全に同一。
+ * を提供し、wrapper レベルでエラー型を 1 つに統一する。
+ */
+import { invoke, type InvokeArgs } from '@tauri-apps/api/core';
+
+/**
+ * すべての IPC コマンド失敗を表す共通 Error。
+ *
+ * `code` は Rust 側が `{"code","message"}` の JSON 文字列で返した場合のみ非 null。
+ * 非構造化エラー (素の message 文字列) の場合は `code === null`。
+ * `raw` には reject された元の値を保持する (デバッグ / 後方互換の JSON.parse 用)。
+ */
+export class CommandError extends Error {
+  /** 構造化エラーの machine-readable code。非構造化なら null。 */
+  readonly code: string | null;
+  /** どの IPC コマンドで失敗したか。 */
+  readonly command: string;
+  /** reject された元の値 (string / object など)。 */
+  readonly raw: unknown;
+
+  constructor(command: string, message: string, code: string | null, raw: unknown) {
+    super(message);
+    this.name = 'CommandError';
+    this.command = command;
+    this.code = code;
+    this.raw = raw;
+  }
+
+  /**
+   * `invoke()` の reject 値を `CommandError` に正規化する。
+   *
+   * - 既に `CommandError` ならそのまま返す。
+   * - string なら `{"code","message"}` JSON として parse を試み、成功すれば `code` を立てる。
+   *   (Rust の `CommandError` は message 文字列で来るため、JSON でなければ message 全体を使う)
+   * - object なら `code` / `message` フィールドを拾う。
+   * - それ以外は `String(value)` を message にする。
+   */
+  static from(command: string, value: unknown): CommandError {
+    if (value instanceof CommandError) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      // `{"code":"...","message":"..."}` の構造化ペイロードを試行的に parse。
+      // 旧来の素の message 文字列はここで parse 失敗 → message 全体をそのまま使う。
+      try {
+        const parsed: unknown = JSON.parse(value);
+        if (parsed && typeof parsed === 'object') {
+          const obj = parsed as Record<string, unknown>;
+          const code = typeof obj.code === 'string' ? obj.code : null;
+          const message = typeof obj.message === 'string' ? obj.message : value;
+          if (code !== null) {
+            return new CommandError(command, message, code, value);
+          }
+        }
+      } catch {
+        // 非 JSON の素の message 文字列。fall through。
+      }
+      return new CommandError(command, value, null, value);
+    }
+    if (value && typeof value === 'object') {
+      const obj = value as Record<string, unknown>;
+      const code = typeof obj.code === 'string' ? obj.code : null;
+      const message =
+        typeof obj.message === 'string' ? obj.message : JSON.stringify(value);
+      return new CommandError(command, message, code, value);
+    }
+    return new CommandError(command, String(value), null, value);
+  }
+}
+
+/**
+ * `invoke()` の薄いラッパ。reject を必ず `CommandError` に正規化して再 throw する。
+ *
+ * 成功時の戻り値・引数の渡し方は `invoke()` と完全に同一なので、既存 wrapper の
+ * `invoke('cmd', args)` をそのまま `invokeCommand('cmd', args)` に置換できる。
+ */
+export async function invokeCommand<T>(command: string, args?: InvokeArgs): Promise<T> {
+  try {
+    return await invoke<T>(command, args);
+  } catch (err) {
+    throw CommandError.from(command, err);
+  }
+}

--- a/src/renderer/src/lib/tauri-api/command-error.ts
+++ b/src/renderer/src/lib/tauri-api/command-error.ts
@@ -95,6 +95,7 @@ export class CommandError extends Error {
  * 扱う箇所 (`JSON.parse(err)` / `err.startsWith()` / `err.includes()` 等) は 0 件で、
  * 全 caller は generic な error handler を使う。よって本ラッパへの切替で実行時に
  * 壊れる diff 外の呼び出し元は存在しない。
+ */
 export async function invokeCommand<T>(command: string, args?: InvokeArgs): Promise<T> {
   try {
     return await invoke<T>(command, args);

--- a/src/renderer/src/lib/tauri-api/command-error.ts
+++ b/src/renderer/src/lib/tauri-api/command-error.ts
@@ -87,7 +87,14 @@ export class CommandError extends Error {
  *
  * 成功時の戻り値・引数の渡し方は `invoke()` と完全に同一なので、既存 wrapper の
  * `invoke('cmd', args)` をそのまま `invokeCommand('cmd', args)` に置換できる。
- */
+ *
+ * 呼び出し側の後方互換 (Issue #737): reject 値の型が「素の string / object」から
+ * `CommandError` に変わる。ただし `CommandError` は `Error` のサブクラスであり、
+ * `.message` / `String(err)` / `err instanceof Error` のいずれも従来どおり機能する。
+ * renderer (`src/renderer/src`) 全体を監査した結果、catch したエラーを文字列特化で
+ * 扱う箇所 (`JSON.parse(err)` / `err.startsWith()` / `err.includes()` 等) は 0 件で、
+ * 全 caller は generic な error handler を使う。よって本ラッパへの切替で実行時に
+ * 壊れる diff 外の呼び出し元は存在しない。
 export async function invokeCommand<T>(command: string, args?: InvokeArgs): Promise<T> {
   try {
     return await invoke<T>(command, args);

--- a/src/renderer/src/lib/tauri-api/command-error.ts
+++ b/src/renderer/src/lib/tauri-api/command-error.ts
@@ -20,7 +20,7 @@ import { invoke, type InvokeArgs } from '@tauri-apps/api/core';
 /**
  * すべての IPC コマンド失敗を表す共通 Error。
  *
- * `code` は Rust 側が `{"code","message"}` の JSON 文字列で返した場合のみ非 null。
+ * `code` は Rust 側が `{"code":"...","message":"..."}` の JSON 文字列で返した場合のみ非 null。
  * 非構造化エラー (素の message 文字列) の場合は `code === null`。
  * `raw` には reject された元の値を保持する (デバッグ / 後方互換の JSON.parse 用)。
  */
@@ -44,7 +44,7 @@ export class CommandError extends Error {
    * `invoke()` の reject 値を `CommandError` に正規化する。
    *
    * - 既に `CommandError` ならそのまま返す。
-   * - string なら `{"code","message"}` JSON として parse を試み、成功すれば `code` を立てる。
+   * - string なら `{"code":"...","message":"..."}` JSON として parse を試み、成功すれば `code` を立てる。
    *   (Rust の `CommandError` は message 文字列で来るため、JSON でなければ message 全体を使う)
    * - object なら `code` / `message` フィールドを拾う。
    * - それ以外は `String(value)` を message にする。

--- a/src/renderer/src/lib/tauri-api/handoffs.ts
+++ b/src/renderer/src/lib/tauri-api/handoffs.ts
@@ -1,24 +1,27 @@
 // tauri-api/handoffs.ts — handoffs.* IPC namespace (Phase 5 / Issue #373)
+//
+// Issue #737: Rust 側 `handoffs_*` は `CommandResult<T>` (= `Result<T, CommandError>`) を
+// 返すため、reject を共通 `CommandError` に正規化する `invokeCommand` 経由で呼ぶ。
 
-import { invoke } from '@tauri-apps/api/core';
 import type {
   HandoffCheckpoint,
   HandoffCreateRequest,
   HandoffCreateResult,
   HandoffMutationResult
 } from '../../../../types/shared';
+import { invokeCommand } from './command-error';
 
 export const handoffs = {
   create: (request: HandoffCreateRequest): Promise<HandoffCreateResult> =>
-    invoke('handoffs_create', { req: request }),
+    invokeCommand('handoffs_create', { req: request }),
   list: (projectRoot: string, teamId?: string | null): Promise<HandoffCheckpoint[]> =>
-    invoke('handoffs_list', { projectRoot, teamId }),
+    invokeCommand('handoffs_list', { projectRoot, teamId }),
   read: (
     projectRoot: string,
     teamId: string | null | undefined,
     handoffId: string
   ): Promise<HandoffCheckpoint | null> =>
-    invoke('handoffs_read', { projectRoot, teamId, handoffId }),
+    invokeCommand('handoffs_read', { projectRoot, teamId, handoffId }),
   updateStatus: (
     projectRoot: string,
     teamId: string | null | undefined,
@@ -26,5 +29,11 @@ export const handoffs = {
     status: string,
     toAgentId?: string | null
   ): Promise<HandoffMutationResult> =>
-    invoke('handoffs_update_status', { projectRoot, teamId, handoffId, status, toAgentId })
+    invokeCommand('handoffs_update_status', {
+      projectRoot,
+      teamId,
+      handoffId,
+      status,
+      toAgentId
+    })
 };

--- a/src/renderer/src/lib/tauri-api/role-profiles.ts
+++ b/src/renderer/src/lib/tauri-api/role-profiles.ts
@@ -1,9 +1,15 @@
 // tauri-api/role-profiles.ts — roleProfiles.* IPC namespace (Phase 5 / Issue #373)
+//
+// Issue #737: `role_profiles_save` は `CommandResult<()>` を返すため `invokeCommand` 経由で
+// 呼び、reject を共通 `CommandError` に正規化する。`role_profiles_load` は失敗を `Err` では
+// なく fallback 値で表現する command なので素の `invoke` のまま。
 
 import { invoke } from '@tauri-apps/api/core';
 import type { RoleProfilesFile } from '../../../../types/shared';
+import { invokeCommand } from './command-error';
 
 export const roleProfiles = {
   load: (): Promise<RoleProfilesFile | null> => invoke('role_profiles_load'),
-  save: (file: RoleProfilesFile): Promise<void> => invoke('role_profiles_save', { file })
+  save: (file: RoleProfilesFile): Promise<void> =>
+    invokeCommand('role_profiles_save', { file })
 };

--- a/src/renderer/src/lib/tauri-api/team-state.ts
+++ b/src/renderer/src/lib/tauri-api/team-state.ts
@@ -8,21 +8,23 @@
 // 既に読み出し系のみ存在する API。書き出しは MCP 経由で agent から行うため renderer 側
 // wrapper は read のみ用意する (write は agent が `team_assign_task` 等を MCP で叩く)。
 
-import { invoke } from '@tauri-apps/api/core';
+// Issue #737: Rust 側 `team_state_*` / `recruit_observed_while_hidden` は `CommandResult<T>`
+// を返すため、reject を共通 `CommandError` に正規化する `invokeCommand` 経由で呼ぶ。
 import type {
   RecruitObservedWhileHiddenArgs,
   TeamOrchestrationState
 } from '../../../../types/shared';
+import { invokeCommand } from './command-error';
 
 export const teamState = {
   /** 永続化されたチームの orchestration state を読み出す。未保存なら null。 */
   read: (projectRoot: string, teamId: string): Promise<TeamOrchestrationState | null> =>
-    invoke('team_state_read', { projectRoot, teamId }),
+    invokeCommand('team_state_read', { projectRoot, teamId }),
 
   /**
    * Issue #578: Canvas (Tauri webview) が非表示の間に `team:recruit-request` が走った
    * 観測点を Hub 側ログに残す。renderer 側で hidden 経過時間 >= 5000ms を満たす場合のみ呼ぶ。
    */
   recruitObservedWhileHidden: (args: RecruitObservedWhileHiddenArgs): Promise<void> =>
-    invoke('recruit_observed_while_hidden', { args })
+    invokeCommand('recruit_observed_while_hidden', { args })
 };

--- a/src/renderer/src/lib/tauri-api/team.ts
+++ b/src/renderer/src/lib/tauri-api/team.ts
@@ -11,7 +11,6 @@
  * thunk wrapper として動かす。Issue #510 / #514 の diagnostics + tasks IPC が入ったら、
  * ここで invoke を併用して実値を流し込めるようにする。
  */
-import { invoke } from '@tauri-apps/api/core';
 import type { Node } from '@xyflow/react';
 import type { CardData } from '../../stores/canvas';
 import {
@@ -24,6 +23,7 @@ import type {
   RetryInjectResult,
   TeamDiagnosticsMemberRow
 } from '../../../../types/shared';
+import { invokeCommand } from './command-error';
 
 /**
  * Issue #510: `team_diagnostics_read` IPC の戻り値。Rust 側 `team_diagnostics` 関数の
@@ -63,11 +63,12 @@ export const team = {
    *
    * - 成功時: `{ ok: true, deliveredAt }` を返し、Hub は `team:handoff` event を emit する。
    * - 再失敗時: `{ ok: false, reasonCode, error, failedAt }` を返し、Hub は `team:inject_failed` event を再 emit する。
-   * - 不正引数 (unknown team / message が evict 済み / agentId が recipient でない) は `Err(string)` で reject される。
-   *   reject されたエラー文字列は JSON `{"code":"retry_*","message":"..."}` 形式。caller は `JSON.parse()` で分岐できる。
+   * - 不正引数 (unknown team / message が evict 済み / agentId が recipient でない) は reject される。
+   *   Issue #737: reject は共通 `CommandError` に正規化され、`.code` に `retry_*`、`.message`
+   *   に human-readable な説明が入る (旧来は素の JSON 文字列で reject していた)。
    */
   retryInject: (args: RetryInjectArgs): Promise<RetryInjectResult> =>
-    invoke('team_send_retry_inject', { args }),
+    invokeCommand('team_send_retry_inject', { args }),
   /**
    * Issue #510: TeamHub の per-member 診断値を Leader 視点で取得する。
    * 内部で leader 役を impersonate して MCP `team_diagnostics` と同一データを返す。
@@ -82,5 +83,5 @@ export const team = {
    * ここでも他 wrapper と揃えて camelCase で送る。
    */
   diagnosticsRead: (teamId: string): Promise<TeamDiagnosticsResponse> =>
-    invoke('team_diagnostics_read', { teamId })
+    invokeCommand('team_diagnostics_read', { teamId })
 };


### PR DESCRIPTION
## Summary
#737 — Tauri command の error 型 3 流派 (`CommandError` / `Result<T,String>` / `ToolError` JSON-in-String) を統一。

- **型基盤**: `commands/error.rs` に `CommandResult<T> = Result<T, CommandError>` を確立。`CommandError` は `thiserror::Error` + `serde::Serialize`。
- **MCP tools 全面統一**: `team_hub/protocol/tools/error.rs` の `ToolError` (flat JSON struct + `to_json_value()` + `with_details()` + 型エイリアス) に統一。各 tool は `Result<Value, ToolError>` を返し、JSON 化は dispatcher で 1 度だけ。
- **command 移行**: `team_diagnostics_read` / `handoffs_*` 等を `CommandResult<T>` に移行。
- **renderer**: `tauri-api/command-error.ts` に共通 `CommandError` Error subclass + `invokeCommand()` wrapper を新設。

## wire format (#737 の統一の結果)
- 構造化エラー (recruit_* / dismiss_* / send_* / assign_* / task_done_* 等) の `result.content[0].text` shape は **不変** (`{code, message, phase?, elapsed_ms?, ...}`)。
- `task_done_evidence_missing` の `missingCriteria`、`recruit_liveness_error` の agentId/sessionId/exitCode 等は `with_details()` + `#[serde(flatten)]` でトップレベルキーとして保持 (旧 wire 互換、optional 値は `null` 保持)。
- 従来 **plain string** だった一部 error path (`team_recruit`/`team_create_leader` の引数検証・renderer 不在・pending 登録失敗) は #737 の統一により `{code, message}` の構造化エラーへ変更。これは #737 の deliverable (3 流派 → 1 形式) そのもの。`recruit_invalid_args` / `recruit_renderer_unavailable` / `recruit_pending_registration_failed` 等の専用 code を持つ。

Closes #737

## Test plan
- [x] `cargo check` green (pre-existing warning のみ)
- [x] `cargo test --lib` — 556 passed (failed 2 は pre-existing で本変更と無関係)
- [x] `npm run typecheck` green
- [x] `npm test` — 395 passed