### PR TITLE
fix(team_hub): #829 #830 #833 state leak / 破損 state silent 喪失 / task_id 切り詰めの 3 件をバンドル修正

### DIFF
--- a/src-tauri/src/commands/team_state.rs
+++ b/src-tauri/src/commands/team_state.rs
@@ -338,9 +338,113 @@ pub async fn load_orchestration_state(
     team_id: &str,
 ) -> Option<TeamOrchestrationState> {
     let path = team_state_path(project_root, team_id);
-    let bytes = fs::read(&path).await.ok()?;
-    let state = serde_json::from_slice::<TeamOrchestrationState>(&bytes).ok()?;
-    Some(normalize(state))
+    load_orchestration_state_from_path(&path).await
+}
+
+/// Issue #830: orchestration state を 1 ファイルから読み込む内部実装。
+///
+/// 旧 `load_orchestration_state` は read 失敗と parse 失敗を両方 `.ok()?` で `None` に
+/// 丸め込み、ログを一切出さなかった。`register_team` はこの `None` を「永続化が無い」と
+/// 等価に扱うため、`<team>.json` が部分書き込みや手編集で 1 byte でも壊れていると、leader
+/// handoff・open task・human gate 状態がすべて **silent に消失** していた (最も発見が難しい
+/// 類の障害)。fail-safe にするため:
+///   - read 失敗は NotFound (= 未保存 / 初回起動) を silent に、それ以外の IO エラーは warn。
+///   - parse 失敗は warn + 破損ファイルを `.corrupt` へ best-effort 退避する (後から調査・
+///     手動復旧でき、退避後の原本は次回 save で健全な状態に上書きされる)。
+///   - 読み込んだ schema_version が現行と異なる場合は warn (`normalize` が無条件で上書きする
+///     前に検知する。将来の migration 判定の足場)。
+async fn load_orchestration_state_from_path(path: &Path) -> Option<TeamOrchestrationState> {
+    let bytes = match fs::read(path).await {
+        Ok(b) => b,
+        Err(e) => {
+            // NotFound は通常状態 (team-state 未保存 / 初回起動) なので silent。
+            // それ以外の IO エラー (権限 / I/O 障害) は痕跡を残す。
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    "[team_state] failed to read orchestration state at {}: {e}",
+                    path.display()
+                );
+            }
+            return None;
+        }
+    };
+    match serde_json::from_slice::<TeamOrchestrationState>(&bytes) {
+        Ok(state) => {
+            if state.schema_version != TEAM_STATE_SCHEMA_VERSION {
+                tracing::warn!(
+                    "[team_state] orchestration state at {} has schema_version {} (expected {}); \
+                     loading as-is",
+                    path.display(),
+                    state.schema_version,
+                    TEAM_STATE_SCHEMA_VERSION
+                );
+            }
+            Some(normalize(state))
+        }
+        Err(e) => {
+            tracing::warn!(
+                "[team_state] failed to parse orchestration state at {}: {e}; backing up corrupt \
+                 file and skipping restore (task/handoff/human-gate state will be recreated on next save)",
+                path.display()
+            );
+            backup_corrupt_state_file(path).await;
+            None
+        }
+    }
+}
+
+/// Issue #830: 破損した team-state JSON を `<file>.corrupt` (衝突時は `.corrupt.1` ..
+/// `.corrupt.9`) に best-effort で退避する。退避できれば原本は消えるので、次回
+/// `save_orchestration_state` が健全な状態で上書きできる。退避失敗 (rename 不可 / backup
+/// が増え過ぎ) は warn に留め、load 自体は失敗させない。
+async fn backup_corrupt_state_file(path: &Path) {
+    let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+        tracing::warn!(
+            "[team_state] cannot derive file name for corrupt backup of {}",
+            path.display()
+        );
+        return;
+    };
+    let Some(parent) = path.parent() else {
+        tracing::warn!(
+            "[team_state] cannot derive parent dir for corrupt backup of {}",
+            path.display()
+        );
+        return;
+    };
+    // 既存 backup を上書きしない (forensic 情報を保持する) ため、空きスロットを探す。
+    for idx in 0..=9u32 {
+        let candidate_name = if idx == 0 {
+            format!("{file_name}.corrupt")
+        } else {
+            format!("{file_name}.corrupt.{idx}")
+        };
+        let candidate = parent.join(&candidate_name);
+        if fs::metadata(&candidate).await.is_ok() {
+            continue;
+        }
+        match fs::rename(path, &candidate).await {
+            Ok(()) => {
+                tracing::warn!(
+                    "[team_state] moved corrupt orchestration state to {}",
+                    candidate.display()
+                );
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[team_state] failed to move corrupt state {} -> {}: {e}",
+                    path.display(),
+                    candidate.display()
+                );
+                return;
+            }
+        }
+    }
+    tracing::warn!(
+        "[team_state] too many corrupt backups already exist for {}; leaving file in place",
+        path.display()
+    );
 }
 
 pub async fn save_orchestration_state(
@@ -461,5 +565,94 @@ mod tests {
         });
         assert_eq!(state.pending_tasks.len(), 1);
         assert_eq!(state.pending_tasks[0].id, 2);
+    }
+
+    /// Issue #830: 未保存 (ファイル不在) は silent に None を返し、退避ファイルも作らない。
+    #[tokio::test]
+    async fn load_from_path_returns_none_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.json");
+        assert!(load_orchestration_state_from_path(&path).await.is_none());
+        assert!(
+            fs::metadata(dir.path().join("missing.json.corrupt"))
+                .await
+                .is_err(),
+            "missing file must not produce a corrupt backup"
+        );
+    }
+
+    /// Issue #830: 正常な JSON はこれまで通り読み込めて normalize される (回帰防止)。
+    #[tokio::test]
+    async fn load_from_path_parses_valid_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("team.json");
+        let state = TeamOrchestrationState {
+            project_root: "C:/repo".into(),
+            team_id: "team-x".into(),
+            tasks: vec![TeamTaskSnapshot {
+                id: 5,
+                status: "in_progress".into(),
+                ..TeamTaskSnapshot::default()
+            }],
+            ..TeamOrchestrationState::default()
+        };
+        let json = serde_json::to_vec_pretty(&state).unwrap();
+        fs::write(&path, &json).await.unwrap();
+
+        let loaded = load_orchestration_state_from_path(&path)
+            .await
+            .expect("valid state should load");
+        assert_eq!(loaded.team_id, "team-x");
+        assert_eq!(loaded.pending_tasks.len(), 1);
+    }
+
+    /// Issue #830 (core): 破損 JSON は silent に捨てず、`.corrupt` に退避してから None を返す。
+    /// 退避後は原本が消えるので、次回 save が健全な状態で上書きできる。
+    #[tokio::test]
+    async fn load_from_path_backs_up_corrupt_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("team.json");
+        let corrupt = b"{ this is not valid json ]";
+        fs::write(&path, corrupt).await.unwrap();
+
+        let loaded = load_orchestration_state_from_path(&path).await;
+        assert!(loaded.is_none(), "corrupt JSON must not silently load");
+
+        // 原本は退避されて消え、`.corrupt` に同じ内容が残っている。
+        assert!(
+            fs::metadata(&path).await.is_err(),
+            "corrupt original should be moved away"
+        );
+        let backup = dir.path().join("team.json.corrupt");
+        let backup_bytes = fs::read(&backup).await.expect("corrupt backup must exist");
+        assert_eq!(backup_bytes, corrupt);
+    }
+
+    /// Issue #830: 既に `.corrupt` がある場合は上書きせず `.corrupt.1` に退避する (forensic 保持)。
+    #[tokio::test]
+    async fn backup_corrupt_state_file_does_not_clobber_existing_backup() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("team.json");
+        fs::write(&path, b"corrupt-2").await.unwrap();
+        fs::write(dir.path().join("team.json.corrupt"), b"corrupt-1")
+            .await
+            .unwrap();
+
+        backup_corrupt_state_file(&path).await;
+
+        // 既存 backup は不変、新 backup は `.corrupt.1` に置かれる。
+        assert_eq!(
+            fs::read(dir.path().join("team.json.corrupt"))
+                .await
+                .unwrap(),
+            b"corrupt-1"
+        );
+        assert_eq!(
+            fs::read(dir.path().join("team.json.corrupt.1"))
+                .await
+                .unwrap(),
+            b"corrupt-2"
+        );
+        assert!(fs::metadata(&path).await.is_err());
     }
 }

--- a/src-tauri/src/team_hub/protocol/schema.rs
+++ b/src-tauri/src/team_hub/protocol/schema.rs
@@ -216,7 +216,12 @@ pub(super) fn tool_defs() -> Value {
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "task_id": { "type": "number" },
+                    "task_id": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 4294967295u32,
+                        "description": "Numeric task id from team_assign_task (must fit in a u32; missing or out-of-range values are rejected with update_task_invalid_args)."
+                    },
                     "status": { "type": "string" },
                     "summary": { "type": "string" },
                     "blocked_reason": { "type": "string" },

--- a/src-tauri/src/team_hub/protocol/tools/update_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/update_task.rs
@@ -159,12 +159,50 @@ fn looks_like_human_gate(text: &str) -> bool {
         || text.contains("判断")
 }
 
+/// Issue #833: `task_id` を厳格に `u32` へ解釈する。
+///
+/// 旧実装は `args.get("task_id").and_then(|v| v.as_u64()).unwrap_or(0) as u32` で、
+/// (a) `task_id` 欠落時に黙って `0` になり `invalid_args` で弾けず、(b) `u32::MAX` を超える
+/// 数値が下位 32bit へ wrap して **別の既存タスク id に誤マッチ** しうる穴があった
+/// (例: `4294967297` = 2^32 + 1 → `1`)。ヒットしたタスクの `assigned_to` で assignee/leader
+/// ガードを判定するため、巨大値経由で意図しない別タスクを done 化し done_evidence を誤適用する
+/// 事故が成立しえた。`report.rs` の `parse_task_id` と同じ厳格度に揃え、欠落 / 範囲外 / 非整数を
+/// `update_task_invalid_args` で明示的に拒否する。
+fn parse_task_id(args: &Value) -> Result<u32, ToolError> {
+    let value = args
+        .get("task_id")
+        .or_else(|| args.get("taskId"))
+        .ok_or_else(|| ToolError::invalid_args("update_task", "task_id is required"))?;
+    // JSON number はそのまま、整数表現の文字列も許容する (LLM が "2" を送るケース)。
+    // いずれも u32 の範囲に収まらなければ拒否し、暗黙の切り詰めや 0 fallback を排除する。
+    if let Some(n) = value.as_u64() {
+        u32::try_from(n).map_err(|_| {
+            ToolError::invalid_args(
+                "update_task",
+                format!("task_id {n} is out of range (must be 0..={})", u32::MAX),
+            )
+        })
+    } else if let Some(s) = value.as_str() {
+        s.trim().parse::<u32>().map_err(|_| {
+            ToolError::invalid_args(
+                "update_task",
+                "task_id must be a non-negative integer that fits in u32",
+            )
+        })
+    } else {
+        Err(ToolError::invalid_args(
+            "update_task",
+            "task_id must be a non-negative integer",
+        ))
+    }
+}
+
 pub async fn team_update_task(
     hub: &TeamHub,
     ctx: &CallContext,
     args: &Value,
 ) -> Result<Value, ToolError> {
-    let task_id = args.get("task_id").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    let task_id = parse_task_id(args)?;
     let status = args.get("status").and_then(|v| v.as_str()).unwrap_or("");
     let done_evidence = parse_done_evidence(args)?;
     let summary = optional_string(args, "summary", "summary");
@@ -923,5 +961,139 @@ mod tests {
         assert_eq!(task.status, "done");
         assert_eq!(task.done_evidence.len(), 2);
         assert_eq!(team.worker_reports.len(), 1);
+    }
+
+    /// Issue #833: `task_id` 欠落時は黙って `0` にフォールバックせず
+    /// `update_task_invalid_args` で明示的に拒否する (report.rs / assign_task.rs と対称)。
+    #[tokio::test]
+    async fn update_task_rejects_missing_task_id() {
+        let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+        let team_id = "team-833-missing".to_string();
+        {
+            let mut state = hub.state.lock().await;
+            state
+                .teams
+                .entry(team_id.clone())
+                .or_insert_with(TeamInfo::default);
+        }
+        let ctx = CallContext {
+            team_id,
+            role: "worker".into(),
+            agent_id: "vc-833-a".into(),
+        };
+        let err = team_update_task(&hub, &ctx, &json!({ "status": "in_progress" }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, "update_task_invalid_args");
+    }
+
+    /// Issue #833 (core): `u32::MAX` を超える task_id (例 `2^32 + 1`) を渡しても、下位 32bit へ
+    /// wrap して別の既存タスク (id=1) に誤マッチしてはならない。`update_task_invalid_args` で
+    /// 拒否され、id=1 のタスクは status / updated_at とも一切 mutate されないことを検証する。
+    #[tokio::test]
+    async fn update_task_rejects_out_of_range_task_id_without_truncation() {
+        let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+        let team_id = "team-833-wrap".to_string();
+        {
+            let mut state = hub.state.lock().await;
+            let team = state
+                .teams
+                .entry(team_id.clone())
+                .or_insert_with(TeamInfo::default);
+            // 旧実装では task_id=2^32+1 が `1` に切り詰められ、この id=1 タスクへ誤マッチした。
+            team.tasks.push_back(TeamTask {
+                id: 1,
+                assigned_to: "worker".into(),
+                description: "victim task".into(),
+                status: "in_progress".into(),
+                created_by: "leader".into(),
+                created_at: "2026-05-30T10:00:00Z".into(),
+                updated_at: None,
+                summary: None,
+                blocked_reason: None,
+                next_action: None,
+                artifact_path: None,
+                blocked_by_human_gate: false,
+                required_human_decision: None,
+                target_paths: Vec::new(),
+                lock_conflicts: Vec::new(),
+                pre_approval: None,
+                done_criteria: Vec::new(),
+                done_evidence: Vec::new(),
+            });
+        }
+        let ctx = CallContext {
+            team_id: team_id.clone(),
+            role: "worker".into(),
+            agent_id: "vc-833-b".into(),
+        };
+        // 4294967297 = 2^32 + 1。`as u32` だと 1 に wrap してしまう値。
+        let err = team_update_task(
+            &hub,
+            &ctx,
+            &json!({ "task_id": 4_294_967_297u64, "status": "done" }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, "update_task_invalid_args");
+
+        // id=1 のタスクは誤マッチされず完全に元のまま。
+        let state = hub.state.lock().await;
+        let team = state.teams.get(&team_id).unwrap();
+        let task = team.tasks.iter().find(|t| t.id == 1).unwrap();
+        assert_eq!(task.status, "in_progress");
+        assert!(task.updated_at.is_none());
+    }
+
+    /// Issue #833: 整数表現の文字列 task_id ("3") も u32 として受理される (LLM 互換)。
+    /// 旧実装の `as_u64()` 経路では文字列は `0` fallback に落ちて task_not_found になっていた。
+    #[tokio::test]
+    async fn update_task_accepts_integer_string_task_id() {
+        let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+        let team_id = "team-833-str".to_string();
+        {
+            let mut state = hub.state.lock().await;
+            let team = state
+                .teams
+                .entry(team_id.clone())
+                .or_insert_with(TeamInfo::default);
+            team.tasks.push_back(TeamTask {
+                id: 3,
+                assigned_to: "worker".into(),
+                description: "string id".into(),
+                status: "pending".into(),
+                created_by: "leader".into(),
+                created_at: "2026-05-30T10:00:00Z".into(),
+                updated_at: None,
+                summary: None,
+                blocked_reason: None,
+                next_action: None,
+                artifact_path: None,
+                blocked_by_human_gate: false,
+                required_human_decision: None,
+                target_paths: Vec::new(),
+                lock_conflicts: Vec::new(),
+                pre_approval: None,
+                done_criteria: Vec::new(),
+                done_evidence: Vec::new(),
+            });
+        }
+        let ctx = CallContext {
+            team_id: team_id.clone(),
+            role: "worker".into(),
+            agent_id: "vc-833-c".into(),
+        };
+        team_update_task(
+            &hub,
+            &ctx,
+            &json!({ "task_id": "3", "status": "in_progress", "summary": "ack via string id" }),
+        )
+        .await
+        .expect("integer-string task_id should be accepted");
+        let state = hub.state.lock().await;
+        let team = state.teams.get(&team_id).unwrap();
+        let task = team.tasks.iter().find(|t| t.id == 3).unwrap();
+        assert_eq!(task.status, "in_progress");
+        assert_eq!(task.summary.as_deref(), Some("ack via string id"));
     }
 }

--- a/src-tauri/src/team_hub/state/persistence.rs
+++ b/src-tauri/src/team_hub/state/persistence.rs
@@ -147,6 +147,43 @@ impl TeamHub {
         s.active_teams.remove(team_id);
         // 動的ロールもチーム単位でクリア (チーム破棄でロール定義を残す意味は無い)
         s.dynamic_roles.remove(team_id);
+
+        // Issue #829: team scope に紐付く in-memory state を漏れなく解放する。旧実装は
+        // teams / active_teams / dynamic_roles の 3 つしか掃除せず、`recruit_semaphores` /
+        // `file_locks` / `agent_role_bindings` / `member_diagnostics` / `last_status_call_at`
+        // は破棄済みチーム分も残り続けたため、長時間運用 (多数 team の作成・破棄 /
+        // recruit→dismiss の反復) でこれらが単調増加し、Hub (= アプリ) 再起動でしか
+        // 解放されなかった。
+
+        // (1) team_id 単体を key に持つ recruit 直列化 semaphore。
+        s.recruit_semaphores.remove(team_id);
+
+        // (2) member_diagnostics / last_status_call_at は agent_id 単体 key なので、
+        // (team_id, agent_id) を key に持つ agent_role_bindings から当該 team の agent_id を
+        // 逆引きして remove する。ただし同一 agent_id が **別 team にも** bind されている場合は
+        // 残す (cross-team で誤って別 team の診断を巻き込まない)。実運用では agent_id は
+        // recruit ごとに `vc-{uuid}` で一意採番されるため衝突はまず無いが、防御的に絞る。
+        // MutexGuard 越しの分割 borrow を避けるため、まず owned String に収集してから mutate する。
+        let mut this_team_agents: Vec<String> = Vec::new();
+        let mut other_team_agents: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (tid, aid) in s.agent_role_bindings.keys() {
+            if tid == team_id {
+                this_team_agents.push(aid.clone());
+            } else {
+                other_team_agents.insert(aid.clone());
+            }
+        }
+        for aid in &this_team_agents {
+            if !other_team_agents.contains(aid) {
+                s.member_diagnostics.remove(aid);
+                s.last_status_call_at.remove(aid);
+            }
+        }
+
+        // (3) (team_id, *) を key に持つマップは retain で当該 team 分を一括除去する。
+        s.agent_role_bindings.retain(|(tid, _), _| tid != team_id);
+        s.file_locks.retain(|(tid, _), _| tid != team_id);
+
         s.active_teams.is_empty()
     }
 
@@ -375,5 +412,200 @@ mod register_team_binding_seed_tests {
                 .await,
             "team scope 外の agent_id は seed されず handshake は通らない"
         );
+    }
+}
+
+/// Issue #829: `clear_team` が team scope の全 in-memory state を漏れなく解放することの単体テスト。
+///
+/// 旧実装は `teams` / `active_teams` / `dynamic_roles` の 3 つしか掃除せず、
+/// `recruit_semaphores` / `file_locks` / `agent_role_bindings` / `member_diagnostics` /
+/// `last_status_call_at` が破棄済みチーム分も残り続け、長時間運用で in-memory state が
+/// 単調増加していた (= メモリリーク)。
+#[cfg(test)]
+mod clear_team_release_tests {
+    use crate::pty::SessionRegistry;
+    use crate::team_hub::{TeamHub, TeamInfo};
+    use std::sync::Arc;
+    use std::time::Instant;
+    use tokio::sync::Semaphore;
+
+    fn make_hub() -> TeamHub {
+        TeamHub::new(Arc::new(SessionRegistry::new()))
+    }
+
+    /// `clear_team` は破棄対象 team scope の recruit_semaphores / file_locks /
+    /// agent_role_bindings / member_diagnostics / last_status_call_at を全て解放し、
+    /// 別 team の同種 state は保持する。
+    #[tokio::test]
+    async fn clear_team_releases_all_team_scoped_state() {
+        let hub = make_hub();
+        let team_a = "team-829-a";
+        let agent_a = "vc-829-a";
+        let team_b = "team-829-b";
+        let agent_b = "vc-829-b";
+
+        // 両 team に binding / diagnostics / status timestamp / semaphore を仕込む。
+        {
+            let mut s = hub.state.lock().await;
+            s.teams
+                .entry(team_a.to_string())
+                .or_insert_with(TeamInfo::default);
+            s.active_teams.insert(team_a.to_string());
+            s.teams
+                .entry(team_b.to_string())
+                .or_insert_with(TeamInfo::default);
+            s.active_teams.insert(team_b.to_string());
+
+            s.agent_role_bindings.insert(
+                (team_a.to_string(), agent_a.to_string()),
+                "programmer".to_string(),
+            );
+            s.agent_role_bindings.insert(
+                (team_b.to_string(), agent_b.to_string()),
+                "programmer".to_string(),
+            );
+
+            s.member_diagnostics.entry(agent_a.to_string()).or_default();
+            s.member_diagnostics.entry(agent_b.to_string()).or_default();
+
+            s.last_status_call_at
+                .insert(agent_a.to_string(), Instant::now());
+            s.last_status_call_at
+                .insert(agent_b.to_string(), Instant::now());
+
+            s.recruit_semaphores
+                .insert(team_a.to_string(), Arc::new(Semaphore::new(1)));
+            s.recruit_semaphores
+                .insert(team_b.to_string(), Arc::new(Semaphore::new(1)));
+        }
+
+        // file lock は public method 経由で取得する (内部で state.lock するのでガード保持外で呼ぶ)。
+        hub.try_acquire_file_locks_with_cap(
+            team_a,
+            agent_a,
+            "programmer",
+            &["src/a.rs".to_string()],
+            16,
+        )
+        .await
+        .expect("team_a lock acquire");
+        hub.try_acquire_file_locks_with_cap(
+            team_b,
+            agent_b,
+            "programmer",
+            &["src/b.rs".to_string()],
+            16,
+        )
+        .await
+        .expect("team_b lock acquire");
+
+        // 破棄前の前提条件 (team_a 側が確かに積まれている)。
+        {
+            let s = hub.state.lock().await;
+            assert!(s.recruit_semaphores.contains_key(team_a));
+            assert!(s.member_diagnostics.contains_key(agent_a));
+            assert!(s.last_status_call_at.contains_key(agent_a));
+            assert!(s
+                .agent_role_bindings
+                .contains_key(&(team_a.to_string(), agent_a.to_string())));
+            assert!(s
+                .file_locks
+                .contains_key(&(team_a.to_string(), "src/a.rs".to_string())));
+        }
+
+        // team_a を破棄。team_b がまだ active なので戻り値は false。
+        let active_empty = hub.clear_team(team_a).await;
+        assert!(!active_empty, "team_b がまだ active なので false のはず");
+
+        let s = hub.state.lock().await;
+        // team_a 由来の state は全て解放されている (leak していないこと)。
+        assert!(!s.teams.contains_key(team_a));
+        assert!(!s.active_teams.contains(team_a));
+        assert!(
+            !s.recruit_semaphores.contains_key(team_a),
+            "recruit_semaphores leak"
+        );
+        assert!(
+            !s.member_diagnostics.contains_key(agent_a),
+            "member_diagnostics leak"
+        );
+        assert!(
+            !s.last_status_call_at.contains_key(agent_a),
+            "last_status_call_at leak"
+        );
+        assert!(
+            !s.agent_role_bindings
+                .contains_key(&(team_a.to_string(), agent_a.to_string())),
+            "agent_role_bindings leak"
+        );
+        assert!(
+            !s.file_locks
+                .contains_key(&(team_a.to_string(), "src/a.rs".to_string())),
+            "file_locks leak"
+        );
+
+        // team_b 由来の state は一切影響を受けない。
+        assert!(s.teams.contains_key(team_b));
+        assert!(s.recruit_semaphores.contains_key(team_b));
+        assert!(s.member_diagnostics.contains_key(agent_b));
+        assert!(s.last_status_call_at.contains_key(agent_b));
+        assert!(s
+            .agent_role_bindings
+            .contains_key(&(team_b.to_string(), agent_b.to_string())));
+        assert!(s
+            .file_locks
+            .contains_key(&(team_b.to_string(), "src/b.rs".to_string())));
+    }
+
+    /// 同一 agent_id が複数 team に bind されている (実運用では稀) 場合、破棄した team 以外が
+    /// まだその agent_id を参照しているなら member_diagnostics / last_status_call_at は残す。
+    #[tokio::test]
+    async fn clear_team_keeps_diagnostics_for_agent_shared_with_other_team() {
+        let hub = make_hub();
+        let team_a = "team-829-shared-a";
+        let team_b = "team-829-shared-b";
+        let shared_agent = "vc-shared";
+        {
+            let mut s = hub.state.lock().await;
+            s.teams
+                .entry(team_a.to_string())
+                .or_insert_with(TeamInfo::default);
+            s.active_teams.insert(team_a.to_string());
+            s.teams
+                .entry(team_b.to_string())
+                .or_insert_with(TeamInfo::default);
+            s.active_teams.insert(team_b.to_string());
+            // 同一 agent_id を両 team に bind。
+            s.agent_role_bindings.insert(
+                (team_a.to_string(), shared_agent.to_string()),
+                "programmer".to_string(),
+            );
+            s.agent_role_bindings.insert(
+                (team_b.to_string(), shared_agent.to_string()),
+                "programmer".to_string(),
+            );
+            s.member_diagnostics
+                .entry(shared_agent.to_string())
+                .or_default();
+            s.last_status_call_at
+                .insert(shared_agent.to_string(), Instant::now());
+        }
+
+        hub.clear_team(team_a).await;
+
+        let s = hub.state.lock().await;
+        // team_a の binding は消えるが、team_b がまだ shared_agent を参照しているので
+        // member_diagnostics / last_status_call_at は残す。
+        assert!(!s
+            .agent_role_bindings
+            .contains_key(&(team_a.to_string(), shared_agent.to_string())));
+        assert!(s
+            .agent_role_bindings
+            .contains_key(&(team_b.to_string(), shared_agent.to_string())));
+        assert!(
+            s.member_diagnostics.contains_key(shared_agent),
+            "shared agent diagnostics must survive while team_b still references it"
+        );
+        assert!(s.last_status_call_at.contains_key(shared_agent));
     }
 }


### PR DESCRIPTION
## Summary
team_hub モジュールの bug / perf / data-loss 3 件を 1 commit/issue でバンドル修正。いずれも `src-tauri/src/team_hub/` (+ `commands/team_state.rs`) 配下。

- **#829 (perf / memory leak)**: `clear_team` が `teams` / `active_teams` / `dynamic_roles` の 3 つしか掃除せず、`recruit_semaphores` / `file_locks` / `agent_role_bindings` / `member_diagnostics` / `last_status_call_at` が破棄済みチーム分も残り続けて in-memory state が単調増加していた (Hub 再起動でしか解放されない)。team scope の全 state を解放するよう修正。同一 `agent_id` が別 team にも bind されている場合は `member_diagnostics` / `last_status_call_at` を残す防御付き。
- **#830 (data-loss)**: `load_orchestration_state` が read 失敗・parse 失敗を両方 `.ok()?` で握り潰し、`<team>.json` が部分書き込み/手編集で 1 byte でも破損すると task/handoff/human_gate 状態が silent に全喪失していた。read (NotFound は silent / その他 IO エラーは warn) と parse (warn + 破損ファイルを `.corrupt` に best-effort 退避) を切り分け、未知 `schema_version` も warn する fail-safe に変更。退避後の原本は次回 save で健全な状態に上書きされる。
- **#833 (correctness / security)**: `team_update_task` の `task_id` が `as_u64().unwrap_or(0) as u32` で、(a) 欠落時に黙って `0` fallback し invalid_args で弾けず、(b) `u32::MAX` 超で下位 32bit へ wrap し別タスクへ誤マッチ (例 `4294967297` = 2^32+1 → `1`) しうる穴があった。ヒットしたタスクの `assigned_to` で assignee/leader ガードを判定するため、巨大値経由で別タスクを done 化し done_evidence を誤適用する事故が成立しえた。`report.rs` の `parse_task_id` と同じ厳格度に揃え、欠落 / 範囲外 / 非整数を `update_task_invalid_args` で明示拒否。schema も `integer` + `minimum` / `maximum` を付与。

Closes #829 #830 #833

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib team_hub` → **253 passed / 0 failed** (#829・#833 の回帰テスト含む)
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib team_state` → **5 passed / 0 failed** (#830 の回帰テスト含む)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 通過
- [x] `cargo clippy --lib --all-targets` で変更 4 ファイル由来の新規 warning 0 件 (既存の crate-wide warning のみ)

追加した回帰テスト:
- #829: `clear_team_releases_all_team_scoped_state` / `clear_team_keeps_diagnostics_for_agent_shared_with_other_team`
- #830: `load_from_path_backs_up_corrupt_json` / `load_from_path_returns_none_for_missing_file` / `load_from_path_parses_valid_state` / `backup_corrupt_state_file_does_not_clobber_existing_backup`
- #833: `update_task_rejects_out_of_range_task_id_without_truncation` / `update_task_rejects_missing_task_id` / `update_task_accepts_integer_string_task_id`

## 補足
- TS 側は無変更のため `npm run typecheck` の結果は本 PR で不変。
- 全 commit は origin/main (f361881) 上に 1 issue = 1 commit で積んでいる。
