### PR TITLE
fix(ui): コマンドパレットのフォーカス制御を追加

### DIFF
--- a/src/renderer/src/components/CommandPalette.tsx
+++ b/src/renderer/src/components/CommandPalette.tsx
@@ -27,8 +27,26 @@ export function CommandPalette({
   const [selected, setSelected] = useState<number>(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const wasOpenRef = useRef(false);
 
   const filtered = useMemo(() => filterCommands(commands, query), [commands, query]);
+
+  // Issue #846: モーダルを閉じた後、開く前に操作していた要素へ focus を戻す。
+  useEffect(() => {
+    if (open && !wasOpenRef.current) {
+      restoreFocusRef.current =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    } else if (!open && wasOpenRef.current) {
+      const target = restoreFocusRef.current;
+      restoreFocusRef.current = null;
+      if (target && document.contains(target)) {
+        target.focus();
+      }
+    }
+    wasOpenRef.current = open;
+  }, [open]);
 
   // 開いた瞬間に入力フォーカス＋クエリクリア
   useEffect(() => {
@@ -82,6 +100,33 @@ export function CommandPalette({
     [filtered.length, runSelected, onClose]
   );
 
+  const handleDialogKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (e.key !== 'Tab') return;
+
+    const root = dialogRef.current;
+    if (!root) return;
+
+    const focusables = Array.from(
+      root.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex="-1"])'
+      )
+    ).filter((el) => el.tabIndex >= 0);
+
+    if (focusables.length === 0) return;
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+
+    if (e.shiftKey && active === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }, []);
+
   // Issue #180: 旧実装は backdrop onClick={onClose} で閉じていたため、リスト内/入力欄で
   // mousedown → backdrop で mouseup と移動するドラッグ選択 (テキスト選択) でも click が
   // backdrop に届いて閉じていた。
@@ -106,10 +151,12 @@ export function CommandPalette({
 
   return createPortal(
     <div
+      ref={dialogRef}
       className="cmdp-backdrop"
       data-state={dataState}
       data-motion={motion}
       onMouseDown={handleBackdropMouseDown}
+      onKeyDown={handleDialogKeyDown}
       role="dialog"
       aria-modal="true"
       aria-label={t('palette.ariaLabel')}

--- a/src/renderer/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/renderer/src/components/__tests__/CommandPalette.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { CommandPalette } from '../CommandPalette';
 import { SettingsProvider } from '../../lib/settings-context';
 import type { Command } from '../../lib/commands';
@@ -27,6 +27,23 @@ function installWindowApi(): void {
   };
 }
 
+function renderPalette(open: boolean, onClose = vi.fn()) {
+  const result = render(
+    <SettingsProvider>
+      <CommandPalette open={open} commands={commands} onClose={onClose} />
+    </SettingsProvider>
+  );
+  return { ...result, onClose };
+}
+
+function paletteNode(open: boolean, onClose: () => void) {
+  return (
+    <SettingsProvider>
+      <CommandPalette open={open} commands={commands} onClose={onClose} />
+    </SettingsProvider>
+  );
+}
+
 describe('CommandPalette', () => {
   beforeEach(() => {
     installWindowApi();
@@ -38,18 +55,51 @@ describe('CommandPalette', () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    document.body.innerHTML = '';
   });
 
   it('renders the backdrop through a body portal', () => {
-    const { container } = render(
-      <SettingsProvider>
-        <CommandPalette open commands={commands} onClose={vi.fn()} />
-      </SettingsProvider>
-    );
+    const { container } = renderPalette(true);
 
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveClass('cmdp-backdrop');
     expect(dialog.parentElement).toBe(document.body);
     expect(container.querySelector('.cmdp-backdrop')).toBeNull();
+  });
+
+  it('Tab / Shift+Tab を dialog 内に trap して背後 UI へ抜けさせない (Issue #846)', () => {
+    const behindButton = document.createElement('button');
+    behindButton.textContent = 'Behind UI';
+    document.body.appendChild(behindButton);
+
+    renderPalette(true);
+
+    const input = screen.getByRole('combobox');
+    input.focus();
+
+    expect(fireEvent.keyDown(input, { key: 'Tab' })).toBe(false);
+    expect(input).toHaveFocus();
+
+    expect(fireEvent.keyDown(input, { key: 'Tab', shiftKey: true })).toBe(false);
+    expect(input).toHaveFocus();
+    expect(behindButton).not.toHaveFocus();
+  });
+
+  it('閉じた後に CommandPalette を開く前の要素へ focus を戻す (Issue #846)', () => {
+    const opener = document.createElement('button');
+    opener.textContent = 'Open palette';
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const onClose = vi.fn();
+    const { rerender } = render(paletteNode(true, onClose));
+
+    const input = screen.getByRole('combobox');
+    input.focus();
+    expect(input).toHaveFocus();
+
+    rerender(paletteNode(false, onClose));
+
+    expect(opener).toHaveFocus();
   });
 });


### PR DESCRIPTION
## 概要
- CommandPalette を開く前の focus 要素を保存し、閉じた後に復帰するように修正
- Tab / Shift+Tab を dialog 内で循環させ、背後 UI に抜けないように修正
- Issue #846 の回帰テストを追加

## 検証
- npm run typecheck
- npx vitest run src/renderer/src/components/__tests__/CommandPalette.test.tsx

Closes #846