### PR TITLE
fix(settings): custom agent 予約 ID 衝突を防止

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -361,6 +361,24 @@ pub(crate) fn check_schema_compat(
         .check_compat(disk_schema_version, incoming_schema_version)
 }
 
+fn is_reserved_custom_agent_id(id: &str) -> bool {
+    matches!(id.trim().to_ascii_lowercase().as_str(), "claude" | "codex")
+}
+
+pub(crate) fn validate_custom_agent_ids(settings: &Settings) -> Result<(), CommandError> {
+    if let Some(agents) = settings.custom_agents.as_ref() {
+        for agent in agents {
+            if is_reserved_custom_agent_id(&agent.id) {
+                return Err(CommandError::validation(format!(
+                    "customAgents.id '{}' is reserved for a built-in agent",
+                    agent.id
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// disk から既存 settings.json の `schema_version` だけを軽量に読み取る。
 /// ファイル不在 / parse 失敗 / フィールド欠落はすべて `None` を返し、check_schema_compat 側で
 /// 「ガード対象外」として扱う (= 旧データ / 初回保存 / 破損ファイルは save を許容する)。
@@ -379,6 +397,7 @@ pub async fn settings_save(app: tauri::AppHandle, settings: Settings) -> Command
     // ため reject する (renderer 側でユーザーに「最新版に更新してください」を表示する経路)。
     let disk_v = read_disk_schema_version(&path).await;
     check_schema_compat(disk_v, settings.schema_version)?;
+    validate_custom_agent_ids(&settings)?;
     let json = serde_json::to_vec_pretty(&settings)?;
     // Issue #37: 書き込み中の crash で settings.json が半端 JSON にならないよう atomic
     atomic_write(&path, &json)
@@ -600,6 +619,37 @@ mod tests {
             msg.contains("future schema"),
             "error message must mention future schema: got {msg}"
         );
+    }
+
+    #[test]
+    fn custom_agent_reserved_ids_are_rejected() {
+        let mut s = Settings::default();
+        s.custom_agents = Some(vec![AgentConfig {
+            id: "claude".into(),
+            name: "Shadow Claude".into(),
+            command: "shadow".into(),
+            args: "".into(),
+            cwd: None,
+            color: None,
+        }]);
+
+        let err = validate_custom_agent_ids(&s).unwrap_err();
+        assert!(err.to_string().contains("reserved"));
+    }
+
+    #[test]
+    fn custom_agent_non_reserved_ids_are_allowed() {
+        let mut s = Settings::default();
+        s.custom_agents = Some(vec![AgentConfig {
+            id: "aider".into(),
+            name: "Aider".into(),
+            command: "aider".into(),
+            args: "".into(),
+            cwd: None,
+            color: None,
+        }]);
+
+        assert!(validate_custom_agent_ids(&s).is_ok());
     }
 
     /// `read_disk_schema_version` の挙動 sanity: 通常 JSON から正しく読める。

--- a/src/renderer/src/lib/__tests__/agent-resolver.test.ts
+++ b/src/renderer/src/lib/__tests__/agent-resolver.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_SETTINGS, type AppSettings } from '../../../../types/shared';
+import { resolveAgentConfig } from '../agent-resolver';
+
+describe('resolveAgentConfig', () => {
+  it('customAgents に claude が残っていても built-in Claude を優先する (Issue #821)', () => {
+    const settings: AppSettings = {
+      ...DEFAULT_SETTINGS,
+      claudeCommand: 'builtin-claude',
+      claudeArgs: '--builtin',
+      customAgents: [
+        {
+          id: 'claude',
+          name: 'Shadow Claude',
+          command: 'shadow-claude',
+          args: '--shadow'
+        }
+      ]
+    };
+
+    const resolved = resolveAgentConfig('claude', settings);
+
+    expect(resolved.name).toBe('Claude Code');
+    expect(resolved.command).toBe('builtin-claude');
+    expect(resolved.args).toBe('--builtin');
+  });
+
+  it('customAgents に codex が残っていても built-in Codex を優先する (Issue #821)', () => {
+    const settings: AppSettings = {
+      ...DEFAULT_SETTINGS,
+      codexCommand: 'builtin-codex',
+      codexArgs: '--builtin',
+      customAgents: [
+        {
+          id: 'codex',
+          name: 'Shadow Codex',
+          command: 'shadow-codex',
+          args: '--shadow'
+        }
+      ]
+    };
+
+    const resolved = resolveAgentConfig('codex', settings);
+
+    expect(resolved.name).toBe('Codex');
+    expect(resolved.command).toBe('builtin-codex');
+    expect(resolved.args).toBe('--builtin');
+  });
+
+  it('予約語以外の custom agent は従来どおり解決する', () => {
+    const settings: AppSettings = {
+      ...DEFAULT_SETTINGS,
+      lastOpenedRoot: 'F:/workspace',
+      customAgents: [
+        {
+          id: 'aider',
+          name: 'Aider',
+          command: 'aider',
+          args: '--yes',
+          color: '#00ffaa'
+        }
+      ]
+    };
+
+    const resolved = resolveAgentConfig('aider', settings);
+
+    expect(resolved).toMatchObject({
+      id: 'aider',
+      name: 'Aider',
+      command: 'aider',
+      args: '--yes',
+      cwd: 'F:/workspace',
+      color: '#00ffaa'
+    });
+  });
+});

--- a/src/renderer/src/lib/__tests__/settings-migrate.test.ts
+++ b/src/renderer/src/lib/__tests__/settings-migrate.test.ts
@@ -61,6 +61,45 @@ describe('migrateSettings', () => {
     });
   });
 
+  // ---------- Issue #821: customAgents.id の built-in 予約語衝突を修復 ----------
+  describe('custom agent reserved id migration (Issue #821)', () => {
+    it('claude / codex と衝突する customAgents.id を user namespace に改名する', () => {
+      const migrated = migrateSettings({
+        schemaVersion: APP_SETTINGS_SCHEMA_VERSION,
+        language: 'ja',
+        theme: 'claude-dark',
+        customAgents: [
+          { id: 'claude', name: 'Shadow Claude', command: 'shadow', args: '' },
+          { id: 'codex', name: 'Shadow Codex', command: 'shadow', args: '' },
+          { id: 'aider', name: 'Aider', command: 'aider', args: '' }
+        ]
+      });
+
+      expect(migrated.customAgents?.map((agent) => agent.id)).toEqual([
+        '_user_claude',
+        '_user_codex',
+        'aider'
+      ]);
+    });
+
+    it('改名先が既に存在する場合は suffix を付けて重複を避ける', () => {
+      const migrated = migrateSettings({
+        schemaVersion: APP_SETTINGS_SCHEMA_VERSION,
+        language: 'ja',
+        theme: 'claude-dark',
+        customAgents: [
+          { id: '_user_claude', name: 'Existing', command: 'existing', args: '' },
+          { id: 'claude', name: 'Shadow Claude', command: 'shadow', args: '' }
+        ]
+      });
+
+      expect(migrated.customAgents?.map((agent) => agent.id)).toEqual([
+        '_user_claude',
+        '_user_claude_2'
+      ]);
+    });
+  });
+
   // ---------- Issue #449: v9 → v10 Unicode dash 正規化 ----------
   describe('v9 → v10 Unicode dash normalization (Issue #449)', () => {
     it('normalizes leading Unicode dash in codexArgs to ASCII "--"', () => {

--- a/src/renderer/src/lib/agent-resolver.ts
+++ b/src/renderer/src/lib/agent-resolver.ts
@@ -23,17 +23,6 @@ export function resolveAgentConfig(
   agentId: string,
   settings: AppSettings
 ): ResolvedAgent {
-  const custom = (settings.customAgents ?? []).find((a) => a.id === agentId);
-  if (custom) {
-    return {
-      id: custom.id,
-      name: custom.name,
-      command: custom.command,
-      args: custom.args,
-      cwd: custom.cwd || settings.lastOpenedRoot || '',
-      color: custom.color
-    };
-  }
   if (agentId === 'codex') {
     return {
       id: 'codex',
@@ -42,6 +31,19 @@ export function resolveAgentConfig(
       args: settings.codexArgs || '',
       cwd: settings.lastOpenedRoot || ''
     };
+  }
+  if (agentId !== 'claude') {
+    const custom = (settings.customAgents ?? []).find((a) => a.id === agentId);
+    if (custom) {
+      return {
+        id: custom.id,
+        name: custom.name,
+        command: custom.command,
+        args: custom.args,
+        cwd: custom.cwd || settings.lastOpenedRoot || '',
+        color: custom.color
+      };
+    }
   }
   // claude (default fallback)
   return {

--- a/src/renderer/src/lib/settings-migrate.ts
+++ b/src/renderer/src/lib/settings-migrate.ts
@@ -28,6 +28,37 @@ function isObject(v: unknown): v is Raw {
   return v !== null && typeof v === 'object' && !Array.isArray(v);
 }
 
+const RESERVED_CUSTOM_AGENT_IDS = new Set(['claude', 'codex']);
+
+function uniqueCustomAgentId(base: string, used: Set<string>): string {
+  let candidate = base;
+  let suffix = 2;
+  while (used.has(candidate)) {
+    candidate = `${base}_${suffix}`;
+    suffix++;
+  }
+  return candidate;
+}
+
+function sanitizeCustomAgentIds(value: unknown): unknown {
+  if (!Array.isArray(value)) return value;
+  const used = new Set<string>();
+  return value.map((entry, index) => {
+    if (!isObject(entry)) return entry;
+    const rawId =
+      typeof entry.id === 'string' && entry.id.trim()
+        ? entry.id.trim()
+        : `custom_${index + 1}`;
+    const base = RESERVED_CUSTOM_AGENT_IDS.has(rawId.toLowerCase())
+      ? `_user_${rawId.toLowerCase()}`
+      : rawId;
+    const id = uniqueCustomAgentId(base, used);
+    used.add(id);
+    if (id === entry.id) return entry;
+    return { ...entry, id };
+  });
+}
+
 /**
  * Issue #449: 引数文字列をパースして再構築することで、各 token 先頭の Unicode dash を
  * ASCII '-' に正規化する。空白を含む値は再構築時に `"..."` で囲み直す。
@@ -221,6 +252,10 @@ export function migrateSettings(raw: unknown): AppSettings {
       });
     }
   }
+
+  // Issue #821: customAgents.id の 'claude' / 'codex' は built-in agent と衝突する予約語。
+  // 既存 settings.json に残っている場合は、読み込み時にユーザー定義用 ID へ改名する。
+  data.customAgents = sanitizeCustomAgentIds(data.customAgents);
 
   // --- Version 10 → 11: Windows ConPTY UTF-8 強制フラグの導入 (Issue #618) ---
   // 旧 settings.json には `terminalForceUtf8` フィールドが存在しないため、`true` (default) で


### PR DESCRIPTION
## Summary
- customAgents.id が `claude` / `codex` の場合、読み込み時に `_user_claude` / `_user_codex` へ自動改名する migration を追加
- agent resolver で built-in の `claude` / `codex` を custom agent より優先し、silent override を防止
- Rust 側 settings save でも予約 ID を validation error として拒否し、回帰テストを追加

Closes #821

## Test plan
- [x] `npx vitest run src/renderer/src/lib/__tests__/settings-migrate.test.ts src/renderer/src/lib/__tests__/agent-resolver.test.ts --reporter=dot`
- [x] `npm run typecheck`
- [x] `$env:CARGO_TARGET_DIR='C:\Users\yusei\AppData\Local\Temp\vibe-editor-issue-821-target'; cargo test --manifest-path src-tauri/Cargo.toml custom_agent -- --nocapture`
- [x] `$env:CARGO_TARGET_DIR='C:\Users\yusei\AppData\Local\Temp\vibe-editor-issue-821-target'; cargo check --manifest-path src-tauri/Cargo.toml`
- [ ] `npm test` は 66 files / 421 tests 本体は通過したが、既存の `settings-context.tsx` debounce timer が test teardown 後に `window is not defined` を出す未処理エラーで exit 1