### PR TITLE
perf(canvas): team health の同一 snapshot 通知を抑制

### DIFF
--- a/src/renderer/src/components/canvas/StageHud.tsx
+++ b/src/renderer/src/components/canvas/StageHud.tsx
@@ -199,6 +199,12 @@ export function StageHud(): JSX.Element {
     return Array.from(seen);
   }, [agentNodes]);
   const healthSnapshot = useTeamHealthMulti(aggregatedTeamIds);
+  const [healthNowTick, setHealthNowTick] = useState(() => Date.now());
+  useEffect(() => {
+    if (aggregatedTeamIds.length === 0) return;
+    const timer = window.setInterval(() => setHealthNowTick(Date.now()), 15_000);
+    return () => window.clearInterval(timer);
+  }, [aggregatedTeamIds.length]);
   const deadCount = useMemo(() => {
     let n = 0;
     for (const node of agentNodes) {
@@ -206,11 +212,11 @@ export function StageHud(): JSX.Element {
       const payload = agentPayloadOf(node.data);
       if (!payload?.agentId) continue;
       const row = healthSnapshot.byAgentId[payload.agentId];
-      const h = deriveHealth(row);
+      const h = deriveHealth(row, healthNowTick);
       if (h.state === 'dead') n += 1;
     }
     return n;
-  }, [agentNodes, healthSnapshot]);
+  }, [agentNodes, healthSnapshot, healthNowTick]);
 
   // Issue #514 / #615: dashboard に渡す teamId / projectRoot を canvas state + settings から導出。
   // dual preset で 2 team が並ぶケースに対応するため、active な全 teamId を array で渡す。

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -330,7 +330,7 @@ function AgentNodeCardImpl({
   const healthRow = payload.agentId
     ? healthSnapshot.byAgentId[payload.agentId] ?? null
     : null;
-  const health = useMemo(() => deriveHealth(healthRow), [healthRow]);
+  const health = useMemo(() => deriveHealth(healthRow, nowTick), [healthRow, nowTick]);
   const hasHealthRow = healthRow !== null;
   const unreadInboxCount = hasHealthRow
     ? health.pendingInboxCount

--- a/src/renderer/src/lib/__tests__/agent-health.test.ts
+++ b/src/renderer/src/lib/__tests__/agent-health.test.ts
@@ -33,6 +33,36 @@ function row(overrides: Partial<TeamDiagnosticsMemberRow> = {}): TeamDiagnostics
 }
 
 describe('deriveHealth', () => {
+  it('recomputes age from stable RFC3339 timestamps', () => {
+    const health = deriveHealth(
+      row({
+        lastStatusAt: '2026-05-16T00:00:00Z',
+        lastStatusAgeMs: 1,
+        lastPtyOutputAt: '2026-05-16T00:01:00Z',
+        lastPtyActivityAgeMs: 1
+      }),
+      Date.parse('2026-05-16T00:02:30Z')
+    );
+
+    expect(health.state).toBe('alive');
+    expect(health.ageMs).toBe(90_000);
+  });
+
+  it('can become dead from timestamp age even when the frozen row age was fresh', () => {
+    const health = deriveHealth(
+      row({
+        lastStatusAt: '2026-05-16T00:00:00Z',
+        lastStatusAgeMs: 1,
+        lastPtyOutputAt: '2026-05-16T00:00:00Z',
+        lastPtyActivityAgeMs: 1
+      }),
+      Date.parse('2026-05-16T00:16:00Z')
+    );
+
+    expect(health.state).toBe('dead');
+    expect(health.ageMs).toBe(960_000);
+  });
+
   it('passes through pending inbox diagnostics for unread badge rendering', () => {
     const health = deriveHealth(
       row({

--- a/src/renderer/src/lib/__tests__/agent-health.test.ts
+++ b/src/renderer/src/lib/__tests__/agent-health.test.ts
@@ -63,6 +63,22 @@ describe('deriveHealth', () => {
     expect(health.ageMs).toBe(960_000);
   });
 
+  it('keeps never-observed diagnostics unknown when the hub has not marked them stale', () => {
+    const health = deriveHealth(
+      row({
+        lastStatusAt: null,
+        lastStatusAgeMs: null,
+        lastPtyOutputAt: null,
+        lastPtyActivityAgeMs: null,
+        autoStale: false
+      }),
+      Date.parse('2026-05-16T00:16:00Z')
+    );
+
+    expect(health.state).toBe('unknown');
+    expect(health.ageMs).toBeNull();
+  });
+
   it('passes through pending inbox diagnostics for unread badge rendering', () => {
     const health = deriveHealth(
       row({

--- a/src/renderer/src/lib/__tests__/use-team-health.test.ts
+++ b/src/renderer/src/lib/__tests__/use-team-health.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { TeamDiagnosticsMemberRow } from '../../../../types/shared';
+import { __teamHealthTest } from '../use-team-health';
+
+function row(overrides: Partial<TeamDiagnosticsMemberRow> = {}): TeamDiagnosticsMemberRow {
+  return {
+    agentId: 'worker-1',
+    role: 'programmer',
+    online: true,
+    inconsistent: false,
+    recruitedAt: '2026-05-16T00:00:00Z',
+    lastHandshakeAt: null,
+    lastSeenAt: null,
+    lastAgentActivityAt: null,
+    lastMessageInAt: null,
+    lastMessageOutAt: null,
+    messagesInCount: 0,
+    messagesOutCount: 0,
+    tasksClaimedCount: 0,
+    pendingInbox: [],
+    pendingInboxCount: 0,
+    oldestPendingInboxAgeMs: null,
+    stalledInbound: false,
+    currentStatus: null,
+    lastStatusAt: null,
+    lastPtyOutputAt: null,
+    lastStatusAgeMs: null,
+    lastPtyActivityAgeMs: null,
+    autoStale: false,
+    stalenessThresholdMs: 300_000,
+    ...overrides
+  };
+}
+
+describe('team health snapshot signature', () => {
+  it('ignores server-computed age fields that change on every poll', () => {
+    const first = __teamHealthTest.snapshotSignature({
+      'worker-1': row({
+        lastStatusAgeMs: 5_000,
+        lastPtyActivityAgeMs: 10_000,
+        oldestPendingInboxAgeMs: 15_000
+      })
+    });
+    const second = __teamHealthTest.snapshotSignature({
+      'worker-1': row({
+        lastStatusAgeMs: 10_000,
+        lastPtyActivityAgeMs: 15_000,
+        oldestPendingInboxAgeMs: 20_000
+      })
+    });
+
+    expect(second).toBe(first);
+  });
+
+  it('changes when stable diagnostics fields change', () => {
+    const first = __teamHealthTest.snapshotSignature({
+      'worker-1': row({ currentStatus: 'building' })
+    });
+    const second = __teamHealthTest.snapshotSignature({
+      'worker-1': row({ currentStatus: 'testing' })
+    });
+
+    expect(second).not.toBe(first);
+  });
+
+  it('is stable regardless of agent object insertion order', () => {
+    const first = __teamHealthTest.snapshotSignature({
+      'worker-2': row({ agentId: 'worker-2' }),
+      'worker-1': row({ agentId: 'worker-1' })
+    });
+    const second = __teamHealthTest.snapshotSignature({
+      'worker-1': row({ agentId: 'worker-1' }),
+      'worker-2': row({ agentId: 'worker-2' })
+    });
+
+    expect(second).toBe(first);
+  });
+});

--- a/src/renderer/src/lib/agent-health.ts
+++ b/src/renderer/src/lib/agent-health.ts
@@ -67,12 +67,14 @@ export function deriveHealth(
   const lastPtyActivityAgeMs =
     ageFromRfc3339(row.lastPtyOutputAt, now) ?? row.lastPtyActivityAgeMs;
   const ageMs = lastPtyActivityAgeMs ?? lastStatusAgeMs;
+  const hasObservation =
+    lastPtyActivityAgeMs !== null || lastStatusAgeMs !== null;
 
   const statusIsStale =
     lastStatusAgeMs === null || lastStatusAgeMs >= row.stalenessThresholdMs;
   const ptyIsRecentlyActive =
     lastPtyActivityAgeMs !== null && lastPtyActivityAgeMs < row.stalenessThresholdMs;
-  const autoStale = statusIsStale && !ptyIsRecentlyActive;
+  const autoStale = hasObservation && statusIsStale && !ptyIsRecentlyActive;
 
   let state: HealthState;
   if (lastPtyActivityAgeMs !== null && lastPtyActivityAgeMs >= DEAD_THRESHOLD_MS) {
@@ -81,7 +83,7 @@ export function deriveHealth(
     state = 'dead';
   } else if (row.autoStale || autoStale) {
     state = 'stale';
-  } else if (lastPtyActivityAgeMs !== null || lastStatusAgeMs !== null) {
+  } else if (hasObservation) {
     state = 'alive';
   } else {
     // 1 度も観測されていない (= recruit 直後の handshake 前) は unknown 扱い。

--- a/src/renderer/src/lib/agent-health.ts
+++ b/src/renderer/src/lib/agent-health.ts
@@ -36,8 +36,16 @@ export interface HealthDerived {
   stalledInbound: boolean;
 }
 
+function ageFromRfc3339(value: string | null | undefined, now: number): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) return null;
+  return Math.max(0, now - ms);
+}
+
 export function deriveHealth(
-  row: TeamDiagnosticsMemberRow | null | undefined
+  row: TeamDiagnosticsMemberRow | null | undefined,
+  now: number = Date.now()
 ): HealthDerived {
   if (!row) {
     return {
@@ -50,18 +58,30 @@ export function deriveHealth(
     };
   }
 
-  // 「最終出力 (= プロセスが本当に動いた最後の物理シグナル)」を最も信頼する。
-  // PTY 出力時刻が無いときは status 申告の age をフォールバック表示。
-  const ageMs = row.lastPtyActivityAgeMs ?? row.lastStatusAgeMs;
+  // Issue #910: use-team-health が age 系フィールドだけの変化では snapshot を固定する。
+  // 経過表示と stale/dead 判定が止まらないよう、安定な RFC3339 timestamp から
+  // クライアント側の now に対する age を再計算する。timestamp が読めない旧データだけ
+  // Hub が返した age にフォールバックする。
+  const lastStatusAgeMs =
+    ageFromRfc3339(row.lastStatusAt, now) ?? row.lastStatusAgeMs;
+  const lastPtyActivityAgeMs =
+    ageFromRfc3339(row.lastPtyOutputAt, now) ?? row.lastPtyActivityAgeMs;
+  const ageMs = lastPtyActivityAgeMs ?? lastStatusAgeMs;
+
+  const statusIsStale =
+    lastStatusAgeMs === null || lastStatusAgeMs >= row.stalenessThresholdMs;
+  const ptyIsRecentlyActive =
+    lastPtyActivityAgeMs !== null && lastPtyActivityAgeMs < row.stalenessThresholdMs;
+  const autoStale = statusIsStale && !ptyIsRecentlyActive;
 
   let state: HealthState;
-  if (row.lastPtyActivityAgeMs !== null && row.lastPtyActivityAgeMs >= DEAD_THRESHOLD_MS) {
+  if (lastPtyActivityAgeMs !== null && lastPtyActivityAgeMs >= DEAD_THRESHOLD_MS) {
     // PTY 出力が 15 分以上途絶 → dead。lastStatusAgeMs もチェックしないのは、
     // status 申告は agent が忘れがちなので、PTY の絶対沈黙が確定的シグナル。
     state = 'dead';
-  } else if (row.autoStale) {
+  } else if (row.autoStale || autoStale) {
     state = 'stale';
-  } else if (row.lastPtyActivityAgeMs !== null || row.lastStatusAgeMs !== null) {
+  } else if (lastPtyActivityAgeMs !== null || lastStatusAgeMs !== null) {
     state = 'alive';
   } else {
     // 1 度も観測されていない (= recruit 直後の handshake 前) は unknown 扱い。

--- a/src/renderer/src/lib/use-team-health.ts
+++ b/src/renderer/src/lib/use-team-health.ts
@@ -31,6 +31,7 @@ interface Snapshot {
 interface RegistryEntry {
   refCount: number;
   snapshot: Snapshot | null;
+  stableSignature: string | null;
   listeners: Set<(snap: Snapshot | null) => void>;
   timer: number | null;
   /** in-flight な fetch があれば true (同時多重を防ぐ) */
@@ -42,6 +43,33 @@ const registry = new Map<string, RegistryEntry>();
 function notify(entry: RegistryEntry): void {
   for (const fn of entry.listeners) fn(entry.snapshot);
 }
+
+function stableRowForSignature(row: TeamDiagnosticsMemberRow): Omit<
+  TeamDiagnosticsMemberRow,
+  'lastStatusAgeMs' | 'lastPtyActivityAgeMs' | 'oldestPendingInboxAgeMs'
+> {
+  const {
+    lastStatusAgeMs: _lastStatusAgeMs,
+    lastPtyActivityAgeMs: _lastPtyActivityAgeMs,
+    oldestPendingInboxAgeMs: _oldestPendingInboxAgeMs,
+    ...stable
+  } = row;
+  return stable;
+}
+
+function snapshotSignature(
+  byAgentId: Record<string, TeamDiagnosticsMemberRow>
+): string {
+  return JSON.stringify(
+    Object.entries(byAgentId)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([agentId, row]) => [agentId, stableRowForSignature(row)])
+  );
+}
+
+export const __teamHealthTest = {
+  snapshotSignature
+};
 
 async function fetchOnce(teamId: string, entry: RegistryEntry): Promise<void> {
   if (entry.inflight) return;
@@ -58,7 +86,10 @@ async function fetchOnce(teamId: string, entry: RegistryEntry): Promise<void> {
     const res = await window.api.team.diagnosticsRead(teamId);
     const byAgentId: Record<string, TeamDiagnosticsMemberRow> = {};
     for (const m of res.members) byAgentId[m.agentId] = m;
+    const nextSignature = snapshotSignature(byAgentId);
+    if (entry.stableSignature === nextSignature) return;
     entry.snapshot = { byAgentId, fetchedAt: Date.now() };
+    entry.stableSignature = nextSignature;
     notify(entry);
   } catch (err) {
     // Issue #802: team-health poll は best-effort。失敗 (Hub 未起動 / 復元された stale
@@ -105,6 +136,7 @@ export function useTeamHealth(
       entry = {
         refCount: 0,
         snapshot: null,
+        stableSignature: null,
         listeners: new Set(),
         timer: null,
         inflight: false
@@ -192,6 +224,7 @@ export function useTeamHealthMulti(teamIds: readonly string[]): {
         entry = {
           refCount: 0,
           snapshot: null,
+          stableSignature: null,
           listeners: new Set(),
           timer: null,
           inflight: false
@@ -207,7 +240,11 @@ export function useTeamHealthMulti(teamIds: readonly string[]): {
       };
       entry.listeners.add(listener);
       // 既存スナップショットがあれば即座に反映 (poll を待たない)。
-      setSnapshots((prev) => ({ ...prev, [teamId]: entry?.snapshot ?? null }));
+      setSnapshots((prev) => {
+        const snap = entry?.snapshot ?? null;
+        if (prev[teamId] === snap) return prev;
+        return { ...prev, [teamId]: snap };
+      });
       ensurePoll(teamId, entry);
 
       const onVisibility = () => {


### PR DESCRIPTION
## Summary
- `useTeamHealth` の snapshot に age 系フィールドを除外した安定 signature を持たせ、実質同じ diagnostics では listener notify をスキップ
- `deriveHealth` で RFC3339 timestamp から経過時間・stale/dead を再計算し、snapshot 固定中も表示と判定が進むように変更
- AgentNodeCard / StageHud から現在時刻 tick を渡し、回帰テストを追加

Closes #910

## Test plan
- [x] `npx vitest run src/renderer/src/lib/__tests__/agent-health.test.ts src/renderer/src/lib/__tests__/use-team-health.test.ts --reporter=dot`
- [x] `npm run typecheck`
- [x] `git diff --check`
- [ ] `npx tsc -p tsconfig.web.json --noEmit` は #841 未 merge の既存 `baseUrl` deprecation で停止
- [ ] `npx tsc -p tsconfig.web.json --noEmit --ignoreDeprecations 6.0` は #841 で修正済みの既存型エラー群で停止