### PR TITLE
chore(release): bump version to 1.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5205,7 +5205,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.6.2"
+version = "1.6.3"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## Summary
v1.6.2 から 1 件の fix を含む patch リリース。

## Changes since v1.6.2

### 🐛 Bug fixes
- fix(team_hub): #811 RECRUIT_TIMEOUT を 60s に拡大し env override 化 (Windows + codex cold start 対策) (#812)

## Release artifacts
main に merge 後、`v1.6.3` annotated tag を push して `release.yml` を発火させる。tauri-action が以下を生成する:
- Windows `.exe` (NSIS インストーラ)
- macOS universal `.dmg`
- Linux `.AppImage` / `.deb`
- `latest.json` (tauri-plugin-updater 用)

## Test plan
- [x] `bump-version.ps1` で 3 ファイル + Cargo.lock を 1.6.3 に同期 (整合性チェック OK)
- [ ] CI typecheck / lint 通過
- [ ] merge 後の v1.6.3 タグ push で release.yml 発火 → 全 OS ビルド成功
- [ ] draft Release に latest.json 含む全成果物が添付される
- [ ] Release notes 編集 → publish