### PR TITLE
fix(terminal): #788 settings 由来の --dangerously-* フラグを誤拒否しないよう修正

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -272,7 +272,8 @@ pub async fn terminal_create(
             ..Default::default()
         });
     }
-    if let Some(reason) = command_validation::reject_danger_flags(&args) {
+    let sanctioned_flags = command_validation::settings_sanctioned_danger_flags();
+    if let Some(reason) = command_validation::reject_danger_flags(&args, &sanctioned_flags) {
         return Ok(TerminalCreateResult {
             ok: false,
             error: Some(reason),

--- a/src-tauri/src/commands/terminal/command_validation.rs
+++ b/src-tauri/src/commands/terminal/command_validation.rs
@@ -199,21 +199,89 @@ pub fn is_allowed_terminal_command(command: &str) -> bool {
     configured_terminal_commands().contains(&trimmed.to_ascii_lowercase())
 }
 
-/// Issue #743: Claude / Codex の承認スキップ・サンドボックス回避フラグを spawn 前に拒否する。
+/// Issue #743 / #788: Claude / Codex の承認スキップ・サンドボックス回避フラグの扱い。
 ///
-/// settings.json (`claude_args` / `codex_args`) や起動コマンドの inline 引数経由で
-/// 以下フラグが投入されると外部 CLI が承認・サンドボックス無しで起動できてしまい、
-/// vibe-editor が前提とする「人間レビューア」の制御を回避する経路になる。
-/// normalize 後の args をスキャンして、いずれかが含まれていれば error 文を返す。
+/// 以下フラグは外部 CLI を承認・サンドボックス無しで起動できてしまうため、renderer
+/// から **動的に注入された** もの (prompt injection 等の経路) は spawn 前に拒否する。
+///
+/// 一方 vibe-editor は Claude Code / Codex 専用エディタであり、ユーザーが自分の
+/// マシンの `~/.vibe-editor/settings.json` (`claudeArgs` / `codexArgs` /
+/// `customAgents[].args`) に **明示的に書いた** フラグは信頼境界の内側にある正規の
+/// opt-in なので許可する。`reject_danger_flags` には settings 由来の sanction 集合
+/// ([`settings_sanctioned_danger_flags`]) を渡し、その集合に無いフラグだけを拒否する。
 const DENY_FLAGS: &[&str] = &[
     "--dangerously-skip-permissions",
     "--dangerously-bypass-approvals-and-sandbox",
 ];
 
-pub fn reject_danger_flags(args: &[String]) -> Option<String> {
-    args.iter()
-        .find(|a| DENY_FLAGS.contains(&a.trim()))
-        .map(|flag| format!("dangerous flag is not allowed: {flag}"))
+/// token 先頭の dash 類 (ASCII `-` / Unicode ダッシュ) を全て剥がした stem が
+/// `DENY_FLAGS` のいずれかと一致すれば、canonical な `--` 形のフラグを返す。
+///
+/// renderer 側 `parse-args.ts` の `normalizeLeadingDashes` (Issue #449) と同様に、
+/// autocorrect 由来の en dash や単一 `-` 等の dash 表記揺れを吸収する。これにより
+/// settings.json に表記揺れで保存された値も正しく sanction 集合へ取り込める。
+fn canonical_danger_flag(token: &str) -> Option<&'static str> {
+    let stem = token.trim().trim_start_matches(|c: char| {
+        c == '-'
+            || matches!(
+                c,
+                '\u{2010}'..='\u{2015}' | '\u{2212}' | '\u{FE58}' | '\u{FE63}' | '\u{FF0D}'
+            )
+    });
+    if stem.is_empty() {
+        return None;
+    }
+    DENY_FLAGS
+        .iter()
+        .copied()
+        .find(|flag| flag.trim_start_matches('-') == stem)
+}
+
+/// Issue #788: `~/.vibe-editor/settings.json` の `claudeArgs` / `codexArgs` /
+/// `customAgents[].args` にユーザーが明示的に書いた危険フラグを canonical 形で集める。
+/// ここに含まれるフラグは「ユーザー自身が opt-in したもの」として spawn を許可する。
+///
+/// settings.json が無い / parse 失敗の場合は空集合 (= 何も sanction しない) を返す。
+/// `terminal_create` / spawn 境界から spawn 直前にだけ呼ぶ想定 (1 spawn = 1 file read)。
+pub fn settings_sanctioned_danger_flags() -> HashSet<String> {
+    let mut out = HashSet::new();
+    let path = crate::util::config_paths::settings_path();
+    let Ok(bytes) = std::fs::read(path) else {
+        return out;
+    };
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return out;
+    };
+    let mut collect = |raw: Option<&str>| {
+        if let Some(s) = raw {
+            for token in split_command_line(s) {
+                if let Some(flag) = canonical_danger_flag(&token) {
+                    out.insert(flag.to_string());
+                }
+            }
+        }
+    };
+    collect(value.get("claudeArgs").and_then(|v| v.as_str()));
+    collect(value.get("codexArgs").and_then(|v| v.as_str()));
+    if let Some(custom) = value.get("customAgents").and_then(|v| v.as_array()) {
+        for agent in custom {
+            collect(agent.get("args").and_then(|v| v.as_str()));
+        }
+    }
+    out
+}
+
+/// `args` に含まれる危険フラグ (`DENY_FLAGS`) のうち、`sanctioned`
+/// (= ユーザーが settings.json に明示した集合 / [`settings_sanctioned_danger_flags`])
+/// に **無い** ものを 1 つでも見つけたら error 文を返す。sanction 済みフラグは許可する。
+pub fn reject_danger_flags(args: &[String], sanctioned: &HashSet<String>) -> Option<String> {
+    for arg in args {
+        let flag = arg.trim();
+        if DENY_FLAGS.contains(&flag) && !sanctioned.contains(flag) {
+            return Some(format!("dangerous flag is not allowed: {flag}"));
+        }
+    }
+    None
 }
 
 pub fn reject_immediate_exec_args(command: &str, args: &[String]) -> Option<&'static str> {
@@ -505,9 +573,10 @@ mod codex_command_tests {
 #[cfg(test)]
 mod command_normalization_tests {
     use super::{
-        normalize_terminal_command, reject_danger_flags, reject_immediate_exec_args,
-        split_command_line,
+        canonical_danger_flag, normalize_terminal_command, reject_danger_flags,
+        reject_immediate_exec_args, split_command_line,
     };
+    use std::collections::HashSet;
 
     #[test]
     fn splits_inline_codex_flags_from_command_field() {
@@ -619,7 +688,7 @@ mod command_normalization_tests {
     fn rejects_claude_skip_permissions_flag() {
         let args = vec!["--dangerously-skip-permissions".to_string()];
         assert_eq!(
-            reject_danger_flags(&args),
+            reject_danger_flags(&args, &HashSet::new()),
             Some("dangerous flag is not allowed: --dangerously-skip-permissions".to_string())
         );
     }
@@ -628,7 +697,7 @@ mod command_normalization_tests {
     fn rejects_codex_bypass_approvals_and_sandbox_flag() {
         let args = vec!["--dangerously-bypass-approvals-and-sandbox".to_string()];
         assert_eq!(
-            reject_danger_flags(&args),
+            reject_danger_flags(&args, &HashSet::new()),
             Some(
                 "dangerous flag is not allowed: --dangerously-bypass-approvals-and-sandbox"
                     .to_string()
@@ -645,7 +714,7 @@ mod command_normalization_tests {
             "--append-system-prompt".to_string(),
             "hi".to_string(),
         ];
-        assert!(reject_danger_flags(&args).is_some());
+        assert!(reject_danger_flags(&args, &HashSet::new()).is_some());
     }
 
     #[test]
@@ -658,7 +727,7 @@ mod command_normalization_tests {
         );
 
         assert_eq!(command, "claude");
-        assert!(reject_danger_flags(&args).is_some());
+        assert!(reject_danger_flags(&args, &HashSet::new()).is_some());
     }
 
     #[test]
@@ -674,7 +743,7 @@ mod command_normalization_tests {
         );
 
         assert_eq!(command, "codex");
-        assert!(reject_danger_flags(&args).is_some());
+        assert!(reject_danger_flags(&args, &HashSet::new()).is_some());
     }
 
     #[test]
@@ -685,18 +754,69 @@ mod command_normalization_tests {
             "--append-system-prompt".to_string(),
             "hi".to_string(),
         ];
-        assert_eq!(reject_danger_flags(&args), None);
+        assert_eq!(reject_danger_flags(&args, &HashSet::new()), None);
     }
 
     #[test]
     fn passes_empty_args() {
-        assert_eq!(reject_danger_flags(&[]), None);
+        assert_eq!(reject_danger_flags(&[], &HashSet::new()), None);
     }
 
     #[test]
     fn does_not_match_substring_of_dangerous_flag() {
         // 例えば --dangerously-skip-permissions-x のような未来の擬似フラグは別物として扱う
         let args = vec!["--dangerously-skip-permissions-extra".to_string()];
-        assert_eq!(reject_danger_flags(&args), None);
+        assert_eq!(reject_danger_flags(&args, &HashSet::new()), None);
+    }
+
+    // Issue #788: settings.json でユーザーが明示した危険フラグは許可する
+    #[test]
+    fn allows_sanctioned_flag_from_user_settings() {
+        // ユーザーが settings.json (claudeArgs 等) に明示したフラグは sanction 集合に
+        // 入るため許可される (vibe-editor の autonomous 起動の正規ユース)。
+        let args = vec!["--dangerously-skip-permissions".to_string()];
+        let sanctioned: HashSet<String> = ["--dangerously-skip-permissions".to_string()]
+            .into_iter()
+            .collect();
+        assert_eq!(reject_danger_flags(&args, &sanctioned), None);
+    }
+
+    #[test]
+    fn rejects_unsanctioned_flag_even_when_other_flag_is_sanctioned() {
+        // skip-permissions だけ sanction されていても、settings に無い
+        // bypass-approvals フラグ (renderer 動的注入相当) は別物として拒否する。
+        let args = vec!["--dangerously-bypass-approvals-and-sandbox".to_string()];
+        let sanctioned: HashSet<String> = ["--dangerously-skip-permissions".to_string()]
+            .into_iter()
+            .collect();
+        assert!(reject_danger_flags(&args, &sanctioned).is_some());
+    }
+
+    #[test]
+    fn canonical_danger_flag_normalizes_dash_variants() {
+        // ASCII `--` / 単一 `-` / en dash いずれの dash 表記でも canonical 形へ解決する。
+        assert_eq!(
+            canonical_danger_flag("--dangerously-skip-permissions"),
+            Some("--dangerously-skip-permissions")
+        );
+        assert_eq!(
+            canonical_danger_flag("-dangerously-skip-permissions"),
+            Some("--dangerously-skip-permissions")
+        );
+        assert_eq!(
+            canonical_danger_flag("\u{2013}dangerously-bypass-approvals-and-sandbox"),
+            Some("--dangerously-bypass-approvals-and-sandbox")
+        );
+    }
+
+    #[test]
+    fn canonical_danger_flag_ignores_non_danger_tokens() {
+        assert_eq!(canonical_danger_flag("--resume"), None);
+        assert_eq!(
+            canonical_danger_flag("--dangerously-skip-permissions-extra"),
+            None
+        );
+        assert_eq!(canonical_danger_flag(""), None);
+        assert_eq!(canonical_danger_flag("--"), None);
     }
 }

--- a/src-tauri/src/pty/session/spawn.rs
+++ b/src-tauri/src/pty/session/spawn.rs
@@ -104,7 +104,8 @@ pub(crate) fn prepare_spawn_command(opts: &SpawnOptions) -> Result<PreparedSpawn
     if let Some(reason) = command_validation::reject_immediate_exec_args(&command, &args) {
         return Err(anyhow!("{reason}"));
     }
-    if let Some(reason) = command_validation::reject_danger_flags(&args) {
+    let sanctioned_flags = command_validation::settings_sanctioned_danger_flags();
+    if let Some(reason) = command_validation::reject_danger_flags(&args, &sanctioned_flags) {
         return Err(anyhow!("{reason}"));
     }
     resolve_spawn_command(&command, args, &opts.env)

--- a/src-tauri/src/pty/tests/session_windows.rs
+++ b/src-tauri/src/pty/tests/session_windows.rs
@@ -223,10 +223,10 @@ mod resolution_tests {
         let tmp = tempfile::tempdir().unwrap();
         let cli = tmp.path().join("codex.exe");
         std::fs::write(&cli, "").unwrap();
-        let command = format!(
-            r#""{}" --dangerously-bypass-approvals-and-sandbox"#,
-            cli.display()
-        );
+        // Issue #788: spawn 境界の inline command 再 normalize を検証する。危険フラグ
+        // 自体の拒否は command_validation 側のユニットテストでカバーするため、ここでは
+        // benign な inline フラグを使い settings 状態に依存しないようにする。
+        let command = format!(r#""{}" --foo"#, cli.display());
         let mut opts = base_spawn_options(
             command,
             vec![
@@ -240,11 +240,7 @@ mod resolution_tests {
         assert_eq!(PathBuf::from(&prepared.program), cli);
         assert_eq!(
             prepared.args,
-            vec![
-                "--dangerously-bypass-approvals-and-sandbox",
-                "--config",
-                "disable_paste_burst=true",
-            ]
+            vec!["--foo", "--config", "disable_paste_burst=true"]
         );
 
         opts.command = "cmd /c echo unsafe".to_string();


### PR DESCRIPTION
## Summary
- #743 (PR #757) で追加された `reject_danger_flags` が、ユーザーが `~/.vibe-editor/settings.json` の `claudeArgs` / `codexArgs` に明示した `--dangerously-skip-permissions` 等まで spawn 前に拒否し、Claude / Codex ターミナルが `[起動エラー] dangerous flag is not allowed` で起動不能だった。
- vibe-editor は Claude Code / Codex 専用エディタであり、ユーザーが自分の設定ファイルに明示したフラグは信頼境界の内側。#743 が本来防ぎたいのは renderer からの動的注入 (prompt injection 経路)。
- `settings_sanctioned_danger_flags()` を追加し、settings (`claudeArgs` / `codexArgs` / `customAgents[].args`) 由来の危険フラグを「sanction 集合」として収集。`reject_danger_flags` はその集合に **無い** フラグ (renderer 動的注入相当) だけを拒否するよう変更し、`terminal_create` / spawn 境界の両呼び出し元から渡す。
- `canonical_danger_flag()` で dash 表記揺れ (en dash / 単一 `-`) を吸収 — renderer 側 `parse-args.ts` の `normalizeLeadingDashes` (#449) と整合。
- 副次修正: `pty/tests/session_windows.rs::normalizes_inline_command_again_at_spawn_boundary` は #757 が `prepare_spawn_command` に `reject_danger_flags` を追加した際に未更新で `main` で FAIL していた (Windows 限定テストのため Linux CI で未検知)。benign フラグへ変更して修正。

## Test plan
- [x] `cargo test -- command_normalization_tests` — 19 件 pass (新規 4 件: sanction 許可 / 非 sanction 拒否 / canonical 正規化 / 非危険トークン)
- [x] `cargo test -- normalizes_inline_command_again_at_spawn_boundary` — 修正後 pass (修正前は main で FAIL)
- [x] `npm run dev` 実機: `claudeArgs: "--dangerously-skip-permissions"` 設定下で `terminal_create command=claude` → `[pty] spawn ok` を確認 (`[起動エラー]` 0 件)

Closes #788