### PR TITLE
fix(settings): theme と language を毎ロード検証

### DIFF
--- a/src/renderer/src/lib/__tests__/settings-migrate.test.ts
+++ b/src/renderer/src/lib/__tests__/settings-migrate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { APP_SETTINGS_SCHEMA_VERSION } from '../../../../types/shared';
+import { APP_SETTINGS_SCHEMA_VERSION, DEFAULT_SETTINGS } from '../../../../types/shared';
 import { migrateSettings } from '../settings-migrate';
 
 describe('migrateSettings', () => {
@@ -34,6 +34,31 @@ describe('migrateSettings', () => {
     });
 
     expect(migrated.statusMascotVariant).toBe('vibe');
+  });
+
+  // ---------- Issue #836: schemaVersion >= 1 でも theme / language を毎ロード検証 ----------
+  describe('theme / language validation (Issue #836)', () => {
+    it('current schema でも未知 theme / language を default に戻す', () => {
+      const migrated = migrateSettings({
+        schemaVersion: APP_SETTINGS_SCHEMA_VERSION,
+        language: 'xx',
+        theme: 'removed-theme'
+      });
+
+      expect(migrated.language).toBe(DEFAULT_SETTINGS.language);
+      expect(migrated.theme).toBe(DEFAULT_SETTINGS.theme);
+    });
+
+    it('current schema の有効な theme / language は維持する', () => {
+      const migrated = migrateSettings({
+        schemaVersion: APP_SETTINGS_SCHEMA_VERSION,
+        language: 'en',
+        theme: 'glass'
+      });
+
+      expect(migrated.language).toBe('en');
+      expect(migrated.theme).toBe('glass');
+    });
   });
 
   // ---------- Issue #449: v9 → v10 Unicode dash 正規化 ----------

--- a/src/renderer/src/lib/settings-migrate.ts
+++ b/src/renderer/src/lib/settings-migrate.ts
@@ -66,24 +66,27 @@ export function migrateSettings(raw: unknown): AppSettings {
     if (!Array.isArray(data.workspaceFolders)) {
       data.workspaceFolders = [];
     }
-    // language/theme が unknown 値 → デフォルトに戻す
-    const validLanguages: Language[] = ['ja', 'en'];
-    if (!validLanguages.includes(data.language as Language)) {
-      data.language = DEFAULT_SETTINGS.language;
-    }
-    // Issue #109: 'glass' を validThemes に追加 (UI/ThemeName には既に存在するが、
-    // ここに無いと migration で claude-dark に戻されてしまう)。
-    const validThemes: ThemeName[] = [
-      'claude-dark',
-      'claude-light',
-      'dark',
-      'light',
-      'midnight',
-      'glass'
-    ];
-    if (!validThemes.includes(data.theme as ThemeName)) {
-      data.theme = DEFAULT_SETTINGS.theme;
-    }
+  }
+
+  // Issue #836: theme/language は schemaVersion に関係なく毎ロード検証する。
+  // 新旧バージョン差分だけでなく、改竄・削除済みテーマ・将来バージョン由来の未知値も
+  // renderer の各 consumer に届く前に default へ戻す。
+  const validLanguages: Language[] = ['ja', 'en'];
+  if (!validLanguages.includes(data.language as Language)) {
+    data.language = DEFAULT_SETTINGS.language;
+  }
+  // Issue #109: 'glass' を validThemes に追加 (UI/ThemeName には既に存在するが、
+  // ここに無いと migration で claude-dark に戻されてしまう)。
+  const validThemes: ThemeName[] = [
+    'claude-dark',
+    'claude-light',
+    'dark',
+    'light',
+    'midnight',
+    'glass'
+  ];
+  if (!validThemes.includes(data.theme as ThemeName)) {
+    data.theme = DEFAULT_SETTINGS.theme;
   }
 
   // --- Version 1 → 2: 初回オンボーディングフラグの導入 ---


### PR DESCRIPTION
## Summary
- migrateSettings で theme / language の妥当性検証を schemaVersion に関係なく毎ロード実行するようにしました
- 未知または削除済みの theme / language が保存済み設定に残っていても DEFAULT_SETTINGS に戻します
- current schema で未知値を戻すケースと、有効値を維持するケースの回帰テストを追加しました

Closes #836

## Test plan
- [x] npm run typecheck
- [x] npm test
- [x] npx vitest run src/renderer/src/lib/__tests__/settings-migrate.test.ts --reporter=dot