### PR TITLE
fix(team_hub): #800 #801 #802 の 3 件をバンドル修正

### DIFF
--- a/src-tauri/src/commands/app/team_mcp.rs
+++ b/src-tauri/src/commands/app/team_mcp.rs
@@ -36,15 +36,15 @@ pub struct TeamHubInfo {
     pub bridge_path: String,
 }
 
-// Issue #336: 全フィールドが現状未参照だが、renderer から `app_setup_team_mcp` に
-// 渡される情報のシグネチャを保つため struct ごと保持する。将来 MCP 設定生成や
-// telemetry で読み出しを再開する想定。
+// Issue #336 / #800: `agent_id` と `role` は register_team の binding seed に使う。
+// `agent` フィールドは現状未参照だが、renderer から `app_setup_team_mcp` に渡される
+// 情報のシグネチャを保つため保持する (将来 MCP 設定生成や telemetry で読み出しを再開する想定)。
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 pub struct TeamMcpMember {
     pub agent_id: String,
     pub role: String,
+    #[allow(dead_code)]
     pub agent: String,
 }
 
@@ -146,7 +146,7 @@ pub async fn app_setup_team_mcp(
     project_root: String,
     team_id: String,
     team_name: String,
-    _members: Vec<TeamMcpMember>,
+    members: Vec<TeamMcpMember>,
 ) -> crate::commands::error::CommandResult<SetupTeamMcpResult> {
     let hub = state.team_hub.clone();
     // 念のため Hub を起動 (setup でも spawn 済み)
@@ -157,7 +157,15 @@ pub async fn app_setup_team_mcp(
             ..Default::default()
         });
     }
-    hub.register_team(&team_id, &team_name, Some(&project_root))
+    // Issue #800: Canvas spawn 由来の初代 leader / worker は recruit grant 経路を
+    // 通らないため、team setup 時に member の (agent_id, role) を binding として
+    // 事前 seed する。これにより handshake (resolve_pending_recruit) が既存 binding
+    // 経路でこれらを許可する。
+    let member_bindings: Vec<(String, String)> = members
+        .iter()
+        .map(|m| (m.agent_id.clone(), m.role.clone()))
+        .collect();
+    hub.register_team(&team_id, &team_name, Some(&project_root), &member_bindings)
         .await;
 
     // vibe-team Skill ファイルを best-effort で配置/同期する。

--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -128,7 +128,7 @@ pub async fn assert_active_project_root(
 ///   区別しない recon 抑止の方針 (issue #601 案1)。
 /// - reject 時は clamp 済み team_id を log に残す。空 team_id は `warn!` (caller bug)、
 ///   active set 未登録は `debug!` — Issue #802: 復元された stale team の team-health
-///   poll 等で routine に発生するため WARN ノイズにしない。recon 抑止は generic message
+///   poll 等で routinely に発生するため WARN ノイズにしない。recon 抑止は generic message
 ///   側で担保しており log レベルとは独立。
 /// - 返却型は `()` (active 確認だけが目的、戻り値で team の詳細を返さない)。
 pub async fn assert_active_team(hub: &TeamHub, team_id: &str) -> CommandResult<()> {
@@ -149,7 +149,7 @@ pub async fn assert_active_team(hub: &TeamHub, team_id: &str) -> CommandResult<(
         let active_count = state.active_teams.len();
         drop(state);
         // Issue #802: active set 未登録は dismiss 済み / 復元された stale team を probe
-        // した想定内の結果で、起動時の team-health poll 等で routine に発生する。本物の
+        // した想定内の結果で、起動時の team-health poll 等で routinely に発生する。本物の
         // 異常用に WARN は温存し、ここは debug に下げて起動時ログのノイズを抑える。
         tracing::debug!(
             team_id = %clamp_team_id_for_log(team_id),

--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -126,7 +126,10 @@ pub async fn assert_active_project_root(
 /// - 「空 team_id」「未登録 team_id」「正常な team_id」のうち最初の 2 つは同じ
 ///   `Authz("team is not active or does not exist")` で reject する。これは存在 / 非存在を
 ///   区別しない recon 抑止の方針 (issue #601 案1)。
-/// - reject 時は `tracing::warn!` で clamp 済み team_id を audit log に残す。
+/// - reject 時は clamp 済み team_id を log に残す。空 team_id は `warn!` (caller bug)、
+///   active set 未登録は `debug!` — Issue #802: 復元された stale team の team-health
+///   poll 等で routine に発生するため WARN ノイズにしない。recon 抑止は generic message
+///   側で担保しており log レベルとは独立。
 /// - 返却型は `()` (active 確認だけが目的、戻り値で team の詳細を返さない)。
 pub async fn assert_active_team(hub: &TeamHub, team_id: &str) -> CommandResult<()> {
     let trimmed = team_id.trim();
@@ -145,7 +148,10 @@ pub async fn assert_active_team(hub: &TeamHub, team_id: &str) -> CommandResult<(
         // `members` の中に過去の (= dismiss 済み) team_id が残っていても probe させない。
         let active_count = state.active_teams.len();
         drop(state);
-        tracing::warn!(
+        // Issue #802: active set 未登録は dismiss 済み / 復元された stale team を probe
+        // した想定内の結果で、起動時の team-health poll 等で routine に発生する。本物の
+        // 異常用に WARN は温存し、ここは debug に下げて起動時ログのノイズを抑える。
+        tracing::debug!(
             team_id = %clamp_team_id_for_log(team_id),
             active_count,
             "[authz] assert_active_team rejected: team_id not in active set"

--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -128,7 +128,7 @@ pub async fn assert_active_project_root(
 ///   区別しない recon 抑止の方針 (issue #601 案1)。
 /// - reject 時は clamp 済み team_id を log に残す。空 team_id は `warn!` (caller bug)、
 ///   active set 未登録は `debug!` — Issue #802: 復元された stale team の team-health
-///   poll 等で routinely に発生するため WARN ノイズにしない。recon 抑止は generic message
+///   poll 等で 日常的に発生するため WARN ノイズにしない。recon 抑止は generic message
 ///   側で担保しており log レベルとは独立。
 /// - 返却型は `()` (active 確認だけが目的、戻り値で team の詳細を返さない)。
 pub async fn assert_active_team(hub: &TeamHub, team_id: &str) -> CommandResult<()> {
@@ -149,7 +149,7 @@ pub async fn assert_active_team(hub: &TeamHub, team_id: &str) -> CommandResult<(
         let active_count = state.active_teams.len();
         drop(state);
         // Issue #802: active set 未登録は dismiss 済み / 復元された stale team を probe
-        // した想定内の結果で、起動時の team-health poll 等で routinely に発生する。本物の
+        // した想定内の結果で、起動時の team-health poll 等で 日常的に発生する。本物の
         // 異常用に WARN は温存し、ここは debug に下げて起動時ログのノイズを抑える。
         tracing::debug!(
             team_id = %clamp_team_id_for_log(team_id),

--- a/src-tauri/src/team_hub/file_locks.rs
+++ b/src-tauri/src/team_hub/file_locks.rs
@@ -109,6 +109,9 @@ pub struct LockResult {
 }
 
 impl LockResult {
+    /// `conflicts` が空でないかを返す partial-success 判定ヘルパー。Issue #801:
+    /// caller は `#[cfg(test)]` モジュールのみのため test build 限定にし dead_code 警告を解消する。
+    #[cfg(test)]
     pub fn has_conflicts(&self) -> bool {
         !self.conflicts.is_empty()
     }

--- a/src-tauri/src/team_hub/protocol/role_template.rs
+++ b/src-tauri/src/team_hub/protocol/role_template.rs
@@ -44,6 +44,12 @@ impl TemplateReport {
         self.findings.iter().any(|f| f.level == TemplateLevel::Deny)
     }
 
+    /// Warn レベル findings を抽出する (`warn_message` が使用)。`has_deny` / `deny_message`
+    /// (production 配線済み) の warn 版だが recruit 時の配線は未実装で、現状 caller は
+    /// `#[cfg(test)]` のみ。Issue #801: test build 限定にし dead_code 警告を解消する
+    /// (production で warn findings を通知する際は `warnings` / `warn_message` 双方の
+    /// `#[cfg(test)]` を外して配線する)。
+    #[cfg(test)]
     pub fn warnings(&self) -> Vec<&TemplateFinding> {
         self.findings
             .iter()
@@ -64,6 +70,9 @@ impl TemplateReport {
         )
     }
 
+    /// Warn レベル findings を 1 行メッセージに整形する。`warnings` と同じく現状は
+    /// `#[cfg(test)]` のみが使用 (Issue #801)。
+    #[cfg(test)]
     pub fn warn_message(&self) -> Option<String> {
         let parts: Vec<String> = self
             .warnings()

--- a/src-tauri/src/team_hub/state/hub_state.rs
+++ b/src-tauri/src/team_hub/state/hub_state.rs
@@ -466,6 +466,10 @@ pub struct CallContext {
 }
 
 impl TeamHub {
+    /// テスト専用コンストラクタ。production は in-flight tracker を共有する
+    /// `with_inflight` を使う (`AppState::new` 経由)。Issue #801: caller は
+    /// `#[cfg(test)]` モジュールのみのため test build 限定にし dead_code 警告を解消する。
+    #[cfg(test)]
     pub fn new(registry: Arc<SessionRegistry>) -> Self {
         Self::with_inflight(registry, crate::pty::InFlightTracker::new())
     }

--- a/src-tauri/src/team_hub/state/persistence.rs
+++ b/src-tauri/src/team_hub/state/persistence.rs
@@ -12,7 +12,13 @@ use super::hub_state::{TeamInfo, TeamTask};
 
 impl TeamHub {
     /// チームを active list に追加 (renderer の setupTeamMcp 経由)
-    pub async fn register_team(&self, team_id: &str, name: &str, project_root: Option<&str>) {
+    pub async fn register_team(
+        &self,
+        team_id: &str,
+        name: &str,
+        project_root: Option<&str>,
+        members: &[(String, String)],
+    ) {
         if team_id.is_empty() || team_id == "_init" {
             return;
         }
@@ -30,6 +36,20 @@ impl TeamHub {
 
         let mut s = self.state.lock().await;
         s.active_teams.insert(team_id.to_string());
+        // Issue #800: Canvas spawn 由来の初代 member (leader / worker) は
+        // `team_recruit` / `team_create_leader` の recruit grant 経路を通らないため、
+        // team 登録時に `(team_id, agent_id) -> role` の binding を事前 seed する。
+        // これで `resolve_pending_recruit` が既存 binding 経路でこれらの handshake を
+        // 許可する (#742 の binding 強制で初代 member が全 reject される回帰の修正)。
+        // `or_insert_with` で、handshake 成功や別経路で既に確立済みの binding は上書きしない。
+        for (agent_id, role) in members {
+            if agent_id.trim().is_empty() || role.trim().is_empty() {
+                continue;
+            }
+            s.agent_role_bindings
+                .entry((team_id.to_string(), agent_id.clone()))
+                .or_insert_with(|| role.clone());
+        }
         let team = s
             .teams
             .entry(team_id.to_string())
@@ -274,4 +294,46 @@ async fn load_persisted_dynamic_for_team(
         }
     }
     out
+}
+
+/// Issue #800: `register_team` が team member の `agent_role_bindings` を seed することの単体テスト。
+///
+/// PR #742 (Security) で handshake が「Hub 発行の recruit grant か既存 binding が必須」に
+/// 強化された結果、Canvas の team spawn で renderer が直接生成する初代 leader / worker
+/// (`leader-0-team-<id>` / `worker-N-team-<id>` 形式) が grant 経路を通らず全 reject される
+/// 回帰が発生した。`register_team` が member の binding を事前 seed することで、
+/// `resolve_pending_recruit` が既存 binding 経路でこれらを許可することを検証する。
+#[cfg(test)]
+mod register_team_binding_seed_tests {
+    use crate::pty::SessionRegistry;
+    use crate::team_hub::TeamHub;
+    use std::sync::Arc;
+
+    fn make_hub() -> TeamHub {
+        TeamHub::new(Arc::new(SessionRegistry::new()))
+    }
+
+    /// `register_team` で seed された team member は、recruit grant が無くても
+    /// handshake (`resolve_pending_recruit`) を通る。leader / worker いずれも対象。
+    #[tokio::test]
+    async fn register_team_seeds_member_bindings_so_handshake_passes_without_grant() {
+        let hub = make_hub();
+        let team_id = "team-800";
+        let members = [
+            ("leader-0-team-800".to_string(), "leader".to_string()),
+            ("worker-1-team-800".to_string(), "programmer".to_string()),
+        ];
+        hub.register_team(team_id, "Team 800", None, &members).await;
+
+        assert!(
+            hub.resolve_pending_recruit("leader-0-team-800", team_id, "leader")
+                .await,
+            "seeded leader should pass handshake without a recruit grant"
+        );
+        assert!(
+            hub.resolve_pending_recruit("worker-1-team-800", team_id, "programmer")
+                .await,
+            "seeded worker should pass handshake without a recruit grant"
+        );
+    }
 }

--- a/src-tauri/src/team_hub/state/persistence.rs
+++ b/src-tauri/src/team_hub/state/persistence.rs
@@ -42,8 +42,22 @@ impl TeamHub {
         // これで `resolve_pending_recruit` が既存 binding 経路でこれらの handshake を
         // 許可する (#742 の binding 強制で初代 member が全 reject される回帰の修正)。
         // `or_insert_with` で、handshake 成功や別経路で既に確立済みの binding は上書きしない。
+        //
+        // PR #805 review: `members` は renderer 由来のため、無検証で seed すると #742 の
+        // handshake binding 強制を任意入力で満たせてしまう。Canvas spawn の member id は
+        // `<role>-<n>-team-<teamId>` 形式で team_id を suffix に内包するので、team_id を
+        // suffix に持たない agent_id は別 team / 不正入力とみなして seed しない
+        // (= 事前 seed する binding を必ず当該 team scope に閉じる)。
         for (agent_id, role) in members {
             if agent_id.trim().is_empty() || role.trim().is_empty() {
+                continue;
+            }
+            if !agent_id.ends_with(team_id) {
+                tracing::warn!(
+                    team_id = %team_id,
+                    agent_id = %agent_id,
+                    "[teamhub] register_team: agent_id が team scope 外のため binding seed をスキップ"
+                );
                 continue;
             }
             s.agent_role_bindings
@@ -334,6 +348,32 @@ mod register_team_binding_seed_tests {
             hub.resolve_pending_recruit("worker-1-team-800", team_id, "programmer")
                 .await,
             "seeded worker should pass handshake without a recruit grant"
+        );
+    }
+
+    /// PR #805 review: `team_id` を suffix に持たない (= 別 team / 不正な) agent_id は
+    /// binding seed されず handshake も通らない。renderer 入力で任意の binding を
+    /// 注入できないこと (#742 の binding 強制が後退しないこと) を検証する。
+    #[tokio::test]
+    async fn register_team_skips_member_agent_id_outside_team_scope() {
+        let hub = make_hub();
+        let team_id = "team-805";
+        let members = [
+            ("leader-0-team-805".to_string(), "leader".to_string()),
+            // team-805 を suffix に持たない別 team scope の agent_id。
+            ("worker-9-team-other".to_string(), "programmer".to_string()),
+        ];
+        hub.register_team(team_id, "Team 805", None, &members).await;
+
+        assert!(
+            hub.resolve_pending_recruit("leader-0-team-805", team_id, "leader")
+                .await,
+            "team scope 内の leader は seed され handshake を通る"
+        );
+        assert!(
+            !hub.resolve_pending_recruit("worker-9-team-other", team_id, "programmer")
+                .await,
+            "team scope 外の agent_id は seed されず handshake は通らない"
         );
     }
 }

--- a/src/renderer/src/lib/use-team-health.ts
+++ b/src/renderer/src/lib/use-team-health.ts
@@ -17,17 +17,9 @@
  */
 import { useEffect, useMemo, useState } from 'react';
 import type { TeamDiagnosticsMemberRow } from '../../../types/shared';
-import { CommandError } from './tauri-api/command-error';
 
 /** poll 間隔。CPU 負荷と "agent が止まったとき何秒以内に気づくか" のバランス。 */
 const POLL_INTERVAL_MS = 5_000;
-
-/**
- * Issue #802: Rust 側 `assert_active_team` (`commands/authz.rs`) が非アクティブ team の
- * reject に使う固定 message。recon 抑止のため存在/非存在を区別しない generic 文言で、
- * authz テストでも pin されている安定値。team-health poll での想定内エラー判定に使う。
- */
-const TEAM_NOT_ACTIVE_MESSAGE = 'team is not active or does not exist';
 
 interface Snapshot {
   /** agentId → 最新行 */
@@ -69,15 +61,11 @@ async function fetchOnce(teamId: string, entry: RegistryEntry): Promise<void> {
     entry.snapshot = { byAgentId, fetchedAt: Date.now() };
     notify(entry);
   } catch (err) {
-    // Issue #802: "team is not active or does not exist" は、復元された stale team や
-    // dismiss 済み team を poll した想定内の結果。起動のたびに出る WARN ノイズを避ける
-    // ため debug 扱いにする。それ以外 (Hub 未起動・IPC 失敗等) は従来どおり warn。
-    // いずれの場合も UI は old snapshot で続行する。
-    if (err instanceof CommandError && err.message === TEAM_NOT_ACTIVE_MESSAGE) {
-      console.debug('[team-health] team not active, skipping poll:', teamId);
-    } else {
-      console.warn('[team-health] diagnostics fetch failed:', err);
-    }
+    // Issue #802: team-health poll は best-effort。失敗 (Hub 未起動 / 復元された stale
+    // team の authz reject / IPC エラー等) はいずれも非致命的で、UI は old snapshot の
+    // まま継続する。起動のたびに復元 stale team の reject で WARN が出るノイズを避ける
+    // ため一律 debug にとどめる (devtools の debug レベルでは引き続き確認できる)。
+    console.debug('[team-health] diagnostics fetch failed:', err);
   } finally {
     entry.inflight = false;
   }

--- a/src/renderer/src/lib/use-team-health.ts
+++ b/src/renderer/src/lib/use-team-health.ts
@@ -17,9 +17,17 @@
  */
 import { useEffect, useMemo, useState } from 'react';
 import type { TeamDiagnosticsMemberRow } from '../../../types/shared';
+import { CommandError } from './tauri-api/command-error';
 
 /** poll 間隔。CPU 負荷と "agent が止まったとき何秒以内に気づくか" のバランス。 */
 const POLL_INTERVAL_MS = 5_000;
+
+/**
+ * Issue #802: Rust 側 `assert_active_team` (`commands/authz.rs`) が非アクティブ team の
+ * reject に使う固定 message。recon 抑止のため存在/非存在を区別しない generic 文言で、
+ * authz テストでも pin されている安定値。team-health poll での想定内エラー判定に使う。
+ */
+const TEAM_NOT_ACTIVE_MESSAGE = 'team is not active or does not exist';
 
 interface Snapshot {
   /** agentId → 最新行 */
@@ -61,8 +69,15 @@ async function fetchOnce(teamId: string, entry: RegistryEntry): Promise<void> {
     entry.snapshot = { byAgentId, fetchedAt: Date.now() };
     notify(entry);
   } catch (err) {
-    // Hub 未起動など想定内エラーは warn にとどめる (UI は old snapshot で続行)。
-    console.warn('[team-health] diagnostics fetch failed:', err);
+    // Issue #802: "team is not active or does not exist" は、復元された stale team や
+    // dismiss 済み team を poll した想定内の結果。起動のたびに出る WARN ノイズを避ける
+    // ため debug 扱いにする。それ以外 (Hub 未起動・IPC 失敗等) は従来どおり warn。
+    // いずれの場合も UI は old snapshot で続行する。
+    if (err instanceof CommandError && err.message === TEAM_NOT_ACTIVE_MESSAGE) {
+      console.debug('[team-health] team not active, skipping poll:', teamId);
+    } else {
+      console.warn('[team-health] diagnostics fetch failed:', err);
+    }
   } finally {
     entry.inflight = false;
   }


### PR DESCRIPTION
## Summary
TeamHub 周りの独立した 3 issue を 1 PR にバンドル (1 commit / issue)。

- **#800** (`fix` / regression): Canvas spawn 由来の初代 leader/worker が PR #742 の
  binding 強制で handshake を全 reject され、bridge 再接続ループに陥る回帰を修正。
  `app_setup_team_mcp` が既に受け取る `members` を使い、`register_team` で
  `(team_id, agent_id) -> role` binding を事前 seed する。`resolve_pending_recruit`
  (handshake 判定) は不変で #742 のセキュリティモデルを維持。binding seed の単体テスト付き。
- **#802** (`fix`): 起動時に復元された stale team を team-health が poll し、authz
  reject のたびに WARN ログ + `console.warn` が出るノイズを解消。「team is not active」は
  復元 team / dismiss 済み team を poll した想定内の結果なので、Rust `assert_active_team`
  の active set 未登録 reject を `warn!`→`debug!`、renderer `fetchOnce` catch も該当
  message のみ `console.debug` へ降格。reject 挙動・recon 抑止 message は不変。
- **#801** (`refactor`): `team_hub` の `dead_code` 警告 3 件を解消。`TeamHub::new` /
  `LockResult::has_conflicts` / `TemplateReport::warnings`・`warn_message` はいずれも
  caller が `#[cfg(test)]` モジュールのみ (`new` は ~40 テストが使用) のため、削除でなく
  `#[cfg(test)]` を付与し test build 限定にする。機能変更なし。

## Test plan
- [x] `cargo check --lib` 通過 — lib 警告ゼロ (#801 の dead_code 3 件解消を確認)
- [x] `cargo test --lib` — 563 passed / 0 failed / 2 ignored (#800 の register_team
      binding-seed テスト含む全テスト通過)
- [x] `npm run typecheck` 通過 (#802 の renderer 変更)
- [x] `npm run dev` 起動ログで実機確認 — 初代 leader が handshake 成功
      (`[teamhub] client authed role=leader`、reject 再接続ループ無し)、#802 の authz
      reject は `DEBUG` 化し起動時の WARN ノイズが消失

Closes #800
Closes #801
Closes #802