### PR TITLE
fix(mcp_config): #901 読み込み失敗時の設定上書きを防止

### DIFF
--- a/src-tauri/src/commands/app/team_mcp.rs
+++ b/src-tauri/src/commands/app/team_mcp.rs
@@ -536,7 +536,7 @@ mod tests {
 
         let res = run_setup_at(&claude_path, &codex_path, &desired, "/tmp/bridge.js").await;
 
-        assert!(res.is_err(), "codex setup should reject non UTF-8 config");
+        assert!(res.is_err(), "codex setup should reject non-UTF-8 config");
         let msg = format!("{:#}", res.unwrap_err());
         assert!(
             msg.contains("codex mcp setup"),

--- a/src-tauri/src/commands/app/team_mcp.rs
+++ b/src-tauri/src/commands/app/team_mcp.rs
@@ -75,13 +75,27 @@ async fn run_setup_at(
         Ok(c) => changed |= c,
         Err(e) => {
             let mut error_msg = format!("claude mcp setup: {e:#}");
-            rollback_both(claude_path, claude_snap, codex_path, codex_snap, &mut error_msg).await;
+            rollback_both(
+                claude_path,
+                claude_snap,
+                codex_path,
+                codex_snap,
+                &mut error_msg,
+            )
+            .await;
             return Err(anyhow!(error_msg));
         }
     }
     if let Err(e) = crate::mcp_config::codex::setup_at(codex_path, bridge_path).await {
         let mut error_msg = format!("codex mcp setup: {e:#}");
-        rollback_both(claude_path, claude_snap, codex_path, codex_snap, &mut error_msg).await;
+        rollback_both(
+            claude_path,
+            claude_snap,
+            codex_path,
+            codex_snap,
+            &mut error_msg,
+        )
+        .await;
         return Err(anyhow!(error_msg));
     }
     Ok(changed)
@@ -101,13 +115,27 @@ async fn run_cleanup_at(claude_path: &Path, codex_path: &Path) -> Result<bool> {
         Ok(r) => removed |= r,
         Err(e) => {
             let mut error_msg = format!("claude mcp cleanup: {e:#}");
-            rollback_both(claude_path, claude_snap, codex_path, codex_snap, &mut error_msg).await;
+            rollback_both(
+                claude_path,
+                claude_snap,
+                codex_path,
+                codex_snap,
+                &mut error_msg,
+            )
+            .await;
             return Err(anyhow!(error_msg));
         }
     }
     if let Err(e) = crate::mcp_config::codex::cleanup_at(codex_path).await {
         let mut error_msg = format!("codex mcp cleanup: {e:#}");
-        rollback_both(claude_path, claude_snap, codex_path, codex_snap, &mut error_msg).await;
+        rollback_both(
+            claude_path,
+            claude_snap,
+            codex_path,
+            codex_snap,
+            &mut error_msg,
+        )
+        .await;
         return Err(anyhow!(error_msg));
     }
     Ok(removed)
@@ -180,8 +208,7 @@ pub async fn app_setup_team_mcp(
     // → app_install_vibe_team_skill と同じく req_canon == active_canon を検証してから install する。
     let trimmed = project_root.trim();
     if !trimmed.is_empty() {
-        let active =
-            crate::state::current_project_root(&state.project_root).unwrap_or_default();
+        let active = crate::state::current_project_root(&state.project_root).unwrap_or_default();
         if active.trim().is_empty() {
             tracing::warn!(
                 "[setup_team_mcp] skipping skill install: no active project_root configured"
@@ -464,7 +491,10 @@ mod tests {
         });
 
         let res = run_setup_at(&claude_path, &codex_path, &desired, "/tmp/bridge.js").await;
-        assert!(res.is_err(), "codex setup should fail when parent is a file");
+        assert!(
+            res.is_err(),
+            "codex setup should fail when parent is a file"
+        );
         let msg = format!("{:#}", res.unwrap_err());
         assert!(
             msg.contains("codex mcp setup"),
@@ -481,6 +511,50 @@ mod tests {
         assert!(
             !codex_path.exists(),
             "codex file should not exist after failed setup"
+        );
+    }
+
+    #[tokio::test]
+    async fn setup_rolls_back_both_when_codex_config_is_not_utf8() {
+        let tmp = TempDir::new().unwrap();
+        let claude_path = tmp.path().join(".claude.json");
+        let original_claude = br#"{"mcpServers":{"other":{"command":"node"}}}"#.to_vec();
+        fs::write(&claude_path, &original_claude).await.unwrap();
+
+        let codex_path = tmp.path().join(".codex").join("config.toml");
+        fs::create_dir_all(codex_path.parent().unwrap())
+            .await
+            .unwrap();
+        let original_codex = b"[other]\n# invalid utf8: \x82\xa0\n".to_vec();
+        fs::write(&codex_path, &original_codex).await.unwrap();
+
+        let desired = json!({
+            "type": "stdio",
+            "command": "node",
+            "args": ["/tmp/bridge.js"]
+        });
+
+        let res = run_setup_at(&claude_path, &codex_path, &desired, "/tmp/bridge.js").await;
+
+        assert!(res.is_err(), "codex setup should reject non UTF-8 config");
+        let msg = format!("{:#}", res.unwrap_err());
+        assert!(
+            msg.contains("codex mcp setup"),
+            "error should mention codex mcp setup, got: {msg}"
+        );
+        assert!(
+            msg.contains("not valid UTF-8"),
+            "error should mention UTF-8 decode failure, got: {msg}"
+        );
+        let claude_after = fs::read(&claude_path).await.unwrap();
+        assert_eq!(
+            claude_after, original_claude,
+            "claude must be rolled back after codex decode failure"
+        );
+        let codex_after = fs::read(&codex_path).await.unwrap();
+        assert_eq!(
+            codex_after, original_codex,
+            "codex invalid bytes must be preserved for manual repair"
         );
     }
 

--- a/src-tauri/src/mcp_config/claude.rs
+++ b/src-tauri/src/mcp_config/claude.rs
@@ -1,6 +1,6 @@
 // Claude Code MCP 設定 (~/.claude.json) の `mcpServers.vibe-team` を更新
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 use tokio::fs;
@@ -19,10 +19,19 @@ pub(crate) fn config_path() -> PathBuf {
 /// Issue #597: テスト容易化のため path を引数に取る (production code は config_path() を渡す)。
 pub(crate) async fn setup_at(path: &Path, desired: &Value) -> Result<bool> {
     let mut config: Value = match fs::read(path).await {
-        Ok(bytes) => {
-            serde_json::from_slice(&bytes).unwrap_or_else(|_| Value::Object(Default::default()))
+        Ok(bytes) if bytes.is_empty() => Value::Object(Default::default()),
+        Ok(bytes) => serde_json::from_slice(&bytes).with_context(|| {
+            format!(
+                "{} contains invalid JSON; refusing to overwrite",
+                path.display()
+            )
+        })?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Value::Object(Default::default()),
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!("failed to read {}; refusing to overwrite", path.display())
+            });
         }
-        Err(_) => Value::Object(Default::default()),
     };
     let obj = config
         .as_object_mut()
@@ -43,7 +52,7 @@ pub(crate) async fn setup_at(path: &Path, desired: &Value) -> Result<bool> {
     let json = serde_json::to_vec_pretty(&config)?;
     // Issue #37: ~/.claude.json は他アプリとも共有。半端書き込みで全消失するのを避けるため atomic に。
     // Issue #608 (Security): API token 等を含むため 0o600 を強制 (Unix のみ effective)。
-crate::commands::atomic_write::atomic_write_with_mode(path, &json, Some(0o600)).await?;
+    crate::commands::atomic_write::atomic_write_with_mode(path, &json, Some(0o600)).await?;
     Ok(true)
 }
 
@@ -92,7 +101,7 @@ pub(crate) async fn cleanup_at(path: &Path) -> Result<bool> {
         // 直接 fs::write で上書きすると、書き込み中のクラッシュで `~/.claude.json` が
         // 空 / 半端な状態で残り、Claude Code 全体の設定が失われる事故になる。
         // Issue #608 (Security): API token 等を含むため 0o600 を強制 (Unix のみ effective)。
-crate::commands::atomic_write::atomic_write_with_mode(path, &json, Some(0o600)).await?;
+        crate::commands::atomic_write::atomic_write_with_mode(path, &json, Some(0o600)).await?;
     }
     Ok(removed)
 }
@@ -137,5 +146,47 @@ mod tests {
         // ファイルは触られていないはず
         let still = fs::read(&path).await.unwrap();
         assert_eq!(still, b"[]");
+    }
+
+    #[tokio::test]
+    async fn setup_at_returns_err_when_json_parse_fails() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(".claude.json");
+        let original = br#"{"mcpServers": {"other": true,}}"#;
+        fs::write(&path, original).await.unwrap();
+        let desired = json!({ "type": "stdio" });
+
+        let res = setup_at(&path, &desired).await;
+
+        assert!(
+            res.is_err(),
+            "invalid JSON must not be treated as empty config"
+        );
+        let msg = format!("{:#}", res.unwrap_err());
+        assert!(
+            msg.contains("invalid JSON"),
+            "error should explain parse failure: {msg}"
+        );
+        let still = fs::read(&path).await.unwrap();
+        assert_eq!(still, original, "invalid JSON file must not be overwritten");
+    }
+
+    #[tokio::test]
+    async fn setup_at_allows_absent_and_empty_files() {
+        let tmp = TempDir::new().unwrap();
+        let absent_path = tmp.path().join("absent.claude.json");
+        let desired = json!({ "type": "stdio" });
+
+        let changed = setup_at(&absent_path, &desired).await.unwrap();
+        assert!(changed, "absent file should be created");
+        let created = fs::read_to_string(&absent_path).await.unwrap();
+        assert!(created.contains("vibe-team"));
+
+        let empty_path = tmp.path().join("empty.claude.json");
+        fs::write(&empty_path, b"").await.unwrap();
+        let changed = setup_at(&empty_path, &desired).await.unwrap();
+        assert!(changed, "empty file should be initialized");
+        let initialized = fs::read_to_string(&empty_path).await.unwrap();
+        assert!(initialized.contains("vibe-team"));
     }
 }

--- a/src-tauri/src/mcp_config/codex.rs
+++ b/src-tauri/src/mcp_config/codex.rs
@@ -1,6 +1,6 @@
 // Codex MCP 設定 (~/.codex/config.toml) の `[mcp_servers.vibe-team]` を更新
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use tokio::fs;
 
@@ -62,7 +62,21 @@ pub(crate) async fn setup_at(path: &Path, bridge_path: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).await?;
     }
-    let mut content: String = fs::read_to_string(path).await.unwrap_or_default();
+    let mut content: String = match fs::read(path).await {
+        Ok(bytes) if bytes.is_empty() => String::new(),
+        Ok(bytes) => String::from_utf8(bytes).with_context(|| {
+            format!(
+                "{} is not valid UTF-8; refusing to overwrite",
+                path.display()
+            )
+        })?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!("failed to read {}; refusing to overwrite", path.display())
+            });
+        }
+    };
     content = remove_toml_section(&content, SECTION);
     content = remove_toml_section(&content, LEGACY_SECTION);
     // Issue #44: bridge_path を TOML basic string 用に正規 escape。
@@ -199,12 +213,17 @@ mod tests {
         // setup を走らせて vibe-team section を追加
         setup_at(&path, "/tmp/bridge.js").await.unwrap();
         let after_setup = fs::read(&path).await.unwrap();
-        assert!(after_setup.windows(SECTION.len()).any(|w| w == SECTION.as_bytes()));
+        assert!(after_setup
+            .windows(SECTION.len())
+            .any(|w| w == SECTION.as_bytes()));
 
         // snapshot を使って巻き戻す
         restore_at(&path, snap).await.unwrap();
         let restored = fs::read(&path).await.unwrap();
-        assert_eq!(restored, original, "restore should match original byte-for-byte");
+        assert_eq!(
+            restored, original,
+            "restore should match original byte-for-byte"
+        );
     }
 
     #[tokio::test]
@@ -218,6 +237,31 @@ mod tests {
         assert!(path.exists());
         // restore(None) でファイル削除
         restore_at(&path, snap).await.unwrap();
-        assert!(!path.exists(), "restore(None) should remove file created by setup");
+        assert!(
+            !path.exists(),
+            "restore(None) should remove file created by setup"
+        );
+    }
+
+    #[tokio::test]
+    async fn setup_at_returns_err_when_config_is_not_utf8() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        let original = b"[other]\n# cp932-ish invalid utf8: \x82\xa0\n".to_vec();
+        fs::write(&path, &original).await.unwrap();
+
+        let res = setup_at(&path, "/tmp/bridge.js").await;
+
+        assert!(
+            res.is_err(),
+            "non UTF-8 config must not be treated as empty"
+        );
+        let msg = format!("{:#}", res.unwrap_err());
+        assert!(
+            msg.contains("not valid UTF-8"),
+            "error should explain UTF-8 decode failure: {msg}"
+        );
+        let still = fs::read(&path).await.unwrap();
+        assert_eq!(still, original, "non UTF-8 config must not be overwritten");
     }
 }

--- a/src-tauri/src/mcp_config/codex.rs
+++ b/src-tauri/src/mcp_config/codex.rs
@@ -254,7 +254,7 @@ mod tests {
 
         assert!(
             res.is_err(),
-            "non UTF-8 config must not be treated as empty"
+            "non-UTF-8 config must not be treated as empty"
         );
         let msg = format!("{:#}", res.unwrap_err());
         assert!(
@@ -262,6 +262,6 @@ mod tests {
             "error should explain UTF-8 decode failure: {msg}"
         );
         let still = fs::read(&path).await.unwrap();
-        assert_eq!(still, original, "non UTF-8 config must not be overwritten");
+        assert_eq!(still, original, "non-UTF-8 config must not be overwritten");
     }
 }


### PR DESCRIPTION
## Summary
- ~/.claude.json の JSON parse 失敗を空設定扱いせず Err にして、既存ファイルを上書きしないようにしました
- ~/.codex/config.toml の非 UTF-8 / read 失敗も Err にし、NotFound と 0 bytes だけ新規設定扱いにしました
- codex 側 decode 失敗時に claude 側も snapshot へ rollback されることをテストで固定しました

## Test plan
- [x] `cargo test --manifest-path src-tauri\Cargo.toml mcp --lib`
- [x] `npm run typecheck`
- [x] `git diff --check`

## Notes
- `npm ci` 実行時に既存依存の警告として 2 vulnerabilities (1 moderate, 1 critical) が表示されました。今回の変更起因ではありません。

Closes #901