### PR TITLE
fix(team_hub): #811 RECRUIT_TIMEOUT を 60s に拡大し env override 化 (Windows + codex cold start 対策)

### DIFF
--- a/src-tauri/src/team_hub/protocol/consts.rs
+++ b/src-tauri/src/team_hub/protocol/consts.rs
@@ -8,7 +8,25 @@
 
 use std::time::Duration;
 
-pub(crate) const RECRUIT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Issue #811: spawn された agent の bridge.js が Hub に socket connect し
+/// `resolve_pending_recruit` で認証されるまで待つ上限時間。`team_recruit` /
+/// `team_create_leader` / `acquire_recruit_permit` で共有される。
+///
+/// 旧既定値は 30s だったが、Windows + Codex (npm shim 経由 codex.cmd → node 製
+/// bridge.js + ConPTY) の cold start で毎回 30s ギリギリ〜超過する観測があり
+/// (Claude は Rust 単体起動で十分高速、Codex は構造的に遅い)、`recruit_handshake_timeout`
+/// が 1 人目から再現するケースが報告されたため 60s に倍化した。`RECRUIT_ACK_TIMEOUT`
+/// が #574 で 5s → 15s に env override 化されたのと完全に対称な扱い。
+///
+/// 実行時値は環境変数 `VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS` で
+/// `1..=RECRUIT_HANDSHAKE_TIMEOUT_MAX_SECS` の範囲に上書き可能 (範囲外 / parse 失敗時は
+/// 本既定値にフォールバック)。参照は `protocol/tools/recruit.rs` の
+/// `recruit_handshake_timeout_duration()` ヘルパ経由。
+pub(crate) const RECRUIT_TIMEOUT: Duration = Duration::from_secs(60);
+/// Issue #811: `VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS` で受け付ける handshake timeout
+/// 秒数の上限。`RECRUIT_ACK_TIMEOUT_MAX_SECS` (= 600s = 10 分) と同値で揃え、
+/// 「ack 上限と handshake 上限は同じスケール」という不変式を維持する。
+pub(crate) const RECRUIT_HANDSHAKE_TIMEOUT_MAX_SECS: u64 = 600;
 /// Issue #576: 1 チームあたり「同時に renderer に投げる recruit 件数」の既定上限。
 /// `team_recruit` / `team_create_leader` の冒頭で `team_id` 単位 semaphore の permit を
 /// 取得し、permit 保持のまま emit → ack 受領 (or timeout) → cancel までを 1 クリティカル

--- a/src-tauri/src/team_hub/protocol/tools/create_leader.rs
+++ b/src-tauri/src/team_hub/protocol/tools/create_leader.rs
@@ -14,10 +14,10 @@ use std::time::Instant;
 use tauri::Emitter;
 use uuid::Uuid;
 
-use super::super::consts::RECRUIT_TIMEOUT;
+use super::super::consts::RECRUIT_HANDSHAKE_TIMEOUT_MAX_SECS;
 use super::super::permissions::{check_permission, Permission};
 use super::error::RecruitError;
-use super::recruit::recruit_ack_timeout;
+use super::recruit::{recruit_ack_timeout, recruit_handshake_timeout_duration};
 
 /// `team_create_leader` — 引き継ぎ用に同 teamId へ追加の leader カードを spawn する。
 ///
@@ -247,7 +247,9 @@ pub async fn team_create_leader(
     }
 
     // handshake 完了待機 (新 leader の MCP bridge が hub に繋いでくる)
-    match tokio::time::timeout(RECRUIT_TIMEOUT, rx).await {
+    // Issue #811: timeout 値は `recruit_handshake_timeout_duration()` (env override 込み、default 60s)。
+    let handshake_timeout = recruit_handshake_timeout_duration();
+    match tokio::time::timeout(handshake_timeout, rx).await {
         Ok(Ok(outcome)) => {
             let diag = hub.get_member_diagnostics(&outcome.agent_id).await;
             let recruited_at = diag
@@ -296,11 +298,14 @@ pub async fn team_create_leader(
                     json!({ "newAgentId": new_agent_id, "reason": "handshake_timeout" }),
                 );
             }
+            // Issue #811: env override で延長可能であることを message に明示する
+            // (運用者がログから即座に対処できるように)。
             Err(RecruitError {
                 code: "create_leader_handshake_timeout".into(),
                 message: format!(
-                    "new leader did not handshake within {}s",
-                    RECRUIT_TIMEOUT.as_secs()
+                    "new leader did not handshake within {}s (extend via VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS, max {}s)",
+                    handshake_timeout.as_secs(),
+                    RECRUIT_HANDSHAKE_TIMEOUT_MAX_SECS,
                 ),
                 phase: Some("handshake".into()),
                 elapsed_ms: Some(started.elapsed().as_millis() as u64),

--- a/src-tauri/src/team_hub/protocol/tools/recruit.rs
+++ b/src-tauri/src/team_hub/protocol/tools/recruit.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use super::super::consts::RECRUIT_ACK_TIMEOUT;
 use super::super::consts::RECRUIT_ACK_TIMEOUT_MAX_SECS;
+use super::super::consts::RECRUIT_HANDSHAKE_TIMEOUT_MAX_SECS;
 use super::super::consts::RECRUIT_POST_HANDSHAKE_LIVENESS_GRACE;
 use super::super::consts::RECRUIT_TIMEOUT;
 use super::super::dynamic_role::{validate_and_register_dynamic_role, DynamicRoleOutcome};
@@ -57,6 +58,46 @@ pub(super) fn recruit_ack_timeout() -> Duration {
             default = RECRUIT_ACK_TIMEOUT.as_secs(),
         );
         RECRUIT_ACK_TIMEOUT
+    }
+}
+
+/// Issue #811: `RECRUIT_TIMEOUT` の実行時値を env override 込みで返す。
+///
+/// `VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS` を u64 秒として読み出し、
+/// `1..=RECRUIT_HANDSHAKE_TIMEOUT_MAX_SECS` の範囲に収まっていればその Duration を返す。
+/// 未設定 / parse 失敗 / 0 / 上限超過のときは `RECRUIT_TIMEOUT` (= 60s) を返す。
+///
+/// 範囲外の値が渡された場合は `tracing::warn!` で notice する
+/// (= 「env を設定したのに反映されない」相談時に運用が即座に気付けるようにする)。
+///
+/// `team_recruit` / `team_create_leader` の双方の handshake 待機 (`tokio::time::timeout`)
+/// から参照される共通入口。`recruit_ack_timeout()` と完全に対称な実装。
+pub(super) fn recruit_handshake_timeout_duration() -> Duration {
+    let Ok(raw) = std::env::var("VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS") else {
+        return RECRUIT_TIMEOUT;
+    };
+    let trimmed = raw.trim();
+    let parsed = match trimmed.parse::<u64>() {
+        Ok(v) => v,
+        Err(_) => {
+            tracing::warn!(
+                "[teamhub] VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS={trimmed:?} could not be parsed as u64; \
+                 falling back to default {default}s",
+                default = RECRUIT_TIMEOUT.as_secs(),
+            );
+            return RECRUIT_TIMEOUT;
+        }
+    };
+    if (1..=RECRUIT_HANDSHAKE_TIMEOUT_MAX_SECS).contains(&parsed) {
+        Duration::from_secs(parsed)
+    } else {
+        tracing::warn!(
+            "[teamhub] VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS={parsed} is out of range \
+             (must be 1..={max}); falling back to default {default}s",
+            max = RECRUIT_HANDSHAKE_TIMEOUT_MAX_SECS,
+            default = RECRUIT_TIMEOUT.as_secs(),
+        );
+        RECRUIT_TIMEOUT
     }
 }
 
@@ -188,7 +229,8 @@ async fn verify_recruit_liveness(
 }
 
 /// team_recruit: 新メンバーをチームに追加する。Renderer に event::emit でカード生成を依頼し、
-/// その新 agentId が handshake してくるまで oneshot で待機 (timeout 30s)。
+/// その新 agentId が handshake してくるまで oneshot で待機 (timeout 60s、Issue #811 で 30s → 60s に倍化、
+/// `VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS` で 1..600s に調整可)。
 ///
 /// フラット引数の API:
 ///   - role_id (必須): snake_case 識別子。既存 (leader/hr/動的ロール) を再利用する場合はこれだけで OK。
@@ -209,7 +251,7 @@ pub async fn team_recruit(
     // permit 保持のまま emit → ack 受領 (or timeout) → cancel_pending_recruit までを
     // 1 クリティカルセクションに包むため、関数末尾まで `_permit` で束ねて Drop で自動解放。
     // 取得待ちが長引いて caller (MCP client) が timeout するのを避けるため、permit 取得側にも
-    // `RECRUIT_TIMEOUT` (30s) と同水準の上限が掛かっている。
+    // `RECRUIT_TIMEOUT` (= 60s、Issue #811 で 30s → 60s に倍化) と同水準の上限が掛かっている。
     let _permit = match hub.acquire_recruit_permit(&ctx.team_id).await {
         Ok(p) => p,
         Err(msg) => {
@@ -504,7 +546,7 @@ pub async fn team_recruit(
     }
 
     // Issue #342 Phase 1 (1.11): 環境変数 `VIBE_TEAM_DISABLE_RECRUIT_ACK=1` で旧 fire-and-forget
-    // 動作にフォールバック (ack 待ちをスキップしていきなり handshake 30s 待機)。緊急ロールバック用。
+    // 動作にフォールバック (ack 待ちをスキップしていきなり handshake 待機 = Issue #811 で 60s)。緊急ロールバック用。
     let disable_ack = std::env::var("VIBE_TEAM_DISABLE_RECRUIT_ACK").as_deref() == Ok("1");
 
     if !disable_ack {
@@ -592,7 +634,9 @@ pub async fn team_recruit(
     }
 
     // handshake 完了を待つ (Issue #342 Phase 1: ack 成功後のみ到達。disable_ack=1 では従来通り即座に到達)
-    match tokio::time::timeout(RECRUIT_TIMEOUT, rx).await {
+    // Issue #811: timeout 値は `recruit_handshake_timeout_duration()` (env override 込み、default 60s)。
+    let handshake_timeout = recruit_handshake_timeout_duration();
+    match tokio::time::timeout(handshake_timeout, rx).await {
         Ok(Ok(outcome)) => {
             verify_recruit_liveness(
                 hub,
@@ -676,11 +720,14 @@ pub async fn team_recruit(
                 );
             }
             // Issue #342 Phase 1: 構造化エラー化
+            // Issue #811: env override で延長可能であることを message に明示する
+            // (運用者がログから即座に対処できるように)。
             Err(RecruitError::new(
                 "recruit_handshake_timeout",
                 format!(
-                    "agent did not handshake within {}s",
-                    RECRUIT_TIMEOUT.as_secs()
+                    "agent did not handshake within {}s (extend via VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS, max {}s)",
+                    handshake_timeout.as_secs(),
+                    RECRUIT_HANDSHAKE_TIMEOUT_MAX_SECS,
                 ),
             )
             .with_phase("handshake")
@@ -692,17 +739,18 @@ pub async fn team_recruit(
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_wait_policy, recruit_ack_timeout, DEFAULT_WAIT_POLICY, RECRUIT_ACK_TIMEOUT,
-        RECRUIT_ACK_TIMEOUT_MAX_SECS,
+        parse_wait_policy, recruit_ack_timeout, recruit_handshake_timeout_duration,
+        DEFAULT_WAIT_POLICY, RECRUIT_ACK_TIMEOUT, RECRUIT_ACK_TIMEOUT_MAX_SECS,
+        RECRUIT_HANDSHAKE_TIMEOUT_MAX_SECS, RECRUIT_TIMEOUT,
     };
     use serde_json::json;
     use std::sync::Mutex;
     use std::time::Duration;
 
-    /// `VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS` はプロセス global な env var なので、
+    /// `VIBE_TEAM_RECRUIT_*_TIMEOUT_SECS` はプロセス global な env var なので、
     /// 境界値テストを並列に走らせると set / unset が交差して flaky になる。
-    /// テスト間で直列化するための Mutex。`std::env::set_var` の unsafe 化に巻き込まれない
-    /// よう、テスト中は guard を必ず保持する。
+    /// ack / handshake どちらの境界値テストでも共通の Mutex で直列化する。
+    /// `std::env::set_var` の unsafe 化に巻き込まれないよう、テスト中は guard を必ず保持する。
     static ENV_GUARD: Mutex<()> = Mutex::new(());
 
     fn with_env<F: FnOnce()>(value: Option<&str>, f: F) {
@@ -713,6 +761,16 @@ mod tests {
         }
         f();
         std::env::remove_var("VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS");
+    }
+
+    fn with_handshake_env<F: FnOnce()>(value: Option<&str>, f: F) {
+        let _g = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        match value {
+            Some(v) => std::env::set_var("VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS", v),
+            None => std::env::remove_var("VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS"),
+        }
+        f();
+        std::env::remove_var("VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS");
     }
 
     #[test]
@@ -797,5 +855,80 @@ mod tests {
         with_env(Some("not-a-number"), || {
             assert_eq!(recruit_ack_timeout(), RECRUIT_ACK_TIMEOUT);
         });
+    }
+
+    // ---------- Issue #811: handshake timeout env override 境界値テスト ----------
+    //
+    // `recruit_handshake_timeout_duration()` は `recruit_ack_timeout()` と完全に
+    // 対称な実装。同じ範囲・同じフォールバック挙動を持つことを 1:1 で確認する。
+
+    /// `VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS=0` は default にフォールバック。
+    #[test]
+    fn handshake_timeout_zero_falls_back_to_default() {
+        with_handshake_env(Some("0"), || {
+            assert_eq!(recruit_handshake_timeout_duration(), RECRUIT_TIMEOUT);
+        });
+    }
+
+    /// 下限 1 はそのまま採用される。
+    #[test]
+    fn handshake_timeout_lower_bound_one_is_accepted() {
+        with_handshake_env(Some("1"), || {
+            assert_eq!(
+                recruit_handshake_timeout_duration(),
+                Duration::from_secs(1)
+            );
+        });
+    }
+
+    /// 上限 600 はそのまま採用される。
+    #[test]
+    fn handshake_timeout_upper_bound_is_accepted() {
+        with_handshake_env(Some("600"), || {
+            assert_eq!(
+                recruit_handshake_timeout_duration(),
+                Duration::from_secs(RECRUIT_HANDSHAKE_TIMEOUT_MAX_SECS)
+            );
+        });
+    }
+
+    /// 上限 + 1 (= 601) は範囲外なので default にフォールバック。
+    #[test]
+    fn handshake_timeout_just_above_upper_bound_falls_back_to_default() {
+        with_handshake_env(Some("601"), || {
+            assert_eq!(recruit_handshake_timeout_duration(), RECRUIT_TIMEOUT);
+        });
+    }
+
+    /// 巨大値 (= 約 31 年) も範囲外なので default にフォールバック。
+    /// クランプを忘れると pending が事実上永久に残る事故になるため明示確認。
+    #[test]
+    fn handshake_timeout_extreme_value_falls_back_to_default() {
+        with_handshake_env(Some("999999999"), || {
+            assert_eq!(recruit_handshake_timeout_duration(), RECRUIT_TIMEOUT);
+        });
+    }
+
+    /// 未設定なら default (= `RECRUIT_TIMEOUT` = 60s)。
+    #[test]
+    fn handshake_timeout_unset_returns_default() {
+        with_handshake_env(None, || {
+            assert_eq!(recruit_handshake_timeout_duration(), RECRUIT_TIMEOUT);
+        });
+    }
+
+    /// parse 失敗 (非 u64 文字列) も default にフォールバック。
+    #[test]
+    fn handshake_timeout_garbage_value_falls_back_to_default() {
+        with_handshake_env(Some("not-a-number"), || {
+            assert_eq!(recruit_handshake_timeout_duration(), RECRUIT_TIMEOUT);
+        });
+    }
+
+    /// 新 default が想定どおり 60s であることを明示するピン留めテスト。
+    /// 値を別の数値に動かすときは Issue #811 のコメント / 通知メッセージも同時に更新する。
+    #[test]
+    fn handshake_timeout_default_is_60s() {
+        assert_eq!(RECRUIT_TIMEOUT, Duration::from_secs(60));
     }
 }

--- a/src-tauri/src/team_hub/state/recruit.rs
+++ b/src-tauri/src/team_hub/state/recruit.rs
@@ -23,10 +23,15 @@ const RECRUIT_GRACE_MAX_MS: u64 = 10_000;
 /// この時間内に来なければ「期限切れ token」として reject する。短い TTL により、
 /// `VIBE_TEAM_TOKEN` を盗んだ別プロセスが「子プロセスが起動に失敗して未 handshake のまま
 /// 放置された grant」を後から悪用できる窓を最小化する。
-/// recruit フロー自体の `RECRUIT_TIMEOUT` (30s) より長めの 60s を既定にして、
-/// recruit-timeout 側 cleanup の belt に対する suspenders として機能させる。
+///
+/// Issue #811: `RECRUIT_TIMEOUT` を 30s → 60s に倍化したのに伴い grant TTL も
+/// 60s → 120s に倍化し、「recruit-timeout 側 cleanup の belt に対する suspenders」
+/// 関係 (= TTL >= RECRUIT_TIMEOUT * 2) を維持する。grant が handshake 完了より先に
+/// 期限切れになると、agent が socket 接続しても `resolve_pending_recruit` で reject
+/// されて handshake が永遠に成立しなくなるため、TTL は常に RECRUIT_TIMEOUT より長く
+/// 保たなければならない。
 /// `VIBE_TEAM_HANDSHAKE_TTL_MS` で上書き可能 (parse 失敗 / 範囲外 / 未設定は既定値)。
-const HANDSHAKE_GRANT_TTL_DEFAULT_MS: u64 = 60_000;
+const HANDSHAKE_GRANT_TTL_DEFAULT_MS: u64 = 120_000;
 /// TTL の許容上限。これより大きい env 値は無効として既定値に丸める
 /// (TTL を実質無効化するような巨大値の誤設定 / 改ざんを防ぐ)。
 const HANDSHAKE_GRANT_TTL_MAX_MS: u64 = 300_000;
@@ -94,7 +99,7 @@ pub struct RecruitAckOutcome {
 ///
 /// - `ack`: renderer から `app_recruit_ack` invoke が来たら resolve される短期 (5s) 待機用
 /// - `handshake`: spawn された agent が socket / pipe で handshake を済ませると resolve される
-///   長期 (30s) 待機用 (既存 `resolve_pending_recruit` 経路)
+///   長期 (60s、Issue #811 で 30s → 60s) 待機用 (既存 `resolve_pending_recruit` 経路)
 pub struct PendingRecruitChannels {
     pub handshake: oneshot::Receiver<RecruitOutcome>,
     pub ack: oneshot::Receiver<RecruitAckOutcome>,
@@ -370,7 +375,7 @@ impl TeamHub {
     /// (= 起動時にのみ調整する想定)。
     ///
     /// permit 取得待ちが長引いて caller (MCP client) が timeout するのを避けるため、
-    /// 既存 `RECRUIT_TIMEOUT` (30s) と同水準の上限を取得側にも入れている。
+    /// 既存 `RECRUIT_TIMEOUT` (= 60s、Issue #811 で 30s → 60s に倍化) と同水準の上限を取得側にも入れている。
     ///
     /// 戻り値の `Err(String)` は **人間可読メッセージのみ** を含む (= `"recruit_permit_timeout"`
     /// 等の error code prefix は付けない)。caller 側で `RecruitError::new("recruit_permit_timeout",

--- a/src/renderer/src/lib/use-recruit-listener.ts
+++ b/src/renderer/src/lib/use-recruit-listener.ts
@@ -274,7 +274,7 @@ export function useRecruitListener(): void {
         // 追加されたばかりの worker が viewport の中央に来る。
         store.notifyRecruit(newNodeId);
         // Issue #342 Phase 1: addCard 完了 (= spawn 開始) 時点で Hub に受領通知を返す。
-        // handshake 完了は待たない (それは Hub 側 RECRUIT_TIMEOUT=30s 経路の責務)。
+        // handshake 完了は待たない (それは Hub 側 RECRUIT_TIMEOUT=60s 経路の責務、Issue #811)。
         // ack(true) だけでは MCP success にはならず、真の成功判定は handshake のみ。
         try {
           await ackRecruit(p.newAgentId, p.teamId, { ok: true });


### PR DESCRIPTION
Closes #811

## Summary

Windows 環境で Codex worker を `team_recruit({engine:"codex"})` で雇用すると 1 人目から毎回 `recruit_handshake_timeout` (elapsed≒30000ms) で失敗していた問題を修正する。Claude engine では同条件で成功するが、Codex は ConPTY → `codex.cmd` (npm shim) → node 製 bridge.js の cold start で構造的に 30s ギリギリ〜超過しており、`RECRUIT_TIMEOUT` (30s 固定) に間に合っていなかった。

- `RECRUIT_TIMEOUT` を **30s → 60s** に倍化 (Codex の MCP `DEFAULT_STARTUP_TIMEOUT` も同じ 30s で揃っており、両方が同時に切れる構造を解消)
- `VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS` 環境変数で `1..=600s` に上書き可能化 (`VIBE_TEAM_RECRUIT_ACK_TIMEOUT_SECS` (#574) と完全対称)
- `HANDSHAKE_GRANT_TTL_DEFAULT_MS` を 60s → 120s に倍化 (TTL ≥ RECRUIT_TIMEOUT * 2 の belt-suspenders 関係を維持。grant が handshake 完了より先に期限切れになると socket 接続しても reject されて永遠に成立しなくなる)
- timeout error message に env override のヒントを追加 (運用者がログから即座に対処可能に)

## 変更点

| ファイル | 変更内容 |
|---|---|
| `src-tauri/src/team_hub/protocol/consts.rs` | `RECRUIT_TIMEOUT = 60s`、`RECRUIT_HANDSHAKE_TIMEOUT_MAX_SECS = 600` 追加 |
| `src-tauri/src/team_hub/protocol/tools/recruit.rs` | `recruit_handshake_timeout_duration()` helper 追加 / 境界値テスト 7 件追加 / handshake 待機を helper 経由に置換 |
| `src-tauri/src/team_hub/protocol/tools/create_leader.rs` | 同 helper 経由に置換、error message 拡張 |
| `src-tauri/src/team_hub/state/recruit.rs` | `HANDSHAKE_GRANT_TTL_DEFAULT_MS = 120_000` (旧 60_000) に拡大、コメント更新 |
| `src/renderer/src/lib/use-recruit-listener.ts` | コメントの値を最新化 |

## 設計判断

- **対症療法ではなく構造的修正**: Codex は Rust 本体 + Node 製 bridge.js の構造を取るため、Claude (Rust 単体) より cold start が遅いのは仕様。30s を「広めに見ても狭い」値として 60s に倍化するのが現実に即している。`RECRUIT_ACK_TIMEOUT` も #574 で 5s → 15s の倍化前例あり。
- **error code 文字列は変更しない**: `recruit_handshake_timeout` / `create_leader_handshake_timeout` の code はそのまま。message のみ拡張 (renderer 側で code 文字列を分岐に使っている箇所への regression を回避)。
- **`HANDSHAKE_GRANT_TTL` の連動**: `RECRUIT_TIMEOUT` を倍化したのに grant TTL を据え置くと、env override で handshake_timeout を伸ばした場合に grant が先切れする逆転が発生する。default 値も 2 倍化して invariant を維持。
- **テスト**: `recruit_ack_timeout()` の既存 6 件と並んで `recruit_handshake_timeout_duration()` の境界値 7 件を追加 (0 / 1 / 600 / 601 / 999999999 / 未設定 / parse 失敗 + default=60s ピン留め)。process global env のため `ENV_GUARD` Mutex を共有して直列化。

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 通過
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib team_hub` 通過 (248 passed / 0 failed)
- [x] `npm run typecheck` 通過
- [ ] 手動: Windows 上で Claude leader から `team_recruit({engine:"codex"})` を 1 人採用、handshake が 30〜60s の間に完了することを確認
- [ ] 手動: `VIBE_TEAM_RECRUIT_HANDSHAKE_TIMEOUT_SECS=15` で短縮し旧 30s 相当より厳しい状態で意図的 timeout も観測