### PR TITLE
fix(canvas): #894 手動リサイズ属性を整列時に除去

### DIFF
--- a/src/renderer/src/lib/__tests__/canvas-arrange.test.ts
+++ b/src/renderer/src/lib/__tests__/canvas-arrange.test.ts
@@ -136,6 +136,22 @@ describe('canvas-arrange / tidyTerminals', () => {
     expect(positions[1].x - positions[0].x).toBe(NODE_W + ARRANGE_GAP_PX.normal);
     expect(positions[2].y - positions[0].y).toBe(NODE_H + ARRANGE_GAP_PX.normal);
   });
+
+  it('clears direct width/height attributes so tidy size wins after manual resize', () => {
+    const manuallyResized = {
+      ...makeNode('t1', 'terminal', { x: 0, y: 0 }, { width: NODE_W, height: NODE_H }),
+      width: 980,
+      height: 640
+    } as Node<CardData>;
+
+    const out = tidyTerminals([manuallyResized]);
+    const node = out[0] as unknown as Record<string, unknown>;
+
+    expect(node.width).toBeUndefined();
+    expect(node.height).toBeUndefined();
+    expect(out[0].style?.width).toBe(NODE_W);
+    expect(out[0].style?.height).toBe(NODE_H);
+  });
 });
 
 describe('canvas-arrange / unifyTerminalSize', () => {
@@ -158,5 +174,21 @@ describe('canvas-arrange / unifyTerminalSize', () => {
     const nodes: Node<CardData>[] = [makeNode('e1', 'editor', { x: 0, y: 0 })];
     const out = unifyTerminalSize(nodes);
     expect(out).toBe(nodes);
+  });
+
+  it('clears direct width/height attributes so unified style size is rendered', () => {
+    const manuallyResized = {
+      ...makeNode('a1', 'agent', { x: 10, y: 20 }, { width: 500, height: 300 }),
+      width: 900,
+      height: 700
+    } as Node<CardData>;
+
+    const out = unifyTerminalSize([manuallyResized]);
+    const node = out[0] as unknown as Record<string, unknown>;
+
+    expect(node.width).toBeUndefined();
+    expect(node.height).toBeUndefined();
+    expect(out[0].style?.width).toBe(NODE_W);
+    expect(out[0].style?.height).toBe(NODE_H);
   });
 });

--- a/src/renderer/src/lib/canvas-arrange.ts
+++ b/src/renderer/src/lib/canvas-arrange.ts
@@ -31,6 +31,13 @@ export function computeColumns(count: number): number {
   return Math.max(1, Math.ceil(Math.sqrt(count)));
 }
 
+function withoutDirectDimensions(node: Node<CardData>): Node<CardData> {
+  const next = { ...node } as Record<string, unknown>;
+  delete next.width;
+  delete next.height;
+  return next as Node<CardData>;
+}
+
 interface ArrangeOptions {
   /** ピッチ (cards 間 gap) */
   gap?: ArrangeGap;
@@ -72,14 +79,15 @@ export function tidyTerminals(
     const idx = orderById.get(n.id) ?? 0;
     const col = idx % cols;
     const row = Math.floor(idx / cols);
+    const node = withoutDirectDimensions(n);
     return {
-      ...n,
+      ...node,
       position: {
         x: originX + col * (width + gap),
         y: originY + row * (height + gap)
       },
       style: {
-        ...(n.style ?? {}),
+        ...(node.style ?? {}),
         width,
         height
       }
@@ -100,10 +108,11 @@ export function unifyTerminalSize(
   const next = nodes.map((n) => {
     if (!isTerminalLike(n)) return n;
     touched = true;
+    const node = withoutDirectDimensions(n);
     return {
-      ...n,
+      ...node,
       style: {
-        ...(n.style ?? {}),
+        ...(node.style ?? {}),
         width,
         height
       }

--- a/src/renderer/src/lib/hooks/__tests__/use-canvas-auto-save.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-canvas-auto-save.test.tsx
@@ -1,0 +1,93 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Node } from '@xyflow/react';
+import type { Dispatch, SetStateAction } from 'react';
+import { useCanvasAutoSave } from '../use-canvas-auto-save';
+import type { CardData } from '../../../stores/canvas';
+import type { TeamHistoryEntry } from '../../../../../types/shared';
+
+type TestWindow = Window &
+  typeof globalThis & {
+    api?: {
+      teamHistory: {
+        saveBatch: ReturnType<typeof vi.fn>;
+        list: ReturnType<typeof vi.fn>;
+      };
+    };
+  };
+
+function makeAgentNode(): Node<CardData> {
+  return {
+    id: 'agent-card',
+    type: 'agent',
+    position: { x: 12.2, y: 34.7 },
+    width: 900,
+    height: 700,
+    data: {
+      cardType: 'agent',
+      title: 'Leader',
+      payload: {
+        agent: 'claude',
+        teamId: 'team-1',
+        agentId: 'leader-1',
+        roleProfileId: 'leader'
+      }
+    },
+    style: { width: 500, height: 300 }
+  } as Node<CardData>;
+}
+
+describe('useCanvasAutoSave (Issue #894)', () => {
+  let originalApi: unknown;
+  let saveBatch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    originalApi = (window as TestWindow).api;
+    saveBatch = vi.fn(async () => ({ externalChangeMerged: false }));
+    (window as TestWindow).api = {
+      teamHistory: {
+        saveBatch,
+        list: vi.fn(async () => [])
+      }
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    if (originalApi === undefined) {
+      delete (window as TestWindow).api;
+    } else {
+      (window as TestWindow).api = originalApi as TestWindow['api'];
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('team-history には style ではなく React Flow の実描画 width/height を保存する', async () => {
+    const setRecent = vi.fn() as unknown as Dispatch<SetStateAction<TeamHistoryEntry[]>>;
+    renderHook(() =>
+      useCanvasAutoSave({
+        projectRoot: '/repo',
+        nodes: [makeAgentNode()],
+        viewport: { x: 0, y: 0, zoom: 1 },
+        recent: [],
+        setRecent
+      })
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
+
+    expect(saveBatch).toHaveBeenCalledTimes(1);
+    const entries = saveBatch.mock.calls[0]![0] as TeamHistoryEntry[];
+    expect(entries[0].canvasState?.nodes[0]).toMatchObject({
+      agentId: 'leader-1',
+      x: 12,
+      y: 35,
+      width: 900,
+      height: 700
+    });
+  });
+});

--- a/src/renderer/src/lib/hooks/use-canvas-auto-save.ts
+++ b/src/renderer/src/lib/hooks/use-canvas-auto-save.ts
@@ -19,6 +19,14 @@ interface UseCanvasAutoSaveOptions {
   setRecent: Dispatch<SetStateAction<TeamHistoryEntry[]>>;
 }
 
+function nodeRenderedDimension(
+  direct: number | undefined,
+  styleValue: unknown
+): number | undefined {
+  const value = typeof direct === 'number' ? direct : styleValue;
+  return typeof value === 'number' ? Math.round(value) : undefined;
+}
+
 /** Phase 5: Canvas state が変わったら、active な team について team-history へ自動保存。
  *
  *  Issue #124: ドラッグ中は React Flow が onNodesChange で毎フレーム新しい nodes 配列を
@@ -101,8 +109,8 @@ export function useCanvasAutoSave(opts: UseCanvasAutoSaveOptions): void {
         // 位置は整数に丸めて key の微動を抑える (サブピクセル更新で再保存しない)
         x: Math.round(n.position.x),
         y: Math.round(n.position.y),
-        width: typeof n.style?.width === 'number' ? Math.round(n.style.width as number) : undefined,
-        height: typeof n.style?.height === 'number' ? Math.round(n.style.height as number) : undefined
+        width: nodeRenderedDimension(n.width, n.style?.width),
+        height: nodeRenderedDimension(n.height, n.style?.height)
       });
       if (p.latestHandoff) {
         const prev = entry.latestHandoff;


### PR DESCRIPTION
## 概要
- tidyTerminals / unifyTerminalSize で terminal-like ノードの直下 width/height を除去し、style.width/height が確実に描画に効くようにしました
- team-history 自動保存でも React Flow の実描画優先順位に合わせ、node.width/height を style より優先して保存します
- 手動リサイズ済みカードの整頓・サイズ統一・保存サイズをテストで固定しました

## 検証
- npx vitest run src/renderer/src/lib/__tests__/canvas-arrange.test.ts src/renderer/src/lib/hooks/__tests__/use-canvas-auto-save.test.tsx
- npm run typecheck
- git diff --check

## 補足
- npm ci で既存依存の監査結果として 2 vulnerabilities (1 moderate, 1 critical) が表示されましたが、今回の差分では依存関係は変更していません

Closes #894