### PR TITLE
fix(ui): タブバーのキーボード移動を追加

### DIFF
--- a/src/renderer/src/components/TabBar.tsx
+++ b/src/renderer/src/components/TabBar.tsx
@@ -27,9 +27,22 @@ export function TabBar({
   onTogglePin
 }: TabBarProps): JSX.Element {
   const t = useT();
+
+  const selectAndFocusTab = (targetIndex: number, tablist: HTMLElement | null): void => {
+    const targetTab = tabs[targetIndex];
+    if (!targetTab) {
+      return;
+    }
+
+    onSelect(targetTab.id);
+
+    const tabElements = Array.from(tablist?.querySelectorAll<HTMLElement>('[role="tab"]') ?? []);
+    tabElements[targetIndex]?.focus();
+  };
+
   return (
     <div className="tabbar" role="tablist">
-      {tabs.map((tab) => {
+      {tabs.map((tab, index) => {
         const active = tab.id === activeId;
 
         return (
@@ -47,9 +60,31 @@ export function TabBar({
             aria-selected={active}
             tabIndex={active ? 0 : -1}
             onKeyDown={(e) => {
+              if (e.target !== e.currentTarget) {
+                return;
+              }
+
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 onSelect(tab.id);
+                return;
+              }
+
+              const lastIndex = tabs.length - 1;
+              const tablist = e.currentTarget.closest<HTMLElement>('[role="tablist"]');
+
+              if (e.key === 'ArrowRight') {
+                e.preventDefault();
+                selectAndFocusTab(index >= lastIndex ? 0 : index + 1, tablist);
+              } else if (e.key === 'ArrowLeft') {
+                e.preventDefault();
+                selectAndFocusTab(index <= 0 ? lastIndex : index - 1, tablist);
+              } else if (e.key === 'Home') {
+                e.preventDefault();
+                selectAndFocusTab(0, tablist);
+              } else if (e.key === 'End') {
+                e.preventDefault();
+                selectAndFocusTab(lastIndex, tablist);
               }
             }}
           >

--- a/src/renderer/src/components/__tests__/TabBar.test.tsx
+++ b/src/renderer/src/components/__tests__/TabBar.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { TabBar, type TabItem } from '../TabBar';
+
+vi.mock('../../lib/i18n', () => ({
+  useT: () => (key: string) => key
+}));
+
+const TABS: TabItem[] = [
+  { id: 'terminal', title: 'Terminal' },
+  { id: 'editor', title: 'Editor' },
+  { id: 'preview', title: 'Preview' }
+];
+
+function renderTabBar(activeId = 'terminal') {
+  const onSelect = vi.fn();
+  const result = render(<TabBar tabs={TABS} activeId={activeId} onSelect={onSelect} />);
+  return { ...result, onSelect };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('TabBar keyboard navigation', () => {
+  it('ArrowRight / ArrowLeft で隣の tab を選択して focus を移す (Issue #847)', () => {
+    const { onSelect } = renderTabBar('terminal');
+    const tabs = screen.getAllByRole('tab');
+
+    tabs[0]?.focus();
+    fireEvent.keyDown(tabs[0]!, { key: 'ArrowRight' });
+    expect(onSelect).toHaveBeenLastCalledWith('editor');
+    expect(tabs[1]).toHaveFocus();
+
+    fireEvent.keyDown(tabs[0]!, { key: 'ArrowLeft' });
+    expect(onSelect).toHaveBeenLastCalledWith('preview');
+    expect(tabs[2]).toHaveFocus();
+  });
+
+  it('Home / End で先頭と末尾の tab を選択して focus を移す', () => {
+    const { onSelect } = renderTabBar('editor');
+    const tabs = screen.getAllByRole('tab');
+
+    tabs[1]?.focus();
+    fireEvent.keyDown(tabs[1]!, { key: 'End' });
+    expect(onSelect).toHaveBeenLastCalledWith('preview');
+    expect(tabs[2]).toHaveFocus();
+
+    fireEvent.keyDown(tabs[1]!, { key: 'Home' });
+    expect(onSelect).toHaveBeenLastCalledWith('terminal');
+    expect(tabs[0]).toHaveFocus();
+  });
+});


### PR DESCRIPTION
## 概要
- TabBar の role=tab に ArrowLeft / ArrowRight / Home / End のキーボード移動を追加
- 移動先タブを選択し、DOM focus も移すように修正
- Issue #847 の回帰テストを追加

## 検証
- npm run typecheck
- npx vitest run src/renderer/src/components/__tests__/TabBar.test.tsx

Closes #847