### PR TITLE
fix(pty): #827 spawn 二重 normalize 廃止 / #834 codex broker cleanup 非ブロッキング化

### DIFF
--- a/src-tauri/src/commands/terminal/command_validation.rs
+++ b/src-tauri/src/commands/terminal/command_validation.rs
@@ -648,6 +648,37 @@ mod command_normalization_tests {
         assert_eq!(args, vec!["--foo", "bar baz"]);
     }
 
+    /// Issue #827: `normalize_terminal_command` を 2 回適用すると、1 回目で quote が剥がれた
+    /// 「スペースを含む実行ファイルパス」が 2 回目に空白で再分割されてしまう (= 非冪等)。
+    /// この性質が「spawn 境界で再 normalize してはいけない」根拠になっている。退行で
+    /// `prepare_spawn_command` に再 normalize が復活した場合に気付けるよう、根本原因を固定する。
+    #[test]
+    fn double_normalize_breaks_spaced_executable_path() {
+        // 1 回目: quote 付き inline command → quote 除去済みのスペース入りパス + args。
+        let (cmd1, args1) = normalize_terminal_command(
+            Some(r#""C:\Program Files\Codex\codex.exe" --foo "bar baz""#.to_string()),
+            None,
+        );
+        assert_eq!(cmd1, r"C:\Program Files\Codex\codex.exe");
+        assert_eq!(args1, vec!["--foo", "bar baz"]);
+
+        // 2 回目: 1 回目の出力をそのまま再投入すると、quote の無いスペース入りパスが
+        // 空白で割れて command が `C:\Program` に壊れる (allowlist basename が `program` になり
+        // spawn 境界で弾かれる = #827 の発生機序)。
+        let (cmd2, args2) =
+            normalize_terminal_command(Some(cmd1.clone()), Some(args1.clone()));
+        assert_eq!(cmd2, r"C:\Program", "二重 normalize は spaced path を壊す");
+        assert_eq!(
+            args2,
+            vec![r"Files\Codex\codex.exe", "--foo", "bar baz"],
+            "残りのパス断片が args 先頭に紛れ込む"
+        );
+        assert_ne!(
+            cmd2, cmd1,
+            "normalize は spaced path に対して非冪等 (= 二重適用してはならない)"
+        );
+    }
+
     #[test]
     fn defaults_to_claude_when_command_is_blank() {
         let (command, args) =

--- a/src-tauri/src/pty/codex_broker.rs
+++ b/src-tauri/src/pty/codex_broker.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use crate::util::log_redact::redact_home;
 
@@ -18,6 +19,11 @@ const CODEX_PLUGIN_DATA_DIR: &str = "codex-openai-codex";
 const BROKER_STATE_FILE: &str = "broker.json";
 const FALLBACK_STATE_ROOT_DIR: &str = "codex-companion";
 const BROKER_SESSION_PREFIX: &str = "cxc-";
+
+/// Issue #834: broker プロセスがまだ生きている (`skipped_live > 0`) とき、その終了を待って
+/// もう一度 stale state を掃除するまでの猶予。旧実装は `Duration::from_millis(250)` の
+/// 直書きだった。ここで kill した codex の broker が落ちるのにかかる実測の目安。
+const BROKER_RECLEANUP_DELAY: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct CleanupSummary {
@@ -57,6 +63,33 @@ pub fn cleanup_stale_for_cwd(cwd: &str) -> CleanupSummary {
         );
     }
     summary
+}
+
+/// Issue #834: codex PTY を kill した後の broker 掃除を「最初の cleanup → broker がまだ
+/// 生きていれば (`skipped_live > 0`) 終了猶予を置いて 1 度だけ再 cleanup」という手順で
+/// 実行する。実 sleep / 実 fs 操作を行う同期版で、**ブロックして良い文脈** (detached
+/// background thread / 次回起動前の spawn 準備) からのみ呼ぶこと。
+///
+/// 呼び出し元 (exit watcher / `terminal_kill`) を直接ブロックしないために
+/// `SessionHandle::cleanup_codex_broker_after_kill` 側で background thread に逃がしている。
+pub fn cleanup_stale_for_cwd_with_retry(cwd: &str) {
+    run_cleanup_with_retry(|| cleanup_stale_for_cwd(cwd), std::thread::sleep);
+}
+
+/// `cleanup_stale_for_cwd_with_retry` の手順 (cleanup → 条件付き sleep + 再 cleanup) を、
+/// `cleanup` / `sleep` を注入可能にした pure な orchestration として切り出したもの。
+/// これにより「skipped_live > 0 のときだけ 2 回目の cleanup が走り、その前に sleep が入る」
+/// という分岐を、子プロセス spawn や実 sleep 無しで決定的にテストできる。
+fn run_cleanup_with_retry<C, S>(mut cleanup: C, sleep: S)
+where
+    C: FnMut() -> CleanupSummary,
+    S: FnOnce(Duration),
+{
+    let summary = cleanup();
+    if summary.skipped_live > 0 {
+        sleep(BROKER_RECLEANUP_DELAY);
+        cleanup();
+    }
 }
 
 fn cleanup_stale_in_state_dir(state_dir: &Path, is_alive: impl Fn(u32) -> bool) -> CleanupSummary {
@@ -424,5 +457,47 @@ mod tests {
         assert!(!state_dir.join(BROKER_STATE_FILE).exists());
         assert!(unsafe_dir.join("broker.pid").exists());
         let _ = fs::remove_dir_all(state_dir);
+    }
+
+    /// Issue #834: broker がまだ生きている (`skipped_live > 0`) ときだけ、sleep を挟んで
+    /// 2 回目の cleanup が走ることを、子プロセス spawn や実 sleep 無しで決定的に検証する。
+    #[test]
+    fn retry_runs_second_cleanup_with_sleep_when_broker_live() {
+        use std::cell::Cell;
+        let calls = Cell::new(0usize);
+        let slept = Cell::new(false);
+        run_cleanup_with_retry(
+            || {
+                calls.set(calls.get() + 1);
+                CleanupSummary {
+                    skipped_live: 1,
+                    ..Default::default()
+                }
+            },
+            |d| {
+                slept.set(true);
+                assert_eq!(d, BROKER_RECLEANUP_DELAY, "再 cleanup 前の sleep 量を固定");
+            },
+        );
+        assert_eq!(calls.get(), 2, "skipped_live>0 のとき cleanup は 2 回呼ばれる");
+        assert!(slept.get(), "2 回目の前に sleep が入る");
+    }
+
+    /// Issue #834: broker が生存していない (`skipped_live == 0`) ときは 1 回で終わり、
+    /// sleep も再 cleanup も走らないこと (= 終了処理を無駄にブロックしない)。
+    #[test]
+    fn retry_skips_second_cleanup_when_nothing_live() {
+        use std::cell::Cell;
+        let calls = Cell::new(0usize);
+        let slept = Cell::new(false);
+        run_cleanup_with_retry(
+            || {
+                calls.set(calls.get() + 1);
+                CleanupSummary::default()
+            },
+            |_| slept.set(true),
+        );
+        assert_eq!(calls.get(), 1, "skipped_live==0 のとき再 cleanup しない");
+        assert!(!slept.get(), "sleep も入らない");
     }
 }

--- a/src-tauri/src/pty/registry.rs
+++ b/src-tauri/src/pty/registry.rs
@@ -350,6 +350,17 @@ impl SessionRegistry {
         removed
     }
 
+    /// アプリ終了 (window CloseRequested → `app.exit(0)` 直前) に全 PTY を kill する。
+    ///
+    /// Issue #834: 旧実装は各 session で `cleanup_codex_broker_after_kill()` を**同期直列**に
+    /// 呼んでおり、これが `git`/`tasklist` 子プロセス spawn + (broker 生存時) 250ms sleep を
+    /// 伴うため、codex タブ数ぶんアプリ終了がブロックされていた (#630 で inject drain を
+    /// 非同期化した狙いが相殺されていた)。
+    ///
+    /// 終了経路では broker の stale state 掃除を**スキップ**する。掃除は best-effort な
+    /// state file の後始末に過ぎず、残っても次回起動時の spawn 前 cleanup
+    /// (`cleanup_codex_broker_if_stale`) で確実に回収できる。ここでは `s.kill()` による
+    /// 子プロセス停止だけを直列で確実に行い (これは速い)、即座に呼び出し元へ返す。
     pub fn kill_all(&self) {
         let sessions: Vec<Arc<SessionHandle>> = {
             let mut g = recover(self.inner.lock());
@@ -359,7 +370,6 @@ impl SessionRegistry {
         };
         for s in sessions {
             let _ = s.kill();
-            s.cleanup_codex_broker_after_kill();
         }
     }
 }

--- a/src-tauri/src/pty/session/handle.rs
+++ b/src-tauri/src/pty/session/handle.rs
@@ -17,7 +17,7 @@ use serde::Serialize;
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use super::injecting_guard::InjectingGuard;
 use super::lock::{lock_poisoned, LockResult};
@@ -170,15 +170,25 @@ impl SessionHandle {
         }
     }
 
+    /// Issue #834: codex PTY を kill した後の broker stale state 掃除。
+    ///
+    /// `cleanup_stale_for_cwd` は `git rev-parse` / `tasklist` (Windows) / `kill` (Unix) の
+    /// 子プロセス spawn を伴い、broker プロセスがまだ生きている (`skipped_live > 0`) ときは
+    /// その終了を待つために 250ms sleep + 再 cleanup まで行う。これを呼び出し元
+    /// (exit watcher thread / `terminal_kill` async command / 旧 `kill_all`) で同期実行すると、
+    /// codex タブを閉じるたび caller が子プロセス spawn + 最大 250ms ぶんブロックされ、特に
+    /// 複数 codex タブを開いた状態でのアプリ終了が PTY 数ぶん直列に遅延していた (#834)。
+    ///
+    /// 掃除自体は best-effort (state file の後始末) なので、処理全体を detached background
+    /// thread に逃がして呼び出し元は即座に返す。スレッドの完了は待たない。
     pub fn cleanup_codex_broker_after_kill(&self) {
         if !self.is_codex {
             return;
         }
-        let summary = crate::pty::codex_broker::cleanup_stale_for_cwd(&self.cwd);
-        if summary.skipped_live > 0 {
-            std::thread::sleep(Duration::from_millis(250));
-            crate::pty::codex_broker::cleanup_stale_for_cwd(&self.cwd);
-        }
+        let cwd = self.cwd.clone();
+        std::thread::spawn(move || {
+            crate::pty::codex_broker::cleanup_stale_for_cwd_with_retry(&cwd);
+        });
     }
 }
 

--- a/src-tauri/src/pty/session/spawn.rs
+++ b/src-tauri/src/pty/session/spawn.rs
@@ -123,10 +123,19 @@ pub(crate) struct PreparedSpawnCommand {
 }
 
 pub(crate) fn prepare_spawn_command(opts: &SpawnOptions) -> Result<PreparedSpawnCommand> {
-    let (command, args) = command_validation::normalize_terminal_command(
-        Some(opts.command.clone()),
-        Some(opts.args.clone()),
-    );
+    // Issue #827: `terminal_create` は SpawnOptions を組む前に
+    // `command_validation::normalize_terminal_command` で既に command/args を 1 度
+    // split + quote 除去済みにしている。ここで再び normalize_terminal_command を通すと、
+    // `split_command_line` が非冪等なため、1 回目で quote が剥がれた「スペースを含む実行
+    // ファイルパス」(例 `C:\Program Files\Codex\codex.exe`) を 2 回目で空白再分割してしまい、
+    // command=`C:\Program` / args=[`Files\Codex\codex.exe`, ...] に壊れて spawn 境界の
+    // allowlist (`is_allowed_terminal_command("C:\Program")` = false) で起動失敗する。
+    //
+    // よって spawn 境界では再 split せず、正規化済みの command/args をそのまま信頼する。
+    // ただし allowlist / immediate-exec / danger-flag の再チェックは defense-in-depth として
+    // 維持する (SpawnOptions が将来別経路から組まれても spawn 直前に弾けるようにする)。
+    let command = opts.command.clone();
+    let args = opts.args.clone();
     if !command_validation::is_allowed_terminal_command(&command) {
         return Err(anyhow!(
             "command is not allowed at spawn boundary: {command}"
@@ -629,5 +638,86 @@ mod resolve_valid_cwd_tests {
         // params keys are passed as-is from Rust callsite (`requested` / `fallback`).
         assert!(json.contains("\"requested\""), "params.requested missing in {json}");
         assert!(json.contains("\"fallback\""), "params.fallback missing in {json}");
+    }
+}
+
+#[cfg(test)]
+mod prepare_spawn_command_boundary_tests {
+    //! Issue #827: spawn 境界 (`prepare_spawn_command`) が `terminal_create` で既に
+    //! normalize 済みの command/args を **再 split しない** ことを保証する cross-platform
+    //! テスト。Windows 実パス解決込みの検証は `pty::tests::session_windows` 側にあるが、
+    //! bot CI (Linux) でも退行を捕まえられるよう、ここでは platform 非依存の不変式
+    //! (allowlist 通過 + args 非分割 + defense-in-depth 再チェック維持) を固定する。
+
+    use super::{prepare_spawn_command, SpawnOptions};
+    use std::collections::HashMap;
+
+    fn opts(command: String, args: &[&str]) -> SpawnOptions {
+        SpawnOptions {
+            command,
+            args: args.iter().map(|s| s.to_string()).collect(),
+            cwd: ".".to_string(),
+            is_codex: false,
+            cols: 80,
+            rows: 24,
+            env: HashMap::new(),
+            agent_id: None,
+            session_key: None,
+            team_id: None,
+            role: None,
+        }
+    }
+
+    #[test]
+    fn preserves_spaced_executable_path_without_resplit() {
+        // 旧実装は spawn 境界で再度 normalize_terminal_command を通し、quote 除去済みの
+        // スペース入りパス (`...\Program Files\...\codex.exe`) を空白で再分割し、command を
+        // `...\Program` に壊して allowlist (basename=`program`) で弾いていた (#827)。
+        // 新契約では再 split せず、basename `codex` で allowlist を通過し、args も保持する。
+        //
+        // Windows の spawn 境界は実パス解決まで行い、存在しないパスは
+        // "command executable was not found" を返す (これは allowlist 通過後の別段階)。
+        // cross-platform に「allowlist で弾かれない + args 非分割」を決定的に検証するため、
+        // スペースを含む実ディレクトリに実ファイルを置いて program に渡す。
+        let tmp = tempfile::tempdir().unwrap();
+        let spaced_dir = tmp.path().join("Program Files");
+        std::fs::create_dir_all(&spaced_dir).unwrap();
+        let cli = spaced_dir.join("codex.exe");
+        std::fs::write(&cli, "").unwrap();
+        let cli_s = cli.to_string_lossy().into_owned();
+
+        let o = opts(cli_s.clone(), &["--foo", "bar baz"]);
+        let prepared =
+            prepare_spawn_command(&o).expect("spaced executable path must pass spawn boundary");
+        // args は再分割されず、スペース入り引数 "bar baz" も 1 要素として保たれる。
+        assert_eq!(prepared.args, vec!["--foo", "bar baz"]);
+        // requested_command は渡したスペース入りパスのまま (空白で割れていない)。
+        assert_eq!(prepared.requested_command, cli_s);
+    }
+
+    #[test]
+    fn rejects_non_allowlisted_command_at_boundary() {
+        // Issue #827: 再 normalize を廃止しても spawn 境界の allowlist は basename で判定し、
+        // 許可外コマンドを弾く (defense-in-depth)。spaced path でも basename ベースで評価される。
+        let o = opts(r"C:\Program Files\Evil\evilbin.exe".to_string(), &["--foo"]);
+        let err = prepare_spawn_command(&o)
+            .expect_err("non-allowlisted basename must be rejected at boundary");
+        assert!(
+            err.to_string().contains("not allowed at spawn boundary"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn still_rejects_immediate_exec_flags_at_boundary() {
+        // Issue #827: 再 normalize を廃止しても defense-in-depth の再チェックは維持する。
+        // 正規化済み形 (command=cmd, args=[/c, ...]) を渡し /c が弾かれることを確認する。
+        let o = opts("cmd".to_string(), &["/c", "echo", "unsafe"]);
+        let err = prepare_spawn_command(&o)
+            .expect_err("cmd immediate-exec must be rejected at boundary");
+        assert!(
+            err.to_string().contains("cmd immediate-exec flags"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src-tauri/src/pty/tests/session_windows.rs
+++ b/src-tauri/src/pty/tests/session_windows.rs
@@ -219,32 +219,45 @@ mod resolution_tests {
     }
 
     #[test]
-    fn normalizes_inline_command_again_at_spawn_boundary() {
+    fn preserves_normalized_spaced_path_at_spawn_boundary() {
+        // Issue #827: `terminal_create` は SpawnOptions を組む前に
+        // `normalize_terminal_command` で command/args を 1 度 split + quote 除去済みに
+        // している。spawn 境界 (`prepare_spawn_command`) はそれを **再 split せず** そのまま
+        // 信頼する契約に変わった。スペースを含むディレクトリ配下の実行ファイルを直接
+        // program として渡しても、空白で再分割されず正しく resolve されることを Windows の
+        // 実パス解決込みで検証する。旧実装は spawn 境界で normalize_terminal_command を
+        // 二重適用し、`...\Program Files\...\codex.exe` を `...\Program` に割って allowlist で
+        // 弾いていた (= #827 の退行)。
         let tmp = tempfile::tempdir().unwrap();
-        let cli = tmp.path().join("codex.exe");
+        let spaced_dir = tmp.path().join("Program Files");
+        std::fs::create_dir_all(&spaced_dir).unwrap();
+        let cli = spaced_dir.join("codex.exe");
         std::fs::write(&cli, "").unwrap();
-        // Issue #788: spawn 境界の inline command 再 normalize を検証する。危険フラグ
-        // 自体の拒否は command_validation 側のユニットテストでカバーするため、ここでは
-        // benign な inline フラグを使い settings 状態に依存しないようにする。
-        let command = format!(r#""{}" --foo"#, cli.display());
-        let mut opts = base_spawn_options(
-            command,
-            vec![
-                "--config".to_string(),
-                "disable_paste_burst=true".to_string(),
-            ],
+
+        let opts = base_spawn_options(
+            cli.to_string_lossy().into_owned(),
+            vec!["--foo".to_string(), "bar baz".to_string()],
         );
 
         let prepared = prepare_spawn_command(&opts).unwrap();
 
+        // .exe は cmd.exe ラッパ無しで直接 program になり、args は再分割されず保持される。
         assert_eq!(PathBuf::from(&prepared.program), cli);
-        assert_eq!(
-            prepared.args,
-            vec!["--foo", "--config", "disable_paste_burst=true"]
-        );
+        assert_eq!(prepared.args, vec!["--foo", "bar baz"]);
+    }
 
-        opts.command = "cmd /c echo unsafe".to_string();
-        opts.args.clear();
+    #[test]
+    fn spawn_boundary_still_rejects_immediate_exec_flags() {
+        // Issue #827: 再 normalize を廃止しても spawn 境界の defense-in-depth 再チェックは
+        // 維持する。正規化済み形 (command=cmd, args=[/c, ...]) を渡し /c が弾かれること。
+        let opts = base_spawn_options(
+            "cmd".to_string(),
+            vec![
+                "/c".to_string(),
+                "echo".to_string(),
+                "unsafe".to_string(),
+            ],
+        );
         let err = prepare_spawn_command(&opts).unwrap_err().to_string();
         assert!(err.contains("cmd immediate-exec flags"));
     }


### PR DESCRIPTION
## Summary
Rust PTY / terminal spawn 周りの bug/perf を 2 件、1 issue = 1 commit でバンドル修正。

### #827 [bug] spawn 境界の二重 normalize でスペース入りクォート実行パスが起動失敗
- `terminal_create` が `normalize_terminal_command` で 1 度 split + quote 除去した command/args を、spawn 境界の `prepare_spawn_command` が**もう一度** `normalize_terminal_command` していた。
- `split_command_line` は非冪等で、1 回目で quote が剥がれた `C:\Program Files\Codex\codex.exe` を 2 回目で空白再分割し、`command=C:\Program` に壊して spawn 境界 allowlist で `command is not allowed at spawn boundary: C:\Program` を返していた。
- **修正**: 再 normalize を廃止し、正規化済みの command/args をそのまま信頼。allowlist / immediate-exec / danger-flag の再チェックは defense-in-depth として維持。

### #834 [performance] codex broker cleanup がアプリ終了を直列ブロック
- `cleanup_codex_broker_after_kill` が `git rev-parse` / `tasklist` 子プロセス spawn + (broker 生存時) 250ms sleep + 再 cleanup を、exit watcher / `kill_all` から**同期直列**に実行。codex タブ数 × (子プロセス spawn + 最大 250ms) ぶんアプリ終了がブロックされていた。
- **修正**:
  - `cleanup_codex_broker_after_kill` を detached background thread に逃がし、呼び出し元を即座に返す。
  - `kill_all` (アプリ終了経路) は broker cleanup をスキップ。残った stale state は次回起動前の `cleanup_codex_broker_if_stale` で回収。
  - retry orchestration を inject 可能な pure 関数に切り出し決定的にテスト可能化。250ms を定数化。

## Test plan
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 通過
- [x] `cargo test --lib "pty::"` 全 pass (103 passed / 0 failed / 2 ignored=Windows e2e manual)
- [x] `cargo test --lib command_validation` 全 pass (50 passed / 0 failed)
- [x] `cargo clippy --lib` 変更ファイルに新規 warning 無し
- 追加した回帰テスト:
  - `command_validation::double_normalize_breaks_spaced_executable_path` — 根本原因 (normalize 非冪等) を固定
  - `spawn::prepare_spawn_command_boundary_tests` (cross-platform / CI 通過) — spaced path 非分割 + allowlist 通過 + defense-in-depth 維持
  - `session_windows::resolution_tests::preserves_normalized_spaced_path_at_spawn_boundary` — Windows 実パス解決込み (旧 `normalizes_inline_command_again_at_spawn_boundary` を新契約へ書き換え)
  - `codex_broker::retry_runs_second_cleanup_with_sleep_when_broker_live` / `retry_skips_second_cleanup_when_nothing_live` — retry 分岐を子プロセス spawn 無しで検証

Closes #827 #834