### PR TITLE
fix(canvas): #896 チーム削除確認に表示名を渡す

### DIFF
--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/types.ts
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/types.ts
@@ -18,6 +18,8 @@ export interface AgentPayload {
   /** @deprecated 旧フィールド。canvas store v2 マイグレーションで roleProfileId に移行済み */
   role?: string;
   teamId?: string;
+  /** チーム表示名。cascade close 確認やチーム所属表示で使う。 */
+  teamName?: string;
   agentId?: string;
   command?: string;
   args?: string[];

--- a/src/renderer/src/lib/__tests__/canvas-team-spawn.test.ts
+++ b/src/renderer/src/lib/__tests__/canvas-team-spawn.test.ts
@@ -101,6 +101,7 @@ describe('spawnTeams (Issue #611 / #612)', () => {
     expect(cards).toHaveLength(2);
     expect(cards[0].payload).toMatchObject({
       teamId: 'team-a',
+      teamName: 'Org A',
       agentId: 'leader-0-team-a',
       role: 'leader',
       roleProfileId: 'leader',
@@ -109,6 +110,7 @@ describe('spawnTeams (Issue #611 / #612)', () => {
     });
     expect(cards[1].payload).toMatchObject({
       teamId: 'team-a',
+      teamName: 'Org A',
       agentId: 'programmer-1-team-a',
       role: 'programmer',
       organization: ORG_A
@@ -135,6 +137,7 @@ describe('spawnTeams (Issue #611 / #612)', () => {
     expect(cards).toHaveLength(1);
     expect(cards[0].payload).toMatchObject({
       teamId: 'team-user-1',
+      teamName: 'My Preset',
       agentId: 'reviewer-0-team-user-1',
       customInstructions: 'review the diff carefully'
     });
@@ -163,6 +166,7 @@ describe('spawnTeams (Issue #611 / #612)', () => {
 
     expect(cards[0].payload).toMatchObject({
       teamId: 'team-hist-1',
+      teamName: 'Yesterdays team',
       latestHandoff: HANDOFF_REF,
       resumeSessionId: 'sess-abc'
     });
@@ -344,6 +348,7 @@ describe('spawnTeams (Issue #611 / #612)', () => {
     // どの経路でも全 agent に同一 teamId
     for (const card of builtinResult.cards) {
       expect(card.payload.teamId).toBe('team-equiv');
+      expect(card.payload.teamName).toBe('Equiv');
       expect(card.payload.agentId).toMatch(/^(leader|programmer)-\d-team-equiv$/);
       expect(card.payload.cwd).toBe('/repo');
     }

--- a/src/renderer/src/lib/__tests__/use-recruit-listener-team-name.test.tsx
+++ b/src/renderer/src/lib/__tests__/use-recruit-listener-team-name.test.tsx
@@ -1,0 +1,130 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Node } from '@xyflow/react';
+import type { CardData } from '../../stores/canvas';
+
+const mocks = vi.hoisted(() => ({
+  listeners: new Map<string, (event: { payload: unknown }) => void>(),
+  ackRecruit: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (event: string, cb: (e: { payload: unknown }) => void) => {
+    mocks.listeners.set(event, cb);
+    return () => mocks.listeners.delete(event);
+  })
+}));
+
+vi.mock('../recruit-ack', () => ({
+  ackRecruit: (...args: unknown[]) => mocks.ackRecruit(...args)
+}));
+
+vi.mock('../tauri-api', () => ({
+  api: {
+    teamState: {
+      recruitObservedWhileHidden: vi.fn().mockResolvedValue(undefined)
+    }
+  }
+}));
+
+vi.mock('../role-profiles-context', () => ({
+  useRoleProfiles: () => ({ registerDynamicRole: vi.fn() })
+}));
+
+vi.mock('../toast-context', () => ({
+  useToast: () => ({ showToast: vi.fn() })
+}));
+
+vi.mock('../i18n', () => ({
+  useT: () => (key: string) => key
+}));
+
+vi.mock('../use-canvas-visibility', () => ({
+  getHiddenSinceMs: () => null,
+  isCanvasVisibleNow: () => true,
+  subscribeOnVisible: () => () => {}
+}));
+
+import { useRecruitListener } from '../use-recruit-listener';
+import { cardAgentId, useCanvasStore } from '../../stores/canvas';
+
+function Harness(): null {
+  useRecruitListener();
+  return null;
+}
+
+function requesterNode(): Node<CardData> {
+  return {
+    id: 'leader-card',
+    type: 'agent',
+    position: { x: 0, y: 0 },
+    data: {
+      cardType: 'agent',
+      title: 'Leader',
+      payload: {
+        agent: 'claude',
+        roleProfileId: 'leader',
+        role: 'leader',
+        teamId: 'team-alpha',
+        teamName: 'Alpha Team',
+        agentId: 'leader-1',
+        organization: { id: 'org-alpha', name: 'Alpha Team', color: '#ff8800' }
+      }
+    },
+    style: { width: 760, height: 460 }
+  } as Node<CardData>;
+}
+
+describe('useRecruitListener teamName propagation (Issue #896)', () => {
+  beforeEach(() => {
+    mocks.listeners.clear();
+    mocks.ackRecruit.mockClear();
+    useCanvasStore.setState({
+      nodes: [requesterNode()],
+      edges: [],
+      teamLocks: {}
+    } as never);
+  });
+
+  afterEach(() => {
+    cleanup();
+    useCanvasStore.setState({ nodes: [], edges: [], teamLocks: {} } as never);
+    vi.clearAllMocks();
+  });
+
+  it('動的採用で追加される worker payload に依頼元の teamName を引き継ぐ', async () => {
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(mocks.listeners.get('team:recruit-request')).toBeTruthy();
+    });
+
+    mocks.listeners.get('team:recruit-request')?.({
+      payload: {
+        teamId: 'team-alpha',
+        requesterAgentId: 'leader-1',
+        requesterRole: 'leader',
+        newAgentId: 'worker-1',
+        roleProfileId: 'programmer',
+        engine: 'claude',
+        agentLabelHint: 'Programmer'
+      }
+    });
+
+    await waitFor(() => {
+      expect(useCanvasStore.getState().nodes).toHaveLength(2);
+    });
+
+    const worker = useCanvasStore
+      .getState()
+      .nodes.find((node) => cardAgentId(node.data) === 'worker-1');
+    expect(worker?.data.payload).toMatchObject({
+      teamId: 'team-alpha',
+      teamName: 'Alpha Team',
+      agentId: 'worker-1'
+    });
+    expect(mocks.ackRecruit).toHaveBeenCalledWith('worker-1', 'team-alpha', {
+      ok: true
+    });
+  });
+});

--- a/src/renderer/src/lib/canvas-team-spawn.ts
+++ b/src/renderer/src/lib/canvas-team-spawn.ts
@@ -123,6 +123,7 @@ export async function spawnTeams(input: SpawnTeamsInput): Promise<SpawnTeamsResu
         roleProfileId: m.role,
         role: m.role,
         teamId: team.teamId,
+        teamName: team.teamName,
         agentId,
         cwd: input.cwd
       };

--- a/src/renderer/src/lib/use-recruit-listener.ts
+++ b/src/renderer/src/lib/use-recruit-listener.ts
@@ -19,6 +19,7 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import {
   useCanvasStore,
   cardTeamId,
+  cardTeamName,
   cardAgentId,
   cardRoleId,
   agentPayloadOf
@@ -246,6 +247,7 @@ export function useRecruitListener(): void {
         // payload (AgentPayload) を取り出し、organization を継承させる
         // (旧 `payload as { organization?: unknown }` の置き換え)。
         const requesterOrganization = agentPayloadOf(requester.data)?.organization;
+        const requesterTeamName = cardTeamName(requester.data);
         const teamNodes = store.nodes.filter(
           (n) => cardTeamId(n.data) === p.teamId
         );
@@ -261,6 +263,7 @@ export function useRecruitListener(): void {
             // 旧コード互換: role 旧フィールドにも書く (一時的)
             role: p.roleProfileId,
             teamId: p.teamId,
+            teamName: requesterTeamName,
             agentId: p.newAgentId,
             organization: requesterOrganization,
             // Issue #117: AgentNodeCard が拾って Claude(--append-system-prompt) /


### PR DESCRIPTION
## 概要
- spawnTeams が生成する agent payload に teamName を保存するようにしました
- team_recruit で後から追加される worker も、依頼元カードの teamName を引き継ぐようにしました
- AgentPayload に teamName を型として明示し、通常 spawn と動的採用のテストを追加しました

## 検証
- npx vitest run src/renderer/src/lib/__tests__/canvas-team-spawn.test.ts src/renderer/src/lib/__tests__/use-recruit-listener-team-name.test.tsx src/renderer/src/lib/__tests__/use-confirm-remove-card.test.tsx
- npm run typecheck
- git diff --check

## 補足
- use-confirm-remove-card の既存テストで React act 警告が表示されましたが、テスト自体は成功しています
- npm ci で既存依存の監査結果として 2 vulnerabilities (1 moderate, 1 critical) が表示されましたが、今回の差分では依存関係は変更していません

Closes #896