### PR TITLE
fix: Rust backend の独立 4 件 (#828 #831 #837 #838) をバンドル修正

### DIFF
--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -76,7 +76,15 @@ pub async fn assert_active_project_root(
         return Err(CommandError::authz("no active project_root configured"));
     }
 
-    let req_canon = match std::fs::canonicalize(trimmed) {
+    // Issue #831: canonicalize は同期 blocking I/O。本 helper は handoffs_* / team_state_read
+    // から高頻度に呼ばれ、network mount / 低速 FS では `std::fs::canonicalize` が Tokio worker
+    // スレッドを完了まで塞ぐ (#620 と同種のアンチパターン)。`tokio::fs::canonicalize` に置換し、
+    // req と active は独立なので `tokio::join!` で並列実行する (team_mcp.rs と同形)。
+    let (req_res, active_res) = tokio::join!(
+        tokio::fs::canonicalize(trimmed),
+        tokio::fs::canonicalize(active.trim())
+    );
+    let req_canon = match req_res {
         Ok(p) => p,
         Err(e) => {
             tracing::warn!(
@@ -89,7 +97,7 @@ pub async fn assert_active_project_root(
             )));
         }
     };
-    let active_canon = match std::fs::canonicalize(active.trim()) {
+    let active_canon = match active_res {
         Ok(p) => p,
         Err(e) => {
             tracing::warn!(

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -16,6 +16,13 @@ use hash::{mtime_ms_of, sha256_hex};
 // safe_join は外部 (commands/git.rs) からも呼ばれるので pub use で再 export する。
 pub use path_safety::safe_join;
 
+/// open / ハッシュ検証で一括メモリ読込してよい最大ファイルサイズ (50 MiB)。
+/// Issue #207: `files_read` はこれを超えるファイルの open を拒否する。
+/// Issue #828: `files_write` の content-hash 衝突検出 (#119) も同じ上限を尊重させるため
+/// モジュールスコープに昇格した。これを超えるサイズのファイルは全読込せず conflict 扱いに
+/// する (`tokio::fs::read` での GB 級一括読込による OOM/フリーズを防ぐ)。
+pub(crate) const MAX_READ_BYTES: u64 = 50 * 1024 * 1024;
+
 #[derive(Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct FileNode {
@@ -140,7 +147,6 @@ pub async fn files_list(project_root: String, rel_path: String) -> FileListResul
 
 #[tauri::command]
 pub async fn files_read(project_root: String, rel_path: String) -> FileReadResult {
-    const MAX_READ_BYTES: u64 = 50 * 1024 * 1024;
     let Some(abs) = safe_join(&project_root, &rel_path) else {
         return FileReadResult {
             ok: false,
@@ -286,6 +292,26 @@ pub async fn files_write(
         // Issue #119: 同サイズかつ 1 秒以内の編集は mtime/size 両方で見逃すため、
         // 期待ハッシュが渡ってきていれば現在ファイル内容とハッシュ比較する。
         if let Some(expected_hash) = expected_content_hash.as_deref() {
+            // Issue #828: `files_read` は MAX_READ_BYTES (50MB) 超を open 拒否するため、
+            // open 時の `content_hash` は ≤50MB のファイルに対してのみ計算されている。
+            // save 直前にディスク上のファイルが上限を超えている場合、(1) open 以降に肥大化した
+            // = 内容が変わったことが確定し、かつ (2) `tokio::fs::read` で GB 級を一括メモリ読込
+            // すると OOM/フリーズしうる。そのため hash 全読込はせず conflict として早期 return し、
+            // read 側の上限 (#207) と対称にする。
+            if meta.len() > MAX_READ_BYTES {
+                return FileWriteResult {
+                    ok: false,
+                    error: Some(format!(
+                        "file grew too large to verify safely ({} bytes > {} bytes limit); it changed on disk since it was opened",
+                        meta.len(),
+                        MAX_READ_BYTES
+                    )),
+                    mtime_ms: mtime_ms_of(&meta),
+                    size_bytes: Some(meta.len()),
+                    conflict: true,
+                    ..Default::default()
+                };
+            }
             if let Ok(current_bytes) = tokio::fs::read(&abs).await {
                 let current_hash = sha256_hex(&current_bytes);
                 if current_hash != expected_hash {
@@ -981,5 +1007,106 @@ mod issue_592_tests {
         let root = root_str(&td);
         let res = files_delete(root, "".into(), Some(true)).await;
         assert!(!res.ok);
+    }
+}
+
+/// Issue #828: `files_write` の content-hash 衝突検出 (#119) が MAX_READ_BYTES を尊重し、
+/// 巨大ファイルを一括メモリ読込せず conflict 扱いにすることを保証する回帰テスト。
+#[cfg(test)]
+mod issue_828_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn root_str(td: &tempfile::TempDir) -> String {
+        td.path()
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// save 直前にディスク上のファイルが 50MB を超えている場合、hash 全読込せず
+    /// conflict として早期 return する (OOM/フリーズ防止)。sparse file (`set_len`) を使い
+    /// 実バイトを書かずに 50MB+1 のメタデータを作る。
+    #[tokio::test]
+    async fn files_write_skips_hash_check_for_oversized_file() {
+        let td = tempdir().unwrap();
+        let root = root_str(&td);
+        let path = td.path().join("huge.txt");
+        let f = std::fs::File::create(&path).unwrap();
+        // sparse に 50MB+1 へ拡張 (実データは書かないので高速)。
+        f.set_len(MAX_READ_BYTES + 1).unwrap();
+        drop(f);
+
+        // expected_content_hash のみ渡し、mtime/size 検証はスキップさせて hash 経路に入れる。
+        let res = files_write(
+            root,
+            "huge.txt".into(),
+            "new content".into(),
+            None,                      // expected_mtime_ms
+            None,                      // expected_size_bytes
+            None,                      // encoding
+            Some("deadbeef".into()),   // expected_content_hash
+        )
+        .await;
+
+        assert!(!res.ok, "oversized file must not be written via hash-check path");
+        assert!(
+            res.conflict,
+            "oversized-at-save file must be reported as conflict"
+        );
+        assert_eq!(res.size_bytes, Some(MAX_READ_BYTES + 1));
+        // 巨大ファイルが上書きされていない (= save が拒否された) ことを確認。
+        let meta = std::fs::metadata(td.path().join("huge.txt")).unwrap();
+        assert_eq!(meta.len(), MAX_READ_BYTES + 1);
+    }
+
+    /// ≤50MB の通常ファイルでは従来通り hash 不一致を conflict 検出し、原本を保持する。
+    #[tokio::test]
+    async fn files_write_detects_hash_conflict_for_small_file() {
+        let td = tempdir().unwrap();
+        let root = root_str(&td);
+        let path = td.path().join("s.txt");
+        std::fs::write(&path, b"original").unwrap();
+
+        let res = files_write(
+            root,
+            "s.txt".into(),
+            "updated".into(),
+            None,
+            None,
+            None,
+            Some("0000".into()), // 故意に不一致な hash
+        )
+        .await;
+
+        assert!(!res.ok);
+        assert!(res.conflict);
+        // 原本は保持される。
+        assert_eq!(std::fs::read(&path).unwrap(), b"original");
+    }
+
+    /// ≤50MB の通常ファイルで hash が一致すれば従来通り保存に成功する (回帰防止)。
+    #[tokio::test]
+    async fn files_write_succeeds_when_hash_matches() {
+        let td = tempdir().unwrap();
+        let root = root_str(&td);
+        let path = td.path().join("s.txt");
+        std::fs::write(&path, b"original").unwrap();
+        let expected = sha256_hex(b"original");
+
+        let res = files_write(
+            root,
+            "s.txt".into(),
+            "updated".into(),
+            None,
+            None,
+            None,
+            Some(expected),
+        )
+        .await;
+
+        assert!(res.ok, "{:?}", res.error);
+        assert_eq!(std::fs::read(&path).unwrap(), b"updated");
     }
 }

--- a/src-tauri/src/commands/role_profiles.rs
+++ b/src-tauri/src/commands/role_profiles.rs
@@ -51,9 +51,8 @@ pub async fn role_profiles_load() -> Value {
 pub async fn role_profiles_save(file: Value) -> crate::commands::error::CommandResult<()> {
     let _g = SAVE_LOCK.lock().await;
     let path = crate::util::config_paths::role_profiles_path();
-    if let Some(dir) = path.parent() {
-        let _ = fs::create_dir_all(dir).await;
-    }
+    // Issue #838: 親ディレクトリ作成は `atomic_write_with_mode` 冒頭で行われるため、
+    // ここでの明示的な create_dir_all は冗長 (settings_save も手動 create はしない)。削除した。
     let json = serde_json::to_vec_pretty(&file).map_err(|e| e.to_string())?;
     // Issue #608 (Security): instructions が機密扱いなので 0o600 で永続化。
     Ok(atomic_write_with_mode(&path, &json, Some(0o600))

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -14,7 +14,13 @@ pub struct SessionInfo {
     pub id: String,
     pub path: String,
     pub title: String,
+    /// Issue #837: 会話メッセージ (type == "user" | "assistant") の件数。
+    /// `message_count_capped == true` のとき、先頭 HEAD_LIMIT_LINES 行で打ち切った
+    /// 下限値 (= "N+" 表示用) であり、正確な総数ではない。
     pub message_count: u32,
+    /// Issue #837: `message_count` が先頭 HEAD_LIMIT_LINES (2000) 行の走査上限に達して
+    /// 打ち切られたかどうか。true のとき UI は "N+" を描画する。
+    pub message_count_capped: bool,
     pub last_modified_at: String,
     pub last_modified_ms: i64,
 }
@@ -86,14 +92,13 @@ pub async fn sessions_list(project_root: String) -> Vec<SessionInfo> {
     const CONCURRENCY: usize = 8;
     let mut sessions: Vec<SessionInfo> = Vec::with_capacity(candidates.len());
     let mut iter = candidates.into_iter();
-    let mut in_flight: tokio::task::JoinSet<(Candidate, String, u32, Option<String>)> =
+    let mut in_flight: tokio::task::JoinSet<(Candidate, JsonlSummary)> =
         tokio::task::JoinSet::new();
 
-    let spawn_one = |set: &mut tokio::task::JoinSet<(Candidate, String, u32, Option<String>)>,
-                     cand: Candidate| {
+    let spawn_one = |set: &mut tokio::task::JoinSet<(Candidate, JsonlSummary)>, cand: Candidate| {
         set.spawn(async move {
-            let (title, count, cwd) = read_jsonl_summary(&cand.path).await;
-            (cand, title, count, cwd)
+            let summary = read_jsonl_summary(&cand.path).await;
+            (cand, summary)
         });
     };
 
@@ -103,13 +108,13 @@ pub async fn sessions_list(project_root: String) -> Vec<SessionInfo> {
         }
     }
     while let Some(joined) = in_flight.join_next().await {
-        if let Ok((cand, title, count, cwd)) = joined {
+        if let Ok((cand, summary)) = joined {
             // 後続を 1 件 spawn して並列度を維持
             if let Some(next) = iter.next() {
                 spawn_one(&mut in_flight, next);
             }
             // cwd が jsonl から取れたときだけ厳密チェック (取れないものは fail-open)
-            if let Some(ref c) = cwd {
+            if let Some(ref c) = summary.cwd {
                 if !c.trim().is_empty() && normalize_project_root(c) != requested_norm {
                     tracing::debug!(
                         "[sessions] skipping colliding session {}: cwd={} != requested={}",
@@ -123,8 +128,9 @@ pub async fn sessions_list(project_root: String) -> Vec<SessionInfo> {
             sessions.push(SessionInfo {
                 id: cand.id,
                 path: cand.path.to_string_lossy().into_owned(),
-                title,
-                message_count: count,
+                title: summary.title,
+                message_count: summary.message_count,
+                message_count_capped: summary.capped,
                 last_modified_at: cand.last_modified_at,
                 last_modified_ms: cand.last_modified_ms,
             });
@@ -135,34 +141,80 @@ pub async fn sessions_list(project_root: String) -> Vec<SessionInfo> {
     sessions
 }
 
-/// jsonl から (title, count, cwd) を抽出。cwd は最初に見つかった `cwd` フィールド。
+/// `read_jsonl_summary` の戻り値。
 ///
-/// Issue #43: 大きなセッション (数百 MB) の jsonl を毎回全行読みすると list API が
+/// Issue #837: 旧実装は `(title, count, cwd)` の tuple を返し、`count` は **行種別を問わない
+/// 非空行数 (上限付き)** だった。これを (1) 会話メッセージ件数に限定し、(2) 走査上限に達したかを
+/// 表す `capped` を加えた struct に置き換える。フィールド名で意味が自明になり、UI 側が "N+" を
+/// 描画できるようになる。
+pub(crate) struct JsonlSummary {
+    /// 最初のユーザーメッセージ先頭行 (最大 80 文字)。
+    pub title: String,
+    /// 会話メッセージ (type == "user" | "assistant") の件数。
+    /// `capped == true` のときは走査上限内で数えた下限値。
+    pub message_count: u32,
+    /// jsonl 内で最初に見つかった `cwd` フィールド。
+    pub cwd: Option<String>,
+    /// `message_count` が先頭 HEAD_LIMIT_LINES 行で打ち切られたか。
+    pub capped: bool,
+}
+
+/// 各行の `type` だけを安価に取り出すための最小デシリアライズ型。
+/// 全行を `serde_json::Value` ツリーに起こすより軽く、会話メッセージ判定にだけ使う。
+#[derive(serde::Deserialize)]
+struct JsonlLineType {
+    #[serde(rename = "type", default)]
+    ty: Option<String>,
+}
+
+/// jsonl から title / message_count / cwd / capped を抽出する。
+///
+/// Issue #43 / #106: 大きなセッション (数百 MB) の jsonl を毎回全行読みすると list API が
 /// 数秒〜十数秒ブロックする。
-///   - title / cwd は先頭付近 (1〜8 行目) にしか出ないので早期 break する
-///   - message_count の「正確な数」は UI で "500+" 等と見せれば十分なので、
-///     先頭 HEAD_LIMIT_LINES = 2000 行まで数え、超えたら上限値を返す
-///     (正確な行数は fs::metadata の行数相当だと OS 依存で取れないので割り切る)
+///   - title / cwd は先頭付近 (1〜8 行目) にしか出ないので先頭 8 行だけ full parse する
+///   - I/O 量は「走査した非空行数」を先頭 HEAD_LIMIT_LINES = 2000 行で打ち切って bound する
+///
+/// Issue #837: 旧実装は行種別を問わず数え、2000 行で無告知に頭打ちしていた。本実装では
+///   - 会話メッセージ (type == "user" | "assistant") のみを `message_count` に数える
+///     (summary / system / tool_result / file-history-snapshot 等は除外)
+///   - 走査上限に達し、かつさらに行が残っていれば `capped = true` を立てて UI が "N+" を
+///     描画できるようにする
 ///
 /// Issue #494: integration test (`commands/tests/sessions.rs`) から fixture jsonl に対して
 /// 直接呼べるよう `pub(crate)` で expose。Tauri command 経由ではないので AppHandle / State 不要。
-pub(crate) async fn read_jsonl_summary(path: &std::path::Path) -> (String, u32, Option<String>) {
+pub(crate) async fn read_jsonl_summary(path: &std::path::Path) -> JsonlSummary {
     const HEAD_LIMIT_LINES: u32 = 2000;
     let Ok(f) = tokio::fs::File::open(path).await else {
-        return (String::new(), 0, None);
+        return JsonlSummary {
+            title: String::new(),
+            message_count: 0,
+            cwd: None,
+            capped: false,
+        };
     };
     let reader = tokio::io::BufReader::new(f);
     let mut lines = reader.lines();
     let mut title = String::new();
-    let mut count = 0u32;
+    let mut message_count = 0u32;
     let mut cwd: Option<String> = None;
+    // I/O 量は「走査した非空行数」で bound する (message_count ではなく行数で打ち切る)。
+    let mut lines_scanned = 0u32;
+    let mut capped = false;
     while let Ok(Some(line)) = lines.next_line().await {
         if line.trim().is_empty() {
             continue;
         }
-        count += 1;
-        // 先頭 8 行だけ serde_json で parse (title / cwd 抽出用)
-        if count <= 8 && (title.is_empty() || cwd.is_none()) {
+        lines_scanned += 1;
+
+        // Issue #837: 会話メッセージ (type == user|assistant) だけを数える。
+        if let Ok(parsed) = serde_json::from_str::<JsonlLineType>(&line) {
+            if matches!(parsed.ty.as_deref(), Some("user") | Some("assistant")) {
+                message_count += 1;
+            }
+        }
+
+        // 先頭 8 行だけ serde_json で full parse (title / cwd 抽出用)
+        if lines_scanned <= 8 && (title.is_empty() || cwd.is_none()) {
             if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
                 if cwd.is_none() {
                     if let Some(c) = v.get("cwd").and_then(|c| c.as_str()) {
@@ -187,9 +239,18 @@ pub(crate) async fn read_jsonl_summary(path: &std::path::Path) -> (String, u32, 
         // 旧実装は break 条件に `!title.is_empty() && cwd.is_some()` を含めていたため、
         // それらが欠けた jsonl (壊れている / 古い形式) では数百 MB を最後まで読み続け、
         // セッション履歴表示が数秒〜十数秒ブロックしていた。
-        if count >= HEAD_LIMIT_LINES {
+        if lines_scanned >= HEAD_LIMIT_LINES {
+            // Issue #837: 上限到達。さらに非空行が残っているかを 1 行だけ覗いて capped を確定する
+            // (ちょうど HEAD_LIMIT_LINES 行のセッションを誤って "N+" と表示しないため。
+            //  追加読込は 1 行のみなので I/O bound は維持される)。
+            capped = matches!(lines.next_line().await, Ok(Some(_)));
             break;
         }
     }
-    (title, count, cwd)
+    JsonlSummary {
+        title,
+        message_count,
+        cwd,
+        capped,
+    }
 }

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -159,12 +159,26 @@ pub(crate) struct JsonlSummary {
     pub capped: bool,
 }
 
-/// 各行の `type` だけを安価に取り出すための最小デシリアライズ型。
-/// 全行を `serde_json::Value` ツリーに起こすより軽く、会話メッセージ判定にだけ使う。
-#[derive(serde::Deserialize)]
-struct JsonlLineType {
-    #[serde(rename = "type", default)]
-    ty: Option<String>,
+/// 行が会話メッセージ (`type == "user" | "assistant"`) かを、全文 JSON パースを避けて
+/// 安価に判定する (Issue #837 / PR #851 review)。
+///
+/// Claude Code の JSONL は compact JSON (`serde_json::to_string` 相当) で 1 行 1 オブジェクトを
+/// 書き、JSON 文字列値の中の `"` は必ず `\"` にエスケープされる。したがって **未エスケープの
+/// `"type":"user"` / `"type":"assistant"` という並びは実際のキー:値ペアにしか出現しない**
+/// (content 文字列の中身には現れない)。これにより、大きな content を含む行でも全文を
+/// `serde_json` でトークナイズ/アロケートせず、SIMD 化された substring 検索だけで判定できる
+/// (旧実装は最大 2000 行に対し毎行 `from_str` していて large-content セッションで CPU を浪費していた)。
+///
+/// 末尾の閉じ `"` まで含めて照合するので `"type":"user_cancelled"` のような前方一致型では
+/// 誤検出しない。compact 形と「コロン後 1 スペース」形の両方を許容する。
+fn line_is_conversation_message(line: &str) -> bool {
+    const PATTERNS: [&str; 4] = [
+        r#""type":"user""#,
+        r#""type":"assistant""#,
+        r#""type": "user""#,
+        r#""type": "assistant""#,
+    ];
+    PATTERNS.iter().any(|p| line.contains(p))
 }
 
 /// jsonl から title / message_count / cwd / capped を抽出する。
@@ -207,10 +221,9 @@ pub(crate) async fn read_jsonl_summary(path: &std::path::Path) -> JsonlSummary {
         lines_scanned += 1;
 
         // Issue #837: 会話メッセージ (type == user|assistant) だけを数える。
-        if let Ok(parsed) = serde_json::from_str::<JsonlLineType>(&line) {
-            if matches!(parsed.ty.as_deref(), Some("user") | Some("assistant")) {
-                message_count += 1;
-            }
+        // 全文 JSON パースを避けるため substring 検索で判定する (PR #851 review / perf)。
+        if line_is_conversation_message(&line) {
+            message_count += 1;
         }
 
         // 先頭 8 行だけ serde_json で full parse (title / cwd 抽出用)

--- a/src-tauri/src/commands/tests/sessions.rs
+++ b/src-tauri/src/commands/tests/sessions.rs
@@ -1,7 +1,7 @@
-//! Issue #494: `commands::sessions::read_jsonl_summary` の integration test。
+//! Issue #494 / #837: `commands::sessions::read_jsonl_summary` の integration test。
 //!
 //! 本物の `~/.claude/projects/<encoded>/*.jsonl` を fixture として tempdir に作り、
-//! title / cwd / message_count の抽出が期待通り動くことを検証する。
+//! title / cwd / message_count / capped の抽出が期待通り動くことを検証する。
 
 use crate::commands::sessions::read_jsonl_summary;
 use serde_json::json;
@@ -38,10 +38,11 @@ async fn extracts_title_from_first_user_message_string_content() {
     )
     .await;
 
-    let (title, count, cwd) = read_jsonl_summary(&path).await;
-    assert!(title.starts_with("最初のユーザーメッセージ"));
-    assert_eq!(count, 2);
-    assert_eq!(cwd.as_deref(), Some("/home/user/proj"));
+    let s = read_jsonl_summary(&path).await;
+    assert!(s.title.starts_with("最初のユーザーメッセージ"));
+    assert_eq!(s.message_count, 2);
+    assert_eq!(s.cwd.as_deref(), Some("/home/user/proj"));
+    assert!(!s.capped);
 }
 
 #[tokio::test]
@@ -63,10 +64,11 @@ async fn extracts_title_from_first_user_message_array_content() {
     )
     .await;
 
-    let (title, count, cwd) = read_jsonl_summary(&path).await;
-    assert_eq!(title, "Hello, can you check this?");
-    assert_eq!(count, 1);
-    assert_eq!(cwd.as_deref(), Some("C:\\repo\\proj"));
+    let s = read_jsonl_summary(&path).await;
+    assert_eq!(s.title, "Hello, can you check this?");
+    assert_eq!(s.message_count, 1);
+    assert_eq!(s.cwd.as_deref(), Some("C:\\repo\\proj"));
+    assert!(!s.capped);
 }
 
 /// title が 1 行 80 文字で truncate されること。
@@ -85,10 +87,10 @@ async fn title_truncates_to_first_line_80_chars() {
     )
     .await;
 
-    let (title, _count, _cwd) = read_jsonl_summary(&path).await;
+    let s = read_jsonl_summary(&path).await;
     // chars().take(80) なので 80 文字までで止まる (バイト数ではなく char count)
-    assert_eq!(title.chars().count(), 80);
-    assert_eq!(title, "あ".repeat(80));
+    assert_eq!(s.title.chars().count(), 80);
+    assert_eq!(s.title, "あ".repeat(80));
 }
 
 /// `\n` を含むメッセージは最初の行だけ title になる (改行で truncate)。
@@ -106,8 +108,8 @@ async fn title_takes_first_line_only() {
     )
     .await;
 
-    let (title, _count, _cwd) = read_jsonl_summary(&path).await;
-    assert_eq!(title, "first line");
+    let s = read_jsonl_summary(&path).await;
+    assert_eq!(s.title, "first line");
 }
 
 /// 空行 / 不正 JSON 行は parse error 扱いで count に加算されない (空行) ようにする。
@@ -122,25 +124,57 @@ async fn empty_lines_are_skipped_in_count() {
     );
     tokio::fs::write(&path, body).await.unwrap();
 
-    let (title, count, cwd) = read_jsonl_summary(&path).await;
-    assert_eq!(title, "hi");
-    assert_eq!(count, 2, "blank lines must not be counted");
-    assert_eq!(cwd.as_deref(), Some("/x"));
+    let s = read_jsonl_summary(&path).await;
+    assert_eq!(s.title, "hi");
+    assert_eq!(s.message_count, 2, "blank lines must not be counted");
+    assert_eq!(s.cwd.as_deref(), Some("/x"));
 }
 
-/// 存在しないファイルは empty triple を返す (panic しない)。
+/// 存在しないファイルは empty summary を返す (panic しない)。
 #[tokio::test]
-async fn missing_file_returns_empty_triple() {
+async fn missing_file_returns_empty_summary() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("nonexistent.jsonl");
-    let (title, count, cwd) = read_jsonl_summary(&path).await;
-    assert_eq!(title, "");
-    assert_eq!(count, 0);
-    assert!(cwd.is_none());
+    let s = read_jsonl_summary(&path).await;
+    assert_eq!(s.title, "");
+    assert_eq!(s.message_count, 0);
+    assert!(s.cwd.is_none());
+    assert!(!s.capped);
 }
 
-/// HEAD_LIMIT_LINES (= 2000) で count が打ち切られる。
-/// 2500 行書いて count == 2000 を確認する。
+/// Issue #837: 会話メッセージ (type == "user" | "assistant") だけを数え、
+/// summary / system / tool_result / file-history-snapshot 等は除外する。
+#[tokio::test]
+async fn only_user_and_assistant_lines_are_counted() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("session-mixed.jsonl");
+    write_jsonl(
+        &path,
+        &[
+            json!({ "type": "summary", "summary": "session summary" }),
+            json!({ "type": "user", "cwd": "/x", "message": { "content": "q1" } }),
+            json!({ "type": "assistant", "message": { "content": "a1" } }),
+            json!({ "type": "system", "content": "system notice" }),
+            json!({ "type": "tool_result", "content": "tool output" }),
+            json!({ "type": "file-history-snapshot", "snapshot": {} }),
+            json!({ "type": "user", "message": { "content": "q2" } }),
+            json!({ "type": "assistant", "message": { "content": "a2" } }),
+        ],
+    )
+    .await;
+
+    let s = read_jsonl_summary(&path).await;
+    // user 2 + assistant 2 = 4 (summary / system / tool_result / snapshot は除外)
+    assert_eq!(
+        s.message_count, 4,
+        "only user/assistant messages must be counted"
+    );
+    assert_eq!(s.title, "q1");
+    assert!(!s.capped);
+}
+
+/// HEAD_LIMIT_LINES (= 2000) を超えるセッションは message_count が打ち切られ、capped=true。
+/// 2500 行書いて count == 2000 / capped == true を確認する。
 #[tokio::test]
 async fn message_count_caps_at_head_limit() {
     let dir = tempdir().unwrap();
@@ -159,13 +193,42 @@ async fn message_count_caps_at_head_limit() {
     }
     write_jsonl(&path, &lines).await;
 
-    let (title, count, _cwd) = read_jsonl_summary(&path).await;
-    assert_eq!(title, "title here");
-    assert_eq!(count, 2000, "should cap at HEAD_LIMIT_LINES");
+    let s = read_jsonl_summary(&path).await;
+    assert_eq!(s.title, "title here");
+    assert_eq!(s.message_count, 2000, "should cap at HEAD_LIMIT_LINES");
+    assert!(s.capped, "exceeding the scan limit must set capped=true");
+}
+
+/// ちょうど HEAD_LIMIT_LINES 行のセッションは capped=false (= "N+" ではなく正確な値)。
+#[tokio::test]
+async fn exactly_head_limit_is_not_capped() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("session-exact.jsonl");
+    let mut lines: Vec<serde_json::Value> = Vec::with_capacity(2000);
+    lines.push(json!({
+        "type": "user",
+        "cwd": "/x",
+        "message": { "content": "title here" }
+    }));
+    for _ in 0..1999 {
+        lines.push(json!({
+            "type": "assistant",
+            "message": { "content": "reply" }
+        }));
+    }
+    write_jsonl(&path, &lines).await;
+
+    let s = read_jsonl_summary(&path).await;
+    assert_eq!(s.message_count, 2000);
+    assert!(
+        !s.capped,
+        "exactly HEAD_LIMIT_LINES messages must not be reported as capped"
+    );
 }
 
 /// title / cwd が先頭 8 行内に無くても、count は最後まで (上限まで) カウントされる。
-/// 旧 Issue #106 互換: 取れなくても break しない。
+/// 旧 Issue #106 互換: 取れなくても break しない。Issue #837 に伴い fixture を
+/// 会話メッセージ (assistant) に変更 (system は count 対象外になったため)。
 #[tokio::test]
 async fn missing_title_and_cwd_does_not_block_count() {
     let dir = tempdir().unwrap();
@@ -173,15 +236,17 @@ async fn missing_title_and_cwd_does_not_block_count() {
     let lines: Vec<serde_json::Value> = (0..50)
         .map(|i| {
             json!({
-                "type": "system",
-                "message": { "content": format!("system msg {i}") }
+                "type": "assistant",
+                "message": { "content": format!("assistant msg {i}") }
             })
         })
         .collect();
     write_jsonl(&path, &lines).await;
 
-    let (title, count, cwd) = read_jsonl_summary(&path).await;
-    assert_eq!(title, "");
-    assert!(cwd.is_none());
-    assert_eq!(count, 50);
+    let s = read_jsonl_summary(&path).await;
+    // 先頭に user メッセージが無いので title は空・cwd も無し。
+    assert_eq!(s.title, "");
+    assert!(s.cwd.is_none());
+    assert_eq!(s.message_count, 50);
+    assert!(!s.capped);
 }

--- a/src-tauri/src/commands/tests/sessions.rs
+++ b/src-tauri/src/commands/tests/sessions.rs
@@ -173,6 +173,38 @@ async fn only_user_and_assistant_lines_are_counted() {
     assert!(!s.capped);
 }
 
+/// PR #851 review (perf 対応): 会話メッセージ判定を substring 検索に変えても、
+/// content 文字列内に `"type":"assistant"` 等のリテラルを含む行を二重カウントしない
+/// (JSON エスケープにより未エスケープの並びはキー:値にしか出ないことの回帰ガード)。
+#[tokio::test]
+async fn content_containing_type_literal_is_not_double_counted() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("session-tricky.jsonl");
+    write_jsonl(
+        &path,
+        &[
+            // content にまぎらわしいリテラルを含む user メッセージ 1 件。
+            json!({
+                "type": "user",
+                "cwd": "/x",
+                "message": { "content": "JSON の {\"type\":\"assistant\"} について教えて" }
+            }),
+            json!({
+                "type": "assistant",
+                "message": { "content": "はい、それは {\"type\":\"user\"} とは別物です" }
+            }),
+        ],
+    )
+    .await;
+
+    let s = read_jsonl_summary(&path).await;
+    // user 1 + assistant 1 = 2。content 内のリテラルは数に影響しない。
+    assert_eq!(
+        s.message_count, 2,
+        "literals inside content must not inflate the count"
+    );
+}
+
 /// HEAD_LIMIT_LINES (= 2000) を超えるセッションは message_count が打ち切られ、capped=true。
 /// 2500 行書いて count == 2000 / capped == true を確認する。
 #[tokio::test]

--- a/src/renderer/src/components/SessionsPanel.tsx
+++ b/src/renderer/src/components/SessionsPanel.tsx
@@ -211,7 +211,9 @@ export function SessionsPanel({
                     {relativeTime(sessionTimes[i] ?? 0, rtf, dateFormatter)}
                   </span>
                   <span className="session__count">
-                    {t('sessions.messages', { count: s.messageCount })}
+                    {s.messageCountCapped
+                      ? t('sessions.messagesCapped', { count: s.messageCount })
+                      : t('sessions.messages', { count: s.messageCount })}
                   </span>
                 </div>
                 <div className="session__title">{s.title}</div>

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -1168,7 +1168,7 @@ const en: Dict = {
   // ---------- Sessions ----------
   'sessions.resume': 'Resume session {id}',
   'sessions.messages': '{count} msgs',
-  // Issue #837: "N+" rendering when messageCount hit the scan limit.
+  // Issue #837: "N+" rendering when messageCount reaches the scan limit.
   'sessions.messagesCapped': '{count}+ msgs',
   'sessions.loadMore': 'Load {remaining} more',
 

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -379,6 +379,8 @@ const ja: Dict = {
   // ---------- Sessions ----------
   'sessions.resume': 'セッション {id} に戻る',
   'sessions.messages': '{count} 件',
+  // Issue #837: messageCount が走査上限で打ち切られたときの "N+" 表示。
+  'sessions.messagesCapped': '{count}+ 件',
   'sessions.loadMore': '残り {remaining} 件を表示',
 
   // ---------- Tab ----------
@@ -1166,6 +1168,8 @@ const en: Dict = {
   // ---------- Sessions ----------
   'sessions.resume': 'Resume session {id}',
   'sessions.messages': '{count} msgs',
+  // Issue #837: "N+" rendering when messageCount hit the scan limit.
+  'sessions.messagesCapped': '{count}+ msgs',
   'sessions.loadMore': 'Load {remaining} more',
 
   // ---------- Tab ----------

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -384,7 +384,13 @@ export interface SessionInfo {
   id: string;
   path: string;
   title: string;
+  /**
+   * 会話メッセージ (type === "user" | "assistant") の件数 (Issue #837)。
+   * `messageCountCapped === true` のときは先頭 2000 行で打ち切った下限値 (= "N+" 表示用)。
+   */
   messageCount: number;
+  /** Issue #837: messageCount が走査上限 (2000 行) に達して打ち切られたか。true で UI は "N+" を描画する。 */
+  messageCountCapped: boolean;
   lastModifiedAt: string;
   /** Rust 側で事前計算した epoch ms。SessionsPanel の再描画ごとの Date.parse を避ける。 */
   lastModifiedMs?: number;


### PR DESCRIPTION
## Summary

Rust backend の独立した 4 件の issue を 1 PR にバンドル (1 commit / issue) で修正しました。各 issue は別ファイルで相互依存はありません。

- **#828 (files)**: `files_write` の content-hash 衝突検出 (#119) が `MAX_READ_BYTES` (50MB) を無視し、ディスク上の現ファイルを `tokio::fs::read` で**サイズ無制限に全読込**して OOM/フリーズしうる非対称バグを修正。`files_read` のローカル const だった `MAX_READ_BYTES` をモジュールスコープに昇格し、hash 検証前に `meta.len() > MAX_READ_BYTES` なら全読込せず **conflict として早期 return**（open 以降に 50MB を超えた = 内容変更が確定するため）。read 側の上限 (#207) と対称になりました。
- **#831 (authz)**: `assert_active_project_root` が `async fn` 内で blocking `std::fs::canonicalize` を 2 回呼び、`handoffs_*` / `team_state_read` の高頻度経路で Tokio worker を塞ぐ問題 (#620 と同種) を修正。`tokio::fs::canonicalize` + `tokio::join!` 並列実行に置換しました（`team_mcp.rs:190-195` と同形）。**挙動・エラーメッセージ・ログは不変**。
- **#837 (sessions)**: セッション履歴の `messageCount` が JSONL の全行種別を数え、2000 行で**無告知に頭打ち**していた問題を修正。(1) カウント対象を会話メッセージ (`type == "user" | "assistant"`) に限定（summary / system / tool_result / file-history-snapshot 等を除外）、(2) 走査上限到達を `messageCountCapped` で明示し、UI が `"N+"` を描画できるようにしました。`shared.ts` / `SessionsPanel.tsx` / `i18n.ts` を同期。I/O 量の bound は従来どおり「走査した非空行数 2000」で維持（追加読込は capped 判定の 1 行のみ）。
- **#838 (role_profiles)**: `role_profiles_save` の冗長な `create_dir_all` を削除。直後の `atomic_write_with_mode` が親ディレクトリを作成済み (`atomic_write.rs:41-43`) で、`settings_save` とも挙動を揃えます。純粋な dead code 整理。

## Test plan

- `cargo check --manifest-path src-tauri/Cargo.toml --tests` ✅ (Finished, 0 error)
- `cargo test`（対象モジュール）✅ 37 passed / 0 failed
  - #828 回帰テスト 3 件: oversized ファイルは hash 全読込せず conflict / 小ファイルの hash 不一致検出 / hash 一致時の保存成功
  - #837: 会話メッセージ限定カウント / `capped=true` (2500 行) / `capped=false` (ちょうど 2000 行) / 既存 title・truncate・空行スキップ
  - #831: 既存 authz テスト 12 件で canonicalize 経路の挙動不変を確認
- `npm run typecheck` ✅ (exit 0)

Closes #828 #831 #837 #838

<!-- GitHub の `Closes #a #b #c` は先頭しか auto-close しないため、各 issue に keyword を個別付与する -->
Closes #828
Closes #831
Closes #837
Closes #838
