### PR TITLE
fix(canvas): Glass テーマの「チーム起動」ボタン/popover 可読性 + 未読 inbox 行撤去 (#806/#808)

### DIFF
--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -183,7 +183,9 @@
 .canvas-btn--primary {
   background: var(--claude-brand, var(--accent));
   border-color: transparent;
-  color: var(--accent-foreground);
+  /* Issue #806: brand 背景は常に orange なので、`--accent-foreground` ではなく
+     brand 専用 foreground を使う。Glass テーマでも warm white が乗る。 */
+  color: var(--claude-brand-foreground, var(--accent-foreground));
 }
 .canvas-btn--primary:hover {
   background: var(--claude-brand-strong, var(--accent-hover));
@@ -308,7 +310,8 @@
   font-size: 9px;
   font-weight: 700;
   line-height: 1;
-  color: var(--accent-foreground);
+  /* Issue #806: brand 背景 (orange) に対する foreground は brand 専用を使う。 */
+  color: var(--claude-brand-foreground, var(--accent-foreground));
   background: var(--claude-brand, var(--accent));
   border-radius: 999px;
 }

--- a/src/renderer/src/styles/components/glass.css
+++ b/src/renderer/src/styles/components/glass.css
@@ -75,17 +75,21 @@
 }
 
 /*
- * Glass テーマでも UI overlay 系 (menubar dropdown / app-menu dropdown / context menu) は
- * 読みやすさを優先して bg を高めに保つ。tokens.css の `--bg-panel` (alpha 0.22) のままだと
- * 背後の壁紙が透けてラベルが読めない。
+ * Glass テーマでも UI overlay 系 (menubar dropdown / app-menu dropdown / context menu /
+ * canvas のチーム起動 popover) は読みやすさを優先して bg を高めに保つ。tokens.css の
+ * `--bg-panel` (alpha ~0.52) のままだと背後の壁紙やドットグリッドが透けてラベルが
+ * 読めない (Issue #806)。
  *   - 不透明度 0.92 の濃いブルーグレーで「読み物として成立する」濃度に。
  *   - backdrop-filter は当てて、テーマの一体感は維持。
  *   - border / shadow も glass 系トークンに揃えて浮かせる。
+ *   - layout/surface alpha (~0.52) には触らないこと。overlay レイヤだけを濃くする
+ *     ことで、glass 全面の milky 化 (#16 / #367 / #445 / #709→#803) を回避する。
  */
 :root[data-theme='glass'] .menubar__dropdown,
 :root[data-theme='glass'] .app-menu__dropdown,
 :root[data-theme='glass'] .user-menu__dropdown,
-:root[data-theme='glass'] .context-menu {
+:root[data-theme='glass'] .context-menu,
+:root[data-theme='glass'] .canvas-popover {
   background: rgba(15, 18, 28, 0.92);
   border-color: var(--glass-border, rgba(255, 255, 255, 0.10));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -172,6 +172,14 @@
   --claude-brand: #d97757;          /* terra cotta / Claude Orange */
   --claude-brand-strong: #c6613f;   /* hover / pressed */
   --claude-brand-glow: rgba(217, 119, 87, 0.12);
+  /*
+   * Issue #806: `--claude-brand` を background に使う CTA は、テーマに関わらず
+   * 同じ orange (#d97757) の上に乗る。`--accent-foreground` を文字色に流用すると、
+   * Glass テーマだけ `--accent` を青に振り替えている都合で foreground が暗色
+   * (`#0B0F1A`) になり、orange CTA に黒文字が乗って読みにくくなる。
+   * brand 専用 foreground を切り出して、CTA の文字色は常に warm white で固定する。
+   */
+  --claude-brand-foreground: #fffdf7;
   --claude-accent-blue: #3886e5;
   --claude-accent-violet: #7261e0;
 


### PR DESCRIPTION
直交する 2 件をバンドル (1 commit / issue)。

## Commit 1 — fix(canvas): #806 Glass テーマで「チーム起動」ボタンとポップオーバーが読みにくい問題を修正
- Glass テーマで `--accent-foreground` (#0B0F1A) が orange な `--claude-brand` 背景の CTA に乗って黒文字になっていた問題を、`--claude-brand-foreground` (warm white) を新設して解消。
- `.canvas-popover` を `glass.css` の overlay 不透明リスト (`rgba(15, 18, 28, 0.92)`) に追加し、Canvas モードのドットグリッドが透けてラベルが読めない問題を解消。
- layout/surface alpha (~0.52) には触らず overlay レイヤだけ濃くすることで、Glass の milky 化退行 (#16 / #367 / #445 / #709→#803) を避ける設計。

## Commit 2 — refactor(canvas): #808 AgentNodeCard の「未読 N 件」 inbox 表示行を削除
- CardSummary 内の Issue #509 で導入された「未読 {count} 件 ({ageSec}s 経過)」行を撤去。Leader の ping 判断は health 行 (stalled inbound) と TeamHub diagnostics で十分。
- 背後の `unreadInboxCount` 追跡 (Issue #596 race fix 済み) と `team:handoff` event handler は触らず残す。`stalledInbound` の警告色は health 行が引き続き使うため tracking は有効。

Closes #806
Closes #808

## Test plan
- [x] `npm run typecheck` 通過
- [x] `glass-css-contract.test.ts` / `theme-contrast.test.ts` 通過
- [x] `unread-inbox-count.test.ts` (Issue #596 race fix) 通過 — 背後の tracking は意図通り無傷
- [ ] Glass テーマで「チーム起動」ボタンの文字が white になることを実機確認
- [ ] Glass テーマで caret を開いたとき、popover が不透明になり「Leader のみで起動 (Claude Code)」等のラベルが読めることを実機確認
- [ ] AgentNodeCard で未読が発生する状況 (handoff 直後 / team_read 未呼出) で「未読 N 件」行が描画されないことを実機確認
- [ ] claude-dark / dark / midnight / light / claude-light でも CTA のコントラストが退行していないことを確認