### PR TITLE
refactor(canvas): #808 AgentNodeCard の「未読 N 件」 inbox 表示行を削除

### DIFF
--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardSummary.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardSummary.tsx
@@ -9,7 +9,7 @@
  * `deriveHealth` で算出して props で渡す。本コンポーネントは store も IPC も触らない。
  * 挙動・DOM・クラス名は元 `.canvas-agent-card__summary` ブロックと完全一致。
  */
-import { AlertTriangle, Clock, ClipboardList, Heart, HeartPulse, Inbox, Skull } from 'lucide-react';
+import { AlertTriangle, Clock, ClipboardList, Heart, HeartPulse, Skull } from 'lucide-react';
 import type { HealthState } from '../../../../lib/agent-health';
 import type { CardSummary as CardSummaryData } from '../../../../lib/agent-summary';
 
@@ -159,34 +159,12 @@ export function CardSummary({
           </span>
         </div>
       ) : null}
-      {/* Issue #509: 配送済みだが team_read で確認していない message の数。 */}
-      {/* 60s 超過で stalled クラスを追加して警告色に切り替える。 */}
-      {unreadInboxCount > 0
-        ? (() => {
-            const ageMs = hasHealthRow
-              ? health.oldestPendingInboxAgeMs ?? 0
-              : oldestUnreadDeliveredAt
-                ? Math.max(0, nowTick - new Date(oldestUnreadDeliveredAt).getTime())
-                : 0;
-            const stalled = hasHealthRow ? health.stalledInbound : ageMs >= 60_000;
-            const ageSec = Math.floor(ageMs / 1000);
-            return (
-              <div
-                className={
-                  'canvas-agent-card__summary-row canvas-agent-card__summary-row--unread' +
-                  (stalled ? ' canvas-agent-card__summary-row--unread-stalled' : '')
-                }
-                role="status"
-                title={t('inboxUnread.tooltip', { count: unreadInboxCount, ageSec })}
-              >
-                <Inbox size={11} strokeWidth={2} aria-hidden="true" />
-                <span className="canvas-agent-card__summary-text">
-                  {t('inboxUnread.label', { count: unreadInboxCount, ageSec })}
-                </span>
-              </div>
-            );
-          })()
-        : null}
+      {/*
+       * Issue #808: 配送済み未読 inbox の数を出していた行 (Issue #509) を撤去。
+       * 背後の `unreadInboxCount` / `oldestUnreadDeliveredAt` 追跡 (Issue #596 で
+       * race fix 済み) は store 側に残す: `stalledInbound` の警告色は health 行が
+       * 引き続き表示するため、tracking 自体は alive な観測情報として有効。
+       */}
     </div>
   );
 }


### PR DESCRIPTION
## 経緯
PR #807 で #806 と #808 を 2 コミットバンドルにしたが、bot が 1 コミット目 (head `f8d2af4`) を見て即 auto-merge → 2 コミット目 (#808) が PR にラッチされず merge から漏れた。
本 PR で #808 を単独に切り出して再提出する。

## Summary
- CardSummary 内の Issue #509 で導入された「未読 {count} 件 ({ageSec}s 経過)」行を撤去。Leader の ping 判断は health 行 (stalled inbound) と TeamHub diagnostics で十分代替できる。
- 使われなくなる `Inbox` icon import を削除。
- 背後の `unreadInboxCount` 追跡 (Issue #596 race fix 済み) と `team:handoff` event handler は touched せず残す。`stalledInbound` の警告色は health 行が引き続き使うため tracking は alive。

Closes #808

## Test plan
- [x] `npm run typecheck` 通過
- [x] `unread-inbox-count.test.ts` (Issue #596 race fix, 11 件) 通過 — 背後の tracking は意図通り無傷
- [ ] AgentNodeCard で未読が発生する状況 (handoff 直後 / team_read 未呼出) で「未読 N 件」行が描画されないことを実機確認
- [ ] 同じ状況で health 行の stalled 表示 (heart icon の警告色) は引き続き働くことを確認