### PR TITLE
chore(release): bump version to 1.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5205,7 +5205,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.6.0"
+version = "1.6.2"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.6.0"
+version = "1.6.2"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
v1.6.0 → v1.6.2 リリース bump (v1.6.1 は内部 build only でスキップ)。

`package.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` / `Cargo.lock` の 4 ファイル同期 bump。

## Changes since v1.6.0

### ✨ Features
- topbar マスコット移植 + 自由移動 + custom 画像対応 (#716)
- mascot 状態別アニメ拡張 (sleep / working / thinking / done / error / excited) (#718)

### 🐛 Fixes
- fs 監視と PTY idle 負荷を削減 (#740, perf)
- TerminalSection を `useT()` 化して EN ユーザーへの JP 混入を解消 (#746)
- `app_recruit_ack` の tauri-api wrapper と shared 型を追加 (#747)
- `terminalForceUtf8` の opt-out UI スイッチを追加 (#756)
- カード未読数を `team_diagnostics` の実値で表示 (#771)
- recruit セッション起動の信頼性を修正 (#773, #751)
- `[lib] crate-type` に rlib を復元し desktop ビルドを修復 (#780)
- settings 由来の `--dangerously-*` フラグを誤拒否しないよう修正 (#789)
- Glass テーマの白濁 (milky) を解消 (#804)
- team_hub 3 件をバンドル修正 (#805)
- Glass テーマで「チーム起動」ボタンとポップオーバーが読みにくい問題を修正 (#807)
- i18n: `MascotSection` / `DensitySection` / `CustomAgentEditor` / `SettingsModal` / `RoleProfilesSection` / `WelcomePane` / `TerminalSection` / `labelOf` / `useSettingsNav` / `StatusBar` / `canvas-layout-helpers` / `McpSection` の `isJa` 三項を `t()` に統一、dead key 整理 (#760, #761, #762, #763, #764, #765, #767, #769, #770, #768, #786, #746)

### 🔒 Security
- `--dangerously-*` フラグを spawn 前に拒否 (#757)
- team_hub spool を private mode + `.gitignore` 除外 (#759)
- team_hub handshake token を TTL/single-use 化し agent_id binding を強制 (#776)
- asset scope を動的許可化 + process/updater capability を分離 (#775)

### ♻️ Refactor
- `monacoTheme` の dead `'hc-black'` 除去 + undefined ガード (#749)
- 未使用 Tauri plugin (shell / opener npm) と capabilities 重複を整理 (#750)
- `FileTreePanel` の状態管理を zustand 化し責務分割 (#772)
- `CardData` discriminated union 化 + `CardFrame` 分割 (#778, #735)
- `App.tsx` (1136 行) を Project / Tabs / Team Context に分解 (#777)
- `window.confirm` を `useNativeConfirm` (plugin-dialog.ask) に統一 (#781)
- team_hub `state.rs` god-file を sub-module 分割し `team_send` を段階関数化 (#782)
- `pty/session.rs` god-file を sub-module 分割 + lock helper / VecDeque 定数集約 (#784)
- `AppState` を async 安全化 + team_history/schema/小規模整理 (#785)
- Tauri command の error 型を `CommandResult` / `ToolError` に統一 (#787)
- `AgentNodeCard` の「未読 N 件」 inbox 表示行を削除 (#809)

### 🔧 CI / Build
- `release.yml` universal2 化 + Cargo/npm 設定整理 (#774)
- trufflehog secrets scan を CI に追加 (#758)
- CI に vitest / Windows・macOS cfg ビルド / lint を追加 (#783)

## Test plan
- [x] `npm run typecheck` 通過
- [ ] bot review LGTM
- [ ] merge 後 main で `v1.6.2` annotated tag を打って push
- [ ] `release.yml` (tauri-action) が Windows .exe / macOS .dmg / Linux .AppImage/.deb をビルド
- [ ] GitHub Releases draft を確認 → 上記 CHANGELOG を貼って publish