### PR TITLE
fix(canvas): #893 Recent team再開の重複を防ぐ

### DIFF
--- a/src/renderer/src/components/canvas/CanvasSidebar.tsx
+++ b/src/renderer/src/components/canvas/CanvasSidebar.tsx
@@ -17,6 +17,8 @@ import { useUiStore } from '../../stores/ui';
 import { ROLE_META } from '../../lib/team-roles';
 import { useFilesChanged } from '../../lib/use-files-changed';
 import { spawnTeam, type SpawnTeamMember } from '../../lib/canvas-team-spawn';
+import { findExistingTeamNode } from '../../lib/canvas-existing-team';
+import { useToast } from '../../lib/toast-context';
 
 interface CanvasSidebarProps {
   /** 外部 (CanvasLayout の Rail) から制御したい場合に渡す。省略時はローカル state */
@@ -37,6 +39,7 @@ export function CanvasSidebar({
   const { settings, update } = useSettings();
   const t = useT();
   const confirm = useNativeConfirm();
+  const { showToast } = useToast();
   // Issue #23: projectRoot は「現在開いているプロジェクト」= lastOpenedRoot を優先。
   // claudeCwd は Claude CLI 起動時の作業ディレクトリ設定 (別用途) としてだけ使う。
   // lastOpenedRoot が空 (初回) のときだけ claudeCwd にフォールバック。
@@ -144,6 +147,16 @@ export function CanvasSidebar({
 
   const handleResumeTeam = useCallback(
     async (entry: TeamHistoryEntry): Promise<void> => {
+      const canvas = useCanvasStore.getState();
+      const existing = findExistingTeamNode(canvas.nodes, entry.id);
+      if (existing) {
+        canvas.notifyRecruit(existing.id);
+        showToast(t('teamHistory.alreadyOpen', { name: entry.name || entry.id }), {
+          tone: 'info'
+        });
+        return;
+      }
+
       const cwd = projectRoot || entry.projectRoot;
       // Issue #611 / #612: 旧実装は 520x360 hardcode grid + placeBatchAwayFromNodes
       //   未経由 + latestHandoff 未同梱で、現行 NODE_W/NODE_H (#497) と不整合のうえ
@@ -185,7 +198,7 @@ export function CanvasSidebar({
       });
       addCards(cards);
     },
-    [addCards, projectRoot, settings.mcpAutoSetup]
+    [addCards, projectRoot, settings.mcpAutoSetup, showToast, t]
   );
 
   const handleDeleteTeamHistory = useCallback(

--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -70,6 +70,7 @@ import {
   type SpawnTeamMember,
   type SpawnTeamSpec
 } from '../lib/canvas-team-spawn';
+import { findExistingTeamNode } from '../lib/canvas-existing-team';
 
 type Tab = 'preset' | 'recent';
 
@@ -229,6 +230,16 @@ export function CanvasLayout(): JSX.Element {
   };
 
   const restoreRecent = async (entry: TeamHistoryEntry): Promise<void> => {
+    const existing = findExistingTeamNode(useCanvasStore.getState().nodes, entry.id);
+    if (existing) {
+      notifyRecruit(existing.id);
+      showToast(t('teamHistory.alreadyOpen', { name: entry.name || entry.id }), {
+        tone: 'info'
+      });
+      setSpawnOpen(false);
+      return;
+    }
+
     const cwd = projectRoot || entry.projectRoot;
     // Issue #611 / #612: history-based 復元も spawnTeam 経由に統一。
     //   entry.latestHandoff / entry.organization の payload 同梱と placeBatchAwayFromNodes

--- a/src/renderer/src/lib/__tests__/canvas-existing-team.test.ts
+++ b/src/renderer/src/lib/__tests__/canvas-existing-team.test.ts
@@ -1,0 +1,31 @@
+import type { Node } from '@xyflow/react';
+import { describe, expect, it } from 'vitest';
+import { findExistingTeamNode } from '../canvas-existing-team';
+import type { CardData } from '../../stores/canvas';
+
+function teamNode(id: string, teamId?: string): Node<CardData> {
+  return {
+    id,
+    type: 'agent',
+    position: { x: 0, y: 0 },
+    data: {
+      cardType: 'agent',
+      title: id,
+      payload: teamId ? { teamId } : undefined
+    }
+  } as Node<CardData>;
+}
+
+describe('findExistingTeamNode (Issue #893)', () => {
+  it('同じ teamId を持つ既存ノードを返す', () => {
+    const nodes = [teamNode('a', 'team-a'), teamNode('b', 'team-b')];
+
+    expect(findExistingTeamNode(nodes, 'team-b')?.id).toBe('b');
+  });
+
+  it('teamId が一致しない場合は undefined を返す', () => {
+    const nodes = [teamNode('a', 'team-a'), teamNode('loose')];
+
+    expect(findExistingTeamNode(nodes, 'team-missing')).toBeUndefined();
+  });
+});

--- a/src/renderer/src/lib/canvas-existing-team.ts
+++ b/src/renderer/src/lib/canvas-existing-team.ts
@@ -1,0 +1,13 @@
+import type { Node } from '@xyflow/react';
+import { cardTeamId, type CardData } from '../stores/canvas';
+
+/**
+ * Issue #893: Recent Teams から同じ teamId を再開しようとした時に、
+ * 新しいカードを増やさず既存カードへフォーカスするための検出ヘルパ。
+ */
+export function findExistingTeamNode(
+  nodes: readonly Node<CardData>[],
+  teamId: string
+): Node<CardData> | undefined {
+  return nodes.find((node) => cardTeamId(node.data) === teamId);
+}

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -158,6 +158,7 @@ const ja: Dict = {
   // ---------- Team history ----------
   'teamHistory.resume': 'チーム「{name}」を復元',
   'teamHistory.resumed': 'チーム「{name}」を復元しました',
+  'teamHistory.alreadyOpen': 'チーム「{name}」は既に Canvas 上にあります',
   'teamHistory.delete': '履歴から削除',
 
   // ---------- File tree / Editor ----------
@@ -1006,6 +1007,7 @@ const en: Dict = {
   // ---------- Team history ----------
   'teamHistory.resume': 'Resume team "{name}"',
   'teamHistory.resumed': 'Resumed team "{name}"',
+  'teamHistory.alreadyOpen': 'Team "{name}" is already open on the Canvas',
   'teamHistory.delete': 'Remove from history',
 
   // ---------- File tree / Editor ----------


### PR DESCRIPTION
## 概要
- Recent Teams から既に Canvas 上にある teamId を再開しようとした場合、新規 spawn せず既存カードへフォーカスするようにしました
- CanvasLayout と CanvasSidebar の両方の復元経路に同じガードを追加しました
- 既に開いていることを知らせる日英トースト文言と単体テストを追加しました

## 検証
- npx vitest run src/renderer/src/lib/__tests__/canvas-existing-team.test.ts src/renderer/src/lib/__tests__/canvas-team-spawn.test.ts
- npm run typecheck
- git diff --check

Closes #893