### PR TITLE
perf(canvas): ドラッグ中の保存 flush を抑制

### DIFF
--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -142,8 +142,10 @@ function FlowApp({ actions }: FlowAppProps): JSX.Element {
         : changes;
       if (remaining.length === 0) return;
       const draggingNow = remaining.some((c) => c.type === 'position' && c.dragging);
-      if (useCanvasStore.getState().isDragging !== draggingNow) {
-        setCanvasDragging(draggingNow);
+      const wasDragging = useCanvasStore.getState().isDragging;
+      const draggingChanged = wasDragging !== draggingNow;
+      if (draggingChanged && draggingNow) {
+        setCanvasDragging(true);
       }
 
       // Issue #196: 旧実装は変更ごとに `nodes.find` + `for (other of nodes)` + 内側 `remaining.some(...)`
@@ -245,6 +247,9 @@ function FlowApp({ actions }: FlowAppProps): JSX.Element {
 
       const allChanges = extra.length > 0 ? [...remaining, ...extra] : remaining;
       setNodes(applyNodeChanges(allChanges, currentNodes));
+      if (draggingChanged && !draggingNow) {
+        setCanvasDragging(false);
+      }
     },
     [setNodes, confirmRemoveCard, isTeamLocked, setCanvasDragging]
   );

--- a/src/renderer/src/stores/__tests__/canvas-subscribe.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-subscribe.test.ts
@@ -81,7 +81,7 @@ describe('useCanvasStore subscribeWithSelector middleware (Issue #253 W#2)', () 
     unsubscribe();
   });
 
-  it('drag 中の nodes 更新は localStorage persist を skip し、drag 終了時に flush する', async () => {
+  it('drag 中の nodes 更新は localStorage persist を skip し、drag 終了時に一度だけ flush する (Issue #835)', async () => {
     const { useCanvasStore } = await import('../canvas');
     const store = useCanvasStore.getState();
     store.clear();
@@ -92,9 +92,18 @@ describe('useCanvasStore subscribeWithSelector middleware (Issue #253 W#2)', () 
     store.setCanvasDragging(true);
     store.setNodes([
       {
-        id: 'agent-issue-864',
+        id: 'agent-issue-835',
         type: 'agent',
         position: { x: 10, y: 20 },
+        data: { cardType: 'agent', title: 'agent', payload: { agent: 'claude' } },
+        style: { width: 760, height: 460 }
+      }
+    ]);
+    store.setNodes([
+      {
+        id: 'agent-issue-835',
+        type: 'agent',
+        position: { x: 30, y: 40 },
         data: { cardType: 'agent', title: 'agent', payload: { agent: 'claude' } },
         style: { width: 760, height: 460 }
       }
@@ -109,11 +118,14 @@ describe('useCanvasStore subscribeWithSelector middleware (Issue #253 W#2)', () 
     const canvasWrites = setItemSpy.mock.calls.filter(
       ([name]) => name === 'vibe-editor:canvas'
     );
-    expect(canvasWrites.length).toBeGreaterThanOrEqual(1);
+    expect(canvasWrites).toHaveLength(1);
     const [, raw] = canvasWrites[canvasWrites.length - 1];
-    const saved = JSON.parse(String(raw)) as { state: { nodes: Array<{ id: string }> } };
+    const saved = JSON.parse(String(raw)) as {
+      state: { nodes: Array<{ id: string; position: { x: number; y: number } }> };
+    };
     expect(saved.state.nodes).toHaveLength(1);
-    expect(saved.state.nodes[0].id).toBe('agent-issue-864');
+    expect(saved.state.nodes[0].id).toBe('agent-issue-835');
+    expect(saved.state.nodes[0].position).toEqual({ x: 30, y: 40 });
 
     setItemSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- Canvas の node drag 終了時、最終位置を store に反映してから persist を再開するようにしました
- drag 中の nodes 更新は localStorage へ同期保存せず、drag 終了時に最新位置だけを flush することをテストで固定しました
- 既存の drag 中 persist pause 実装を #835 の回帰テストとして明確化しました

Closes #835

## Test plan
- [x] npm run typecheck
- [x] npm test
- [x] npx vitest run src/renderer/src/stores/__tests__/canvas-subscribe.test.ts --reporter=dot