### PR TITLE
fix(canvas): addCard の重複配置を防止

### DIFF
--- a/src/renderer/src/stores/__tests__/canvas-add-card-position.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-add-card-position.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { NODE_H, NODE_W, useCanvasStore } from '../canvas';
+
+const GAP = 32;
+
+describe('useCanvasStore.addCard fallback placement (Issue #840)', () => {
+  beforeEach(() => {
+    if (typeof localStorage !== 'undefined') localStorage.clear();
+    useCanvasStore.getState().clear();
+  });
+
+  it('カード削除後も position 省略の addCard が既存カードと座標重複しない', () => {
+    const store = useCanvasStore.getState();
+    const ids = Array.from({ length: 7 }, (_, index) =>
+      store.addCard({
+        type: 'terminal',
+        title: `Terminal ${index + 1}`,
+        payload: undefined
+      })
+    );
+
+    store.removeCard(ids[2], { cascadeTeam: false });
+
+    const nextId = store.addCard({
+      type: 'terminal',
+      title: 'Terminal next',
+      payload: undefined
+    });
+
+    const nodes = useCanvasStore.getState().nodes;
+    const next = nodes.find((node) => node.id === nextId);
+    expect(next?.position).toEqual({ x: (NODE_W + GAP) * 2, y: 0 });
+
+    const positions = nodes.map((node) => `${node.position.x},${node.position.y}`);
+    expect(new Set(positions).size).toBe(positions.length);
+  });
+
+  it('position が明示された addCard は指定座標をそのまま使う', () => {
+    const explicit = { x: NODE_W + GAP, y: NODE_H + GAP };
+    const id = useCanvasStore.getState().addCard({
+      type: 'terminal',
+      title: 'Explicit',
+      payload: undefined,
+      position: explicit
+    });
+
+    expect(useCanvasStore.getState().nodes.find((node) => node.id === id)?.position).toEqual(
+      explicit
+    );
+  });
+});

--- a/src/renderer/src/stores/__tests__/canvas-add-card-position.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-add-card-position.test.ts
@@ -9,7 +9,7 @@ describe('useCanvasStore.addCard fallback placement (Issue #840)', () => {
     useCanvasStore.getState().clear();
   });
 
-  it('カード削除後も position 省略の addCard が既存カードと座標重複しない', () => {
+  it('カード削除後も position 省略の addCard が既存カードと座標が重複しない', () => {
     const store = useCanvasStore.getState();
     const ids = Array.from({ length: 7 }, (_, index) =>
       store.addCard({

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -424,7 +424,7 @@ export const useCanvasStore = create<CanvasState>()(
         const existing = get().nodes;
         let pos = position;
         if (!pos) {
-          // Issue #840: 削除後に existing.length だけを見ると既存カードの座標へ重なる。
+          // Issue #840: 削除後に existing.length だけを見ると既存カードと座標が重なる。
           // 6 列グリッド上の占有スロットを避け、最初の空き位置へ配置する。
           pos = nextFallbackCardPosition(existing);
         }

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -366,6 +366,26 @@ function makeCardNode<T extends CardType>(
   };
 }
 
+function nextFallbackCardPosition(nodes: Node<CardData>[]): { x: number; y: number } {
+  const cols = 6;
+  const stepX = NODE_W + 32;
+  const stepY = NODE_H + 32;
+  const occupied = new Set(
+    nodes.map((node) => `${Math.round(node.position.x)},${Math.round(node.position.y)}`)
+  );
+
+  for (let slot = 0; slot <= nodes.length; slot++) {
+    const x = (slot % cols) * stepX;
+    const y = Math.floor(slot / cols) * stepY;
+    if (!occupied.has(`${x},${y}`)) return { x, y };
+  }
+
+  return {
+    x: ((nodes.length + 1) % cols) * stepX,
+    y: Math.floor((nodes.length + 1) / cols) * stepY
+  };
+}
+
 export const useCanvasStore = create<CanvasState>()(
   /**
    * Issue #253 sub: subscribeWithSelector で `subscribe(selector, listener)` API を有効化。
@@ -404,13 +424,9 @@ export const useCanvasStore = create<CanvasState>()(
         const existing = get().nodes;
         let pos = position;
         if (!pos) {
-          // 簡易: 6 列グリッドで右下に積む
-          const idx = existing.length;
-          const cols = 6;
-          pos = {
-            x: (idx % cols) * (NODE_W + 32),
-            y: Math.floor(idx / cols) * (NODE_H + 32)
-          };
+          // Issue #840: 削除後に existing.length だけを見ると既存カードの座標へ重なる。
+          // 6 列グリッド上の占有スロットを避け、最初の空き位置へ配置する。
+          pos = nextFallbackCardPosition(existing);
         }
         set({
           nodes: [...existing, makeCardNode(id, type, pos, title, payload)]


### PR DESCRIPTION
## Summary
- position 省略時の addCard で、既存ノードのグリッド座標を見て最初の空き位置を選ぶようにしました
- 削除後に existing.length だけで座標を決めて既存カードと重なる問題を防ぎました
- 明示 position 指定時は従来どおり指定座標をそのまま使うテストを追加しました

Closes #840

## Test plan
- [x] npm run typecheck
- [x] npm test
- [x] npx vitest run src/renderer/src/stores/__tests__/canvas-add-card-position.test.ts src/renderer/src/stores/__tests__/canvas-subscribe.test.ts --reporter=dot