### PR TITLE
fix(theme): #803 Glass テーマの白濁 (milky) を解消

### DIFF
--- a/src/renderer/src/lib/themes.ts
+++ b/src/renderer/src/lib/themes.ts
@@ -159,19 +159,20 @@ export const THEMES: Record<ThemeName, ThemeVars> = {
      * 設計原則:
      *   1. surface 色相は #141823 系 (低彩度ダークブルーグレー)。Cyber Neon の
      *      ほぼ黒から青に少し振り、Acrylic 越しでも milky 化を防ぐ。
-     *   2. alpha は 0.22〜0.30 と低めに保つ。Glass の本質は「背景が透ける」こと
-     *      なので、白側 (rgba(255,255,255,0.2) 超) は明示的に禁止する。
+     *   2. surface alpha は ~0.50〜0.66。Acrylic 越しでも壁紙の白成分を覆える濃さを
+     *      保ちつつ「背景が透ける」ガラス感は残す。白側 (rgba(255,255,255,0.2) 超)
+     *      は明示的に禁止。値は tokens.css の [data-theme='glass'] と同期させる。
      *   3. accent は落ち着いたスカイブルー (#7AB8FF)。ネオン蛍光ではなく
      *      研磨ガラスのハイライト的な使い方。
      *   4. border / highlight は低 alpha の白系で控えめに。
      *   5. blur / saturate / brightness は tokens.css の `[data-theme='glass']`
-     *      で一元管理 (12px / 130% / 0.9)。
+     *      で一元管理 (12px / 120% / 0.7)。
      */
     bg: 'rgba(0, 0, 0, 0)',
-    bgPanel: 'rgba(20, 24, 35, 0.22)',
-    bgSidebar: 'rgba(18, 22, 32, 0.28)',
-    bgToolbar: 'rgba(16, 20, 28, 0.30)',
-    bgElev: 'rgba(28, 32, 44, 0.30)',
+    bgPanel: 'rgba(20, 24, 35, 0.52)',
+    bgSidebar: 'rgba(18, 22, 32, 0.55)',
+    bgToolbar: 'rgba(16, 20, 28, 0.55)',
+    bgElev: 'rgba(28, 32, 44, 0.66)',
     border: 'rgba(255, 255, 255, 0.10)',
     borderStrong: 'rgba(255, 255, 255, 0.16)',
     bgHover: 'rgba(255, 255, 255, 0.06)',
@@ -186,7 +187,7 @@ export const THEMES: Record<ThemeName, ThemeVars> = {
     text: '#E6EAF5',
     textDim: '#A8B2C7',
     textMute: '#6B7587',
-    surfaceGlass: 'rgba(20, 24, 35, 0.22)',
+    surfaceGlass: 'rgba(20, 24, 35, 0.52)',
     focusRing: '0 0 0 2px rgba(122, 184, 255, 0.40)',
     monacoTheme: 'vs-dark'
   },

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -508,17 +508,19 @@ samp,
    * 設計方針:
    *   - surface 色相は #141823 系 (低彩度のダークブルーグレー)。Cyber Neon の黒寄り
    *     から少し青に振り、Acrylic 越しでも milky 化しない。
-   *   - alpha は 0.22〜0.34 と低く保ち、壁紙 / 背後コンテンツが透けて「ガラス」
-   *     らしさが出るようにする。完全な白背景は使わない (rgba(255,255,255,0.2) 以上禁止)。
+   *   - surface alpha は ~0.50〜0.66。Acrylic 越しでも壁紙の白成分を覆い切れる濃さを
+   *     確保しつつ、壁紙が透けて「ガラス」らしさは残す。完全な白背景は使わない
+   *     (rgba(255,255,255,0.2) 以上禁止)。#709 で alpha を 0.22 系まで薄めた結果
+   *     milky 化が再発したため #803 で復元 (PR #445 の anti-milky 方針へ回帰)。
    *   - border / highlight は白系を低 alpha (0.10〜0.16) で。ネオン蛍光線ではなく
    *     研磨ガラス縁の控えめな反射として機能させる。
    *   - shadow は暗めに (rgba(0,0,0,0.18)) してパネルの浮きを足し腰高な印象に。
    */
   --bg: rgba(0, 0, 0, 0);
-  --bg-panel: rgba(20, 24, 35, 0.22);
-  --bg-sidebar: rgba(18, 22, 32, 0.28);
-  --bg-toolbar: rgba(16, 20, 28, 0.30);
-  --bg-elev: rgba(28, 32, 44, 0.30);
+  --bg-panel: rgba(20, 24, 35, 0.52);
+  --bg-sidebar: rgba(18, 22, 32, 0.55);
+  --bg-toolbar: rgba(16, 20, 28, 0.55);
+  --bg-elev: rgba(28, 32, 44, 0.66);
   --bg-hover: rgba(255, 255, 255, 0.06);
   --bg-active: rgba(255, 255, 255, 0.10);
   --border: rgba(255, 255, 255, 0.10);
@@ -546,7 +548,7 @@ samp,
   --surface-elev: var(--bg-elev);
   --surface-hover: var(--bg-hover);
   --surface-active: var(--bg-active);
-  --surface-glass: rgba(20, 24, 35, 0.22);
+  --surface-glass: rgba(20, 24, 35, 0.52);
   /* 半透明白 dot で acrylic 上でも視認可、暗めガラスでも視覚的に潰れない。 */
   --canvas-grid: rgba(255, 255, 255, 0.14);
   --focus-ring: 0 0 0 2px rgba(122, 184, 255, 0.40);
@@ -555,17 +557,18 @@ samp,
 
 /*
  * Glass テーマ専用オーバーライド。
- * - blur 12px / saturate 130% / brightness 0.9 で、過度なぼかしと壁紙の白成分増幅を避ける。
+ * - blur 12px / saturate 120% / brightness 0.7 で、Acrylic 越しの壁紙を暗化し
+ *   白成分の増幅を抑える (#803: #709 で 130% / 0.9 へ緩めた結果 milky 化したため復元)。
  * - glass-border / glass-highlight は白系の控えめ反射に統一 (旧シアン蛍光線を廃止)。
- * - layout tint も低 alpha のダークブルーグレーに揃え、card 等の半透明と二重で
+ * - layout tint はダークブルーグレーの中 alpha。card 等の半透明と二重で
  *   壁紙を暗化することで milky 化を防ぐ。
  */
 :root[data-theme='glass'] {
-  --glass-layout-tint: rgba(20, 24, 35, 0.32);
-  --glass-canvas-layout-tint: rgba(20, 24, 35, 0.22);
+  --glass-layout-tint: rgba(20, 24, 35, 0.58);
+  --glass-canvas-layout-tint: rgba(20, 24, 35, 0.44);
   --glass-blur: 12px;
-  --glass-saturate: 130%;
-  --glass-brightness: 0.9;
+  --glass-saturate: 120%;
+  --glass-brightness: 0.7;
   --glass-border: rgba(255, 255, 255, 0.10);
   --glass-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }


### PR DESCRIPTION
## Summary
- Glass テーマが Acrylic 適用済みでも白く濁る (milky) 問題を解消。Closes #803。
- 根本原因は PR #709「glass テーマ刷新」(v1.6.0) が、過去の milky 修正
  PR #445 で確立した anti-milky トークンを退行させたこと:
  - `--glass-brightness` 0.7 → 0.9 / `--glass-saturate` 120% → 130%
  - `--glass-layout-tint` α 0.55 → 0.32、`--bg-panel` 等 surface alpha 0.8 系 → 0.22-0.30
- Acrylic 自体は問題なし: Windows 11 では `Effect::Acrylic` は modern な
  `DWMSBT_TRANSIENTWINDOW` (Windows Terminal と同じ backdrop) に正しくマップされる。
  Acrylic に重ねる CSS ダーク tint 層が #709 で薄く・明るくなり、壁紙の白成分を
  覆い切れず milky 化していた。
- `tokens.css` / `themes.ts` の glass トークンを anti-milky 値へ復元。
  overlay (modal/menu/palette) は glass.css 側で従来どおり不透明寄りを維持。

## 変更
- `tokens.css` — `:root[data-theme='glass']` の `--bg-panel/sidebar/toolbar/elev`・
  `--surface-glass`・`--glass-layout-tint`・`--glass-canvas-layout-tint`・
  `--glass-saturate`・`--glass-brightness` を anti-milky 値へ復元、設計コメントも更新。
- `themes.ts` — `THEMES.glass` のミラー値と設計コメントを tokens.css と同期。

## Test plan
- [x] `npm run typecheck` 通過
- [x] vitest: `glass-css-contract` / `theme-contrast` / `xterm-theme` 12 件 green
      (canvas tint α 0.44 < layout tint α 0.58、rgba 形式を維持)
- [x] `npm run dev` で glass テーマを実機確認 — 壁紙が白被りなく深い黒ガラスになること、
      overlay 可読性、他テーマ往復で残留色なしを確認済み