### PR TITLE
fix(ui): React 19 の JSX 型互換 shim を追加

### DIFF
--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -1,9 +1,27 @@
 /// <reference types="vite/client" />
 import type { Api } from './lib/tauri-api';
+import type { JSX as ReactJSX } from 'react';
 
 declare global {
   interface Window {
     api: Api;
+  }
+
+  /**
+   * React 19 の型定義では JSX namespace が React.JSX に移動した。
+   * 既存コードの `JSX.Element` 戻り型を保つため、React 側の JSX 型を
+   * global JSX へ橋渡しする。
+   */
+  namespace JSX {
+    type ElementType = ReactJSX.ElementType;
+    interface Element extends ReactJSX.Element {}
+    interface ElementClass extends ReactJSX.ElementClass {}
+    interface ElementAttributesProperty extends ReactJSX.ElementAttributesProperty {}
+    interface ElementChildrenAttribute extends ReactJSX.ElementChildrenAttribute {}
+    type LibraryManagedAttributes<C, P> = ReactJSX.LibraryManagedAttributes<C, P>;
+    interface IntrinsicAttributes extends ReactJSX.IntrinsicAttributes {}
+    interface IntrinsicClassAttributes<T> extends ReactJSX.IntrinsicClassAttributes<T> {}
+    interface IntrinsicElements extends ReactJSX.IntrinsicElements {}
   }
 }
 


### PR DESCRIPTION
## 概要
- React 19 / @types/react 19 で global JSX namespace が無い問題に対応
- React.JSX の型を global JSX へ橋渡しする shim を env.d.ts に追加
- 既存の 121 箇所の JSX.Element 戻り型を大きく機械置換せず互換性を維持

## 検証
- npm run typecheck
- npx tsc --noEmit -p tsconfig.web.json --ignoreDeprecations 6.0 で Cannot find namespace JSX が 0 件になることを確認

補足: web tsconfig 直接チェック自体は、JSX 以外の既存型エラーで最終的には失敗します。

Closes #842