### PR TITLE
fix(settings): マスコット画像クリア時に既定へ戻す

### DIFF
--- a/src/renderer/src/components/settings/MascotSection.tsx
+++ b/src/renderer/src/components/settings/MascotSection.tsx
@@ -23,6 +23,7 @@ export function MascotSection({ draft, update }: Props): JSX.Element {
 
   const clearCustomImage = (): void => {
     update('statusMascotCustomPath', '');
+    update('statusMascotVariant', DEFAULT_SETTINGS.statusMascotVariant);
   };
 
   return (

--- a/src/renderer/src/components/settings/__tests__/SettingsModal.test.tsx
+++ b/src/renderer/src/components/settings/__tests__/SettingsModal.test.tsx
@@ -165,4 +165,46 @@ describe('SettingsModal', () => {
     expect(onApply).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
   });
+
+  it('カスタム画像のクリアは variant も DEFAULT_SETTINGS に戻す', async () => {
+    const onApply = vi.fn();
+    const onClose = vi.fn();
+    const initial: AppSettings = {
+      ...DEFAULT_SETTINGS,
+      statusMascotVariant: 'custom',
+      statusMascotCustomPath: 'C:/tmp/mascot.png'
+    };
+
+    render(
+      <Wrapper>
+        <SettingsModal
+          open
+          initial={initial}
+          onApply={onApply}
+          onClose={onClose}
+        />
+      </Wrapper>
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '表示' }));
+    const custom = screen.getByRole('radio', { name: /Custom/ }) as HTMLInputElement;
+    expect(custom.checked).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'クリア' }));
+
+    const vibe = screen.getByRole('radio', { name: /Vibe/ }) as HTMLInputElement;
+    expect(vibe.checked).toBe(true);
+
+    const applyBtn = screen.getByRole('button', { name: /適用して保存|Apply & save/ });
+    fireEvent.click(applyBtn);
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    const applied = onApply.mock.calls[0][0] as AppSettings;
+    expect(applied.statusMascotCustomPath).toBe('');
+    expect(applied.statusMascotVariant).toBe(DEFAULT_SETTINGS.statusMascotVariant);
+  });
 });


### PR DESCRIPTION
## Summary
- MascotSection のカスタム画像クリア時に statusMascotCustomPath だけでなく statusMascotVariant も既定値へ戻すようにしました
- クリア後に custom placeholder が残り続ける状態を避けます
- 設定モーダル上でクリア → 適用したときの draft を確認する回帰テストを追加しました

Closes #823

## Test plan
- [x] npm run typecheck
- [x] npm test
- [x] npx vitest run src/renderer/src/components/settings/__tests__/SettingsModal.test.tsx --reporter=dot