### PR TITLE
feat(terminal): Codex セッション復元と復元失敗 toast (#855 #856 #857)

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -155,6 +155,45 @@ fn filter_resume_args_in_place(args: Vec<String>) -> Vec<String> {
     out
 }
 
+/// Issue #607 / #855 (security): Codex の `resume <id>` サブコマンド経路にも #607 と同じ
+/// session id バリデーションを適用する defense-in-depth ヘルパー。
+///
+/// renderer (use-team-launch-helpers / CardFrame / TerminalCard) は capture-then-resume で
+/// args 先頭に `resume <id>` を積む。この id は Codex rollout の payload.id
+/// (`~/.codex/sessions/**/rollout-*.jsonl`) や `terminal-tabs.json` の sessionId 由来で信頼境界の
+/// 外にあるため、`^[A-Za-z0-9_-]{8,64}$` を満たさない id を含む `resume <id>` ペアは strip + warn
+/// して新規 Codex 起動にフォールバックする (`--resume` 用 `filter_resume_args_in_place` と同方針)。
+///
+/// Codex の `resume` は **先頭 positional サブコマンド** なので `args[0] == "resume"` のときだけ
+/// `args[1]` を検証する。renderer の capture-then-resume が積むのは常に valid な session id
+/// なので、それ以外 (信頼境界外の不正 id / `--print=...` 等のフラグ風文字列) は `resume <id>` を
+/// strip して新規 Codex 起動にフォールバックする。`is_codex == false` なら no-op。
+fn filter_codex_resume_id_in_place(is_codex: bool, args: Vec<String>) -> Vec<String> {
+    if !is_codex || args.first().map(String::as_str) != Some("resume") {
+        return args;
+    }
+    match args.get(1) {
+        // 正常な session id (= 我々が積む値) はそのまま通す。
+        Some(id) if command_validation::is_valid_resume_session_id(id) => args,
+        // それ以外 (不正 id / フラグ風文字列) は `resume <bad>` を strip して新規起動に倒す
+        // (#607 の `--resume` strip と同方針の defense-in-depth)。
+        Some(bad) => {
+            let preview: String = bad.chars().take(16).collect();
+            tracing::warn!(
+                "[terminal] codex `resume <id>` rejected by validator (len={}, preview={:?}), stripping subcommand",
+                bad.len(),
+                preview
+            );
+            args.into_iter().skip(2).collect()
+        }
+        // `resume` のみで id 無し → strip。
+        None => {
+            tracing::warn!("[terminal] codex `resume` with no following id, stripping subcommand");
+            args.into_iter().skip(1).collect()
+        }
+    }
+}
+
 /// Codex の system prompt を、PTY (TUI) に直接「最初の入力」として注入する fallback 経路。
 ///
 /// 動作:
@@ -297,6 +336,11 @@ pub async fn terminal_create(
     // 残す (新規起動にフォールバック / UX 維持)。`--resume=<id>` の単一要素形式は
     // 2 要素分離原則を破るため id 内容に関わらず常に strip。
     args = filter_resume_args_in_place(args);
+
+    // Issue #855 (security): Codex の `resume <id>` サブコマンド経路 (renderer の capture-then-resume)
+    // にも #607 と同じ `^[A-Za-z0-9_-]{8,64}$` 検証を適用し、信頼境界外の id (rollout payload.id /
+    // terminal-tabs.json) を strip + warn する。不正時は新規 Codex 起動にフォールバック。
+    args = filter_codex_resume_id_in_place(is_codex_command, args);
 
     // Issue #271: HMR remount 経路では renderer 側 hook が `attachIfExists: true` を立て、
     // 既存 PTY に bind し直したいシグナルを送る。allowlist / immediate-exec チェックを通った
@@ -825,5 +869,78 @@ mod resume_args_filter_tests {
                 "second-valid-uuid-5678",
             ])
         );
+    }
+}
+
+#[cfg(test)]
+mod codex_resume_filter_tests {
+    use super::filter_codex_resume_id_in_place;
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn keeps_valid_codex_resume_id() {
+        let input = s(&["resume", "019b6cec-e0fc-7d32-a4d0-a59cb61ae601"]);
+        let out = filter_codex_resume_id_in_place(true, input.clone());
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn keeps_valid_codex_resume_id_with_trailing_flags() {
+        let input = s(&[
+            "resume",
+            "019b6cec-e0fc-7d32-a4d0-a59cb61ae601",
+            "-c",
+            "disable_paste_burst=true",
+        ]);
+        let out = filter_codex_resume_id_in_place(true, input.clone());
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn strips_flagish_injection_id_and_keeps_trailing_args() {
+        // 信頼境界外の `--print=...` 等のフラグ風 id は strip し、後続 codexArgs を残して新規起動。
+        let input = s(&["resume", "--print=/etc/passwd", "-c", "k=v"]);
+        let out = filter_codex_resume_id_in_place(true, input);
+        assert_eq!(out, s(&["-c", "k=v"]));
+    }
+
+    #[test]
+    fn strips_shell_metachar_codex_resume_id() {
+        let input = s(&["resume", "abc;rm -rf /", "-c", "k=v"]);
+        let out = filter_codex_resume_id_in_place(true, input);
+        assert_eq!(out, s(&["-c", "k=v"]));
+    }
+
+    #[test]
+    fn strips_too_short_positional_codex_resume_id() {
+        let input = s(&["resume", "abc"]);
+        let out = filter_codex_resume_id_in_place(true, input);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn strips_bare_resume_with_no_id() {
+        let input = s(&["resume"]);
+        let out = filter_codex_resume_id_in_place(true, input);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn noop_when_not_codex() {
+        // claude 側は --resume を filter_resume_args_in_place が見るので、ここでは触らない。
+        let input = s(&["resume", "abc;rm -rf /"]);
+        let out = filter_codex_resume_id_in_place(false, input.clone());
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn noop_when_resume_not_first() {
+        // 先頭 positional でない "resume" 文字列は subcommand ではないので対象外。
+        let input = s(&["-c", "k=v", "resume", "abc;rm -rf /"]);
+        let out = filter_codex_resume_id_in_place(true, input.clone());
+        assert_eq!(out, input);
     }
 }

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -538,8 +538,12 @@ pub async fn terminal_create(
                     inject_codex_prompt_to_pty(registry, term_id, instr).await;
                 });
             }
-            // Claude Code 起動時のみ session watcher を仕掛ける (codex は jsonl を作らない)
-            if command.to_lowercase().contains("claude") {
+            // Claude Code / Codex 起動時に session watcher を仕掛ける。
+            //   - Claude: `~/.claude/projects/<encoded>/<uuid>.jsonl` を監視 (claude_watcher)
+            //   - Codex (#855): `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` を監視 (codex_watcher)
+            // どちらも session id を後追いで検出し `terminal:sessionId:{id}` を emit する。
+            let is_claude_command = command.to_lowercase().contains("claude");
+            if is_claude_command || is_codex_command {
                 let watcher_id = id.clone();
                 // Issue #739: ArcSwapOption の lock-free load で現在値を読む。
                 let watcher_root =
@@ -558,17 +562,27 @@ pub async fn terminal_create(
                 // polling していた旧実装より反応が早く、cleanup の遅延を解消する。
                 if let Some(handle) = state.pty_registry.get(&watcher_id) {
                     let cancel = handle.watcher_cancel_token();
-                    crate::pty::claude_watcher::spawn_watcher(
-                        app.clone(),
-                        watcher_id,
-                        actual_root,
-                        spawned_at,
-                        cancel,
-                    );
+                    if is_codex_command {
+                        crate::pty::codex_watcher::spawn_watcher(
+                            app.clone(),
+                            watcher_id,
+                            actual_root,
+                            spawned_at,
+                            cancel,
+                        );
+                    } else {
+                        crate::pty::claude_watcher::spawn_watcher(
+                            app.clone(),
+                            watcher_id,
+                            actual_root,
+                            spawned_at,
+                            cancel,
+                        );
+                    }
                 } else {
                     // insert 直後に外部から remove されるレース。watcher を起こす意味は無い。
                     tracing::debug!(
-                        "[terminal] session {watcher_id} disappeared before claude_watcher spawn"
+                        "[terminal] session {watcher_id} disappeared before session watcher spawn"
                     );
                 }
             }

--- a/src-tauri/src/commands/terminal_tabs.rs
+++ b/src-tauri/src/commands/terminal_tabs.rs
@@ -72,11 +72,15 @@ pub struct DroppedSessionInfo {
     pub kind: String,
     /// drop 理由。現状は transcript / rollout 不在を表す "transcript-missing" のみ。
     pub reason: String,
+    /// この tab が属する project root (= by_project の key)。Issue #859 review: renderer は
+    /// 現在開いている project の drop 件数だけを toast に出す必要があるため、全 project 横断の
+    /// 総数で誤った件数を表示しないよう project ごとに絞り込めるようにする。
+    pub project_root: String,
 }
 
 /// Issue #857: `terminal_tabs_load` の戻り値 contract。
 /// `PersistedTerminalTabsFile` を `#[serde(flatten)]` で展開しつつ `droppedSessions` を追加する。
-/// JSON 形: `{ schemaVersion, lastSavedAt, byProject, droppedSessions: [{tabId, kind, reason}] }`
+/// JSON 形: `{ schemaVersion, lastSavedAt, byProject, droppedSessions: [{tabId, kind, reason, projectRoot}] }`
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct TerminalTabsLoadResult {
@@ -136,43 +140,53 @@ fn claude_jsonl_path(home: &Path, cwd: &str, session_id: &str) -> PathBuf {
         .join(format!("{session_id}.jsonl"))
 }
 
-/// Issue #857: codex の rollout が `<sessions_root>` 配下に存在するか再帰走査で確認する。
-/// ファイル名 stem が `rollout-<ts>-<session_id>` (= prefix `rollout-` かつ `-<session_id>` で
-/// 終わる) の `.jsonl` を探す。見つかれば true。startup load 時のみ・最初の一致で early-exit
-/// するので再帰走査コストは許容する。
-fn codex_rollout_exists_sync(sessions_root: &Path, session_id: &str) -> bool {
-    fn walk(dir: &Path, suffix: &str) -> bool {
+/// Issue #857 / #859 (perf): `<sessions_root>` 配下の `rollout-*.jsonl` の file_stem を
+/// **1 回の再帰走査で** すべて集める。codex tab が複数あっても walk は 1 度だけにして、起動時
+/// sanitize の「tab ごとに full 再帰走査 = O(N×M)」を「O(M) walk + O(N×M) の in-memory 突合」
+/// に落とす。
+fn collect_codex_rollout_stems(sessions_root: &Path) -> Vec<String> {
+    fn walk(dir: &Path, out: &mut Vec<String>) {
         let read = match std::fs::read_dir(dir) {
             Ok(r) => r,
-            Err(_) => return false,
+            Err(_) => return,
         };
         for entry in read.flatten() {
             let path = entry.path();
             match entry.file_type() {
-                Ok(ft) if ft.is_dir() => {
-                    if walk(&path, suffix) {
-                        return true;
-                    }
-                }
+                Ok(ft) if ft.is_dir() => walk(&path, out),
                 Ok(_) => {
                     if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
                         continue;
                     }
                     if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                        if stem.starts_with("rollout-") && stem.ends_with(suffix) {
-                            return true;
+                        if stem.starts_with("rollout-") {
+                            out.push(stem.to_string());
                         }
                     }
                 }
                 _ => {}
             }
         }
-        false
     }
+    let mut out = Vec::new();
+    walk(sessions_root, &mut out);
+    out
+}
+
+/// 収集済み stem 群から session_id 一致 (stem 末尾が `-<session_id>` = `rollout-<ts>-<sid>`) を
+/// 判定する in-memory ヘルパー。空 id は常に false。
+fn codex_rollout_stem_matches(stems: &[String], session_id: &str) -> bool {
     if session_id.is_empty() {
         return false;
     }
-    walk(sessions_root, &format!("-{session_id}"))
+    let suffix = format!("-{session_id}");
+    stems.iter().any(|s| s.ends_with(&suffix))
+}
+
+/// 単発の存在確認 (主に test 用)。1 度 walk して suffix 一致を見る。
+#[cfg(test)]
+fn codex_rollout_exists_sync(sessions_root: &Path, session_id: &str) -> bool {
+    codex_rollout_stem_matches(&collect_codex_rollout_stems(sessions_root), session_id)
 }
 
 /// Issue #702 / #857: 復元データ内の sessionId を sanitize する。
@@ -197,7 +211,25 @@ async fn sanitize_missing_jsonl(
     codex_sessions_root: &Path,
 ) -> Vec<DroppedSessionInfo> {
     let mut dropped = Vec::new();
-    for slot in file.by_project.values_mut() {
+
+    // Issue #859 (perf): codex tab が 1 つでも存在するなら rollout stem を **1 回だけ** 収集する。
+    // 以前は tab ごとに full 再帰走査して O(N×M) だったが、1 回 walk + in-memory 突合に落とす。
+    // 再帰走査は blocking なので spawn_blocking で executor を塞がない。
+    let has_codex_session = file.by_project.values().any(|slot| {
+        slot.tabs
+            .iter()
+            .any(|t| t.kind == "codex" && t.session_id.is_some())
+    });
+    let codex_stems: Vec<String> = if has_codex_session {
+        let root = codex_sessions_root.to_path_buf();
+        tokio::task::spawn_blocking(move || collect_codex_rollout_stems(&root))
+            .await
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    for (project_root, slot) in file.by_project.iter_mut() {
         for tab in slot.tabs.iter_mut() {
             let Some(sid) = tab.session_id.as_deref() else {
                 continue;
@@ -207,16 +239,7 @@ async fn sanitize_missing_jsonl(
                     let path = claude_jsonl_path(home, &tab.cwd, sid);
                     fs::metadata(&path).await.is_err()
                 }
-                "codex" => {
-                    // 再帰走査は blocking。spawn_blocking で executor を塞がない。
-                    let root = codex_sessions_root.to_path_buf();
-                    let sid_owned = sid.to_string();
-                    !tokio::task::spawn_blocking(move || {
-                        codex_rollout_exists_sync(&root, &sid_owned)
-                    })
-                    .await
-                    .unwrap_or(false)
-                }
+                "codex" => !codex_rollout_stem_matches(&codex_stems, sid),
                 // 未知 kind は sanitize 対象外 (session_id 温存)。
                 _ => continue,
             };
@@ -232,6 +255,7 @@ async fn sanitize_missing_jsonl(
                     tab_id: tab.tab_id.clone(),
                     kind: tab.kind.clone(),
                     reason: "transcript-missing".to_string(),
+                    project_root: project_root.clone(),
                 });
                 tab.session_id = None;
             }
@@ -603,6 +627,7 @@ mod tests {
                 tab_id: "tab-1".to_string(),
                 kind: "codex".to_string(),
                 reason: "transcript-missing".to_string(),
+                project_root: "/tmp/proj".to_string(),
             }],
         };
         let json = serde_json::to_string(&result).unwrap();
@@ -613,9 +638,11 @@ mod tests {
         assert!(json.contains("\"droppedSessions\""));
         assert!(json.contains("\"tabId\":\"tab-1\""));
         assert!(json.contains("\"reason\":\"transcript-missing\""));
+        assert!(json.contains("\"projectRoot\":\"/tmp/proj\""));
         // snake_case が漏れていないこと
         assert!(!json.contains("dropped_sessions"));
         assert!(!json.contains("tab_id"));
+        assert!(!json.contains("project_root"));
 
         // round-trip
         let restored: TerminalTabsLoadResult = serde_json::from_str(&json).unwrap();

--- a/src-tauri/src/commands/terminal_tabs.rs
+++ b/src-tauri/src/commands/terminal_tabs.rs
@@ -63,6 +63,28 @@ impl Default for PersistedTerminalTabsFile {
     }
 }
 
+/// Issue #857: sanitize で drop した session の記録。renderer 側はこれを使って
+/// 「復元できなかった tab」をユーザーに通知する。
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DroppedSessionInfo {
+    pub tab_id: String,
+    pub kind: String,
+    /// drop 理由。現状は transcript / rollout 不在を表す "transcript-missing" のみ。
+    pub reason: String,
+}
+
+/// Issue #857: `terminal_tabs_load` の戻り値 contract。
+/// `PersistedTerminalTabsFile` を `#[serde(flatten)]` で展開しつつ `droppedSessions` を追加する。
+/// JSON 形: `{ schemaVersion, lastSavedAt, byProject, droppedSessions: [{tabId, kind, reason}] }`
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalTabsLoadResult {
+    #[serde(flatten)]
+    pub file: PersistedTerminalTabsFile,
+    pub dropped_sessions: Vec<DroppedSessionInfo>,
+}
+
 /// in-memory cache。`None` = 未ロード、`Some(...)` = ディスクと同期済み。
 static CACHE: once_cell::sync::Lazy<Mutex<Option<PersistedTerminalTabsFile>>> =
     once_cell::sync::Lazy::new(|| Mutex::new(None));
@@ -114,40 +136,108 @@ fn claude_jsonl_path(home: &Path, cwd: &str, session_id: &str) -> PathBuf {
         .join(format!("{session_id}.jsonl"))
 }
 
-/// Issue #702: 復元データ内の sessionId を sanitize する。
-/// `kind == "claude"` かつ jsonl 不在の sessionId を None に倒す。
+/// Issue #857: codex の rollout が `<sessions_root>` 配下に存在するか再帰走査で確認する。
+/// ファイル名 stem が `rollout-<ts>-<session_id>` (= prefix `rollout-` かつ `-<session_id>` で
+/// 終わる) の `.jsonl` を探す。見つかれば true。startup load 時のみ・最初の一致で early-exit
+/// するので再帰走査コストは許容する。
+fn codex_rollout_exists_sync(sessions_root: &Path, session_id: &str) -> bool {
+    fn walk(dir: &Path, suffix: &str) -> bool {
+        let read = match std::fs::read_dir(dir) {
+            Ok(r) => r,
+            Err(_) => return false,
+        };
+        for entry in read.flatten() {
+            let path = entry.path();
+            match entry.file_type() {
+                Ok(ft) if ft.is_dir() => {
+                    if walk(&path, suffix) {
+                        return true;
+                    }
+                }
+                Ok(_) => {
+                    if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+                        continue;
+                    }
+                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                        if stem.starts_with("rollout-") && stem.ends_with(suffix) {
+                            return true;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        false
+    }
+    if session_id.is_empty() {
+        return false;
+    }
+    walk(sessions_root, &format!("-{session_id}"))
+}
+
+/// Issue #702 / #857: 復元データ内の sessionId を sanitize する。
+/// transcript / rollout が存在しない sessionId を None に倒し、drop した tab を
+/// `Vec<DroppedSessionInfo>` (reason="transcript-missing") に収集して返す。
+///
+/// - `kind == "claude"`: `~/.claude/projects/<encoded(cwd)>/<sid>.jsonl` 不在で drop。
+/// - `kind == "codex"` (#857): `<codex_sessions_root>` 配下に `rollout-*-<sid>.jsonl` 不在で drop。
 ///
 /// 背景: PR #663 (Issue #660/#661/#662) で IDE モードの terminal タブを永続化したが、
-/// `terminal-tabs.json` に記録された sessionId に対応する jsonl が無いケースがある:
-///   - ユーザーが prompt を 1 件も送らずに閉じた → claude が jsonl を作らないまま終了
-///   - `~/.claude/projects/` を手動削除 / 別マシン環境移行 / Claude Code クリーンアップ
-///   - cwd が変わって encoded path が別ディレクトリを指す
+/// 記録された sessionId に対応する transcript が無いケースがある:
+///   - ユーザーが prompt を 1 件も送らずに閉じた → transcript が作られないまま終了
+///   - `~/.claude/projects/` や `~/.codex/sessions/` を手動削除 / 別マシン環境移行
+///   - cwd が変わって encoded path が別ディレクトリを指す (claude)
 ///
-/// このまま `--resume <存在しない uuid>` で起動すると claude CLI が
-/// `No conversation found with session ID: ...` を出して exitCode=1 で死ぬ。
-/// renderer 側 `use-terminal-tabs-persistence.ts` は sessionId が None なら resumeSessionId を
-/// 渡さず addTerminalTab を呼び、新規 UUID 採番 → `--session-id <new-uuid>` 経路に倒す。
-async fn sanitize_missing_jsonl(file: &mut PersistedTerminalTabsFile, home: &Path) {
+/// このまま `--resume <存在しない id>` で起動すると CLI が
+/// `No conversation found ...` を出して exitCode=1 で死ぬ。renderer 側は sessionId が None なら
+/// resume を渡さず新規 id 採番経路に倒す。`droppedSessions` は UI 通知用。
+async fn sanitize_missing_jsonl(
+    file: &mut PersistedTerminalTabsFile,
+    home: &Path,
+    codex_sessions_root: &Path,
+) -> Vec<DroppedSessionInfo> {
+    let mut dropped = Vec::new();
     for slot in file.by_project.values_mut() {
         for tab in slot.tabs.iter_mut() {
-            if tab.kind != "claude" {
-                continue;
-            }
             let Some(sid) = tab.session_id.as_deref() else {
                 continue;
             };
-            let path = claude_jsonl_path(home, &tab.cwd, sid);
-            if fs::metadata(&path).await.is_err() {
+            let missing = match tab.kind.as_str() {
+                "claude" => {
+                    let path = claude_jsonl_path(home, &tab.cwd, sid);
+                    fs::metadata(&path).await.is_err()
+                }
+                "codex" => {
+                    // 再帰走査は blocking。spawn_blocking で executor を塞がない。
+                    let root = codex_sessions_root.to_path_buf();
+                    let sid_owned = sid.to_string();
+                    !tokio::task::spawn_blocking(move || {
+                        codex_rollout_exists_sync(&root, &sid_owned)
+                    })
+                    .await
+                    .unwrap_or(false)
+                }
+                // 未知 kind は sanitize 対象外 (session_id 温存)。
+                _ => continue,
+            };
+            if missing {
                 tracing::info!(
-                    "[terminal_tabs] session jsonl missing for tab={} sid={} cwd={}, dropping sessionId",
+                    "[terminal_tabs] session transcript missing for tab={} kind={} sid={} cwd={}, dropping sessionId",
                     tab.tab_id,
+                    tab.kind,
                     sid,
                     tab.cwd
                 );
+                dropped.push(DroppedSessionInfo {
+                    tab_id: tab.tab_id.clone(),
+                    kind: tab.kind.clone(),
+                    reason: "transcript-missing".to_string(),
+                });
                 tab.session_id = None;
             }
         }
     }
+    dropped
 }
 
 async fn save_to_disk(file: &PersistedTerminalTabsFile) -> Result<(), String> {
@@ -165,13 +255,13 @@ async fn save_to_disk(file: &PersistedTerminalTabsFile) -> Result<(), String> {
 /// load: 永続化ファイルが空 / 未存在 / schemaVersion 不一致なら `None` 返却。
 /// renderer 側はこれで「素の IDE モード起動」と判定して順序復元をスキップする。
 ///
-/// Issue #702: 戻り値は `sanitize_missing_jsonl` で post-process し、jsonl 不在の
-/// sessionId を None に倒す。cache 自体には触らない (= 次回 load でも同じ check が走る、
-/// idempotent。renderer 側 save が走るまで disk 上の sessionId はそのまま温存され、
-/// 例えばユーザーが claude を直接起動して同じ sessionId の jsonl を作れば次回 load で
-/// 復活できる)。
+/// Issue #702 / #857: 戻り値は `sanitize_missing_jsonl` で post-process し、transcript 不在の
+/// sessionId を None に倒したうえで `droppedSessions` に drop 一覧を載せて返す。cache 自体には
+/// 触らない (= 次回 load でも同じ check が走る、idempotent。renderer 側 save が走るまで disk 上の
+/// sessionId はそのまま温存され、例えばユーザーが claude/codex を直接起動して同じ sessionId の
+/// transcript を作れば次回 load で復活できる)。
 #[tauri::command]
-pub async fn terminal_tabs_load() -> Option<PersistedTerminalTabsFile> {
+pub async fn terminal_tabs_load() -> Option<TerminalTabsLoadResult> {
     let _g = LOCK.lock().await;
     let mut cache = CACHE.lock().await;
     ensure_loaded(&mut cache).await;
@@ -181,8 +271,13 @@ pub async fn terminal_tabs_load() -> Option<PersistedTerminalTabsFile> {
     }
     let mut sanitized = file.clone();
     let home = dirs::home_dir().unwrap_or_default();
-    sanitize_missing_jsonl(&mut sanitized, &home).await;
-    Some(sanitized)
+    let codex_sessions_root = crate::pty::codex_watcher::codex_sessions_dir();
+    let dropped_sessions =
+        sanitize_missing_jsonl(&mut sanitized, &home, &codex_sessions_root).await;
+    Some(TerminalTabsLoadResult {
+        file: sanitized,
+        dropped_sessions,
+    })
 }
 
 /// save: renderer から渡された全体を atomic 上書き。
@@ -368,6 +463,23 @@ mod tests {
         std::fs::write(dir.join(format!("{sid}.jsonl")), "{}\n").expect("write jsonl");
     }
 
+    /// テスト用の codex sessions root (`<base>/.codex/sessions`)。本番の
+    /// `codex_watcher::codex_sessions_dir()` と同じレイアウトを temp 配下に再現する。
+    fn codex_sessions_root_in(base: &Path) -> PathBuf {
+        base.join(".codex").join("sessions")
+    }
+
+    /// 日付サブディレクトリ配下に `rollout-<ts>-<sid>.jsonl` を作る。
+    fn write_codex_rollout(sessions_root: &Path, sid: &str) {
+        let day = sessions_root.join("2026").join("05").join("31");
+        std::fs::create_dir_all(&day).expect("create codex day dir");
+        std::fs::write(
+            day.join(format!("rollout-2026-05-31T00-00-00-{sid}.jsonl")),
+            "{\"type\":\"session_meta\"}\n",
+        )
+        .expect("write codex rollout");
+    }
+
     #[tokio::test]
     async fn sanitize_drops_session_id_when_jsonl_missing() {
         let tmp = unique_temp_dir("terminal-tabs-sanitize-missing");
@@ -375,11 +487,15 @@ mod tests {
         let sid = "11111111-2222-3333-4444-555555555555";
         // jsonl は意図的に作らない
         let mut file = make_file_with_tab("claude", cwd, Some(sid));
-        sanitize_missing_jsonl(&mut file, &tmp).await;
+        let dropped = sanitize_missing_jsonl(&mut file, &tmp, &codex_sessions_root_in(&tmp)).await;
         assert!(
             file.by_project[cwd].tabs[0].session_id.is_none(),
             "missing jsonl should drop sessionId"
         );
+        assert_eq!(dropped.len(), 1, "dropped session should be recorded");
+        assert_eq!(dropped[0].tab_id, "1");
+        assert_eq!(dropped[0].kind, "claude");
+        assert_eq!(dropped[0].reason, "transcript-missing");
         let _ = std::fs::remove_dir_all(tmp);
     }
 
@@ -391,28 +507,55 @@ mod tests {
         write_jsonl(&tmp, cwd, sid);
 
         let mut file = make_file_with_tab("claude", cwd, Some(sid));
-        sanitize_missing_jsonl(&mut file, &tmp).await;
+        let dropped = sanitize_missing_jsonl(&mut file, &tmp, &codex_sessions_root_in(&tmp)).await;
         assert_eq!(
             file.by_project[cwd].tabs[0].session_id.as_deref(),
             Some(sid),
             "existing jsonl should keep sessionId"
         );
+        assert!(dropped.is_empty(), "no drop when jsonl exists");
         let _ = std::fs::remove_dir_all(tmp);
     }
 
+    /// Issue #857: codex tab の rollout が存在すれば sessionId は維持される。
+    /// (旧 `sanitize_skips_non_claude_tabs` の置き換え — codex は skip ではなく rollout 検証対象)
     #[tokio::test]
-    async fn sanitize_skips_non_claude_tabs() {
-        let tmp = unique_temp_dir("terminal-tabs-sanitize-codex");
+    async fn sanitize_keeps_codex_session_id_when_rollout_exists() {
+        let tmp = unique_temp_dir("terminal-tabs-sanitize-codex-exists");
         let cwd = "/tmp/repo-codex";
-        let sid = "yyy-codex-id";
-        // codex は jsonl を作らないので存在チェック対象外。session_id は維持されるべき。
+        let sid = "cccccccc-dddd-eeee-ffff-000000000000";
+        let codex_root = codex_sessions_root_in(&tmp);
+        write_codex_rollout(&codex_root, sid);
+
         let mut file = make_file_with_tab("codex", cwd, Some(sid));
-        sanitize_missing_jsonl(&mut file, &tmp).await;
+        let dropped = sanitize_missing_jsonl(&mut file, &tmp, &codex_root).await;
         assert_eq!(
             file.by_project[cwd].tabs[0].session_id.as_deref(),
             Some(sid),
-            "non-claude kind should skip jsonl check"
+            "codex sessionId kept when rollout exists"
         );
+        assert!(dropped.is_empty(), "no drop when rollout exists");
+        let _ = std::fs::remove_dir_all(tmp);
+    }
+
+    /// Issue #857: codex tab の rollout が不在なら sessionId を drop し記録する。
+    #[tokio::test]
+    async fn sanitize_drops_codex_session_id_when_rollout_missing() {
+        let tmp = unique_temp_dir("terminal-tabs-sanitize-codex-missing");
+        let cwd = "/tmp/repo-codex-missing";
+        let sid = "deadbeef-dddd-eeee-ffff-000000000000";
+        // rollout は意図的に作らない (codex sessions root も存在しない)
+        let codex_root = codex_sessions_root_in(&tmp);
+
+        let mut file = make_file_with_tab("codex", cwd, Some(sid));
+        let dropped = sanitize_missing_jsonl(&mut file, &tmp, &codex_root).await;
+        assert!(
+            file.by_project[cwd].tabs[0].session_id.is_none(),
+            "missing codex rollout should drop sessionId"
+        );
+        assert_eq!(dropped.len(), 1);
+        assert_eq!(dropped[0].kind, "codex");
+        assert_eq!(dropped[0].reason, "transcript-missing");
         let _ = std::fs::remove_dir_all(tmp);
     }
 
@@ -421,9 +564,64 @@ mod tests {
         let tmp = unique_temp_dir("terminal-tabs-sanitize-null");
         let cwd = "/tmp/repo-null";
         let mut file = make_file_with_tab("claude", cwd, None);
-        sanitize_missing_jsonl(&mut file, &tmp).await;
+        let dropped = sanitize_missing_jsonl(&mut file, &tmp, &codex_sessions_root_in(&tmp)).await;
         assert!(file.by_project[cwd].tabs[0].session_id.is_none());
+        assert!(dropped.is_empty());
         let _ = std::fs::remove_dir_all(tmp);
+    }
+
+    /// `codex_rollout_exists_sync` の最小単体: stem 末尾が `-<sid>` の rollout を見つける/弾く。
+    #[test]
+    fn codex_rollout_exists_matches_by_session_id_suffix() {
+        let tmp = unique_temp_dir("terminal-tabs-codex-rollout-lookup");
+        let root = codex_sessions_root_in(&tmp);
+        let sid = "11112222-3333-4444-5555-666677778888";
+        write_codex_rollout(&root, sid);
+
+        assert!(codex_rollout_exists_sync(&root, sid), "should find rollout by sid suffix");
+        assert!(
+            !codex_rollout_exists_sync(&root, "no-such-id"),
+            "unknown sid must not match"
+        );
+        assert!(
+            !codex_rollout_exists_sync(&root, ""),
+            "empty sid never matches"
+        );
+        let _ = std::fs::remove_dir_all(tmp);
+    }
+
+    /// Issue #857: 戻り値 contract (camelCase + droppedSessions) を固定する。
+    #[test]
+    fn load_result_serializes_to_expected_camelcase_contract() {
+        let result = TerminalTabsLoadResult {
+            file: PersistedTerminalTabsFile {
+                schema_version: TERMINAL_TABS_SCHEMA_VERSION,
+                last_saved_at: "2026-05-31T00:00:00Z".to_string(),
+                by_project: HashMap::new(),
+            },
+            dropped_sessions: vec![DroppedSessionInfo {
+                tab_id: "tab-1".to_string(),
+                kind: "codex".to_string(),
+                reason: "transcript-missing".to_string(),
+            }],
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        // flatten で従来フィールドはそのまま + droppedSessions 追加
+        assert!(json.contains("\"schemaVersion\""));
+        assert!(json.contains("\"lastSavedAt\""));
+        assert!(json.contains("\"byProject\""));
+        assert!(json.contains("\"droppedSessions\""));
+        assert!(json.contains("\"tabId\":\"tab-1\""));
+        assert!(json.contains("\"reason\":\"transcript-missing\""));
+        // snake_case が漏れていないこと
+        assert!(!json.contains("dropped_sessions"));
+        assert!(!json.contains("tab_id"));
+
+        // round-trip
+        let restored: TerminalTabsLoadResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.dropped_sessions.len(), 1);
+        assert_eq!(restored.dropped_sessions[0].tab_id, "tab-1");
+        assert_eq!(restored.file.schema_version, TERMINAL_TABS_SCHEMA_VERSION);
     }
 
     #[tokio::test]
@@ -472,11 +670,13 @@ mod tests {
             last_saved_at: "2026-05-10T00:00:00Z".to_string(),
             by_project,
         };
-        sanitize_missing_jsonl(&mut file, &tmp).await;
+        let dropped = sanitize_missing_jsonl(&mut file, &tmp, &codex_sessions_root_in(&tmp)).await;
 
         let tabs = &file.by_project[cwd].tabs;
         assert_eq!(tabs[0].session_id.as_deref(), Some(sid_alive), "alive sid kept");
         assert!(tabs[1].session_id.is_none(), "dead sid dropped");
+        assert_eq!(dropped.len(), 1, "only the dead tab is recorded");
+        assert_eq!(dropped[0].tab_id, "2");
 
         let _ = std::fs::remove_dir_all(tmp);
     }

--- a/src-tauri/src/pty/codex_watcher.rs
+++ b/src-tauri/src/pty/codex_watcher.rs
@@ -1,0 +1,562 @@
+// Codex セッション ID 検出 watcher — Issue #855
+//
+// claude_watcher.rs の Codex 版。Codex CLI (codex 0.130.0 系) が出力する
+// rollout ファイルを後追いで監視し、session id を `terminal:sessionId:{terminal_id}`
+// event として renderer に届ける。
+//
+// Codex 実機事実 (codex 0.130.0):
+//   - session は `~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<UUID>.jsonl` に保存される。
+//     (claude のような project ごとの encoded ディレクトリは無く、日付サブディレクトリ配下)
+//   - rollout の 1 行目は
+//       {"timestamp":...,"type":"session_meta","payload":{"id":"<UUID>","timestamp":...,
+//        "cwd":"<cwd>","originator":...}}
+//   - `payload.id` がファイル名末尾の UUID と一致し、これが Codex の session id。
+//   - `payload.cwd` が codex 起動時の cwd。
+//
+// claude_watcher との差分:
+//   1. 監視 dir は `~/.codex/sessions/` 固定 (CODEX_HOME があればそちら)。日付サブディレクトリ
+//      に新ファイルが現れるため `RecursiveMode::Recursive` で監視する。
+//   2. 候補ファイルは `rollout-*.jsonl` (ファイル名 prefix `rollout-` / 拡張子 `.jsonl`)。
+//   3. session id は **ファイル名ではなく 1 行目 JSON の `session_meta.payload.id`** から読む。
+//      1 行目が session_meta でなければ skip (= 堅牢かつ fail-closed)。
+//   4. cwd 一致判定は `payload.cwd` を `normalize_project_root` した値が、watcher 起動時に
+//      渡された project_root の正規化値と一致した場合のみ採用 (claude の jsonl_matches_project
+//      相当)。読めない / 空 / 不一致は fail-closed で claim させない。
+//   5. claim 機構 (CODEX_CLAIMED_SESSIONS) は claude の sessionId 空間と衝突しないよう
+//      **codex 専用 static** を持つ。
+//
+// spawn_watcher のシグネチャ・deadline(60s)・poll(100ms)・cancel(AtomicBool) 設計は
+// claude_watcher と完全に揃えてある。
+
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use once_cell::sync::Lazy;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::channel;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
+use tauri::{AppHandle, Emitter};
+
+/// session が kill された瞬間に `watcher_cancel` を観測して exit できる polling 間隔。
+/// claude_watcher と同値 (100ms)。
+const WATCHER_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// session 起動から rollout 検出を諦めるまでの最大時間 (= hard deadline)。
+/// claude_watcher と同値 (60 秒)。
+const WATCHER_MAX_LIFETIME: Duration = Duration::from_secs(60);
+
+/// claim 済み codex session id の集合 (id → claimed_at)。
+/// claude の CLAIMED_SESSIONS とは **別 static**。UUID 空間は別だが、万一の衝突や
+/// claude 側 claim による誤排他を避けるため codex 専用に分離する。
+static CODEX_CLAIMED_SESSIONS: Lazy<Mutex<HashMap<String, Instant>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+const CLAIM_TTL_SECS: u64 = 60 * 60; // 1 時間 (claude と同値)
+
+fn evict_expired(map: &mut HashMap<String, Instant>) {
+    let cutoff = Duration::from_secs(CLAIM_TTL_SECS);
+    map.retain(|_, t| t.elapsed() < cutoff);
+}
+
+fn try_claim(session_id: &str) -> bool {
+    let mut guard = match CODEX_CLAIMED_SESSIONS.lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    evict_expired(&mut guard);
+    if guard.contains_key(session_id) {
+        return false;
+    }
+    guard.insert(session_id.to_string(), Instant::now());
+    true
+}
+
+fn is_claimed(session_id: &str) -> bool {
+    let mut guard = match CODEX_CLAIMED_SESSIONS.lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    evict_expired(&mut guard);
+    guard.contains_key(session_id)
+}
+
+/// 監視対象の codex sessions ディレクトリを返す。
+/// `CODEX_HOME` env があれば `<CODEX_HOME>/sessions`、無ければ `~/.codex/sessions`。
+/// terminal_tabs.rs の codex sanitize もこの関数を共有する (SSOT)。
+pub fn codex_sessions_dir() -> PathBuf {
+    if let Ok(home) = std::env::var("CODEX_HOME") {
+        let trimmed = home.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed).join("sessions");
+        }
+    }
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".codex")
+        .join("sessions")
+}
+
+/// `rollout-<ts>-<uuid>.jsonl` 形式のファイルか判定する。
+/// ファイル名 prefix が `rollout-` かつ拡張子が `.jsonl`。
+fn is_rollout_file(path: &Path) -> bool {
+    if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+        return false;
+    }
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .map(|name| name.starts_with("rollout-"))
+        .unwrap_or(false)
+}
+
+/// `~/.codex/sessions/` を再帰走査して rollout ファイルの絶対パスを集める。
+/// (日付サブディレクトリ YYYY/MM/DD 配下に置かれるため再帰が必須)
+fn collect_rollout_paths(dir: &Path, out: &mut Vec<PathBuf>) {
+    let read = match std::fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    for entry in read.flatten() {
+        let path = entry.path();
+        match entry.file_type() {
+            Ok(ft) if ft.is_dir() => collect_rollout_paths(&path, out),
+            Ok(_) if is_rollout_file(&path) => out.push(path),
+            _ => {}
+        }
+    }
+}
+
+/// watcher 起動時点ですでに rollout が作られている race を救済するため、
+/// spawn 開始 (`since`) 以降に更新された rollout を mtime 昇順で返す
+/// (claude の list_recent_session_candidates 相当)。
+fn list_recent_rollout_candidates(dir: &Path, since: SystemTime) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    collect_rollout_paths(dir, &mut paths);
+    let mut recent: Vec<(PathBuf, SystemTime)> = paths
+        .into_iter()
+        .filter_map(|p| {
+            let modified = std::fs::metadata(&p).ok()?.modified().ok()?;
+            if modified >= since {
+                Some((p, modified))
+            } else {
+                None
+            }
+        })
+        .collect();
+    recent.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+    recent.into_iter().map(|(p, _)| p).collect()
+}
+
+/// rollout の 1 行目から `(session_id, cwd)` を抽出する。
+///
+/// 戻り値:
+///   - `Some((id, cwd))`: 1 行目が完全に読めて `type == "session_meta"` かつ `payload.id`
+///     が非空。cwd は欠落時 "" (上位で fail-closed 判定する)。
+///   - `None`: ファイルが開けない / 空 / 1 行目が JSON として未完 (partial write) /
+///     session_meta でない / id 欠落。**未完ケースを `None` に倒すことで上位は recheck できる**。
+fn read_codex_session_meta(path: &Path) -> Option<(String, String)> {
+    use std::io::{BufRead, BufReader};
+    let file = std::fs::File::open(path).ok()?;
+    let mut reader = BufReader::new(file);
+    let mut first = String::new();
+    // 1 行目だけ読む。改行未到達 (partial write) でも read_line は EOF までの断片を返すため、
+    // 断片 JSON は serde の parse 失敗で None に倒れ、上位が次イベントで recheck する。
+    if reader.read_line(&mut first).ok()? == 0 {
+        return None; // 空ファイル
+    }
+    let v: serde_json::Value = serde_json::from_str(first.trim()).ok()?;
+    if v.get("type").and_then(|t| t.as_str()) != Some("session_meta") {
+        return None;
+    }
+    let payload = v.get("payload")?;
+    let id = payload.get("id").and_then(|i| i.as_str())?.to_string();
+    if id.is_empty() {
+        return None;
+    }
+    let cwd = payload
+        .get("cwd")
+        .and_then(|c| c.as_str())
+        .unwrap_or("")
+        .to_string();
+    Some((id, cwd))
+}
+
+/// 1 候補 rollout を処理した結果。
+enum CandidateOutcome {
+    /// claim + emit に成功 → watcher は return すべき。
+    Emitted,
+    /// 確定的に解決済み (cwd 不一致 / 他 watcher が claim 済み / claim 競合敗北 / emit 失敗)
+    /// → seen に入れて再走査しない。
+    Consumed,
+    /// 1 行目がまだ読めない (partial write) → seen に入れず次イベントで再 check。
+    Retry,
+}
+
+fn emit_session_id(app: &AppHandle, terminal_id: &str, session_id: &str) -> bool {
+    let event_name = format!("terminal:sessionId:{terminal_id}");
+    if let Err(e) = app.emit(&event_name, session_id.to_string()) {
+        tracing::warn!("[codex_watcher] emit failed: {e}");
+        false
+    } else {
+        tracing::info!(
+            "[codex_watcher] sessionId detected tid={} sid={}",
+            terminal_id,
+            session_id
+        );
+        true
+    }
+}
+
+/// 1 つの rollout 候補を評価し、cwd 一致 + 未 claim なら claim → emit する。
+fn process_candidate(
+    app: &AppHandle,
+    terminal_id: &str,
+    path: &Path,
+    expected_norm: &str,
+) -> CandidateOutcome {
+    let Some((id, cwd)) = read_codex_session_meta(path) else {
+        // 1 行目未確定 (partial write) / session_meta でない → 再 check 余地を残す。
+        return CandidateOutcome::Retry;
+    };
+    if is_claimed(&id) {
+        return CandidateOutcome::Consumed;
+    }
+    // cwd 一致判定 (fail-closed: 空 / 不一致は採用しない)
+    let cwd_norm = super::path_norm::normalize_project_root(cwd.trim());
+    if cwd_norm.is_empty() || cwd_norm != expected_norm {
+        tracing::debug!(
+            "[codex_watcher] skip {} (cwd mismatch: {:?})",
+            id,
+            cwd
+        );
+        return CandidateOutcome::Consumed;
+    }
+    if !try_claim(&id) {
+        // is_claimed と try_claim の間で他 watcher が先に占有した競合。
+        return CandidateOutcome::Consumed;
+    }
+    if emit_session_id(app, terminal_id, &id) {
+        CandidateOutcome::Emitted
+    } else {
+        // emit 失敗。既に claim 済みなので二重 emit を避けるため Consumed 扱い。
+        CandidateOutcome::Consumed
+    }
+}
+
+/// 1 つの terminal セッションに対して codex rollout watch を開始する。
+///
+/// シグネチャ・cancel(AtomicBool)・deadline(60s)・poll(100ms) は claude_watcher と完全に揃える。
+/// 検出した sessionId は `terminal:sessionId:{terminal_id}` event で 1 回だけ emit される
+/// (claim 機構で multi-watcher 競合は排他)。
+pub fn spawn_watcher(
+    app: AppHandle,
+    terminal_id: String,
+    project_root: String,
+    spawned_at: SystemTime,
+    watcher_cancel: Arc<AtomicBool>,
+) {
+    std::thread::spawn(move || {
+        run_watcher_loop(app, terminal_id, project_root, spawned_at, watcher_cancel)
+    });
+}
+
+/// watcher 本体ループ。テストからの呼び出し利便のため関数として切り出す。
+fn run_watcher_loop(
+    app: AppHandle,
+    terminal_id: String,
+    project_root: String,
+    spawned_at: SystemTime,
+    watcher_cancel: Arc<AtomicBool>,
+) {
+    let is_cancelled = || watcher_cancel.load(Ordering::Acquire);
+
+    let dir = codex_sessions_dir();
+    // ディレクトリが無い場合も codex が起動後に作るので、最大 5 秒待機。
+    // この phase でも `watcher_cancel` を 100ms ごとに観測して即時 exit する。
+    let mut waits = 0;
+    while !dir.exists() && waits < 50 {
+        std::thread::sleep(WATCHER_POLL_INTERVAL);
+        waits += 1;
+        if is_cancelled() {
+            tracing::debug!(
+                "[codex_watcher] tid={} cancelled while waiting for sessions dir",
+                terminal_id
+            );
+            return;
+        }
+    }
+    if !dir.exists() {
+        tracing::debug!("[codex_watcher] {} not appearing, giving up", dir.display());
+        return;
+    }
+
+    let expected_norm = super::path_norm::normalize_project_root(&project_root);
+
+    // 初期 snapshot: 既存の rollout はすべて「この spawn 以前のもの」として除外対象 (seen)。
+    let mut seen: HashSet<PathBuf> = HashSet::new();
+    {
+        let mut snap = Vec::new();
+        collect_rollout_paths(&dir, &mut snap);
+        for p in snap {
+            seen.insert(p);
+        }
+    }
+    tracing::debug!(
+        "[codex_watcher] tid={} dir={} initial={} entries",
+        terminal_id,
+        dir.display(),
+        seen.len()
+    );
+
+    // codex が watcher 起動より速く rollout を作った race を救済する。
+    // spawn 開始以降に更新された rollout は seen 済みでも 1 度だけ評価する。
+    for path in list_recent_rollout_candidates(&dir, spawned_at) {
+        match process_candidate(&app, &terminal_id, &path, &expected_norm) {
+            CandidateOutcome::Emitted => return,
+            CandidateOutcome::Consumed => {} // seen に既に含まれる
+            CandidateOutcome::Retry => {
+                // 1 行目未確定 → seen から外して event loop で再 check させる。
+                seen.remove(&path);
+            }
+        }
+    }
+
+    let (tx, rx) = channel::<notify::Result<Event>>();
+    let mut watcher = match RecommendedWatcher::new(
+        move |res: notify::Result<Event>| {
+            let _ = tx.send(res);
+        },
+        Config::default().with_poll_interval(Duration::from_millis(500)),
+    ) {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!("[codex_watcher] watcher init failed: {e}");
+            return;
+        }
+    };
+    // 日付サブディレクトリ (YYYY/MM/DD) に新ファイルが出るため Recursive で監視する。
+    if let Err(e) = watcher.watch(&dir, RecursiveMode::Recursive) {
+        tracing::warn!("[codex_watcher] watch failed: {e}");
+        return;
+    }
+
+    let watcher_started_at = Instant::now();
+    while watcher_started_at.elapsed() < WATCHER_MAX_LIFETIME {
+        if is_cancelled() {
+            tracing::debug!(
+                "[codex_watcher] tid={} cancelled by session — exiting watcher",
+                terminal_id
+            );
+            return;
+        }
+        match rx.recv_timeout(WATCHER_POLL_INTERVAL) {
+            Ok(Ok(event)) => {
+                if !matches!(event.kind, EventKind::Create(_) | EventKind::Modify(_)) {
+                    continue;
+                }
+                let mut current = Vec::new();
+                collect_rollout_paths(&dir, &mut current);
+                // パス順を安定化 (どの watcher が先に claim してもデテルミニスティックに)。
+                current.sort();
+                for path in current {
+                    if seen.contains(&path) {
+                        continue;
+                    }
+                    match process_candidate(&app, &terminal_id, &path, &expected_norm) {
+                        CandidateOutcome::Emitted => return,
+                        CandidateOutcome::Consumed => {
+                            seen.insert(path);
+                        }
+                        CandidateOutcome::Retry => {
+                            // 1 行目がまだ書かれていない → seen に入れず次イベントで再 check。
+                        }
+                    }
+                }
+            }
+            Ok(Err(_)) | Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(_) => break,
+        }
+    }
+    tracing::debug!(
+        "[codex_watcher] tid={} watcher exit (deadline / cancelled / channel closed)",
+        terminal_id
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("vibe-editor-{name}-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn session_meta_line(id: &str, cwd: &str) -> String {
+        // 実機 rollout の 1 行目を模す (timestamp / originator は任意フィールド)。
+        format!(
+            r#"{{"timestamp":"2026-05-31T00:00:00Z","type":"session_meta","payload":{{"id":"{id}","timestamp":"2026-05-31T00:00:00Z","cwd":"{cwd}","originator":"codex_cli_rs"}}}}"#
+        )
+    }
+
+    fn write_rollout(dir: &Path, ts: &str, id: &str, first_line: &str) -> PathBuf {
+        // YYYY/MM/DD サブディレクトリを模す。
+        let day_dir = dir.join("2026").join("05").join("31");
+        fs::create_dir_all(&day_dir).expect("create day dir");
+        let path = day_dir.join(format!("rollout-{ts}-{id}.jsonl"));
+        fs::write(&path, format!("{first_line}\n")).expect("write rollout");
+        path
+    }
+
+    /// session_meta 1 行目から id (と cwd) を抽出できること。
+    #[test]
+    fn reads_session_id_from_session_meta_first_line() {
+        let dir = unique_temp_dir("codex-watcher-read-id");
+        let id = "11111111-2222-3333-4444-555555555555";
+        let cwd = "/tmp/repo";
+        let path = write_rollout(&dir, "2026-05-31T00-00-00", id, &session_meta_line(id, cwd));
+
+        let meta = read_codex_session_meta(&path);
+        assert_eq!(meta, Some((id.to_string(), cwd.to_string())));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    /// 1 行目が session_meta でなければ None (= skip) になること。
+    #[test]
+    fn rejects_first_line_that_is_not_session_meta() {
+        let dir = unique_temp_dir("codex-watcher-not-meta");
+        let id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        // type が event_msg の行 (session_meta でない)
+        let line = r#"{"timestamp":"2026-05-31T00:00:00Z","type":"event_msg","payload":{"foo":"bar"}}"#;
+        let path = write_rollout(&dir, "2026-05-31T00-00-00", id, line);
+
+        assert!(
+            read_codex_session_meta(&path).is_none(),
+            "non session_meta first line must be skipped"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    /// 空ファイル / partial write は None に倒れること (上位で recheck できる)。
+    #[test]
+    fn returns_none_for_empty_or_partial_first_line() {
+        let dir = unique_temp_dir("codex-watcher-partial");
+        let day_dir = dir.join("2026").join("05").join("31");
+        fs::create_dir_all(&day_dir).expect("create day dir");
+
+        // 空ファイル
+        let empty = day_dir.join("rollout-ts-empty.jsonl");
+        fs::write(&empty, "").expect("write empty");
+        assert!(read_codex_session_meta(&empty).is_none());
+
+        // partial JSON (改行未到達・閉じ括弧無し)
+        let partial = day_dir.join("rollout-ts-partial.jsonl");
+        fs::write(&partial, r#"{"timestamp":"x","type":"session_me"#).expect("write partial");
+        assert!(read_codex_session_meta(&partial).is_none());
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    /// cwd 不一致を弾くこと (fail-closed)。一致時のみ採用。
+    #[test]
+    fn rejects_cwd_mismatch_and_accepts_match() {
+        let id = "cccccccc-dddd-eeee-ffff-000000000000";
+        let cwd = "/tmp/project-a";
+        // codex 起動 cwd と watcher の project_root が異なるケース
+        let expected_other = super::super::path_norm::normalize_project_root("/tmp/project-b");
+        assert_ne!(
+            super::super::path_norm::normalize_project_root(cwd),
+            expected_other,
+            "mismatch cwd must not normalize-equal to a different root"
+        );
+        // 同一なら一致する (正規化往復)
+        let expected_same = super::super::path_norm::normalize_project_root(cwd);
+        assert_eq!(super::super::path_norm::normalize_project_root(cwd), expected_same);
+
+        // session_meta の cwd が確かに抽出され、normalize 比較で弾けることを end-to-end で確認。
+        let dir = unique_temp_dir("codex-watcher-cwd");
+        let path = write_rollout(&dir, "2026-05-31T00-00-00", id, &session_meta_line(id, cwd));
+        let (got_id, got_cwd) = read_codex_session_meta(&path).expect("meta");
+        assert_eq!(got_id, id);
+        assert_ne!(
+            super::super::path_norm::normalize_project_root(got_cwd.trim()),
+            expected_other
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    /// rollout-*.jsonl 以外を無視すること。
+    #[test]
+    fn is_rollout_file_only_matches_rollout_jsonl() {
+        let base = Path::new("/x/2026/05/31");
+        assert!(is_rollout_file(&base.join("rollout-2026-05-31T00-00-00-uuid.jsonl")));
+        // prefix 違い
+        assert!(!is_rollout_file(&base.join("session-uuid.jsonl")));
+        // 拡張子違い
+        assert!(!is_rollout_file(&base.join("rollout-uuid.txt")));
+        assert!(!is_rollout_file(&base.join("rollout-uuid.json")));
+        // prefix も拡張子も違う
+        assert!(!is_rollout_file(&base.join("notes.md")));
+    }
+
+    /// 再帰走査が日付サブディレクトリ配下の rollout のみ拾うこと。
+    #[test]
+    fn collect_rollout_paths_recurses_and_filters() {
+        let dir = unique_temp_dir("codex-watcher-collect");
+        let id = "dddddddd-eeee-ffff-0000-111111111111";
+        let rollout = write_rollout(&dir, "2026-05-31T00-00-00", id, &session_meta_line(id, "/tmp/r"));
+        // 無関係ファイルを同階層に置く
+        let day_dir = dir.join("2026").join("05").join("31");
+        fs::write(day_dir.join("ignore.txt"), "x").expect("write ignore");
+        fs::write(day_dir.join("history.jsonl"), "x").expect("write non-rollout jsonl");
+
+        let mut out = Vec::new();
+        collect_rollout_paths(&dir, &mut out);
+        assert_eq!(out, vec![rollout]);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    /// recent 候補が since 以降に更新された rollout のみを返すこと。
+    #[test]
+    fn recent_candidates_filter_by_mtime() {
+        let dir = unique_temp_dir("codex-watcher-recent");
+        let old_id = "00000000-0000-0000-0000-000000000001";
+        write_rollout(&dir, "old", old_id, &session_meta_line(old_id, "/tmp/r"));
+
+        std::thread::sleep(Duration::from_millis(20));
+        let since = SystemTime::now();
+        std::thread::sleep(Duration::from_millis(20));
+
+        let new_id = "00000000-0000-0000-0000-000000000002";
+        let new_path = write_rollout(&dir, "new", new_id, &session_meta_line(new_id, "/tmp/r"));
+
+        let recent = list_recent_rollout_candidates(&dir, since);
+        assert_eq!(recent, vec![new_path]);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    /// claim 機構: 同 id は 1 回しか claim できないこと (multi-watcher 排他)。
+    #[test]
+    fn claim_is_exclusive_per_session_id() {
+        let id = format!("claim-test-{}", uuid::Uuid::new_v4());
+        assert!(!is_claimed(&id));
+        assert!(try_claim(&id), "first claim succeeds");
+        assert!(is_claimed(&id));
+        assert!(!try_claim(&id), "second claim fails");
+    }
+
+    /// poll interval が 500ms (legacy) より十分短く、busy-loop でないこと。
+    #[test]
+    fn watcher_poll_interval_is_bounded() {
+        assert!(WATCHER_POLL_INTERVAL <= Duration::from_millis(200));
+        assert!(WATCHER_POLL_INTERVAL >= Duration::from_millis(10));
+    }
+
+    /// deadline は 30 秒以上維持されること (codex 起動が遅い環境での検出漏れ防止)。
+    #[test]
+    fn watcher_max_lifetime_is_at_least_30_seconds() {
+        assert!(WATCHER_MAX_LIFETIME >= Duration::from_secs(30));
+    }
+}

--- a/src-tauri/src/pty/codex_watcher.rs
+++ b/src-tauri/src/pty/codex_watcher.rs
@@ -340,7 +340,14 @@ fn run_watcher_loop(
         return;
     }
 
+    // Windows の native backend (ReadDirectoryChangesW) は notify の `with_poll_interval` を
+    // 無視するため、イベント取りこぼし (特に watch 開始後に新規作成される YYYY/MM/DD サブ
+    // ディレクトリ配下の rollout 作成) を救う polling fallback が存在しない。そこで event 到着時
+    // に加えて最低 1 秒ごとに full rescan を回し、取りこぼしを構造的に補償する。`seen` で dedup
+    // 済みなので二重処理は起きず、rescan を 1s に throttle することで walk コストも抑える。
+    // (fs_watch.rs が同じ Windows 事情で Recursive を避けて手動展開しているのと同趣旨の保険)
     let watcher_started_at = Instant::now();
+    let mut last_full_scan = watcher_started_at;
     while watcher_started_at.elapsed() < WATCHER_MAX_LIFETIME {
         if is_cancelled() {
             tracing::debug!(
@@ -349,32 +356,35 @@ fn run_watcher_loop(
             );
             return;
         }
-        match rx.recv_timeout(WATCHER_POLL_INTERVAL) {
-            Ok(Ok(event)) => {
-                if !matches!(event.kind, EventKind::Create(_) | EventKind::Modify(_)) {
-                    continue;
+        // poll interval 単位で待ちつつ event の有無を見る。channel 切断時のみ break。
+        let got_event = match rx.recv_timeout(WATCHER_POLL_INTERVAL) {
+            Ok(Ok(event)) => matches!(event.kind, EventKind::Create(_) | EventKind::Modify(_)),
+            Ok(Err(_)) => false,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => false,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        };
+        // event 到着、または前回 full rescan から 1 秒以上経過したときだけ走査する。
+        if !got_event && last_full_scan.elapsed() < Duration::from_secs(1) {
+            continue;
+        }
+        last_full_scan = Instant::now();
+        let mut current = Vec::new();
+        collect_rollout_paths(&dir, &mut current);
+        // パス順を安定化 (どの watcher が先に claim してもデテルミニスティックに)。
+        current.sort();
+        for path in current {
+            if seen.contains(&path) {
+                continue;
+            }
+            match process_candidate(&app, &terminal_id, &path, &expected_norm) {
+                CandidateOutcome::Emitted => return,
+                CandidateOutcome::Consumed => {
+                    seen.insert(path);
                 }
-                let mut current = Vec::new();
-                collect_rollout_paths(&dir, &mut current);
-                // パス順を安定化 (どの watcher が先に claim してもデテルミニスティックに)。
-                current.sort();
-                for path in current {
-                    if seen.contains(&path) {
-                        continue;
-                    }
-                    match process_candidate(&app, &terminal_id, &path, &expected_norm) {
-                        CandidateOutcome::Emitted => return,
-                        CandidateOutcome::Consumed => {
-                            seen.insert(path);
-                        }
-                        CandidateOutcome::Retry => {
-                            // 1 行目がまだ書かれていない → seen に入れず次イベントで再 check。
-                        }
-                    }
+                CandidateOutcome::Retry => {
+                    // 1 行目がまだ書かれていない → seen に入れず次ループで再 check。
                 }
             }
-            Ok(Err(_)) | Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
-            Err(_) => break,
         }
     }
     tracing::debug!(

--- a/src-tauri/src/pty/codex_watcher.rs
+++ b/src-tauri/src/pty/codex_watcher.rs
@@ -111,7 +111,13 @@ fn is_rollout_file(path: &Path) -> bool {
 
 /// `~/.codex/sessions/` を再帰走査して rollout ファイルの絶対パスを集める。
 /// (日付サブディレクトリ YYYY/MM/DD 配下に置かれるため再帰が必須)
-fn collect_rollout_paths(dir: &Path, out: &mut Vec<PathBuf>) {
+///
+/// Issue #859 (perf): `cutoff` が `Some(t)` のとき、mtime が `t` より古いサブディレクトリには
+/// 降りない。codex は当日の `YYYY/MM/DD` にしか書かないため、過去日付のディレクトリは新規 rollout
+/// を持たず、watcher (60 秒・1s ごとの保険走査) が長い codex 履歴を毎回フル走査するのを防ぐ。
+/// `None` なら全走査 (履歴全体を 1 度だけ見たい sanitize 等の用途)。mtime が読めない場合は安全側で
+/// 降りる。
+fn collect_rollout_paths(dir: &Path, cutoff: Option<SystemTime>, out: &mut Vec<PathBuf>) {
     let read = match std::fs::read_dir(dir) {
         Ok(r) => r,
         Err(_) => return,
@@ -119,11 +125,30 @@ fn collect_rollout_paths(dir: &Path, out: &mut Vec<PathBuf>) {
     for entry in read.flatten() {
         let path = entry.path();
         match entry.file_type() {
-            Ok(ft) if ft.is_dir() => collect_rollout_paths(&path, out),
+            Ok(ft) if ft.is_dir() => {
+                if let Some(c) = cutoff {
+                    let stale = entry
+                        .metadata()
+                        .ok()
+                        .and_then(|m| m.modified().ok())
+                        .map(|m| m < c)
+                        .unwrap_or(false);
+                    if stale {
+                        continue;
+                    }
+                }
+                collect_rollout_paths(&path, cutoff, out);
+            }
             Ok(_) if is_rollout_file(&path) => out.push(path),
             _ => {}
         }
     }
+}
+
+/// watcher 用の日付ディレクトリ pruning 閾値。`since` (= spawn 時刻) から 2 日前を cutoff にして、
+/// 当日 + 直近 (深夜跨ぎや時計ずれの余裕) の日付ディレクトリだけを走査対象にする。
+fn watcher_dir_cutoff(since: SystemTime) -> Option<SystemTime> {
+    since.checked_sub(Duration::from_secs(2 * 24 * 60 * 60))
 }
 
 /// watcher 起動時点ですでに rollout が作られている race を救済するため、
@@ -131,7 +156,8 @@ fn collect_rollout_paths(dir: &Path, out: &mut Vec<PathBuf>) {
 /// (claude の list_recent_session_candidates 相当)。
 fn list_recent_rollout_candidates(dir: &Path, since: SystemTime) -> Vec<PathBuf> {
     let mut paths = Vec::new();
-    collect_rollout_paths(dir, &mut paths);
+    // recent 候補も日付ディレクトリ pruning して、過去日付の全走査を避ける。
+    collect_rollout_paths(dir, watcher_dir_cutoff(since), &mut paths);
     let mut recent: Vec<(PathBuf, SystemTime)> = paths
         .into_iter()
         .filter_map(|p| {
@@ -291,12 +317,15 @@ fn run_watcher_loop(
     }
 
     let expected_norm = super::path_norm::normalize_project_root(&project_root);
+    // Issue #859 (perf): 走査は spawn 時刻から直近 (~2 日) の日付ディレクトリだけに絞る。
+    // 新規 session の rollout は当日に書かれるため、過去日付を毎回走らせる必要はない。
+    let scan_cutoff = watcher_dir_cutoff(spawned_at);
 
     // 初期 snapshot: 既存の rollout はすべて「この spawn 以前のもの」として除外対象 (seen)。
     let mut seen: HashSet<PathBuf> = HashSet::new();
     {
         let mut snap = Vec::new();
-        collect_rollout_paths(&dir, &mut snap);
+        collect_rollout_paths(&dir, scan_cutoff, &mut snap);
         for p in snap {
             seen.insert(p);
         }
@@ -370,7 +399,7 @@ fn run_watcher_loop(
         }
         last_full_scan = Some(Instant::now());
         let mut current = Vec::new();
-        collect_rollout_paths(&dir, &mut current);
+        collect_rollout_paths(&dir, scan_cutoff, &mut current);
         // パス順を安定化 (どの watcher が先に claim してもデテルミニスティックに)。
         current.sort();
         for path in current {
@@ -524,8 +553,29 @@ mod tests {
         fs::write(day_dir.join("history.jsonl"), "x").expect("write non-rollout jsonl");
 
         let mut out = Vec::new();
-        collect_rollout_paths(&dir, &mut out);
+        collect_rollout_paths(&dir, None, &mut out);
         assert_eq!(out, vec![rollout]);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    /// Issue #859 (perf): cutoff より古い mtime の日付ディレクトリには降りないこと。
+    #[test]
+    fn collect_rollout_paths_prunes_stale_dirs_by_cutoff() {
+        let dir = unique_temp_dir("codex-watcher-prune");
+        let id = "eeeeeeee-ffff-0000-1111-222222222222";
+        write_rollout(&dir, "2026-05-31T00-00-00", id, &session_meta_line(id, "/tmp/r"));
+
+        // 未来時刻を cutoff にすれば、現在 mtime の日付ディレクトリは全て stale 扱いで pruning される。
+        let future = SystemTime::now() + Duration::from_secs(3600);
+        let mut pruned = Vec::new();
+        collect_rollout_paths(&dir, Some(future), &mut pruned);
+        assert!(pruned.is_empty(), "stale dirs should be pruned, got {pruned:?}");
+
+        // 過去時刻 cutoff なら通常どおり拾える。
+        let past = SystemTime::now() - Duration::from_secs(3600);
+        let mut kept = Vec::new();
+        collect_rollout_paths(&dir, Some(past), &mut kept);
+        assert_eq!(kept.len(), 1, "recent dirs within cutoff are walked");
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src-tauri/src/pty/codex_watcher.rs
+++ b/src-tauri/src/pty/codex_watcher.rs
@@ -28,7 +28,7 @@
 // spawn_watcher のシグネチャ・deadline(60s)・poll(100ms)・cancel(AtomicBool) 設計は
 // claude_watcher と完全に揃えてある。
 
-use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
 use once_cell::sync::Lazy;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -342,12 +342,14 @@ fn run_watcher_loop(
 
     // Windows の native backend (ReadDirectoryChangesW) は notify の `with_poll_interval` を
     // 無視するため、イベント取りこぼし (特に watch 開始後に新規作成される YYYY/MM/DD サブ
-    // ディレクトリ配下の rollout 作成) を救う polling fallback が存在しない。そこで event 到着時
-    // に加えて最低 1 秒ごとに full rescan を回し、取りこぼしを構造的に補償する。`seen` で dedup
-    // 済みなので二重処理は起きず、rescan を 1s に throttle することで walk コストも抑える。
-    // (fs_watch.rs が同じ Windows 事情で Recursive を避けて手動展開しているのと同趣旨の保険)
+    // ディレクトリ配下の rollout 作成) を救う polling fallback が存在しない。そこで event の有無に
+    // 依らず最低 1 秒ごとに full rescan を回し、取りこぼしを構造的に補償する。`seen` で dedup 済み
+    // かつ rescan を 1s に throttle するので、Codex 起動直後に連続 fs イベントが来ても全再帰走査が
+    // 100ms ごとに繰り返されることはない (event は recv の待ちを短縮するだけで、walk 頻度は throttle
+    // が決める)。(fs_watch.rs が同じ Windows 事情で Recursive を避けて手動展開しているのと同趣旨の保険)
+    const RESCAN_INTERVAL: Duration = Duration::from_secs(1);
     let watcher_started_at = Instant::now();
-    let mut last_full_scan = watcher_started_at;
+    let mut last_full_scan: Option<Instant> = None;
     while watcher_started_at.elapsed() < WATCHER_MAX_LIFETIME {
         if is_cancelled() {
             tracing::debug!(
@@ -356,18 +358,17 @@ fn run_watcher_loop(
             );
             return;
         }
-        // poll interval 単位で待ちつつ event の有無を見る。channel 切断時のみ break。
-        let got_event = match rx.recv_timeout(WATCHER_POLL_INTERVAL) {
-            Ok(Ok(event)) => matches!(event.kind, EventKind::Create(_) | EventKind::Modify(_)),
-            Ok(Err(_)) => false,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => false,
+        // poll interval 単位で待つ。event は recv を早く返すだけで、走査頻度は下の throttle が決める。
+        // channel 切断時のみ break。
+        match rx.recv_timeout(WATCHER_POLL_INTERVAL) {
+            Ok(_) | Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
-        };
-        // event 到着、または前回 full rescan から 1 秒以上経過したときだけ走査する。
-        if !got_event && last_full_scan.elapsed() < Duration::from_secs(1) {
+        }
+        // 連続イベントでも walk は最低 1s 間隔に coalesce する (初回 = None のときだけ即時走査)。
+        if last_full_scan.is_some_and(|t| t.elapsed() < RESCAN_INTERVAL) {
             continue;
         }
-        last_full_scan = Instant::now();
+        last_full_scan = Some(Instant::now());
         let mut current = Vec::new();
         collect_rollout_paths(&dir, &mut current);
         // パス順を安定化 (どの watcher が先に claim してもデテルミニスティックに)。

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -13,6 +13,7 @@
 pub mod batcher;
 pub mod claude_watcher;
 pub mod codex_broker;
+pub mod codex_watcher;
 pub mod inflight;
 pub mod path_norm;
 pub mod registry;

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -866,6 +866,20 @@ export function AppShell({
                       // Issue #660: 初回 spawn の `--session-id` 注入 → jsonl 永続化が
                       // 確認できたので freshSessionId を倒す。次回以降は --resume 経路。
                       markSessionPersisted(tab.id);
+                      // Issue #856: Codex は `--session-id` 事前注入ができず capture-then-resume。
+                      // 初回起動時 resumeSessionId は null のままなので、watcher が捕捉した
+                      // session id をここで terminalTabs に書き戻す。これが terminal-tabs.json
+                      // へ永続化され、次回起動で getTerminalArgs が `codex resume <id>` を組む。
+                      // Claude は addTerminalTab 時点の事前注入 UUID と一致するので no-op。
+                      if (tab.agent === 'codex' && sid) {
+                        setTerminalTabs((prev) =>
+                          prev.map((t) =>
+                            t.id === tab.id && t.resumeSessionId !== sid
+                              ? { ...t, resumeSessionId: sid }
+                              : t
+                          )
+                        );
+                      }
                     }}
                     onResize={(cols, rows) => reportTerminalSize(tab.id, cols, rows)}
                     initialCols={tab.initialCols ?? undefined}

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -224,7 +224,7 @@ function AgentNodeCardImpl({
         base.push('-c', 'disable_paste_burst=true');
       }
     }
-    // Issue #660 / #752 / #753: Claude のみ session 制御フラグを付与 (Codex は両方とも非対応)。
+    // Issue #660 / #752 / #753: Claude の session 制御フラグ (--session-id / --resume) を付与。
     //   - payload.resumeSessionId 既存 → 永続化済みなので `--resume` で前回会話を継続
     //   - payload.resumeSessionId 空 → 採番した UUID を `--session-id` で強制注入
     // 新規 UUID は jsonl 検出後にだけ payload へ保存する。初回 spawn 前に保存すると
@@ -235,6 +235,15 @@ function AgentNodeCardImpl({
       } else {
         base.push('--session-id', ensuredSessionId);
       }
+    }
+    // Issue #856: Codex は capture-then-resume。`--session-id` 事前注入は非対応なので
+    // 初回は素の codex 起動。watcher が捕捉した session id が onSessionId 経由で
+    // payload.resumeSessionId に永続化された後の再起動でのみ、`codex resume <id>`
+    // サブコマンドを base の先頭へ unshift して前回会話を復元する (第 1 引数要求のため)。
+    // 後続の `-c disable_paste_burst=true` / `-c model_instructions_file=<path>` は
+    // `codex resume` が受理するので順序を壊さない。
+    if (isCodex && payload.resumeSessionId) {
+      base.unshift('resume', payload.resumeSessionId);
     }
     return base.length > 0 ? base : undefined;
   }, [

--- a/src/renderer/src/components/canvas/cards/TerminalCard.tsx
+++ b/src/renderer/src/components/canvas/cards/TerminalCard.tsx
@@ -52,11 +52,18 @@ function TerminalCardImpl({ id, data }: NodeProps<Node<CardDataOf<'terminal'>>>)
   const command = payload.command ?? (isCodex ? settings.codexCommand : settings.claudeCommand);
 
   // Issue #22: resumeSessionId があり Claude 側なら --resume <id> を付与して起動。
-  // Codex は `--resume` 非対応なので付けない (IDE 側 App.tsx:1396 と同じ条件)。
+  // Issue #856: Codex は `--resume` フラグ非対応だが `codex resume <id>` サブコマンドで
+  // 復元できる。capture-then-resume で payload.resumeSessionId に session id が
+  // 永続化されていれば、`resume <id>` を base 先頭へ unshift する (Codex は resume を
+  // 第 1 引数に要求するため)。後続の codexInstructions (model_instructions_file) は
+  // `codex resume` が受理するので順序を壊さない。
   const args = useMemo<string[] | undefined>(() => {
     const base = payload.args ? [...payload.args] : [];
     if (payload.resumeSessionId && !isCodex) {
       base.push('--resume', payload.resumeSessionId);
+    }
+    if (payload.resumeSessionId && isCodex) {
+      base.unshift('resume', payload.resumeSessionId);
     }
     return base.length > 0 ? base : undefined;
   }, [payload.args, payload.resumeSessionId, isCodex]);

--- a/src/renderer/src/lib/app-state-context.tsx
+++ b/src/renderer/src/lib/app-state-context.tsx
@@ -211,7 +211,8 @@ export function AppStateProvider({
     terminalTabs,
     activeTerminalTabId,
     setActiveTerminalTabId,
-    addTerminalTab
+    addTerminalTab,
+    showToast
   });
 
   // ----- teams / team-history / launch helpers -----

--- a/src/renderer/src/lib/hooks/use-team-launch-helpers.ts
+++ b/src/renderer/src/lib/hooks/use-team-launch-helpers.ts
@@ -55,6 +55,14 @@ export function useTeamLaunchHelpers(
         } else {
           base.push('--resume', tab.resumeSessionId);
         }
+      } else if (tab.resumeSessionId && isCodex) {
+        // Issue #856: Codex は `--session-id` 事前注入に非対応なので capture-then-resume。
+        // 初回は素の codex 起動 → watcher が emit した session id を捕捉・永続化 → 次回起動で
+        // `codex resume <id>` サブコマンドで前回会話を復元する。Claude の `--resume <id>` フラグ
+        // 形式とは異なり Codex は `resume <uuid>` を **第 1 引数 (サブコマンド)** に要求するため、
+        // base の先頭へ unshift する。後続の `-c disable_paste_burst=true` や main 側が付ける
+        // `-c model_instructions_file=<path>` は `codex resume` が受理するので順序を壊さない。
+        base.unshift('resume', tab.resumeSessionId);
       }
       // Claude のチーム指示は --append-system-prompt で直接渡す。
       if (!isCodex && tab.teamId) {

--- a/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
@@ -17,11 +17,13 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '../tauri-api';
+import { useT } from '../i18n';
 import {
   TERMINAL_TABS_SCHEMA_VERSION,
   type PersistedTerminalTab,
   type PersistedTerminalTabsByProject,
-  type PersistedTerminalTabsFile
+  type PersistedTerminalTabsFile,
+  type TerminalTabsLoadResult
 } from '../../../../types/shared';
 import type {
   AddTerminalTabOptions,
@@ -57,6 +59,14 @@ export interface UseTerminalTabsPersistenceOptions {
   activeTerminalTabId: number;
   setActiveTerminalTabId: React.Dispatch<React.SetStateAction<number>>;
   addTerminalTab: (opts?: AddTerminalTabOptions) => number | null;
+  /**
+   * Issue #857: 復元時に transcript 不在で新規会話へ倒したタブがあったとき、
+   * warning トーストで知らせるために使う。
+   */
+  showToast: (
+    msg: string,
+    opts?: { tone?: 'info' | 'success' | 'warning' | 'error' }
+  ) => void;
 }
 
 export interface UseTerminalTabsPersistenceResult {
@@ -74,8 +84,17 @@ export function useTerminalTabsPersistence(
     terminalTabs,
     activeTerminalTabId,
     addTerminalTab,
-    setActiveTerminalTabId
+    setActiveTerminalTabId,
+    showToast
   } = opts;
+
+  const t = useT();
+  // 復元 effect の deps から外しても最新値を読めるよう ref 経由で参照する
+  // (effect は projectRoot 確定 1 回限りで再実行させない方針のため)。
+  const showToastRef = useRef(showToast);
+  showToastRef.current = showToast;
+  const tRef = useRef(t);
+  tRef.current = t;
 
   const [isReady, setIsReady] = useState(false);
   /** 復元中に save loop が走らないようガードするフラグ */
@@ -95,7 +114,7 @@ export function useTerminalTabsPersistence(
     if (!projectRoot) return;
     let disposed = false;
     void (async () => {
-      let file: PersistedTerminalTabsFile | null = null;
+      let file: TerminalTabsLoadResult | null = null;
       try {
         file = await api.terminalTabs.load();
       } catch (err) {
@@ -103,6 +122,17 @@ export function useTerminalTabsPersistence(
       }
       if (disposed) return;
       fileCacheRef.current = file;
+      // Issue #857: Rust 側が transcript 不在で新規会話に倒したタブ数を warning で通知する。
+      // load() の結果に含まれる droppedSessions が 1 件以上なら 1 回だけトーストを出す。
+      const droppedCount = file?.droppedSessions?.length ?? 0;
+      if (droppedCount > 0) {
+        showToastRef.current(
+          tRef.current('terminalTabs.restore.transcriptMissing', {
+            count: droppedCount
+          }),
+          { tone: 'warning' }
+        );
+      }
       const slot = file?.byProject?.[projectRoot];
       if (slot && slot.tabs.length > 0 && terminalTabs.length === 0) {
         restoringRef.current = true;

--- a/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
@@ -123,8 +123,11 @@ export function useTerminalTabsPersistence(
       if (disposed) return;
       fileCacheRef.current = file;
       // Issue #857: Rust 側が transcript 不在で新規会話に倒したタブ数を warning で通知する。
-      // load() の結果に含まれる droppedSessions が 1 件以上なら 1 回だけトーストを出す。
-      const droppedCount = file?.droppedSessions?.length ?? 0;
+      // Issue #859 review: droppedSessions は全 project 横断で返るため、いま開いている
+      // projectRoot に属する drop だけを数える (別 project のタブ数まで count に含めない)。
+      const droppedCount = (file?.droppedSessions ?? []).filter(
+        (d) => d.projectRoot === projectRoot
+      ).length;
       if (droppedCount > 0) {
         showToastRef.current(
           tRef.current('terminalTabs.restore.transcriptMissing', {

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -760,6 +760,10 @@ const ja: Dict = {
   'toast.tone.warning': '注意',
   'toast.tone.error': 'エラー',
 
+  // ---------- Terminal タブ復元 (Issue #857) ----------
+  'terminalTabs.restore.transcriptMissing':
+    '過去の会話履歴が見つからず {count} 件のタブを新規会話で再起動しました',
+
   // ---------- Status ----------
   'status.noProject': 'プロジェクトが選択されていません',
 
@@ -1555,6 +1559,10 @@ const en: Dict = {
   'toast.tone.success': 'Success',
   'toast.tone.warning': 'Warning',
   'toast.tone.error': 'Error',
+
+  // ---------- Terminal tab restore (Issue #857) ----------
+  'terminalTabs.restore.transcriptMissing':
+    "Couldn't find past transcripts; restarted {count} tab(s) as new conversations.",
 
   'status.noProject': 'No project selected',
 

--- a/src/renderer/src/lib/tauri-api/terminal-tabs.ts
+++ b/src/renderer/src/lib/tauri-api/terminal-tabs.ts
@@ -5,7 +5,10 @@
 // フォールバックする)。
 
 import { invoke } from '@tauri-apps/api/core';
-import type { PersistedTerminalTabsFile } from '../../../../types/shared';
+import type {
+  PersistedTerminalTabsFile,
+  TerminalTabsLoadResult
+} from '../../../../types/shared';
 
 interface MutationResult {
   ok: boolean;
@@ -13,9 +16,14 @@ interface MutationResult {
 }
 
 export const terminalTabs = {
-  /** 永続化ファイルを読む。未存在 / schemaVersion mismatch / parse 失敗で null。 */
-  load: async (): Promise<PersistedTerminalTabsFile | null> => {
-    const result = await invoke<PersistedTerminalTabsFile | null>('terminal_tabs_load');
+  /**
+   * 永続化ファイルを読む。未存在 / schemaVersion mismatch / parse 失敗で null。
+   *
+   * Issue #857: 戻り値が `TerminalTabsLoadResult` (= `PersistedTerminalTabsFile` +
+   * `droppedSessions`) になった。invoke 名は不変。
+   */
+  load: async (): Promise<TerminalTabsLoadResult | null> => {
+    const result = await invoke<TerminalTabsLoadResult | null>('terminal_tabs_load');
     return result ?? null;
   },
   /** 全体を atomic 上書き。read-modify-write は呼び出し側責務。 */

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1190,6 +1190,9 @@ export interface DroppedSessionInfo {
   kind: string;
   /** drop した理由 code。現状 `"transcript-missing"` のみ */
   reason: string;
+  /** この tab が属する project root (= byProject の key)。Issue #859 review: renderer は
+   *  現在開いている project の drop 件数だけを toast に出すために使う (全 project 横断集計の誤り回避)。 */
+  projectRoot: string;
 }
 
 /**

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1183,13 +1183,19 @@ export interface PersistedTerminalTabsFile {
  * `TerminalTabsLoadResult.droppedSessions` に詰めて返す。renderer は件数 > 0 で
  * warning トーストを 1 度出してユーザーに「過去の履歴が復元できなかった」ことを知らせる。
  */
+/**
+ * Issue #857 / #859: session を drop した理由 code。Rust 側 `terminal_tabs.rs` が emit する
+ * 値と 1:1 で対応させる (両側を同時に拡張する契約)。現状は transcript / rollout 不在のみ。
+ */
+export type DroppedSessionReason = 'transcript-missing';
+
 export interface DroppedSessionInfo {
   /** 永続化されていた renderer 側 tabId (= `String(numericId)`) */
   tabId: string;
   /** agent 種別 (`claude` / `codex` 等。`TerminalAgent` と同じ string namespace) */
   kind: string;
-  /** drop した理由 code。現状 `"transcript-missing"` のみ */
-  reason: string;
+  /** drop した理由 code (Rust 側 reason と 1:1)。 */
+  reason: DroppedSessionReason;
   /** この tab が属する project root (= byProject の key)。Issue #859 review: renderer は
    *  現在開いている project の drop 件数だけを toast に出すために使う (全 project 横断集計の誤り回避)。 */
   projectRoot: string;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1177,6 +1177,31 @@ export interface PersistedTerminalTabsFile {
   byProject: Record<string, PersistedTerminalTabsByProject>;
 }
 
+/**
+ * Issue #857: 復元時に session の transcript (jsonl rollout) が見つからず、
+ * 新規会話として起動し直したタブの情報。`terminal_tabs_load` が
+ * `TerminalTabsLoadResult.droppedSessions` に詰めて返す。renderer は件数 > 0 で
+ * warning トーストを 1 度出してユーザーに「過去の履歴が復元できなかった」ことを知らせる。
+ */
+export interface DroppedSessionInfo {
+  /** 永続化されていた renderer 側 tabId (= `String(numericId)`) */
+  tabId: string;
+  /** agent 種別 (`claude` / `codex` 等。`TerminalAgent` と同じ string namespace) */
+  kind: string;
+  /** drop した理由 code。現状 `"transcript-missing"` のみ */
+  reason: string;
+}
+
+/**
+ * Issue #857: `terminal_tabs_load` の戻り値。従来の `PersistedTerminalTabsFile` を
+ * そのまま flatten し、`droppedSessions` だけを追加した拡張形。`byProject` 等の
+ * 既存フィールドへのアクセスは不変 (file が本型になるだけ)。
+ */
+export interface TerminalTabsLoadResult extends PersistedTerminalTabsFile {
+  /** transcript 不在等で新規会話に倒したタブの一覧。空配列なら drop なし。 */
+  droppedSessions: DroppedSessionInfo[];
+}
+
 // ---------- TeamHub inject failure (Issue #511) ----------
 
 /**


### PR DESCRIPTION
## Summary
`deep-research-report (1).md` の調査結果に基づき、Codex エージェントの会話復元ギャップを修正する。Claude は session id 捕捉 → `--resume` で再起動跨ぎ復元できる一方、Codex は session id を一切捕捉しておらず毎回新規会話で始まっていた。Codex CLI 0.130.0 を実機検証し、`codex resume <UUID>` と `~/.codex/sessions/**/rollout-*.jsonl` (1 行目 `session_meta.payload.{id,cwd}`) を確認、Claude と同型の仕組みで復元を実装した。

直交する 3 件を 1 PR にバンドル (1 commit/issue):

- **#855 (Rust)**: `~/.codex/sessions/` を Recursive 監視する `codex_watcher` を追加。新規 rollout の `session_meta.payload.id` を session id として既存 `terminal:sessionId:{id}` event で emit。cwd は `payload.cwd` を normalize 比較し fail-closed。claude_watcher と同じ claim/cancel/deadline(60s)/poll(100ms) 設計 + partial write 再評価。Windows の `ReadDirectoryChangesW` が `with_poll_interval` を無視する件への対策として、event 駆動に加え 1s 周期の full rescan fallback を持つ。
- **#856 (Renderer)**: capture-then-resume 方式。watcher が emit した session id を `resumeSessionId` に焼き付けて永続化し、再起動時は IDE / Canvas (CardFrame / TerminalCard) とも `codex resume <id>` サブコマンドで起動。既存の `-c disable_paste_burst` / `model_instructions_file` 経路は不変。
- **#857 (両側)**: `terminal_tabs_load` の戻り値を `TerminalTabsLoadResult` (= `PersistedTerminalTabsFile` を flatten + `droppedSessions:[{tabId,kind,reason}]`) に変更し、sanitize を claude/codex 両対応に汎用化。transcript/rollout 不在で新規会話に倒した tab を `droppedSessions` に記録し、renderer は件数 > 0 で warning toast を 1 回出す (i18n ja/en)。Rust/TS の serde camelCase 契約は unit test で固定。

Closes #855
Closes #856
Closes #857

## Test plan
- [x] `npm run typecheck` 通過
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 通過 (新規 warning なし)
- [x] `cargo test codex_watcher` 10 passed / `cargo test terminal_tabs` 11 passed (`load_result_serializes_to_expected_camelcase_contract` で serde 契約を固定)
- [x] renderer vitest 398 passed
- [ ] (実機・任意) codex タブ起動 → rollout 生成で `terminal:sessionId` が飛び、再起動後 `codex resume` で会話継続することを手動確認
- [ ] (実機・任意) transcript を削除した tab で復元失敗 warning toast が 1 回出ることを手動確認

## レビュー観点メモ
- IPC 5 点同期 (shared.ts / Rust struct / mod.rs / invoke_handler / tauri-api wrapper) は確認済み。今回は新規 command ではなく `terminal_tabs_load` の戻り値型変更なので登録名・mod 宣言は不変。
- 既知の制約: `normalize_project_root` の canonicalize 成否混在により、project_root が WSL/UNC 等で片側のみ canonicalize 失敗する稀なケースで cwd 比較が fail-closed に倒れうる (claude_watcher と共通の既存挙動、本 PR の新規退行ではない)。