### PR TITLE
fix(settings): reset で既定値を clone する

### DIFF
--- a/src/renderer/src/lib/__tests__/settings-context.test.tsx
+++ b/src/renderer/src/lib/__tests__/settings-context.test.tsx
@@ -106,6 +106,35 @@ describe('settings-context', () => {
     expect(api.settings.save.mock.calls[0][0]).toMatchObject({ editorFontSize: 18 });
   });
 
+  it('reset() は DEFAULT_SETTINGS を clone して live state と保存値に使う', async () => {
+    const api = installApi({
+      recentProjects: ['F:/tmp/project'],
+      workspaceFolders: ['F:/tmp/workspace'],
+      fileTreeExpanded: { 'F:/tmp/project': ['src'] }
+    });
+    const { result } = renderHook(() => useSettings(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    api.settings.save.mockClear();
+
+    await act(async () => {
+      await result.current.reset();
+    });
+
+    const saved = api.settings.save.mock.calls[0][0] as AppSettings;
+    expect(result.current.settings).toEqual(DEFAULT_SETTINGS);
+    expect(result.current.settings).not.toBe(DEFAULT_SETTINGS);
+    expect(result.current.settings.recentProjects).not.toBe(DEFAULT_SETTINGS.recentProjects);
+    expect(result.current.settings.workspaceFolders).not.toBe(DEFAULT_SETTINGS.workspaceFolders);
+    expect(result.current.settings.fileTreeExpanded).not.toBe(DEFAULT_SETTINGS.fileTreeExpanded);
+
+    expect(saved).toEqual(DEFAULT_SETTINGS);
+    expect(saved).not.toBe(DEFAULT_SETTINGS);
+    expect(saved.recentProjects).not.toBe(DEFAULT_SETTINGS.recentProjects);
+    expect(saved.workspaceFolders).not.toBe(DEFAULT_SETTINGS.workspaceFolders);
+    expect(saved.fileTreeExpanded).not.toBe(DEFAULT_SETTINGS.fileTreeExpanded);
+  });
+
   it('save が reject すると Toast が表示される (Issue #490 の昇格挙動)', async () => {
     const api = installApi(undefined, async () => {
       throw new Error('disk full');

--- a/src/renderer/src/lib/settings-context.tsx
+++ b/src/renderer/src/lib/settings-context.tsx
@@ -60,6 +60,13 @@ if (__hot) {
   });
 }
 
+function cloneDefaultSettings(): AppSettings {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(DEFAULT_SETTINGS);
+  }
+  return JSON.parse(JSON.stringify(DEFAULT_SETTINGS)) as AppSettings;
+}
+
 export function SettingsProvider({ children }: { children: ReactNode }): JSX.Element {
   const [settingsState, setSettingsState] = useState<AppSettings>(DEFAULT_SETTINGS);
   const [loadingState, setLoadingState] = useState<boolean>(true);
@@ -220,8 +227,9 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
   }, []);
 
   const reset = useCallback(async () => {
-    commitState(DEFAULT_SETTINGS, loadingRef.current);
-    await window.api.settings.save(DEFAULT_SETTINGS);
+    const next = cloneDefaultSettings();
+    commitState(next, loadingRef.current);
+    await window.api.settings.save(next);
   }, [commitState]);
 
   const store = useMemo<SettingsStore>(


### PR DESCRIPTION
## Summary
- SettingsProvider.reset() で DEFAULT_SETTINGS を直接 live state / 保存値に渡さず、deep clone した値を使うようにしました
- structuredClone が使えない環境向けに JSON コピーへ fallback します
- reset 後の state / save payload が DEFAULT_SETTINGS のネスト参照を共有しない回帰テストを追加しました

Closes #839

## Test plan
- [x] npm run typecheck
- [x] npm test
- [x] npx vitest run src/renderer/src/lib/__tests__/settings-context.test.tsx --reporter=dot