### PR TITLE
fix(settings): #905 読み込み失敗時の初期値上書きを防止

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -19,13 +19,18 @@ use crate::commands::error::{CommandError, CommandResult};
 use crate::util::backup::write_timestamped_backup;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, path::Path, time::Duration};
 use tokio::fs;
 use tokio::sync::Mutex;
 
 /// Issue #37: 並列 save を直列化する。atomic_write だけでは同時 2 save で
 /// どちらかが temp rename 競合して 1 つが失敗しうるが、この Mutex で書き込みを 1 つずつに。
 static SAVE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+const SETTINGS_READ_RETRY_DELAYS: &[Duration] = &[
+    Duration::from_millis(40),
+    Duration::from_millis(120),
+    Duration::from_millis(240),
+];
 
 /// `~/.vibe-editor/settings.json` の serde 表現。renderer 側 `src/types/shared.ts` の
 /// `AppSettings` と完全一致 (camelCase ですべての field が同名・同型)。
@@ -156,8 +161,14 @@ impl std::fmt::Debug for VoiceSettings {
             .field("language", &self.language)
             .field("voice_name", &self.voice_name)
             // device id は機微ではないが、ハードウェア identifier なのでログ出さない
-            .field("input_device_id", &self.input_device_id.as_ref().map(|_| "<set>"))
-            .field("output_device_id", &self.output_device_id.as_ref().map(|_| "<set>"))
+            .field(
+                "input_device_id",
+                &self.input_device_id.as_ref().map(|_| "<set>"),
+            )
+            .field(
+                "output_device_id",
+                &self.output_device_id.as_ref().map(|_| "<set>"),
+            )
             .field("toggle_shortcut", &self.toggle_shortcut)
             .field("confirmation_mode", &self.confirmation_mode)
             .field("has_shown_disclaimer", &self.has_shown_disclaimer)
@@ -292,18 +303,52 @@ fn default_sidebar_width() -> f64 {
     272.0
 }
 
+async fn read_optional_file_with_retry(
+    path: &Path,
+    label: &str,
+    retry_delays: &[Duration],
+) -> CommandResult<Option<Vec<u8>>> {
+    for attempt in 0..=retry_delays.len() {
+        match fs::read(path).await {
+            Ok(bytes) => return Ok(Some(bytes)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                if let Some(delay) = retry_delays.get(attempt) {
+                    tracing::warn!(
+                        "[{label}] read failed at {} (attempt {}/{}): {e}; retrying in {:?}",
+                        path.display(),
+                        attempt + 1,
+                        retry_delays.len() + 1,
+                        delay
+                    );
+                    tokio::time::sleep(*delay).await;
+                    continue;
+                }
+                return Err(CommandError::Io(format!(
+                    "{label} read failed at {} after {} attempt(s): {e}",
+                    path.display(),
+                    retry_delays.len() + 1
+                )));
+            }
+        }
+    }
+    unreachable!("retry loop always returns");
+}
+
 #[tauri::command]
-pub async fn settings_load() -> Settings {
+pub async fn settings_load() -> CommandResult<Settings> {
     tracing::info!("[IPC] settings_load called");
     let path = crate::util::config_paths::settings_path();
-    let Ok(bytes) = fs::read(&path).await else {
-        // Issue #29: 初回起動 / 読み取り不能時は default を返す。renderer 側 `migrateSettings`
-        // は schemaVersion=10 (current) で呼ばれることになるので migration は no-op、
-        // shallow merge で DEFAULT_SETTINGS と一致した値が settingsRef に乗る。
-        return Settings::default();
+    let Some(bytes) =
+        read_optional_file_with_retry(&path, "settings_load", SETTINGS_READ_RETRY_DELAYS).await?
+    else {
+        // Issue #29: 初回起動で settings.json がまだ無いときだけ default を返す。
+        // Issue #905: PermissionDenied / sharing violation 等の読み取り不能は default 扱いに
+        // しない。renderer 側へ Err を返し、default ベースの auto-save で原本を上書きしない。
+        return Ok(Settings::default());
     };
     match serde_json::from_slice::<Settings>(&bytes) {
-        Ok(v) => v,
+        Ok(v) => Ok(v),
         Err(e) => {
             // Issue #170: 旧実装は parse 失敗時に黙って Null を返し、次の save で
             // ユーザー設定が完全消失する事故が起きていた。.bak に元ファイルを退避してから
@@ -319,13 +364,10 @@ pub async fn settings_load() -> Settings {
             );
             // best-effort: バックアップが取れなくても続行
             match write_timestamped_backup(&path, &bytes, None).await {
-                Ok(bak) => tracing::info!(
-                    "[settings] wrote timestamped backup: {}",
-                    bak.display()
-                ),
+                Ok(bak) => tracing::info!("[settings] wrote timestamped backup: {}", bak.display()),
                 Err(berr) => tracing::warn!("[settings] backup write failed: {berr}"),
             }
-            Settings::default()
+            Ok(Settings::default())
         }
     }
 }
@@ -382,10 +424,22 @@ pub(crate) fn validate_custom_agent_ids(settings: &Settings) -> Result<(), Comma
 /// disk から既存 settings.json の `schema_version` だけを軽量に読み取る。
 /// ファイル不在 / parse 失敗 / フィールド欠落はすべて `None` を返し、check_schema_compat 側で
 /// 「ガード対象外」として扱う (= 旧データ / 初回保存 / 破損ファイルは save を許容する)。
-async fn read_disk_schema_version(path: &std::path::Path) -> Option<u32> {
-    let bytes = fs::read(path).await.ok()?;
-    let v: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
-    v.get("schemaVersion").and_then(|n| n.as_u64()).map(|n| n as u32)
+async fn read_disk_schema_version(path: &std::path::Path) -> CommandResult<Option<u32>> {
+    let Some(bytes) = read_optional_file_with_retry(
+        path,
+        "settings_save.schema_version",
+        SETTINGS_READ_RETRY_DELAYS,
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let Ok(v) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return Ok(None);
+    };
+    Ok(v.get("schemaVersion")
+        .and_then(|n| n.as_u64())
+        .map(|n| n as u32))
 }
 
 #[tauri::command]
@@ -395,7 +449,7 @@ pub async fn settings_save(app: tauri::AppHandle, settings: Settings) -> Command
     // Issue #641: 古い build が新スキーマの settings.json を silent に上書きするのを防ぐ。
     // disk の `schemaVersion` が現行 const より大きい場合、新フィールドが silent drop される
     // ため reject する (renderer 側でユーザーに「最新版に更新してください」を表示する経路)。
-    let disk_v = read_disk_schema_version(&path).await;
+    let disk_v = read_disk_schema_version(&path).await?;
     check_schema_compat(disk_v, settings.schema_version)?;
     validate_custom_agent_ids(&settings)?;
     let json = serde_json::to_vec_pretty(&settings)?;
@@ -665,7 +719,7 @@ mod tests {
             .await
             .unwrap();
         let v = read_disk_schema_version(&path).await;
-        assert_eq!(v, Some(42));
+        assert_eq!(v.unwrap(), Some(42));
     }
 
     /// 不在ファイル / parse 失敗 / フィールド欠落はすべて `None` を返す。
@@ -673,14 +727,49 @@ mod tests {
     async fn read_disk_schema_version_returns_none_for_missing_or_invalid() {
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("nope.json");
-        assert_eq!(read_disk_schema_version(&missing).await, None);
+        assert_eq!(read_disk_schema_version(&missing).await.unwrap(), None);
 
         let invalid = dir.path().join("invalid.json");
         tokio::fs::write(&invalid, b"not-json").await.unwrap();
-        assert_eq!(read_disk_schema_version(&invalid).await, None);
+        assert_eq!(read_disk_schema_version(&invalid).await.unwrap(), None);
 
         let no_field = dir.path().join("no-field.json");
-        tokio::fs::write(&no_field, br#"{"language":"ja"}"#).await.unwrap();
-        assert_eq!(read_disk_schema_version(&no_field).await, None);
+        tokio::fs::write(&no_field, br#"{"language":"ja"}"#)
+            .await
+            .unwrap();
+        assert_eq!(read_disk_schema_version(&no_field).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn read_optional_file_with_retry_returns_none_only_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.json");
+        let result = read_optional_file_with_retry(&missing, "test", &[])
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_optional_file_with_retry_rejects_non_not_found_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = read_optional_file_with_retry(dir.path(), "test", &[])
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("test read failed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_disk_schema_version_rejects_non_not_found_read_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = read_disk_schema_version(dir.path()).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("settings_save.schema_version read failed"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -325,8 +325,17 @@ pub fn run() {
             let app_handle_for_root = app.handle().clone();
             spawn_observed("settings_restore", async move {
                 // Issue #493: settings_load は Settings struct を返すようになった。
+                // Issue #905: 一時的な読み取り不能は default 扱いせず Err にする。
+                // ここで復元を諦めることで、原本 settings.json が default で上書きされる
+                // 経路を起動直後から作らない。
                 // last_opened_root を優先し、空なら claudeCwd を fallback。
-                let settings = commands::settings::settings_load().await;
+                let settings = match commands::settings::settings_load().await {
+                    Ok(settings) => settings,
+                    Err(e) => {
+                        tracing::warn!("[setup] settings restore skipped: {e}");
+                        return;
+                    }
+                };
                 let root = Some(settings.last_opened_root.clone())
                     .filter(|s| !s.trim().is_empty())
                     .or_else(|| Some(settings.claude_cwd.clone()).filter(|s| !s.trim().is_empty()));

--- a/src/renderer/src/lib/__tests__/settings-context.test.tsx
+++ b/src/renderer/src/lib/__tests__/settings-context.test.tsx
@@ -36,10 +36,14 @@ interface MockApi {
   };
 }
 
-function installApi(initial?: Partial<AppSettings>, saveImpl?: () => Promise<void>): MockApi {
+function installApi(
+  initial?: Partial<AppSettings>,
+  saveImpl?: () => Promise<void>,
+  loadImpl?: () => Promise<unknown>
+): MockApi {
   const api: MockApi = {
     settings: {
-      load: vi.fn(async () => ({ ...DEFAULT_SETTINGS, ...(initial ?? {}) })),
+      load: vi.fn(loadImpl ?? (async () => ({ ...DEFAULT_SETTINGS, ...(initial ?? {}) }))),
       save: vi.fn(saveImpl ?? (async () => undefined))
     },
     app: {
@@ -159,5 +163,33 @@ describe('settings-context', () => {
       },
       { timeout: 1500 }
     );
+  });
+
+  it('settings load が reject した場合は default 状態の auto-save を抑止する', async () => {
+    const api = installApi(
+      undefined,
+      async () => undefined,
+      async () => {
+        throw new Error('sharing violation');
+      }
+    );
+    const { result } = renderHook(() => useSettings(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await waitFor(
+      () => {
+        const toast = document.querySelector('.toast--error');
+        expect(toast).not.toBeNull();
+      },
+      { timeout: 1500 }
+    );
+
+    await act(async () => {
+      await result.current.update({ editorFontSize: 22 });
+    });
+
+    await new Promise((resolve) => window.setTimeout(resolve, 300));
+    expect(api.settings.save).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -638,6 +638,10 @@ const ja: Dict = {
   'toast.fileOpFailed': 'ファイル操作に失敗しました: {error}',
   'toast.fileOpClipboardEmpty': 'クリップボードに対象がありません',
   'toast.terminalNotReady': 'ターミナルが起動していません',
+  'toast.settings.loadFailed':
+    '設定ファイルを読み込めなかったため、この起動中は設定の自動保存を停止しました: {error}',
+  'toast.settings.saveBlocked':
+    '設定ファイルを読み込めなかったため、設定の保存を停止しています。アプリを再起動してください。',
   'toast.settings.saveFailed': '設定の保存に失敗しました: {error}',
   'toast.settings.projectRootFailed': 'プロジェクトルートの反映に失敗しました: {error}',
   // Issue #578: Canvas 非表示中に recruit が走った件数を可視化時に警告する
@@ -1483,6 +1487,10 @@ const en: Dict = {
   'toast.fileOpFailed': 'File operation failed: {error}',
   'toast.fileOpClipboardEmpty': 'Nothing to paste',
   'toast.terminalNotReady': 'Terminal is not ready',
+  'toast.settings.loadFailed':
+    'Failed to load settings, so automatic settings saves are disabled for this launch: {error}',
+  'toast.settings.saveBlocked':
+    'Settings were not loaded, so saving settings is disabled. Please restart the app.',
   'toast.settings.saveFailed': 'Failed to save settings: {error}',
   'toast.settings.projectRootFailed': 'Failed to apply project root: {error}',
   // Issue #578: Warn when recruits ran while canvas was hidden

--- a/src/renderer/src/lib/settings-context.tsx
+++ b/src/renderer/src/lib/settings-context.tsx
@@ -79,6 +79,7 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
   });
   const listenersRef = useRef(new Set<() => void>());
   const saveTimerRef = useRef<number | null>(null);
+  const saveBlockedRef = useRef(false);
 
   const emitSnapshot = useCallback((): void => {
     snapshotRef.current = {
@@ -116,6 +117,16 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
           merged.language = loc.startsWith('ja') ? 'ja' : 'en';
         }
         commitState(merged, false);
+        saveBlockedRef.current = false;
+      } catch (err) {
+        if (cancelled) return;
+        saveBlockedRef.current = true;
+        bridgedToast(
+          translate(settingsRef.current.language ?? 'ja', 'toast.settings.loadFailed', {
+            error: String(err)
+          }),
+          { tone: 'error' }
+        );
       } finally {
         if (!cancelled && loadingRef.current) {
           commitState(settingsRef.current, false);
@@ -154,6 +165,7 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
         settingsRef.current = updated;
         emitSnapshot();
         if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
+        if (saveBlockedRef.current) return;
         saveTimerRef.current = window.setTimeout(() => {
           saveTimerRef.current = null;
           void window.api.settings.save(settingsRef.current).catch(() => {});
@@ -192,6 +204,9 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
     async (patch: Partial<AppSettings>) => {
       const next = { ...settingsRef.current, ...patch };
       commitState(next, loadingRef.current);
+      if (saveBlockedRef.current) {
+        return;
+      }
       if (saveTimerRef.current !== null) {
         window.clearTimeout(saveTimerRef.current);
       }
@@ -214,6 +229,7 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
 
   useEffect(() => {
     const handler = (): void => {
+      if (saveBlockedRef.current) return;
       if (saveTimerRef.current !== null) {
         window.clearTimeout(saveTimerRef.current);
         saveTimerRef.current = null;
@@ -227,6 +243,13 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
   }, []);
 
   const reset = useCallback(async () => {
+    if (saveBlockedRef.current) {
+      bridgedToast(
+        translate(settingsRef.current.language ?? 'ja', 'toast.settings.saveBlocked'),
+        { tone: 'error' }
+      );
+      return;
+    }
     const next = cloneDefaultSettings();
     commitState(next, loadingRef.current);
     await window.api.settings.save(next);


### PR DESCRIPTION
## Summary
- `settings_load` で `settings.json` の read 失敗を `NotFound` とそれ以外に分離し、一時的な読み取り不能は bounded retry 後に Err へ伝播
- `settings_save` の schemaVersion 読み取りでも non-NotFound read error を保存拒否にし、読めない既存ファイルを上書きしないよう変更
- Renderer の SettingsProvider で load 失敗時に自動保存をブロックし、default 状態が disk 原本を上書きしないようガード
- load 失敗・保存ブロックの toast 文言と回帰テストを追加

Closes #905

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml settings --lib`
- [x] `npm run typecheck`
- [x] `npx vitest run src/renderer/src/lib/__tests__/settings-context.test.tsx`
- [x] `git diff --check`

## Notes
- `npm ci` で既存の audit warning が 2 件 (moderate 1 / critical 1) 表示されましたが、本 PR の変更範囲外です。