### PR TITLE
fix(terminal): #897 Canvasの設定変更fitを抑止

### DIFF
--- a/src/renderer/src/lib/__tests__/use-xterm-instance-fit-guard.test.tsx
+++ b/src/renderer/src/lib/__tests__/use-xterm-instance-fit-guard.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { useXtermInstance } from '../use-xterm-instance';
+import { DEFAULT_SETTINGS, type AppSettings } from '../../../../types/shared';
+
+const xtermMocks = vi.hoisted(() => ({
+  fitInstances: [] as Array<{ fit: ReturnType<typeof vi.fn> }>,
+  terminalInstances: [] as Array<{
+    options: Record<string, unknown>;
+    rows: number;
+    cols: number;
+    open: ReturnType<typeof vi.fn>;
+    loadAddon: ReturnType<typeof vi.fn>;
+    refresh: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+    attachCustomWheelEventHandler: ReturnType<typeof vi.fn>;
+    buffer: { active: { type: string; baseY: number } };
+    scrollLines: ReturnType<typeof vi.fn>;
+  }>
+}));
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(function TerminalMock(options: Record<string, unknown>) {
+    const term = {
+      options: { ...options },
+      rows: 24,
+      cols: 80,
+      open: vi.fn(),
+      loadAddon: vi.fn(),
+      refresh: vi.fn(),
+      dispose: vi.fn(),
+      attachCustomWheelEventHandler: vi.fn(),
+      buffer: { active: { type: 'normal', baseY: 0 } },
+      scrollLines: vi.fn()
+    };
+    xtermMocks.terminalInstances.push(term);
+    return term;
+  })
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(function FitAddonMock() {
+    const fit = { fit: vi.fn() };
+    xtermMocks.fitInstances.push(fit);
+    return fit;
+  })
+}));
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: vi.fn(function WebglAddonMock() {
+    return {
+      onContextLoss: vi.fn(),
+      dispose: vi.fn(),
+      clearTextureAtlas: vi.fn()
+    };
+  })
+}));
+
+function Harness({
+  settings,
+  disableWebgl
+}: {
+  settings: AppSettings;
+  disableWebgl: boolean;
+}) {
+  const { containerRef } = useXtermInstance(settings, disableWebgl);
+  return <div ref={containerRef} data-testid="xterm-container" />;
+}
+
+function makeSettings(overrides: Partial<AppSettings> = {}): AppSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    terminalFontFamily: 'JetBrains Mono Variable',
+    editorFontFamily: 'Geist Mono',
+    terminalFontSize: 13,
+    ...overrides
+  };
+}
+
+describe('useXtermInstance settings fit guard (Issue #897)', () => {
+  let originalFontsDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    xtermMocks.fitInstances.length = 0;
+    xtermMocks.terminalInstances.length = 0;
+    originalFontsDescriptor = Object.getOwnPropertyDescriptor(document, 'fonts');
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: undefined
+    });
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+      cb(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    if (originalFontsDescriptor) {
+      Object.defineProperty(document, 'fonts', originalFontsDescriptor);
+    } else {
+      delete (document as Document & { fonts?: FontFaceSet }).fonts;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('Canvas モードではフォント変更 effect の rAF で FitAddon.fit を呼ばない', async () => {
+    const initial = makeSettings();
+    const { rerender } = render(<Harness settings={initial} disableWebgl />);
+
+    await waitFor(() => expect(xtermMocks.fitInstances).toHaveLength(1));
+    const fit = xtermMocks.fitInstances[0];
+    expect(fit.fit).not.toHaveBeenCalled();
+
+    rerender(
+      <Harness
+        settings={makeSettings({ terminalFontSize: initial.terminalFontSize + 1 })}
+        disableWebgl
+      />
+    );
+
+    expect(fit.fit).not.toHaveBeenCalled();
+  });
+
+  it('IDE モードでは従来どおりフォント変更 effect で FitAddon.fit を呼ぶ', async () => {
+    const initial = makeSettings();
+    const { rerender } = render(<Harness settings={initial} disableWebgl={false} />);
+
+    await waitFor(() => expect(xtermMocks.fitInstances).toHaveLength(1));
+    const fit = xtermMocks.fitInstances[0];
+    fit.fit.mockClear();
+
+    rerender(
+      <Harness
+        settings={makeSettings({ terminalFontSize: initial.terminalFontSize + 1 })}
+        disableWebgl={false}
+      />
+    );
+
+    expect(fit.fit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/src/lib/use-xterm-instance.ts
+++ b/src/renderer/src/lib/use-xterm-instance.ts
@@ -385,7 +385,9 @@ export function useXtermInstance(
     // 文字が滲んだり位置が崩れる。requestAnimationFrame で次の paint 後に再計測する。
     requestAnimationFrame(() => {
       try {
-        fitRef.current?.fit();
+        if (!disableWebgl) {
+          fitRef.current?.fit();
+        }
         // Issue #123: fit() が cols/rows を変えなかった場合、内部的に refresh が走らず
         // 既に描画済みの行が古いフォント glyph のまま残ることがある。明示的に全行 refresh する。
         termRef.current?.refresh(0, (termRef.current.rows ?? 1) - 1);


### PR DESCRIPTION
## 概要
- useXtermInstance のフォント/テーマ変更 effect で、Canvas モード (`disableWebgl=true`) のときは FitAddon.fit() を呼ばないようにしました
- term.refresh() は glyph 再描画のため両モードで維持しました
- Canvas モードでは fit() が呼ばれず、IDE モードでは従来どおり呼ばれる単体テストを追加しました

## 検証
- npx vitest run src/renderer/src/lib/__tests__/use-xterm-instance-fit-guard.test.tsx
- npx vitest run src/renderer/src/lib/__tests__/use-fit-to-container.test.ts src/renderer/src/lib/__tests__/unscaled-fit-invariant.test.ts src/renderer/src/lib/__tests__/use-xterm-instance-fit-guard.test.tsx
- npm run typecheck
- git diff --check

## 補足
- npm ci で既存依存の監査結果として 2 vulnerabilities (1 moderate, 1 critical) が表示されましたが、今回の差分では依存関係は変更していません

Closes #897