### PR TITLE
fix(canvas): 多人数チーム稼働時のフリーズ対策を追加

### DIFF
--- a/src-tauri/src/pty/batcher.rs
+++ b/src-tauri/src/pty/batcher.rs
@@ -1,7 +1,7 @@
 // PTY 出力バッチャ (旧 lib/pty-data-batcher.ts 等価)
 //
-// 16ms or 32KB で flush し、ターミナル出力を tauri::Emitter で送る。
-// 大量出力時に renderer 側のレンダリングを 60fps 以下に保つため必須。
+// 32ms or 64KB で flush し、ターミナル出力を tauri::Emitter で送る。
+// 大量出力時に renderer 側のレンダリングを 30fps 程度に保つため必須。
 
 use crate::pty::scrollback::{append_scrollback, Scrollback};
 use bytes::BytesMut;
@@ -20,8 +20,8 @@ use tokio::time::{interval, MissedTickBehavior};
 /// (closure 内部) の責務 — batcher は単に「データが流れた」事実だけを通知する。
 pub type PtyOutputObserver = Arc<dyn Fn() + Send + Sync>;
 
-const FLUSH_INTERVAL_MS: u64 = 16;
-const FLUSH_BYTES: usize = 32 * 1024;
+const FLUSH_INTERVAL_MS: u64 = 32;
+const FLUSH_BYTES: usize = 64 * 1024;
 /// 起動直後の emit 抑止時間。
 ///
 /// 旧設計 (Issue #285 以前) は renderer が `terminal_create` の戻り値で id を受け取って
@@ -178,7 +178,7 @@ pub(super) fn extract_emit_payload(buf: &mut BytesMut, scrollback: &Scrollback) 
     // 退避 → emit 後に extend_from_slice で書き戻していた。slice 借用で済む処理を
     // Vec 経由に分割していたため、flush ごとに `remainder.to_vec()` の追加 alloc + memcpy
     // が走っていた。安定 API の copy_within で in-place 圧縮することで、flush あたりの
-    // ヒープ allocation を 1 件削減する (60Hz 上限で常時 emit 中は ~60 alloc/s 削減)。
+    // ヒープ allocation を 1 件削減する (30Hz 上限で常時 emit 中は ~30 alloc/s 削減)。
     let emit_slice = &buf[..safe_end];
     append_scrollback(scrollback, emit_slice);
     let text = String::from_utf8_lossy(emit_slice).into_owned();
@@ -190,7 +190,7 @@ pub(super) fn extract_emit_payload(buf: &mut BytesMut, scrollback: &Scrollback) 
     Some(text)
 }
 
-/// Issue #494: spawn_batcher の `recv` 側 flush 判定。32 KiB を超えたらフラッシュする
+/// Issue #494: spawn_batcher の `recv` 側 flush 判定。64 KiB を超えたらフラッシュする
 /// 単純な閾値関数。spawn_batcher 内のロジックと統一して、テスト側からも同じ関数で
 /// 検証できるようにする。
 pub(super) fn should_flush_after_recv(buf_len: usize) -> bool {

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -6,7 +6,7 @@
 // 設計:
 // - portable-pty で PTY ペアを開く (Windows は ConPTY)
 // - reader thread が標準スレッドで master からブロッキング read
-// - 読み取ったバイトを mpsc → batcher (16ms or 32KB) → tauri emit
+// - 読み取ったバイトを mpsc → batcher (32ms or 64KB) → tauri emit
 // - writer は Mutex で保護、resize/kill 用に master の参照も保持
 // - SessionRegistry は AppState 経由で共有
 

--- a/src-tauri/src/pty/session/handle.rs
+++ b/src-tauri/src/pty/session/handle.rs
@@ -49,7 +49,7 @@ pub struct SessionHandle {
     pub role: Option<String>,
     pub cwd: String,
     pub is_codex: bool,
-    /// OS child PID。Windows では `taskkill /T` で MCP 等の孫プロセスまで止めるために使う。
+    /// OS child PID。Windows では `taskkill /T` で MCP 等の孤児化を防ぐために使う。
     pub(super) process_id: Option<u32>,
     /// Issue #153: prompt injection 中はユーザー入力を抑止する。
     /// `inject_codex_prompt_to_pty` 等が begin/end で立て下げる。
@@ -158,8 +158,12 @@ impl SessionHandle {
         // Issue #632: kill 時点で watcher_cancel を立てる。これにより claude_watcher が
         // 60 秒 deadline まで待たずに即座 (短い polling 間隔以内で) exit する。
         self.watcher_cancel.store(true, Ordering::Release);
-        self.kill_process_tree_best_effort();
         let mut k = lock_poisoned!(self.killer, "killer")?;
+        #[cfg(windows)]
+        if let Some(pid) = self.process_id {
+            Self::spawn_process_tree_kill(pid, k.clone_killer());
+            return Ok(());
+        }
         let _ = k.kill();
         Ok(())
     }
@@ -201,10 +205,20 @@ impl SessionHandle {
 
 impl SessionHandle {
     #[cfg(windows)]
-    fn kill_process_tree_best_effort(&self) {
-        let Some(pid) = self.process_id else {
-            return;
-        };
+    fn spawn_process_tree_kill(
+        pid: u32,
+        mut fallback: Box<dyn portable_pty::ChildKiller + Send + Sync>,
+    ) {
+        std::thread::spawn(move || {
+            Self::kill_process_tree_best_effort(pid);
+            if let Err(e) = fallback.kill() {
+                tracing::warn!(?e, "[pty] fallback child kill failed after taskkill");
+            }
+        });
+    }
+
+    #[cfg(windows)]
+    fn kill_process_tree_best_effort(pid: u32) {
         const CREATE_NO_WINDOW: u32 = 0x08000000;
         match Command::new("taskkill")
             .args(["/PID", &pid.to_string(), "/T", "/F"])
@@ -222,9 +236,6 @@ impl SessionHandle {
             }
         }
     }
-
-    #[cfg(not(windows))]
-    fn kill_process_tree_best_effort(&self) {}
 }
 
 /// Issue #144: SessionHandle が drop されたタイミングで child プロセスを必ず kill する。
@@ -250,7 +261,11 @@ impl Drop for SessionHandle {
                 poisoned.into_inner()
             }
         };
-        self.kill_process_tree_best_effort();
+        #[cfg(windows)]
+        if let Some(pid) = self.process_id {
+            Self::spawn_process_tree_kill(pid, k.clone_killer());
+            return;
+        }
         if let Err(e) = k.kill() {
             tracing::warn!(?e, "[pty] SessionHandle child kill failed during drop");
         }

--- a/src-tauri/src/pty/session/handle.rs
+++ b/src-tauri/src/pty/session/handle.rs
@@ -15,6 +15,10 @@ use anyhow::Result;
 use portable_pty::{MasterPty, PtySize};
 use serde::Serialize;
 use std::io::Write;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+#[cfg(windows)]
+use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -45,6 +49,8 @@ pub struct SessionHandle {
     pub role: Option<String>,
     pub cwd: String,
     pub is_codex: bool,
+    /// OS child PID。Windows では `taskkill /T` で MCP 等の孫プロセスまで止めるために使う。
+    pub(super) process_id: Option<u32>,
     /// Issue #153: prompt injection 中はユーザー入力を抑止する。
     /// `inject_codex_prompt_to_pty` 等が begin/end で立て下げる。
     /// renderer 側からの terminal_write は user_write 経由でこのフラグを見る。
@@ -152,6 +158,7 @@ impl SessionHandle {
         // Issue #632: kill 時点で watcher_cancel を立てる。これにより claude_watcher が
         // 60 秒 deadline まで待たずに即座 (短い polling 間隔以内で) exit する。
         self.watcher_cancel.store(true, Ordering::Release);
+        self.kill_process_tree_best_effort();
         let mut k = lock_poisoned!(self.killer, "killer")?;
         let _ = k.kill();
         Ok(())
@@ -192,6 +199,34 @@ impl SessionHandle {
     }
 }
 
+impl SessionHandle {
+    #[cfg(windows)]
+    fn kill_process_tree_best_effort(&self) {
+        let Some(pid) = self.process_id else {
+            return;
+        };
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        match Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .creation_flags(CREATE_NO_WINDOW)
+            .status()
+        {
+            Ok(status) if status.success() => {
+                tracing::info!("[pty] process tree killed pid={pid}");
+            }
+            Ok(status) => {
+                tracing::debug!("[pty] taskkill returned status={status} pid={pid}");
+            }
+            Err(e) => {
+                tracing::debug!("[pty] taskkill failed pid={pid}: {e}");
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    fn kill_process_tree_best_effort(&self) {}
+}
+
 /// Issue #144: SessionHandle が drop されたタイミングで child プロセスを必ず kill する。
 /// SessionRegistry::remove() は kill を呼ばずに Map から外すだけだったため、
 /// Arc の参照が残っている間 reader thread が PTY master を保持し続け、
@@ -215,6 +250,7 @@ impl Drop for SessionHandle {
                 poisoned.into_inner()
             }
         };
+        self.kill_process_tree_best_effort();
         if let Err(e) = k.kill() {
             tracing::warn!(?e, "[pty] SessionHandle child kill failed during drop");
         }
@@ -298,6 +334,7 @@ mod drop_tests {
             role: None,
             cwd: String::new(),
             is_codex: false,
+            process_id: None,
             injecting: AtomicBool::new(false),
             write_budget: Mutex::new(WriteBudget {
                 window_started_at: Instant::now(),

--- a/src-tauri/src/pty/session/spawn.rs
+++ b/src-tauri/src/pty/session/spawn.rs
@@ -353,6 +353,7 @@ pub fn spawn_session(
     };
     drop(pair.slave);
 
+    let process_id = child.process_id();
     let killer = child.clone_killer();
 
     // reader thread (blocking IO -> mpsc)
@@ -421,7 +422,7 @@ pub fn spawn_session(
     // `member_diagnostics[agent_id].last_pty_output_at` を update する observer を渡す。
     // ターミナルタブ等の agent_id 無し PTY では None で no-op。
     //
-    // closure 内 dedup: 1 秒間隔でしか hub.state lock を取らない。flush は最短 16ms 間隔
+    // closure 内 dedup: 1 秒間隔でしか hub.state lock を取らない。flush は最短 32ms 間隔
     // (FLUSH_INTERVAL_MS) で起こり得るので、生の flush ごとに lock 取得すると `inject` /
     // `team_send` 等の MCP tool と競合して latency 悪化を招く。
     let on_output: Option<PtyOutputObserver> = opts.agent_id.as_ref().map(|aid| {
@@ -518,6 +519,7 @@ pub fn spawn_session(
         role: opts.role,
         cwd: opts.cwd,
         is_codex: opts.is_codex,
+        process_id,
         injecting: AtomicBool::new(false),
         write_budget: Mutex::new(WriteBudget {
             window_started_at: Instant::now(),

--- a/src-tauri/src/pty/tests/batcher.rs
+++ b/src-tauri/src/pty/tests/batcher.rs
@@ -15,13 +15,13 @@ use crate::pty::batcher::{
 use crate::pty::scrollback::{new_scrollback, scrollback_to_string, SCROLLBACK_CAPACITY};
 use bytes::BytesMut;
 
-/// 16ms / 32 KiB の閾値が想定値から動いていないこと。
-/// renderer 側 60Hz レンダリングと PTY backpressure の両立に効く重要定数なので
+/// 32ms / 64 KiB の閾値が想定値から動いていないこと。
+/// renderer 側の描画負荷抑制と PTY backpressure の両立に効く重要定数なので
 /// 静的に snapshot しておく。
 #[test]
 fn flush_thresholds_are_pinned_to_expected_values() {
-    assert_eq!(flush_interval_ms(), 16, "flush tick must be ~60Hz (16ms)");
-    assert_eq!(flush_bytes_threshold(), 32 * 1024, "flush byte threshold = 32KiB");
+    assert_eq!(flush_interval_ms(), 32, "flush tick must be ~30Hz (32ms)");
+    assert_eq!(flush_bytes_threshold(), 64 * 1024, "flush byte threshold = 64KiB");
     assert_eq!(
         PTY_CHANNEL_CAPACITY, 256,
         "bounded channel must keep ~4MiB backpressure buffer"
@@ -136,7 +136,7 @@ fn scrollback_caps_at_64kib_after_repeated_extracts() {
     assert!(snap.chars().all(|c| c == 'a'));
 }
 
-/// Issue #48 のクリティカルケース: 「ちょうど 32KiB ぴったりだが末尾が日本語の途中」のとき、
+/// Issue #48 のクリティカルケース: 「ちょうど閾値ぴったりだが末尾が日本語の途中」のとき、
 /// flush threshold を満たしていても境界手前まで emit される (= U+FFFD 化を防ぐ)。
 #[test]
 fn flush_threshold_with_partial_multibyte_tail_emits_safely() {

--- a/src-tauri/src/pty/tests/mod.rs
+++ b/src-tauri/src/pty/tests/mod.rs
@@ -1,6 +1,6 @@
 //! Issue #494: PTY 周辺の integration test 集約モジュール。
 //!
-//! `batcher` の flush 境界条件 (UTF-8 安全境界 / 16ms tick / 32KiB バッファ閾値) を
+//! `batcher` の flush 境界条件 (UTF-8 安全境界 / 32ms tick / 64KiB バッファ閾値) を
 //! Tauri AppHandle に依存せず純粋関数経由で検証する。
 //!
 //! Issue #738: `session.rs` 分割に伴い、旧 `session.rs` 内の `env_strip_tests` /

--- a/src/renderer/src/stores/__tests__/canvas-subscribe.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-subscribe.test.ts
@@ -5,7 +5,7 @@
  * zoomSubscribe が毎フレーム発火する silent breakage になる。型レベルでは検出できないので
  * このテストでガードする。
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 describe('useCanvasStore subscribeWithSelector middleware (Issue #253 W#2)', () => {
   beforeEach(() => {
@@ -79,5 +79,42 @@ describe('useCanvasStore subscribeWithSelector middleware (Issue #253 W#2)', () 
     );
     expect(typeof unsubscribe).toBe('function');
     unsubscribe();
+  });
+
+  it('drag 中の nodes 更新は localStorage persist を skip し、drag 終了時に flush する', async () => {
+    const { useCanvasStore } = await import('../canvas');
+    const store = useCanvasStore.getState();
+    store.clear();
+
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+    setItemSpy.mockClear();
+
+    store.setCanvasDragging(true);
+    store.setNodes([
+      {
+        id: 'agent-issue-864',
+        type: 'agent',
+        position: { x: 10, y: 20 },
+        data: { cardType: 'agent', title: 'agent', payload: { agent: 'claude' } },
+        style: { width: 760, height: 460 }
+      }
+    ]);
+
+    expect(
+      setItemSpy.mock.calls.some(([name]) => name === 'vibe-editor:canvas')
+    ).toBe(false);
+
+    store.setCanvasDragging(false);
+
+    const canvasWrites = setItemSpy.mock.calls.filter(
+      ([name]) => name === 'vibe-editor:canvas'
+    );
+    expect(canvasWrites.length).toBeGreaterThanOrEqual(1);
+    const [, raw] = canvasWrites[canvasWrites.length - 1];
+    const saved = JSON.parse(String(raw)) as { state: { nodes: Array<{ id: string }> } };
+    expect(saved.state.nodes).toHaveLength(1);
+    expect(saved.state.nodes[0].id).toBe('agent-issue-864');
+
+    setItemSpy.mockRestore();
   });
 });

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -21,6 +21,7 @@ import {
   normalizeCanvasState
 } from '../lib/canvas-migrations';
 import type { AgentPayload } from '../components/canvas/cards/AgentNodeCard/types';
+import type { PersistStorage, StorageValue } from 'zustand/middleware';
 
 export type CardType = 'terminal' | 'agent' | 'editor' | 'diff' | 'fileTree' | 'changes';
 
@@ -302,6 +303,39 @@ export const NODE_MIN_H = 280;
  *  - 大量 handoff 時の保留 timer 蓄積を抑える
  */
 const pulseTimers = new Map<string, number>();
+let canvasPersistPaused = false;
+
+type CanvasPersistState = Pick<
+  CanvasState,
+  'nodes' | 'viewport' | 'stageView' | 'teamLocks' | 'arrangeGap'
+>;
+
+function canvasStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+const canvasPersistStorage: PersistStorage<CanvasPersistState> = {
+  getItem: (name) => {
+    const raw = canvasStorage()?.getItem(name);
+    if (!raw) return null;
+    return JSON.parse(raw) as StorageValue<CanvasPersistState>;
+  },
+  setItem: (name, value) => {
+    // Issue #864/#835: drag 中は nodes が毎フレーム変わるため、localStorage への
+    // JSON.stringify が UI スレッドを詰まらせる。drag 終了時の setCanvasDragging(false)
+    // と直後の setNodes で最新状態が flush されるので、drag 中だけ丸ごと skip する。
+    if (canvasPersistPaused) return;
+    canvasStorage()?.setItem(name, JSON.stringify(value));
+  },
+  removeItem: (name) => {
+    canvasStorage()?.removeItem(name);
+  }
+};
 
 /** Issue #385: テストから直接 normalize の挙動を検証するための export。
  *  本体は zustand persist の migrate / merge から間接呼出しされるが、unit test では
@@ -361,7 +395,10 @@ export const useCanvasStore = create<CanvasState>()(
       setNodes: (nodes) => set({ nodes }),
       setEdges: (edges) => set({ edges }),
       setViewport: (viewport) => set({ viewport }),
-      setCanvasDragging: (isDragging) => set({ isDragging }),
+      setCanvasDragging: (isDragging) => {
+        canvasPersistPaused = isDragging;
+        set({ isDragging });
+      },
       addCard: ({ type, title, payload, position }) => {
         const id = newId(type);
         const existing = get().nodes;
@@ -494,6 +531,7 @@ export const useCanvasStore = create<CanvasState>()(
     }),
     {
       name: 'vibe-editor:canvas',
+      storage: canvasPersistStorage,
       // Issue #385: v4 で persisted state は必ず normalizeCanvasState を経由させる。
       // 同 version の rehydrate でも `merge` で再正規化するため、runtime で紛れ込んだ
       // NaN viewport / 範囲外 zoom / 壊れた node も次回起動時には掃除される。


### PR DESCRIPTION
## 概要

- Canvas の zustand persist にカスタム storage を入れ、ドラッグ中の `nodes` 更新では localStorage 書き込みと JSON.stringify を skip するようにしました。
- PTY 出力バッチャの flush 間隔/閾値を 32ms / 64KiB に調整し、多人数エージェント稼働時の renderer 向けイベント数を抑えました。
- Windows では PTY の child PID に対して `taskkill /T /F` を best-effort で実行し、`team-bridge.js` や MCP node プロセスの孤児化を減らします。

## 原因

Issue #864 は、Canvas ドラッグ中の毎フレーム永続化、複数 PTY の同時出力、終了時に親プロセスだけを kill して孫プロセスが残る可能性が重なって、UI 無応答と子プロセス残留につながる問題でした。

## 検証

- `npm run typecheck`
- `npx vitest run src/renderer/src/stores/__tests__/canvas-subscribe.test.ts`
- `cargo test pty::tests::batcher --lib`
- `cargo check`

Closes #864