### PR TITLE
fix(team_hub): clear_team の診断 leak と corrupt backup の TOCTOU を修正 (#829 #853)

### DIFF
--- a/src-tauri/src/commands/team_state.rs
+++ b/src-tauri/src/commands/team_state.rs
@@ -387,7 +387,11 @@ async fn load_orchestration_state_from_path(path: &Path) -> Option<TeamOrchestra
                  file and skipping restore (task/handoff/human-gate state will be recreated on next save)",
                 path.display()
             );
-            backup_corrupt_state_file(path).await;
+            // Issue #853: load 時に読んだ破損 bytes を渡し、退避直前に再 read して
+            // 内容が変化していない (= まだ破損したまま) ときだけ退避する。並行 save が
+            // valid file を置いていれば bytes が変化しているので退避を skip し、valid state を
+            // `.corrupt` へ巻き込まない (TOCTOU の解消)。
+            backup_corrupt_state_file(path, &bytes).await;
             None
         }
     }
@@ -397,7 +401,15 @@ async fn load_orchestration_state_from_path(path: &Path) -> Option<TeamOrchestra
 /// `.corrupt.9`) に best-effort で退避する。退避できれば原本は消えるので、次回
 /// `save_orchestration_state` が健全な状態で上書きできる。退避失敗 (rename 不可 / backup
 /// が増え過ぎ) は warn に留め、load 自体は失敗させない。
-async fn backup_corrupt_state_file(path: &Path) {
+///
+/// Issue #853 (TOCTOU 修正): `corrupt_bytes` は load 時に読んで parse に失敗した原本の bytes。
+/// rename は lock 外で走るため、その間に並行 `save_orchestration_state` (atomic_write) が
+/// **valid な file** を同 path に置き換えうる。素朴に rename するとこの valid file を
+/// `.corrupt` へ追い出し、save 直後の健全な state を失う race があった。退避の直前に現在の
+/// file bytes を再 read し、`corrupt_bytes` と **完全一致するときだけ** 退避する。一致しない
+/// (= 並行 save で内容が変わった / 既に他経路で退避され消えた) 場合は退避を skip し、active
+/// path を温存する。これで「valid file を退避しない」不変条件を保証する。
+async fn backup_corrupt_state_file(path: &Path, corrupt_bytes: &[u8]) {
     let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
         tracing::warn!(
             "[team_state] cannot derive file name for corrupt backup of {}",
@@ -412,6 +424,30 @@ async fn backup_corrupt_state_file(path: &Path) {
         );
         return;
     };
+    // Issue #853: 退避直前の再検証。並行 save が割り込んで file が valid に置き換わって
+    // いれば bytes が変化しているので退避せずに抜ける (valid state を巻き込まない)。
+    // read 失敗 (並行退避で消えた等) も退避対象が消えたとみなし skip する。
+    match fs::read(path).await {
+        Ok(current) if current == corrupt_bytes => {
+            // 依然として load 時の破損 bytes と同一。退避を続行する。
+        }
+        Ok(_) => {
+            tracing::info!(
+                "[team_state] corrupt backup skipped: {} changed since load (likely a concurrent \
+                 valid save); not evicting the active file",
+                path.display()
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::info!(
+                "[team_state] corrupt backup skipped: cannot re-read {} ({e}); file may have been \
+                 replaced or removed by a concurrent save",
+                path.display()
+            );
+            return;
+        }
+    }
     // 既存 backup を上書きしない (forensic 情報を保持する) ため、空きスロットを探す。
     for idx in 0..=9u32 {
         let candidate_name = if idx == 0 {
@@ -638,7 +674,8 @@ mod tests {
             .await
             .unwrap();
 
-        backup_corrupt_state_file(&path).await;
+        // Issue #853: 退避直前に再 read される bytes が load 時の破損 bytes と一致するので退避続行。
+        backup_corrupt_state_file(&path, b"corrupt-2").await;
 
         // 既存 backup は不変、新 backup は `.corrupt.1` に置かれる。
         assert_eq!(
@@ -654,5 +691,64 @@ mod tests {
             b"corrupt-2"
         );
         assert!(fs::metadata(&path).await.is_err());
+    }
+
+    /// Issue #853 (TOCTOU 回帰テスト): load が破損 bytes を読んだ後、退避が走る前に並行 save が
+    /// **valid な内容** で同 path を置き換えた場合、退避はその valid file を `.corrupt` へ追い出して
+    /// はならない。`backup_corrupt_state_file` に load 時の破損 bytes を渡し、退避直前の再 read で
+    /// 内容が変化していれば skip することを検証する。
+    ///
+    /// 修正前 (素の rename) はここで active file (valid) が `.corrupt` に移動して save 直後の
+    /// 健全な state を失うため、この assert は fail する。修正後は valid file が原 path に温存される。
+    #[tokio::test]
+    async fn backup_corrupt_state_file_does_not_evict_concurrently_saved_valid_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("team.json");
+
+        // load 時に読んだ破損 bytes。
+        let corrupt_bytes = b"{ this is not valid json ]".to_vec();
+
+        // 退避が走る前に並行 save が valid file を置いた状況を再現する
+        // (file は corrupt_bytes とは異なる valid な内容になっている)。
+        let valid_bytes = br#"{"schemaVersion":1,"teamId":"t","projectRoot":"/p"}"#.to_vec();
+        fs::write(&path, &valid_bytes).await.unwrap();
+
+        backup_corrupt_state_file(&path, &corrupt_bytes).await;
+
+        // valid file は原 path にそのまま残り、`.corrupt` には退避されていない。
+        assert_eq!(
+            fs::read(&path).await.expect("valid file must remain at the active path"),
+            valid_bytes,
+            "concurrently saved valid state must not be evicted from the active path"
+        );
+        assert!(
+            fs::metadata(dir.path().join("team.json.corrupt"))
+                .await
+                .is_err(),
+            "no corrupt backup should be created when the file changed to a valid one"
+        );
+    }
+
+    /// Issue #853: 破損 bytes が退避直前まで変化していない (= 並行 save が無い) 通常ケースでは
+    /// 従来どおり `.corrupt` へ退避し、原本を消す。再検証の追加で正常系が壊れていないことを確認。
+    #[tokio::test]
+    async fn backup_corrupt_state_file_still_backs_up_unchanged_corrupt_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("team.json");
+        let corrupt_bytes = b"{ broken json".to_vec();
+        fs::write(&path, &corrupt_bytes).await.unwrap();
+
+        backup_corrupt_state_file(&path, &corrupt_bytes).await;
+
+        assert!(
+            fs::metadata(&path).await.is_err(),
+            "unchanged corrupt file should still be moved away"
+        );
+        assert_eq!(
+            fs::read(dir.path().join("team.json.corrupt"))
+                .await
+                .expect("corrupt backup must exist"),
+            corrupt_bytes
+        );
     }
 }

--- a/src-tauri/src/team_hub/state/hub_state.rs
+++ b/src-tauri/src/team_hub/state/hub_state.rs
@@ -76,6 +76,18 @@ pub(crate) struct HubState {
     /// `last_status_at` / `last_seen_at` も更新しない (autoStale 偽装防止)。
     /// in-memory only (Hub 再起動で clear)。
     pub(crate) last_status_call_at: HashMap<String, std::time::Instant>,
+    /// Issue #829: team_id → その team で recruit / handshake された agent_id 集合。
+    ///
+    /// `member_diagnostics` / `last_status_call_at` は agent_id 単体キーで team 次元を持たない。
+    /// これらの解放を `agent_role_bindings` の逆引きに頼ると、binding が
+    /// dismiss / record_agent_process_exit / recruit timeout で先に消えた agent は
+    /// `clear_team` 到達時に逆引きで届かず、両 map が Hub 再起動まで leak する
+    /// (本 issue の支配的経路)。binding と独立した「team の在籍記録」をここに持ち、
+    /// binding が消えた後でも `clear_team` が当該 team の agent を網羅して両 map を
+    /// reclaim できるようにする。team-keyed なので `clear_team` の team prefix retain で
+    /// 一括解放でき、cross-team 共有 agent の防御 (他 team がまだ参照するなら残す) も維持する。
+    /// in-memory only (Hub 再起動で clear)。
+    pub(crate) team_agent_roster: HashMap<String, std::collections::HashSet<String>>,
 }
 
 /// Issue #342 Phase 3 (3.11): tracing-appender が書き出すログファイルの絶対パスを
@@ -496,6 +508,7 @@ impl TeamHub {
                 file_locks: HashMap::new(),
                 recruit_semaphores: HashMap::new(),
                 last_status_call_at: HashMap::new(),
+                team_agent_roster: HashMap::new(),
             })),
             app_handle: Arc::new(Mutex::new(None)),
             inflight,

--- a/src-tauri/src/team_hub/state/persistence.rs
+++ b/src-tauri/src/team_hub/state/persistence.rs
@@ -158,25 +158,38 @@ impl TeamHub {
         // (1) team_id 単体を key に持つ recruit 直列化 semaphore。
         s.recruit_semaphores.remove(team_id);
 
-        // (2) member_diagnostics / last_status_call_at は agent_id 単体 key なので、
-        // (team_id, agent_id) を key に持つ agent_role_bindings から当該 team の agent_id を
-        // 逆引きして remove する。ただし同一 agent_id が **別 team にも** bind されている場合は
-        // 残す (cross-team で誤って別 team の診断を巻き込まない)。実運用では agent_id は
-        // recruit ごとに `vc-{uuid}` で一意採番されるため衝突はまず無いが、防御的に絞る。
-        // MutexGuard 越しの分割 borrow を避けるため、まず owned String に収集してから mutate する。
-        let mut this_team_agents: Vec<String> = Vec::new();
-        let mut other_team_agents: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for (tid, aid) in s.agent_role_bindings.keys() {
-            if tid == team_id {
-                this_team_agents.push(aid.clone());
-            } else {
-                other_team_agents.insert(aid.clone());
-            }
-        }
-        for aid in &this_team_agents {
-            if !other_team_agents.contains(aid) {
-                s.member_diagnostics.remove(aid);
-                s.last_status_call_at.remove(aid);
+        // (2) member_diagnostics / last_status_call_at は agent_id 単体 key で team 次元を
+        // 持たない。旧実装はこの 2 map を `agent_role_bindings` の逆引き (= 当該 team の
+        // binding が生存している agent) でしか掃除しなかったが、binding は dismiss /
+        // record_agent_process_exit / recruit timeout で **clear_team より先に** 消えるのが
+        // 通常運用 (worker は teardown 前に exit/dismiss される)。その結果 clear_team 到達時に
+        // binding が無く、逆引きで届かない agent の両 map が Hub 再起動まで永久 leak していた
+        // (本 issue の支配的経路)。binding と独立した team 在籍記録 `team_agent_roster` を
+        // 正本にして当該 team の agent を網羅し、両 map を reclaim する。
+        //
+        // cross-team 防御: 同一 agent_id が **別 team の roster にも** 在籍している場合は
+        // member_diagnostics / last_status_call_at を残す (別 team の診断を巻き込まない)。
+        // 実運用では agent_id は recruit ごとに `vc-{uuid}` で一意採番されるため衝突はまず
+        // 無いが、防御的に絞る。MutexGuard 越しの分割 borrow を避けるため、まず owned に
+        // 収集してから mutate する。
+        let this_team_agents: Vec<String> = s
+            .team_agent_roster
+            .remove(team_id)
+            .map(|set| set.into_iter().collect())
+            .unwrap_or_default();
+        if !this_team_agents.is_empty() {
+            // `s` は MutexGuard なので、roster の borrow を保持したまま member_diagnostics を
+            // mutate すると分割 borrow 不可。other-team の agent 集合は owned で先に確定させる。
+            let other_team_agents: std::collections::HashSet<String> = s
+                .team_agent_roster
+                .values()
+                .flat_map(|agents| agents.iter().cloned())
+                .collect();
+            for aid in &this_team_agents {
+                if !other_team_agents.contains(aid) {
+                    s.member_diagnostics.remove(aid);
+                    s.last_status_call_at.remove(aid);
+                }
             }
         }
 
@@ -465,6 +478,17 @@ mod clear_team_release_tests {
                 "programmer".to_string(),
             );
 
+            // Issue #829: 在籍記録 (roster) も seed する。clear_team はこれを正本に
+            // agent-keyed な両 map を reclaim する (binding 逆引きではなく)。
+            s.team_agent_roster
+                .entry(team_a.to_string())
+                .or_default()
+                .insert(agent_a.to_string());
+            s.team_agent_roster
+                .entry(team_b.to_string())
+                .or_default()
+                .insert(agent_b.to_string());
+
             s.member_diagnostics.entry(agent_a.to_string()).or_default();
             s.member_diagnostics.entry(agent_b.to_string()).or_default();
 
@@ -543,12 +567,17 @@ mod clear_team_release_tests {
                 .contains_key(&(team_a.to_string(), "src/a.rs".to_string())),
             "file_locks leak"
         );
+        assert!(
+            !s.team_agent_roster.contains_key(team_a),
+            "team_agent_roster leak"
+        );
 
         // team_b 由来の state は一切影響を受けない。
         assert!(s.teams.contains_key(team_b));
         assert!(s.recruit_semaphores.contains_key(team_b));
         assert!(s.member_diagnostics.contains_key(agent_b));
         assert!(s.last_status_call_at.contains_key(agent_b));
+        assert!(s.team_agent_roster.contains_key(team_b));
         assert!(s
             .agent_role_bindings
             .contains_key(&(team_b.to_string(), agent_b.to_string())));
@@ -584,6 +613,15 @@ mod clear_team_release_tests {
                 (team_b.to_string(), shared_agent.to_string()),
                 "programmer".to_string(),
             );
+            // Issue #829: cross-team 防御は roster 在籍を見るので両 team に登録する。
+            s.team_agent_roster
+                .entry(team_a.to_string())
+                .or_default()
+                .insert(shared_agent.to_string());
+            s.team_agent_roster
+                .entry(team_b.to_string())
+                .or_default()
+                .insert(shared_agent.to_string());
             s.member_diagnostics
                 .entry(shared_agent.to_string())
                 .or_default();
@@ -607,5 +645,114 @@ mod clear_team_release_tests {
             "shared agent diagnostics must survive while team_b still references it"
         );
         assert!(s.last_status_call_at.contains_key(shared_agent));
+    }
+
+    /// Issue #829 (本 issue の支配的経路の回帰テスト):
+    /// recruit grant で member_diagnostics / roster を生やした agent が、`clear_team` より
+    /// **先に** dismiss / record_agent_process_exit / recruit timeout で `agent_role_bindings`
+    /// を失う (= teardown 前に exit/dismiss されるという通常運用) と、旧 `clear_team` は掃除
+    /// 対象 agent を binding の逆引きでしか導出しないため逆引きで届かず、member_diagnostics /
+    /// last_status_call_at が Hub 再起動まで永久 leak していた。
+    ///
+    /// binding と独立した `team_agent_roster` を正本に reclaim する修正後は、binding 消滅後でも
+    /// `clear_team` が両 map を解放する。**この修正を当てる前は fail し、当てた後に pass する**。
+    /// production の挿入経路 (`try_register_pending_recruit`) と削除経路
+    /// (`remove_agent_role_binding` = dismiss / 終了が呼ぶ glue) を使って実運用を忠実に再現する。
+    #[tokio::test]
+    async fn clear_team_reclaims_diagnostics_when_binding_removed_before_teardown() {
+        let hub = make_hub();
+        let team_id = "team-829-orphan";
+        let agent_id = "vc-829-orphan";
+
+        s_register_active_team(&hub, team_id).await;
+
+        // (1) recruit grant: member_diagnostics + team_agent_roster に agent を挿入する
+        // production 経路 (try_register_pending_recruit)。
+        hub.try_register_pending_recruit(
+            agent_id.to_string(),
+            team_id.to_string(),
+            "programmer".to_string(),
+            "leader-orphan".to_string(),
+            false,
+            &[],
+        )
+        .await
+        .expect("pending recruit grant should be registered");
+
+        // handshake 成立で binding が確立した状態を再現 (resolve_pending_recruit が
+        // app_handle 依存なしで通せるので直接呼ぶ)。
+        assert!(
+            hub.resolve_pending_recruit(agent_id, team_id, "programmer")
+                .await,
+            "handshake should succeed for the granted recruit"
+        );
+
+        // team_status 呼び出し相当で last_status_call_at にも entry を生やす。
+        {
+            let mut s = hub.state.lock().await;
+            s.last_status_call_at
+                .insert(agent_id.to_string(), Instant::now());
+        }
+
+        // 前提: diagnostics / last_status / binding / roster が全て積まれている。
+        {
+            let s = hub.state.lock().await;
+            assert!(s.member_diagnostics.contains_key(agent_id));
+            assert!(s.last_status_call_at.contains_key(agent_id));
+            assert!(s
+                .agent_role_bindings
+                .contains_key(&(team_id.to_string(), agent_id.to_string())));
+            assert!(s
+                .team_agent_roster
+                .get(team_id)
+                .is_some_and(|set| set.contains(agent_id)));
+        }
+
+        // (2) clear_team **より先に** binding を失う = 通常運用 (dismiss /
+        // record_agent_process_exit / recruit timeout)。remove_agent_role_binding は
+        // dismiss と record_agent_process_exit が共有する production の binding 削除経路。
+        assert!(
+            hub.remove_agent_role_binding(team_id, agent_id).await,
+            "binding should exist and be removed before teardown"
+        );
+        {
+            let s = hub.state.lock().await;
+            // binding は消えたが diagnostics は意図的に残る (旧バグの再現条件)。
+            assert!(!s
+                .agent_role_bindings
+                .contains_key(&(team_id.to_string(), agent_id.to_string())));
+            assert!(
+                s.member_diagnostics.contains_key(agent_id),
+                "diagnostics survive binding removal (this is the leak precondition)"
+            );
+            assert!(s.last_status_call_at.contains_key(agent_id));
+        }
+
+        // (3) teardown。
+        hub.clear_team(team_id).await;
+
+        let s = hub.state.lock().await;
+        // 修正後: roster を正本に reclaim され、両 agent-keyed map が空になる。
+        assert!(
+            !s.member_diagnostics.contains_key(agent_id),
+            "member_diagnostics must be reclaimed even though the binding was gone before clear_team"
+        );
+        assert!(
+            !s.last_status_call_at.contains_key(agent_id),
+            "last_status_call_at must be reclaimed even though the binding was gone before clear_team"
+        );
+        assert!(
+            !s.team_agent_roster.contains_key(team_id),
+            "roster for the cleared team must be dropped"
+        );
+    }
+
+    /// テスト用ヘルパ: 指定 team を active として登録する。
+    async fn s_register_active_team(hub: &TeamHub, team_id: &str) {
+        let mut s = hub.state.lock().await;
+        s.teams
+            .entry(team_id.to_string())
+            .or_insert_with(TeamInfo::default);
+        s.active_teams.insert(team_id.to_string());
     }
 }

--- a/src-tauri/src/team_hub/state/recruit.rs
+++ b/src-tauri/src/team_hub/state/recruit.rs
@@ -154,6 +154,15 @@ impl TeamHub {
                 ..MemberDiagnostics::default()
             },
         );
+        // Issue #829: agent-keyed な member_diagnostics / last_status_call_at を後で漏れなく
+        // 解放できるよう、binding とは独立した team 在籍記録に agent_id を登録する。
+        // recruit grant は member_diagnostics を挿入する最上流なので、ここで roster に入れて
+        // おけば dismiss / record_agent_process_exit / recruit timeout で binding が先に消えても
+        // clear_team が当該 team の agent を網羅して両 map を reclaim できる。
+        s.team_agent_roster
+            .entry(team_id.clone())
+            .or_default()
+            .insert(agent_id.clone());
         s.pending_recruits.insert(
             agent_id,
             PendingRecruit {
@@ -307,6 +316,13 @@ impl TeamHub {
         }
         entry.last_handshake_at = Some(now_iso.clone());
         entry.last_seen_at = Some(now_iso);
+        // Issue #829: 再接続 handshake (binding 経由 / 旧 context 残骸) のように recruit grant を
+        // 経ずに member_diagnostics の entry が生える経路でも team 在籍記録を残す。これにより
+        // clear_team が当該 team の全 agent を網羅できる。
+        s.team_agent_roster
+            .entry(team_id.to_string())
+            .or_default()
+            .insert(agent_id.to_string());
         true
     }
 


### PR DESCRIPTION
## Summary
PR #849 (#830/#829) で導入した修正に残る 2 つの欠陥を塞ぐ。src-tauri の Rust 変更のみ (+294/-22 行)。

- **#829**: `member_diagnostics` / `last_status_call_at` は agent_id 単体キーで、旧 `clear_team` は `agent_role_bindings` の逆引きでしか掃除しなかった。binding は dismiss / process-exit / recruit-timeout で `clear_team` より**先に**消えるのが通常運用のため、teardown 時に逆引きで届かず両 map が Hub 再起動まで永久 leak していた (本 issue の支配的経路)。binding と独立した `team_agent_roster` を `HubState` に追加し、recruit grant / handshake の両経路で登録。`clear_team` は roster を正本に reclaim する (別 team に在籍する agent の診断は保持し cross-team 防御を維持)。
- **#853**: `backup_corrupt_state_file` の lock 外 `fs::rename` が、並行 `save_orchestration_state` (atomic_write) の置いた valid file を `.corrupt` へ追い出す TOCTOU race。退避直前に現ファイルを再 read し、load 時に読んだ破損 bytes と一致するときだけ退避する (変化していれば skip し active path を温存)。copy 残置案が招く `.corrupt.N` 無限増殖の regression を避けつつ「valid file を退避しない」核心要件を満たす。

回帰テスト 3 件を追加 (うち 2 件は旧ロジックに差し戻すと fail することを実証済み)。

Closes #829
Closes #853

## Test plan
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` → 0 errors
- [x] `cargo test --lib team_hub` → 254 passed / 0 failed
- [x] `cargo test --lib commands::team_state` → 7 passed / 0 failed
- [x] 新規回帰テスト: `clear_team_reclaims_diagnostics_when_binding_removed_before_teardown` / `backup_corrupt_state_file_does_not_evict_concurrently_saved_valid_file` / `backup_corrupt_state_file_still_backs_up_unchanged_corrupt_file`