### PR TITLE
fix(canvas): #895 復元時に一時ドラッグ状態を除去

### DIFF
--- a/src/renderer/src/lib/canvas-migrations.ts
+++ b/src/renderer/src/lib/canvas-migrations.ts
@@ -67,6 +67,14 @@ function clampZoom(zoom: number): number {
   return Math.min(Math.max(zoom, VIEWPORT_MIN_ZOOM), VIEWPORT_MAX_ZOOM);
 }
 
+function stripTransientNodeState(raw: Record<string, unknown>): Partial<Node<CardData>> {
+  const node: Record<string, unknown> = { ...raw };
+  delete node.dragging;
+  delete node.selected;
+  delete node.resizing;
+  return node as Partial<Node<CardData>>;
+}
+
 /**
  * crypto.randomUUID() ベースの安定 ID 生成。
  * Issue #157: 旧 `Date.now() + counter` 方式は zustand persist 復元 + リロード後の
@@ -129,7 +137,7 @@ export function normalizeCanvasState(input: unknown): NormalizedCanvasState {
               ? Math.floor(index / 6) * (NODE_H + 32)
               : rawY;
           return {
-            ...(raw as Partial<Node<CardData>>),
+            ...stripTransientNodeState(raw),
             id: typeof raw.id === 'string' && raw.id ? raw.id : newId(type),
             type,
             position: { x: safeX, y: safeY },

--- a/src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts
@@ -109,6 +109,29 @@ describe('normalizeCanvasState (Issue #385)', () => {
     expect(out.nodes[0]!.id.length).toBeGreaterThan(0);
   });
 
+  it('rehydrate 時に React Flow の transient interaction フラグを除去する', () => {
+    const out = normalizeCanvasState({
+      nodes: [
+        {
+          id: 'dragging-node',
+          type: 'agent',
+          position: { x: 0, y: 0 },
+          data: { cardType: 'agent', title: 'Leader' },
+          style: { width: 760, height: 460 },
+          dragging: true,
+          selected: true,
+          resizing: true
+        }
+      ]
+    });
+
+    expect(out.nodes).toHaveLength(1);
+    const node = out.nodes[0] as unknown as Record<string, unknown>;
+    expect(node.dragging).toBeUndefined();
+    expect(node.selected).toBeUndefined();
+    expect(node.resizing).toBeUndefined();
+  });
+
   it('teamLocks に boolean 以外の値が混じっていても落とす', () => {
     const out = normalizeCanvasState({
       nodes: [],


### PR DESCRIPTION
## 概要
- Canvas persist の rehydrate 正規化で React Flow の transient interaction フラグ (`dragging` / `selected` / `resizing`) を除去するようにしました
- 旧版 localStorage に `dragging:true` が残っていても、次回起動時に settled snapshot が凍結しないようにします
- normalizeCanvasState のテストに transient フラグ除去ケースを追加しました

## 検証
- npx vitest run src/renderer/src/stores/__tests__/canvas-restore-normalize.test.ts src/renderer/src/stores/__tests__/canvas-migrate.test.ts
- npm run typecheck
- git diff --check

## 補足
- npm ci で既存依存の監査結果として 2 vulnerabilities (1 moderate, 1 critical) が表示されましたが、今回の差分では依存関係は変更していません

Closes #895