### PR TITLE
fix(ui): FileTreePanel のトースト呼び出しを修正

### DIFF
--- a/src/renderer/src/components/FileTreePanel.tsx
+++ b/src/renderer/src/components/FileTreePanel.tsx
@@ -85,7 +85,7 @@ export function FileTreePanel({
   const [contextMenu, setContextMenu] = useState<
     { x: number; y: number; items: ContextMenuItem[] } | null
   >(null);
-  const showToast = useToast();
+  const { showToast } = useToast();
   // Issue #273: 当該 instance を Provider に登録する一意 id。Sidebar と FileTreeCard が
   // 同居しても useId で生成された値は重複しない (React 18 の機能)。
   const instanceId = useId();


### PR DESCRIPTION
## 概要
- FileTreePanel で useToast() の戻り値を分割代入し、showToast 関数を正しく呼ぶように修正
- ファイル操作時のトースト表示で TypeError が起きる問題を修正

## 検証
- npm run typecheck

補足: npx tsc --noEmit -p tsconfig.web.json --ignoreDeprecations 6.0 も試しましたが、既存の JSX namespace / test mock 型などの広範な既存エラーで停止するため、このPR固有の検証には含めていません。

Closes #843