### PR TITLE
fix(terminal_tabs): #903 破損データの上書き喪失を防止

### DIFF
--- a/src-tauri/src/commands/schema_version.rs
+++ b/src-tauri/src/commands/schema_version.rs
@@ -30,6 +30,10 @@ pub const TEAM_STATE_SCHEMA_VERSION: u32 = 1;
 /// 旧実装は `handoffs.rs` 内に `schema_version: 1` の直書きリテラルだった。
 pub const HANDOFF_SCHEMA_VERSION: u32 = 1;
 
+/// `~/.vibe-editor/terminal-tabs.json` の現行 schema version。
+/// renderer 側 `TERMINAL_TABS_SCHEMA_VERSION` と同期。
+pub const TERMINAL_TABS_SCHEMA_VERSION: u32 = 1;
+
 /// 永続化ストア 1 つ分の schema version 情報。`current` (= この build がネイティブに扱える
 /// 版数) と、互換性ガードの reject メッセージ / ログに使う `store_label` を束ねる。
 #[derive(Clone, Copy, Debug)]
@@ -45,6 +49,12 @@ impl SchemaVersion {
     pub const SETTINGS: SchemaVersion = SchemaVersion {
         current: SETTINGS_SCHEMA_VERSION,
         store_label: "settings.json",
+    };
+
+    /// IDE terminal tabs 永続化ファイル用の `SchemaVersion`。
+    pub const TERMINAL_TABS: SchemaVersion = SchemaVersion {
+        current: TERMINAL_TABS_SCHEMA_VERSION,
+        store_label: "terminal-tabs.json",
     };
 
     /// 永続化前 (= save 直前) の schema version 互換性チェック。
@@ -146,7 +156,10 @@ mod tests {
             msg.contains("newer vibe-editor"),
             "error message must hint at update: got {msg}"
         );
-        assert!(msg.contains("settings.json"), "message must name the store: got {msg}");
+        assert!(
+            msg.contains("settings.json"),
+            "message must name the store: got {msg}"
+        );
     }
 
     /// renderer から未来バージョンが渡された場合は reject。
@@ -169,7 +182,9 @@ mod tests {
             current: TEAM_STATE_SCHEMA_VERSION,
             store_label: "team-state",
         };
-        assert!(team_state.check_compat(Some(TEAM_STATE_SCHEMA_VERSION), None).is_ok());
+        assert!(team_state
+            .check_compat(Some(TEAM_STATE_SCHEMA_VERSION), None)
+            .is_ok());
         let r = team_state.check_compat(Some(TEAM_STATE_SCHEMA_VERSION + 1), None);
         assert!(r.is_err());
         assert!(format!("{}", r.unwrap_err()).contains("team-state"));

--- a/src-tauri/src/commands/terminal_tabs.rs
+++ b/src-tauri/src/commands/terminal_tabs.rs
@@ -9,7 +9,9 @@
 //   - byProject は raw projectRoot を key とし、検索/書込側で `normalize_project_root` 経由
 //   - cache + LOCK で disk I/O 最小化 (team_history.rs と同流儀)
 
+use crate::commands::schema_version::SchemaVersion;
 use crate::commands::team_history::MutationResult;
+use crate::util::backup::write_timestamped_backup;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -17,7 +19,7 @@ use tokio::fs;
 use tokio::sync::Mutex;
 
 /// renderer 側 `TERMINAL_TABS_SCHEMA_VERSION` と一致させる
-pub const TERMINAL_TABS_SCHEMA_VERSION: u32 = 1;
+pub use crate::commands::schema_version::TERMINAL_TABS_SCHEMA_VERSION;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -99,16 +101,38 @@ fn store_path() -> PathBuf {
     crate::util::config_paths::terminal_tabs_path()
 }
 
-/// disk からロードする。schemaVersion 不一致は `None` を返して旧データを無視する。
+/// disk からロードする。parse 失敗時は原本 bytes を timestamped backup に退避する。
 async fn load_from_disk() -> Option<PersistedTerminalTabsFile> {
     let path = store_path();
-    let bytes = fs::read(&path).await.ok()?;
+    load_from_disk_at(&path).await
+}
+
+/// disk からロードする。schemaVersion 不一致は `None` を返して旧データを無視する。
+async fn load_from_disk_at(path: &Path) -> Option<PersistedTerminalTabsFile> {
+    let bytes = match fs::read(path).await {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!(
+                "[terminal_tabs] read failed (treating as missing): {}: {e}",
+                path.display()
+            );
+            return None;
+        }
+    };
     let file: PersistedTerminalTabsFile = match serde_json::from_slice(&bytes) {
         Ok(f) => f,
         Err(e) => {
             tracing::warn!(
-                "[terminal_tabs] parse failed (treating as missing): {e}"
+                "[terminal_tabs] parse failed (backing up then treating as missing): {e}"
             );
+            match write_timestamped_backup(path, &bytes, Some(0o600)).await {
+                Ok(bak) => tracing::info!(
+                    "[terminal_tabs] wrote timestamped backup: {}",
+                    bak.display()
+                ),
+                Err(berr) => tracing::warn!("[terminal_tabs] backup write failed: {berr}"),
+            }
             return None;
         }
     };
@@ -264,8 +288,35 @@ async fn sanitize_missing_jsonl(
     dropped
 }
 
+/// disk にある `schemaVersion` だけを軽量に読む。
+///
+/// ファイル不在 / parse 失敗 / フィールド欠落は `None` として扱う。parse 失敗は
+/// `load_from_disk_at` 側で backup 済みの想定なので、save guard では未来 schema の検出に集中する。
+async fn read_disk_schema_version(path: &Path) -> Result<Option<u32>, String> {
+    let bytes = match fs::read(path).await {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.to_string()),
+    };
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return Ok(None);
+    };
+    Ok(value
+        .get("schemaVersion")
+        .and_then(|n| n.as_u64())
+        .map(|n| n as u32))
+}
+
 async fn save_to_disk(file: &PersistedTerminalTabsFile) -> Result<(), String> {
     let path = store_path();
+    save_to_disk_at(&path, file).await
+}
+
+async fn save_to_disk_at(path: &Path, file: &PersistedTerminalTabsFile) -> Result<(), String> {
+    let disk_schema_version = read_disk_schema_version(path).await?;
+    SchemaVersion::TERMINAL_TABS
+        .check_compat(disk_schema_version, Some(file.schema_version))
+        .map_err(|e| e.to_string())?;
     let json = serde_json::to_vec_pretty(file).map_err(|e| e.to_string())?;
     // Issue #608: terminal-tabs.json は Claude session id (UUID) と cwd を持ち、漏洩すると
     // `~/.claude/projects/<encoded>/<uuid>.jsonl` の会話履歴に間接アクセスできるため
@@ -311,13 +362,15 @@ pub async fn terminal_tabs_load() -> Option<TerminalTabsLoadResult> {
 pub async fn terminal_tabs_save(file: PersistedTerminalTabsFile) -> MutationResult {
     let _g = LOCK.lock().await;
     let mut cache = CACHE.lock().await;
-    *cache = Some(file.clone());
     match save_to_disk(&file).await {
-        Ok(()) => MutationResult {
-            ok: true,
-            error: None,
-            ..Default::default()
-        },
+        Ok(()) => {
+            *cache = Some(file);
+            MutationResult {
+                ok: true,
+                error: None,
+                ..Default::default()
+            }
+        }
         Err(e) => MutationResult {
             ok: false,
             error: Some(e),
@@ -377,6 +430,73 @@ mod tests {
         let f = PersistedTerminalTabsFile::default();
         assert_eq!(f.schema_version, TERMINAL_TABS_SCHEMA_VERSION);
         assert!(f.by_project.is_empty());
+    }
+
+    #[tokio::test]
+    async fn load_from_disk_backs_up_invalid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("terminal-tabs.json");
+        let corrupt = b"{ not valid json";
+        fs::write(&path, corrupt).await.unwrap();
+
+        let loaded = load_from_disk_at(&path).await;
+
+        assert!(loaded.is_none(), "invalid JSON should load as missing");
+        let mut backups = Vec::new();
+        let mut entries = fs::read_dir(dir.path()).await.unwrap();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with("terminal-tabs.json.bak.") {
+                backups.push(entry.path());
+            }
+        }
+        assert_eq!(backups.len(), 1, "exactly one backup should be written");
+        let backup_bytes = fs::read(&backups[0]).await.unwrap();
+        assert_eq!(backup_bytes, corrupt);
+    }
+
+    #[tokio::test]
+    async fn save_to_disk_rejects_future_disk_schema_without_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("terminal-tabs.json");
+        let original = format!(
+            r#"{{"schemaVersion":{},"lastSavedAt":"future","byProject":{{"keep":{{"tabs":[],"activeTabId":null}}}}}}"#,
+            TERMINAL_TABS_SCHEMA_VERSION + 1
+        );
+        fs::write(&path, original.as_bytes()).await.unwrap();
+
+        let err = save_to_disk_at(&path, &PersistedTerminalTabsFile::default())
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.contains("newer vibe-editor"),
+            "error should explain update requirement: {err}"
+        );
+        let after = fs::read_to_string(&path).await.unwrap();
+        assert_eq!(
+            after, original,
+            "future schema file must not be overwritten"
+        );
+    }
+
+    #[tokio::test]
+    async fn save_to_disk_rejects_future_incoming_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("terminal-tabs.json");
+        let mut file = PersistedTerminalTabsFile::default();
+        file.schema_version = TERMINAL_TABS_SCHEMA_VERSION + 1;
+
+        let err = save_to_disk_at(&path, &file).await.unwrap_err();
+
+        assert!(
+            err.contains("future schema"),
+            "error should mention future schema: {err}"
+        );
+        assert!(
+            !path.exists(),
+            "rejected future incoming schema should not create a file"
+        );
     }
 
     #[test]
@@ -441,17 +561,12 @@ mod tests {
     // ---- Issue #702: sanitize_missing_jsonl tests ----
 
     fn unique_temp_dir(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir()
-            .join(format!("vibe-editor-{name}-{}", uuid::Uuid::new_v4()));
+        let dir = std::env::temp_dir().join(format!("vibe-editor-{name}-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).expect("create temp dir");
         dir
     }
 
-    fn make_file_with_tab(
-        kind: &str,
-        cwd: &str,
-        sid: Option<&str>,
-    ) -> PersistedTerminalTabsFile {
+    fn make_file_with_tab(kind: &str, cwd: &str, sid: Option<&str>) -> PersistedTerminalTabsFile {
         let mut by_project = HashMap::new();
         by_project.insert(
             cwd.to_string(),
@@ -602,7 +717,10 @@ mod tests {
         let sid = "11112222-3333-4444-5555-666677778888";
         write_codex_rollout(&root, sid);
 
-        assert!(codex_rollout_exists_sync(&root, sid), "should find rollout by sid suffix");
+        assert!(
+            codex_rollout_exists_sync(&root, sid),
+            "should find rollout by sid suffix"
+        );
         assert!(
             !codex_rollout_exists_sync(&root, "no-such-id"),
             "unknown sid must not match"
@@ -700,7 +818,11 @@ mod tests {
         let dropped = sanitize_missing_jsonl(&mut file, &tmp, &codex_sessions_root_in(&tmp)).await;
 
         let tabs = &file.by_project[cwd].tabs;
-        assert_eq!(tabs[0].session_id.as_deref(), Some(sid_alive), "alive sid kept");
+        assert_eq!(
+            tabs[0].session_id.as_deref(),
+            Some(sid_alive),
+            "alive sid kept"
+        );
         assert!(tabs[1].session_id.is_none(), "dead sid dropped");
         assert_eq!(dropped.len(), 1, "only the dead tab is recorded");
         assert_eq!(dropped[0].tab_id, "2");

--- a/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs-persistence.ts
@@ -105,9 +105,23 @@ export function useTerminalTabsPersistence(
   const cwdMapRef = useRef(new Map<number, string>());
   /** 永続化ファイルの直近キャッシュ。save 時に他プロジェクトの entry を保持する用途 */
   const fileCacheRef = useRef<PersistedTerminalTabsFile | null>(null);
+  /** schema guard 等で保存が拒否されたときの警告 toast はセッション 1 回に抑える */
+  const saveWarningShownRef = useRef(false);
   /** size/cwd の Map 更新を save effect に観測させるための tick */
   const [tickNonce, setTickNonce] = useState(0);
   const bumpTick = useCallback(() => setTickNonce((n) => n + 1), []);
+  const warnSaveFailed = useCallback((err: unknown) => {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.warn('[terminal-tabs] save failed:', err);
+    if (saveWarningShownRef.current) return;
+    saveWarningShownRef.current = true;
+    showToastRef.current(
+      tRef.current('terminalTabs.saveFailed', {
+        error: detail || 'unknown error'
+      }),
+      { tone: 'warning' }
+    );
+  }, []);
 
   // mount 時に 1 度だけ load → 復元
   useEffect(() => {
@@ -225,13 +239,28 @@ export function useTerminalTabsPersistence(
         lastSavedAt: new Date().toISOString(),
         byProject: { ...prevFile.byProject, [projectRoot]: slot }
       };
-      fileCacheRef.current = nextFile;
-      void api.terminalTabs.save(nextFile).catch((err) => {
-        console.warn('[terminal-tabs] save failed:', err);
-      });
+      void api.terminalTabs
+        .save(nextFile)
+        .then((result) => {
+          if (!result.ok) {
+            warnSaveFailed(result.error ?? 'unknown error');
+            return;
+          }
+          fileCacheRef.current = nextFile;
+        })
+        .catch((err) => {
+          warnSaveFailed(err);
+        });
     }, SAVE_DEBOUNCE_MS);
     return () => clearTimeout(timer);
-  }, [terminalTabs, activeTerminalTabId, projectRoot, isReady, tickNonce]);
+  }, [
+    terminalTabs,
+    activeTerminalTabId,
+    projectRoot,
+    isReady,
+    tickNonce,
+    warnSaveFailed
+  ]);
 
   const reportSize = useCallback(
     (tabId: number, cols: number, rows: number) => {

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -805,6 +805,8 @@ const ja: Dict = {
   // ---------- Terminal タブ復元 (Issue #857) ----------
   'terminalTabs.restore.transcriptMissing':
     '過去の会話履歴が見つからず {count} 件のタブを新規会話で再起動しました',
+  'terminalTabs.saveFailed':
+    'ターミナルタブの保存を停止しました: {error}',
 
   // ---------- Status ----------
   'status.noProject': 'プロジェクトが選択されていません',
@@ -1660,6 +1662,7 @@ const en: Dict = {
   // ---------- Terminal tab restore (Issue #857) ----------
   'terminalTabs.restore.transcriptMissing':
     "Couldn't find past transcripts; restarted {count} tab(s) as new conversations.",
+  'terminalTabs.saveFailed': 'Stopped saving terminal tabs: {error}',
 
   'status.noProject': 'No project selected',
 

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -806,7 +806,7 @@ const ja: Dict = {
   'terminalTabs.restore.transcriptMissing':
     '過去の会話履歴が見つからず {count} 件のタブを新規会話で再起動しました',
   'terminalTabs.saveFailed':
-    'ターミナルタブの保存を停止しました: {error}',
+    'ターミナルタブの保存に失敗しました: {error}',
 
   // ---------- Status ----------
   'status.noProject': 'プロジェクトが選択されていません',

--- a/src/renderer/src/lib/tauri-api/terminal-tabs.ts
+++ b/src/renderer/src/lib/tauri-api/terminal-tabs.ts
@@ -1,8 +1,8 @@
 // tauri-api/terminal-tabs.ts — Issue #661 IDE タブ永続化 IPC namespace
 //
 // `~/.vibe-editor/terminal-tabs.json` を Rust 側で atomic write する API のラッパ。
-// 読込時は schemaVersion 不一致 / 未存在で `null` を返す (renderer は素の IDE 起動に
-// フォールバックする)。
+// 読込時は schemaVersion 不一致 / 未存在 / parse 失敗で `null` を返す (parse 失敗時の原本退避と
+// save 前の未来 schema guard は Rust 側が担当する)。
 
 import { invoke } from '@tauri-apps/api/core';
 import type {
@@ -18,6 +18,7 @@ interface MutationResult {
 export const terminalTabs = {
   /**
    * 永続化ファイルを読む。未存在 / schemaVersion mismatch / parse 失敗で null。
+   * parse 失敗時は Rust 側で timestamped backup を作る。
    *
    * Issue #857: 戻り値が `TerminalTabsLoadResult` (= `PersistedTerminalTabsFile` +
    * `droppedSessions`) になった。invoke 名は不変。
@@ -26,7 +27,7 @@ export const terminalTabs = {
     const result = await invoke<TerminalTabsLoadResult | null>('terminal_tabs_load');
     return result ?? null;
   },
-  /** 全体を atomic 上書き。read-modify-write は呼び出し側責務。 */
+  /** 全体を atomic 上書き。read-modify-write は呼び出し側責務。失敗は ok=false で返る。 */
   save: (file: PersistedTerminalTabsFile): Promise<MutationResult> =>
     invoke('terminal_tabs_save', { file }),
   /** ファイルを削除して cache を空に戻す。idempotent。 */


### PR DESCRIPTION
## Summary
- terminal-tabs.json の parse 失敗時に timestamped backup を作ってから未保存扱いへ倒すようにしました
- 保存前に disk / incoming の schemaVersion を共通 SchemaVersion guard で確認し、未来 schema の上書きを拒否します
- renderer 側で terminal_tabs_save の ok=false を検知し、保存拒否を warning toast で 1 回だけ通知します

## Test plan
- [x] `cargo test --manifest-path src-tauri\Cargo.toml terminal_tabs --lib`
- [x] `npm run typecheck`
- [x] `git diff --check`

## Notes
- `npm ci` 実行時に既存依存の警告として 2 vulnerabilities (1 moderate, 1 critical) が表示されました。今回の変更起因ではありません。

Closes #903