### PR TITLE
fix(i18n): #906 UI文言の日本語直書きを翻訳化

### DIFF
--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -562,7 +562,7 @@ export function AppShell({
         className="resize-handle resize-handle--sidebar"
         onMouseDown={onSidebarResizeStart}
         onDoubleClick={onSidebarResizeDouble}
-        title="ドラッグでサイドバー幅を調整 / ダブルクリックでリセット"
+        title={t('layout.sidebarResizeTitle')}
         role="separator"
         aria-orientation="vertical"
       />
@@ -616,7 +616,7 @@ export function AppShell({
         <div
           className="resize-handle"
           onMouseDown={onClaudePanelResizeStart}
-          title="ドラッグで IDE モードパネルの幅を調整"
+          title={t('layout.idePanelResizeTitle')}
           role="separator"
           aria-orientation="vertical"
         />

--- a/src/renderer/src/components/ImagePreview.tsx
+++ b/src/renderer/src/components/ImagePreview.tsx
@@ -10,6 +10,7 @@
  */
 import { useMemo, useState } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
+import { useT } from '../lib/i18n';
 import { isTauri } from '../lib/tauri-api';
 
 interface ImagePreviewProps {
@@ -20,6 +21,7 @@ interface ImagePreviewProps {
 }
 
 export function ImagePreview({ absolutePath, relativePath }: ImagePreviewProps): JSX.Element {
+  const t = useT();
   const [errored, setErrored] = useState(false);
   const tauri = isTauri();
   const url = useMemo(() => {
@@ -34,7 +36,7 @@ export function ImagePreview({ absolutePath, relativePath }: ImagePreviewProps):
   if (!tauri) {
     return (
       <div className="image-preview">
-        <div className="image-preview__error">Image preview is unavailable in dev:vite mode.</div>
+        <div className="image-preview__error">{t('imagePreview.devUnavailable')}</div>
       </div>
     );
   }
@@ -42,7 +44,9 @@ export function ImagePreview({ absolutePath, relativePath }: ImagePreviewProps):
   if (errored || !url) {
     return (
       <div className="image-preview">
-        <div className="image-preview__error">画像を表示できません: {relativePath}</div>
+        <div className="image-preview__error">
+          {t('imagePreview.loadError', { path: relativePath })}
+        </div>
       </div>
     );
   }

--- a/src/renderer/src/components/canvas/Canvas.tsx
+++ b/src/renderer/src/components/canvas/Canvas.tsx
@@ -528,6 +528,7 @@ function FlowApp({ actions }: FlowAppProps): JSX.Element {
 /** stageView === 'list' のときに ReactFlow の代わりに表示する簡易ロスター。
  *  Canvas 上の agent ノードを一覧化する。 */
 function StageListOverlay(): JSX.Element {
+  const t = useT();
   const nodes = useCanvasNodes();
   const { settings } = useSettings();
   const { byId: profilesById } = useRoleProfiles();
@@ -536,11 +537,13 @@ function StageListOverlay(): JSX.Element {
     <div className="tc-list-overlay">
       <div className="tc-list-overlay__inner">
         <div className="tc-list-overlay__head">
-          <h2 className="tc-list-overlay__title">チーム</h2>
-          <span className="tc-list-overlay__sub">{agentNodes.length} agents</span>
+          <h2 className="tc-list-overlay__title">{t('canvas.list.title')}</h2>
+          <span className="tc-list-overlay__sub">
+            {t('canvas.agentCount', { count: agentNodes.length })}
+          </span>
         </div>
         {agentNodes.length === 0 ? (
-          <div className="tc-list-overlay__empty">まだエージェントが配置されていません</div>
+          <div className="tc-list-overlay__empty">{t('canvas.list.empty')}</div>
         ) : (
           agentNodes.map((n) => {
             // Issue #732: 旧 inline 型キャストを agentPayloadOf に置換 (agent カードのみ payload を返す)。

--- a/src/renderer/src/lib/filetree-state-context.tsx
+++ b/src/renderer/src/lib/filetree-state-context.tsx
@@ -39,6 +39,7 @@ import {
   useSettingsLoading,
   useSettingsValue
 } from './settings-context';
+import { useT } from './i18n';
 
 const KEY_SEP_CHAR = '\0';
 
@@ -129,6 +130,7 @@ function serializeExpanded(set: Set<string>): Record<string, string[]> {
 }
 
 export function FileTreeStateProvider({ children }: { children: ReactNode }): JSX.Element {
+  const t = useT();
   // settings の他フィールド (テーマ / フォント等) の変化で Provider が re-render しない
   // ように、必要なフィールドだけ細粒度 selector で購読する。
   const settingsLoading = useSettingsLoading();
@@ -289,7 +291,7 @@ export function FileTreeStateProvider({ children }: { children: ReactNode }): JS
           const next = new Map(prev);
           next.set(dirKey(rootPath, relPath), {
             loading: false,
-            error: 'アプリを再起動してください（preload 更新のため）',
+            error: t('filetree.preloadRestartRequired'),
             entries: []
           });
           return next;
@@ -346,7 +348,7 @@ export function FileTreeStateProvider({ children }: { children: ReactNode }): JS
       pendingPromisesRef.current.set(key, promise);
       return promise;
     },
-    [drainQueue, pruneOnLoadFailure]
+    [drainQueue, pruneOnLoadFailure, t]
   );
 
   // Issue #478: expandedRef を toggleDir より前に配置し、クリック時点の最新 expanded を

--- a/src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx
@@ -1,6 +1,18 @@
 import { act, cleanup, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('../../i18n', () => ({
+  useT: () => (key: string, params?: Record<string, string | number>) => {
+    if (key === 'terminal.limitReached') {
+      return `ターミナル上限（${params?.max}）に達しました`;
+    }
+    if (key === 'terminal.limitWarning') {
+      return `ターミナル数が ${params?.threshold} に達しました（上限 ${params?.max}）`;
+    }
+    return key;
+  }
+}));
+
 import {
   MAX_TERMINALS,
   TERMINAL_WARN_THRESHOLD,

--- a/src/renderer/src/lib/hooks/use-project-loader.ts
+++ b/src/renderer/src/lib/hooks/use-project-loader.ts
@@ -88,7 +88,7 @@ export function useProjectLoader(
         return false;
       }
       setProjectRoot(root);
-      useUiStore.getState().setStatus('プロジェクト読み込み中…');
+      useUiStore.getState().setStatus(t('project.loading'));
       setGitLoading(true);
 
       try {
@@ -124,13 +124,13 @@ export function useProjectLoader(
         }
         return true;
       } catch (err) {
-        useUiStore.getState().setStatus(`読み込みエラー: ${String(err)}`);
+        useUiStore.getState().setStatus(t('project.loadError', { error: String(err) }));
         return false;
       } finally {
         setGitLoading(false);
       }
     },
-    [projectRoot, mcpAutoSetup, recentProjects, updateSettings]
+    [projectRoot, mcpAutoSetup, recentProjects, updateSettings, t]
   );
 
   // 初回ロード — lastOpenedRoot (前回開いたルート) があれば復元、なければフォルダ選択ダイアログ。
@@ -185,7 +185,7 @@ export function useProjectLoader(
         optsRef.current.onLoaded({ gitStatus: gs, sessions: sess });
         useUiStore.getState().setStatus(root.split(/[\\/]/).pop() ?? root);
       } catch (err) {
-        useUiStore.getState().setStatus(`初期化エラー: ${String(err)}`);
+        useUiStore.getState().setStatus(t('project.initError', { error: String(err) }));
         setGitLoading(false);
       }
     })();
@@ -227,39 +227,39 @@ export function useProjectLoader(
 
   const handleNewProject = useCallback(async () => {
     const folder = await window.api.dialog.openFolder(
-      '新規プロジェクト: 空フォルダを選択/作成'
+      t('project.newDialogTitle')
     );
     if (!folder) return;
     const empty = await window.api.dialog.isFolderEmpty(folder);
     const loaded = await loadProject(folder);
     if (!loaded) return;
     if (!empty) {
-      optsRef.current.showToast('フォルダが空ではありません。既存として開きます', {
+      optsRef.current.showToast(t('project.newFolderNotEmpty'), {
         tone: 'warning'
       });
     } else {
-      optsRef.current.showToast('新規プロジェクトを作成', { tone: 'success' });
+      optsRef.current.showToast(t('project.created'), { tone: 'success' });
     }
-  }, [loadProject]);
+  }, [loadProject, t]);
 
   const handleOpenFolder = useCallback(async () => {
-    const folder = await window.api.dialog.openFolder('既存プロジェクトを開く');
+    const folder = await window.api.dialog.openFolder(t('project.openExistingDialogTitle'));
     if (!folder) return;
     await loadProject(folder);
-  }, [loadProject]);
+  }, [loadProject, t]);
 
   const handleOpenFile = useCallback(async () => {
-    const file = await window.api.dialog.openFile('ファイルを開く');
+    const file = await window.api.dialog.openFile(t('appMenu.openFileDialogTitle'));
     if (!file) return;
     const parent = file.replace(/[\\/][^\\/]+$/, '');
     const loaded = await loadProject(parent);
     if (loaded) {
       optsRef.current.showToast(
-        `${file} の親フォルダをプロジェクトとして読み込みました`,
+        t('project.fileParentLoaded', { file }),
         { tone: 'info' }
       );
     }
-  }, [loadProject]);
+  }, [loadProject, t]);
 
   const handleOpenRecent = useCallback(
     async (path: string) => {
@@ -270,10 +270,10 @@ export function useProjectLoader(
 
   const handleClearRecent = useCallback(() => {
     void updateSettings({ recentProjects: [] });
-    optsRef.current.showToast('最近のプロジェクト履歴をクリアしました', {
+    optsRef.current.showToast(t('project.recentCleared'), {
       tone: 'info'
     });
-  }, [updateSettings]);
+  }, [updateSettings, t]);
 
   const handleAddWorkspaceFolder = useCallback(async () => {
     const folder = await window.api.dialog.openFolder(

--- a/src/renderer/src/lib/hooks/use-team-history-sync.ts
+++ b/src/renderer/src/lib/hooks/use-team-history-sync.ts
@@ -130,19 +130,21 @@ export function useTeamHistorySync(
       } = optsRef.current;
       if (!projectRoot) return;
       if (!entry.members || entry.members.length === 0) {
-        showToast('チームメンバー情報が空のため復元できません', { tone: 'warning' });
+        showToast(t('teamHistory.resume.emptyMembers'), { tone: 'warning' });
         return;
       }
       if (entry.projectRoot && entry.projectRoot !== projectRoot) {
         showToast(
-          `このチームは別プロジェクト(${entry.projectRoot.split(/[\\/]/).pop()})の履歴です`,
+          t('teamHistory.resume.otherProject', {
+            project: entry.projectRoot.split(/[\\/]/).pop() ?? entry.projectRoot
+          }),
           { tone: 'warning' }
         );
         return;
       }
       // 容量チェック: 既存タブ + メンバー数 が上限を超えるなら断念
       if (terminalTabs.length + entry.members.length > MAX_TERMINALS) {
-        showToast(`ターミナル上限(${MAX_TERMINALS})を超えるため復元できません`, {
+        showToast(t('teamHistory.resume.terminalLimit', { max: MAX_TERMINALS }), {
           tone: 'warning'
         });
         return;

--- a/src/renderer/src/lib/hooks/use-terminal-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs.ts
@@ -4,6 +4,7 @@ import type {
   TeamRole
 } from '../../../../types/shared';
 import type { TerminalRuntimeStatus } from '../terminal-status';
+import { useT } from '../i18n';
 
 /** 同時に立てられるターミナルの上限。メモリ/レイアウト保護の安全弁 */
 export const MAX_TERMINALS = 30;
@@ -183,6 +184,7 @@ export interface UseTerminalTabsResult {
  *   残るため hook では持たない。
  */
 export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsResult {
+  const t = useT();
   const optsRef = useRef(opts);
   optsRef.current = opts;
 
@@ -280,9 +282,10 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
       let assignedId: number | null = null;
       setTerminalTabs((prev) => {
         if (prev.length >= MAX_TERMINALS) {
-          optsRef.current.showToast(`ターミナル上限（${MAX_TERMINALS}）に達しました`, {
-            tone: 'warning'
-          });
+          optsRef.current.showToast(
+            t('terminal.limitReached', { max: MAX_TERMINALS }),
+            { tone: 'warning' }
+          );
           return prev;
         }
         const id = nextTerminalIdRef.current++;
@@ -321,7 +324,10 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
         // 閾値を超えそうなら軽く警告
         if (prev.length + 1 === TERMINAL_WARN_THRESHOLD) {
           optsRef.current.showToast(
-            `ターミナル数が ${TERMINAL_WARN_THRESHOLD} に達しました（上限 ${MAX_TERMINALS}）`,
+            t('terminal.limitWarning', {
+              threshold: TERMINAL_WARN_THRESHOLD,
+              max: MAX_TERMINALS
+            }),
             { tone: 'info' }
           );
         }
@@ -332,7 +338,7 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
       });
       return assignedId;
     },
-    []
+    [t]
   );
 
   const doCloseTab = useCallback((tabId: number) => {

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -88,6 +88,15 @@ const ja: Dict = {
   'appMenu.newDialogTitle': '新規プロジェクト',
   'appMenu.openFolderDialogTitle': 'フォルダを開く',
   'appMenu.openFileDialogTitle': 'ファイルを開く',
+  'project.newDialogTitle': '新規プロジェクト: 空フォルダを選択/作成',
+  'project.openExistingDialogTitle': '既存プロジェクトを開く',
+  'project.loading': 'プロジェクト読み込み中…',
+  'project.loadError': '読み込みエラー: {error}',
+  'project.initError': '初期化エラー: {error}',
+  'project.newFolderNotEmpty': 'フォルダが空ではありません。既存として開きます',
+  'project.created': '新規プロジェクトを作成',
+  'project.fileParentLoaded': '{file} の親フォルダをプロジェクトとして読み込みました',
+  'project.recentCleared': '最近のプロジェクト履歴をクリアしました',
   'appMenu.addWorkspaceDialogTitle': 'ワークスペースに追加',
   'appMenu.addToWorkspace': 'フォルダをワークスペースに追加…',
   'appMenu.addToWorkspaceHint': 'サイドバーに別ルートを並べる',
@@ -220,6 +229,7 @@ const ja: Dict = {
   'filetree.confirmDeleteFile': '"{name}" をゴミ箱に移動しますか？',
   'filetree.confirmDeleteFolder': '"{name}" とその中身をすべてゴミ箱に移動しますか？',
   'filetree.confirmDeletePermanent': '"{name}" を完全に削除しますか？この操作は元に戻せません。',
+  'filetree.preloadRestartRequired': 'アプリを再起動してください（preload 更新のため）',
   'canvasMenu.lockTeam': 'チームで一緒に動かす',
   'canvasMenu.unlockTeam': 'チーム固定を解除',
   'canvasMenu.deleteCard': 'カードを削除',
@@ -272,6 +282,8 @@ const ja: Dict = {
   'canvas.switchToIde.tooltip': 'IDE — エディタとターミナル中心の IDE モードへ切替',
   'canvas.modeToggle': 'Canvas モードに切り替え',
   'canvas.card.editor': 'エディタ',
+  'canvas.list.title': 'チーム',
+  'canvas.list.empty': 'まだエージェントが配置されていません',
 
   // ---------- Agent Card ----------
   'agentCard.close': 'カードを閉じる',
@@ -385,6 +397,8 @@ const ja: Dict = {
   'dashboard.empty.noMembers':
     'このチームにはまだメンバーがいません。Leader から `team_recruit` でメンバーを招集してください',
   'dashboard.banner.humanGate': 'Human gate が blocked: Leader の判断待ちです',
+  'dashboard.alert.leaderInput': 'Leader 入力待ち',
+  'dashboard.alert.staleOutput': '5 分以上出力なし',
   // Issue #615: dual / multi preset 対応の team section heading
   'dashboard.team.label': 'チーム {index}',
 
@@ -706,8 +720,12 @@ const ja: Dict = {
   'terminal.status.reconnect': '再接続: {command}',
   'terminal.status.reconnectRestored': '再接続 (出力復元): {command}',
   'terminal.status.exception': '例外: {error}',
+  'terminal.limitReached': 'ターミナル上限（{max}）に達しました',
+  'terminal.limitWarning': 'ターミナル数が {threshold} に達しました（上限 {max}）',
   'terminal.restart': '再起動',
   'terminal.closeTab': '閉じる',
+  'layout.sidebarResizeTitle': 'ドラッグでサイドバー幅を調整 / ダブルクリックでリセット',
+  'layout.idePanelResizeTitle': 'ドラッグで IDE モードパネルの幅を調整',
   'cmd.settings.open': '設定を開く',
   'cmd.settings.cycleDensity': '情報密度を切り替え',
   'cmd.settings.cycleDensitySub': '現在: {density}',
@@ -786,6 +804,17 @@ const ja: Dict = {
 
   // ---------- Status ----------
   'status.noProject': 'プロジェクトが選択されていません',
+
+  // ---------- Image preview ----------
+  'imagePreview.devUnavailable': 'dev:vite モードでは画像プレビューを利用できません。',
+  'imagePreview.loadError': '画像を表示できません: {path}',
+
+  // ---------- Team history ----------
+  'teamHistory.resume.emptyMembers': 'チームメンバー情報が空のため復元できません',
+  'teamHistory.resume.otherProject':
+    'このチームは別プロジェクト({project})の履歴です',
+  'teamHistory.resume.terminalLimit':
+    'ターミナル上限({max})を超えるため復元できません',
 
   // ---------- Onboarding ----------
   'onboarding.back': '戻る',
@@ -900,6 +929,15 @@ const en: Dict = {
   'appMenu.newDialogTitle': 'New project',
   'appMenu.openFolderDialogTitle': 'Open folder',
   'appMenu.openFileDialogTitle': 'Open file',
+  'project.newDialogTitle': 'New project: choose or create an empty folder',
+  'project.openExistingDialogTitle': 'Open existing project',
+  'project.loading': 'Loading project…',
+  'project.loadError': 'Load error: {error}',
+  'project.initError': 'Initialization error: {error}',
+  'project.newFolderNotEmpty': 'Folder is not empty. Opening it as an existing project.',
+  'project.created': 'Created new project',
+  'project.fileParentLoaded': 'Loaded the parent folder of {file} as the project',
+  'project.recentCleared': 'Cleared recent project history',
   'appMenu.addWorkspaceDialogTitle': 'Add to workspace',
   'appMenu.openFileHint': 'Single file',
   'appMenu.addToWorkspace': 'Add folder to workspace…',
@@ -1033,6 +1071,7 @@ const en: Dict = {
   'filetree.confirmDeleteFile': 'Move "{name}" to the trash?',
   'filetree.confirmDeleteFolder': 'Move "{name}" and all of its contents to the trash?',
   'filetree.confirmDeletePermanent': 'Permanently delete "{name}"? This action cannot be undone.',
+  'filetree.preloadRestartRequired': 'Restart the app to apply the preload update',
   'canvasMenu.lockTeam': 'Move team together',
   'canvasMenu.unlockTeam': 'Unlock team movement',
   'canvasMenu.deleteCard': 'Delete card',
@@ -1085,6 +1124,8 @@ const en: Dict = {
   'canvas.switchToIde.tooltip': 'IDE — Return to the editor + terminal IDE mode',
   'canvas.modeToggle': 'Switch to Canvas mode',
   'canvas.card.editor': 'Editor',
+  'canvas.list.title': 'Team',
+  'canvas.list.empty': 'No agents have been placed yet',
 
   // ---------- Agent Card ----------
   'agentCard.close': 'Close card',
@@ -1200,6 +1241,8 @@ const en: Dict = {
   'dashboard.empty.noMembers':
     'This team has no members yet. Recruit members from the Leader using `team_recruit`.',
   'dashboard.banner.humanGate': 'Human gate blocked: waiting for leader decision',
+  'dashboard.alert.leaderInput': 'Awaiting Leader input',
+  'dashboard.alert.staleOutput': 'No output for 5+ minutes',
   // Issue #615: dual / multi preset support for team section heading
   'dashboard.team.label': 'Team {index}',
 
@@ -1525,8 +1568,12 @@ const en: Dict = {
   'terminal.status.reconnect': 'Reconnected: {command}',
   'terminal.status.reconnectRestored': 'Reconnected (restored output): {command}',
   'terminal.status.exception': 'Exception: {error}',
+  'terminal.limitReached': 'Terminal limit reached ({max})',
+  'terminal.limitWarning': 'Terminal count reached {threshold} (limit {max})',
   'terminal.restart': 'Restart',
   'terminal.closeTab': 'Close',
+  'layout.sidebarResizeTitle': 'Drag to resize the sidebar / double-click to reset',
+  'layout.idePanelResizeTitle': 'Drag to resize the IDE mode panel',
   'cmd.settings.open': 'Open settings',
   'cmd.settings.cycleDensity': 'Cycle density',
   'cmd.settings.cycleDensitySub': 'Current: {density}',
@@ -1607,6 +1654,17 @@ const en: Dict = {
     "Couldn't find past transcripts; restarted {count} tab(s) as new conversations.",
 
   'status.noProject': 'No project selected',
+
+  // ---------- Image preview ----------
+  'imagePreview.devUnavailable': 'Image preview is unavailable in dev:vite mode.',
+  'imagePreview.loadError': 'Unable to display image: {path}',
+
+  // ---------- Team history ----------
+  'teamHistory.resume.emptyMembers': 'Cannot resume because team member information is empty',
+  'teamHistory.resume.otherProject':
+    'This team history belongs to another project ({project})',
+  'teamHistory.resume.terminalLimit':
+    'Cannot resume because it would exceed the terminal limit ({max})',
 
   // ---------- Onboarding ----------
   'onboarding.back': 'Back',

--- a/src/renderer/src/lib/use-team-dashboard.ts
+++ b/src/renderer/src/lib/use-team-dashboard.ts
@@ -31,6 +31,7 @@ import type {
   AgentPayload,
   AgentStatus
 } from '../components/canvas/cards/AgentNodeCard/types';
+import { useT } from './i18n';
 
 const POLL_INTERVAL_MS = 5_000;
 
@@ -105,6 +106,7 @@ export function useTeamDashboard(input: {
   projectRoot: string | null;
 }): TeamDashboardData {
   const { teamId, projectRoot } = input;
+  const t = useT();
 
   const allNodes = useCanvasNodes();
   const agentNodes = useMemo<Node<CardData>[]>(
@@ -194,10 +196,10 @@ export function useTeamDashboard(input: {
             task?.blockedReason ??
             task?.requiredHumanDecision ??
             (state?.humanGate.blocked ? state.humanGate.reason ?? null : null) ??
-            'Leader 入力待ち'
+            t('dashboard.alert.leaderInput')
           );
         }
-        if (computed === 'stale') return '5 分以上出力なし';
+        if (computed === 'stale') return t('dashboard.alert.staleOutput');
         return null;
       })();
 
@@ -214,7 +216,7 @@ export function useTeamDashboard(input: {
         alert
       };
     });
-  }, [agentNodes, byCard, state]);
+  }, [agentNodes, byCard, state, t]);
 
   const aggregate = useMemo<TeamDashboardAggregate>(() => {
     let active = 0;
@@ -275,6 +277,7 @@ export function useTeamDashboardMulti(input: {
   projectRoot: string | null;
 }): MultiTeamDashboardData {
   const { teamIds, projectRoot } = input;
+  const t = useT();
 
   // teamIds 配列の参照ゆれで useEffect が頻繁に再起動しないよう、安定リスト + JSON key に正規化。
   const stableTeamIds = useMemo<string[]>(() => {
@@ -378,10 +381,10 @@ export function useTeamDashboardMulti(input: {
               task?.blockedReason ??
               task?.requiredHumanDecision ??
               (state?.humanGate.blocked ? state.humanGate.reason ?? null : null) ??
-              'Leader 入力待ち'
+              t('dashboard.alert.leaderInput')
             );
           }
-          if (computed === 'stale') return '5 分以上出力なし';
+          if (computed === 'stale') return t('dashboard.alert.staleOutput');
           return null;
         })();
 
@@ -434,7 +437,7 @@ export function useTeamDashboardMulti(input: {
 
       return { teamId, rows, aggregate, state };
     });
-  }, [stableTeamIds, nodesByTeam, stateByTeam, byCard]);
+  }, [stableTeamIds, nodesByTeam, stateByTeam, byCard, t]);
 
   const total = useMemo<TeamDashboardAggregate>(() => {
     let total = 0;


### PR DESCRIPTION
## Summary
- TeamDashboard / Canvas list / ImagePreview / project loader / terminal tabs / team history / file tree / resize tooltip の直書き文言を i18n キー経由に変更
- `ja` / `en` の翻訳辞書に不足キーを追加
- terminal tabs の既存テストを翻訳化後のメッセージに合わせて更新

Closes #906

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx src/renderer/src/lib/__tests__/filetree-state-context.test.tsx`
- [x] `git diff --check`

## Notes
- `npm ci` で既存の audit warning が 2 件 (moderate 1 / critical 1) 表示されましたが、本 PR の変更範囲外です。