### PR TITLE
fix(i18n): DiffView の文言を翻訳対応する

### DIFF
--- a/src/renderer/src/components/DiffView.tsx
+++ b/src/renderer/src/components/DiffView.tsx
@@ -3,6 +3,7 @@ import { Columns3, Rows3 } from 'lucide-react';
 import '../lib/monaco-setup';
 import type { GitDiffResult } from '../../../types/shared';
 import { detectLanguage } from '../lib/language';
+import { useT } from '../lib/i18n';
 import { useMonacoTheme, useSettings } from '../lib/settings-context';
 
 interface DiffViewProps {
@@ -20,6 +21,7 @@ export function DiffView({
 }: DiffViewProps): JSX.Element {
   const { settings } = useSettings();
   const theme = useMonacoTheme();
+  const t = useT();
 
   if (loading || !result) {
     return (
@@ -28,10 +30,10 @@ export function DiffView({
           {loading ? (
             <>
               <span className="cc-spinner" aria-hidden="true" />
-              <span>diff を読み込み中…</span>
+              <span>{t('diff.loading')}</span>
             </>
           ) : (
-            '差分を表示するファイルを選択してください'
+            t('diff.selectFile')
           )}
         </div>
       </div>
@@ -42,7 +44,7 @@ export function DiffView({
     return (
       <div className="diffview">
         <div className="diffview__placeholder diffview__placeholder--error">
-          エラー: {result.error}
+          {t('diff.error', { error: result.error })}
         </div>
       </div>
     );
@@ -52,7 +54,7 @@ export function DiffView({
     return (
       <div className="diffview">
         <div className="diffview__placeholder">
-          バイナリファイルは diff 表示できません: {result.path}
+          {t('diff.binary', { path: result.path })}
         </div>
       </div>
     );
@@ -60,8 +62,8 @@ export function DiffView({
 
   const language = detectLanguage(result.path);
   const header: string[] = [result.path];
-  if (result.isNew) header.push('(新規追加)');
-  else if (result.isDeleted) header.push('(削除)');
+  if (result.isNew) header.push(t('diff.new'));
+  else if (result.isDeleted) header.push(t('diff.deleted'));
 
   return (
     <div className="diffview">
@@ -71,8 +73,8 @@ export function DiffView({
           type="button"
           className="toolbar__btn toolbar__btn--icon"
           onClick={onToggleSideBySide}
-          title={sideBySide ? 'インラインに切替' : 'サイドバイサイドに切替'}
-          aria-label="差分表示モード切替"
+          title={sideBySide ? t('diff.toggleInline') : t('diff.toggleSideBySide')}
+          aria-label={t('diff.toggleMode')}
         >
           {sideBySide ? (
             <Rows3 size={15} strokeWidth={1.75} />

--- a/src/renderer/src/components/__tests__/DiffView.test.tsx
+++ b/src/renderer/src/components/__tests__/DiffView.test.tsx
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { DiffView } from '../DiffView';
+import { SettingsProvider } from '../../lib/settings-context';
+import { DEFAULT_SETTINGS, type GitDiffResult } from '../../../../types/shared';
+
+vi.mock('../../lib/monaco-setup', () => ({}));
+
+vi.mock('@monaco-editor/react', () => ({
+  DiffEditor: () => <div data-testid="diff-editor" />
+}));
+
+type TestWindow = Window &
+  typeof globalThis & {
+    api?: unknown;
+  };
+
+function installApi(): void {
+  (window as TestWindow).api = {
+    settings: {
+      load: vi.fn(async () => ({ ...DEFAULT_SETTINGS, language: 'en' })),
+      save: vi.fn(async () => undefined)
+    },
+    app: {
+      setProjectRoot: vi.fn(async () => undefined),
+      setZoomLevel: vi.fn(async () => undefined)
+    }
+  };
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <SettingsProvider>{children}</SettingsProvider>;
+}
+
+function renderDiffView(
+  props: Partial<Parameters<typeof DiffView>[0]> = {}
+) {
+  return render(
+    <Wrapper>
+      <DiffView
+        result={props.result ?? null}
+        loading={props.loading ?? false}
+        sideBySide={props.sideBySide ?? true}
+        onToggleSideBySide={props.onToggleSideBySide ?? vi.fn()}
+      />
+    </Wrapper>
+  );
+}
+
+function diffResult(overrides: Partial<GitDiffResult> = {}): GitDiffResult {
+  return {
+    ok: true,
+    path: 'src/example.ts',
+    isNew: false,
+    isDeleted: false,
+    isBinary: false,
+    original: 'old',
+    modified: 'new',
+    ...overrides
+  };
+}
+
+describe('DiffView i18n', () => {
+  let originalApi: unknown;
+
+  beforeEach(() => {
+    originalApi = (window as TestWindow).api;
+    installApi();
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (originalApi === undefined) {
+      delete (window as TestWindow).api;
+    } else {
+      (window as TestWindow).api = originalApi;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('loading / empty / error / binary states use the active locale (Issue #844)', async () => {
+    const { rerender } = renderDiffView({ loading: true });
+    expect(await screen.findByText('Loading diff…')).toBeInTheDocument();
+
+    rerender(
+      <Wrapper>
+        <DiffView result={null} loading={false} sideBySide onToggleSideBySide={vi.fn()} />
+      </Wrapper>
+    );
+    expect(await screen.findByText('Select a file to view its diff')).toBeInTheDocument();
+
+    rerender(
+      <Wrapper>
+        <DiffView
+          result={diffResult({ ok: false, error: 'boom' })}
+          loading={false}
+          sideBySide
+          onToggleSideBySide={vi.fn()}
+        />
+      </Wrapper>
+    );
+    expect(await screen.findByText('Error: boom')).toBeInTheDocument();
+
+    rerender(
+      <Wrapper>
+        <DiffView
+          result={diffResult({ isBinary: true, path: 'asset.png' })}
+          loading={false}
+          sideBySide
+          onToggleSideBySide={vi.fn()}
+        />
+      </Wrapper>
+    );
+    expect(
+      await screen.findByText('Binary files cannot be shown as diffs: asset.png')
+    ).toBeInTheDocument();
+  });
+
+  it('header status and toggle labels use the active locale', async () => {
+    renderDiffView({ result: diffResult({ isNew: true }), sideBySide: true });
+
+    expect(await screen.findByText('src/example.ts (new)')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Toggle diff display mode' })).toHaveAttribute(
+      'title',
+      'Switch to inline'
+    );
+  });
+});

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -153,6 +153,15 @@ const ja: Dict = {
 
   // ---------- File tree / Editor ----------
   'filetree.refresh': '再読込',
+  'diff.loading': 'diff を読み込み中…',
+  'diff.selectFile': '差分を表示するファイルを選択してください',
+  'diff.error': 'エラー: {error}',
+  'diff.binary': 'バイナリファイルは diff 表示できません: {path}',
+  'diff.new': '(新規追加)',
+  'diff.deleted': '(削除)',
+  'diff.toggleMode': '差分表示モード切替',
+  'diff.toggleInline': 'インラインに切替',
+  'diff.toggleSideBySide': 'サイドバイサイドに切替',
   'editor.loading': 'ファイルを読み込み中…',
   'editor.save': '保存 (Ctrl+S)',
   'editor.save.ariaLabel': '保存',
@@ -950,6 +959,15 @@ const en: Dict = {
 
   // ---------- File tree / Editor ----------
   'filetree.refresh': 'Reload',
+  'diff.loading': 'Loading diff…',
+  'diff.selectFile': 'Select a file to view its diff',
+  'diff.error': 'Error: {error}',
+  'diff.binary': 'Binary files cannot be shown as diffs: {path}',
+  'diff.new': '(new)',
+  'diff.deleted': '(deleted)',
+  'diff.toggleMode': 'Toggle diff display mode',
+  'diff.toggleInline': 'Switch to inline',
+  'diff.toggleSideBySide': 'Switch to side by side',
   'editor.loading': 'Loading file…',
   'editor.save': 'Save (Ctrl+S)',
   'editor.save.ariaLabel': 'Save',


### PR DESCRIPTION
## 概要
- DiffView の読み込み中/空/エラー/バイナリ/ヘッダー/表示切替文言を t() 経由に変更
- ja/en の diff.* 翻訳キーを追加
- 英語設定で DiffView の文言が英語になる回帰テストを追加

## 検証
- npm run typecheck
- npx vitest run src/renderer/src/components/__tests__/DiffView.test.tsx

Closes #844