### PR TITLE
fix(canvas): #892 EditorCard保存の外部変更検出を復旧

### DIFF
--- a/src/renderer/src/components/canvas/cards/EditorCard.tsx
+++ b/src/renderer/src/components/canvas/cards/EditorCard.tsx
@@ -16,6 +16,9 @@ import { EditorView } from '../../EditorView';
 import { detectLanguage } from '../../../lib/language';
 import { registerEditorCardDirty } from '../../../lib/editor-card-dirty-registry';
 import type { CardDataOf, EditorCardPayload } from '../../../stores/canvas';
+import { useNativeConfirm } from '../../../lib/use-native-confirm';
+import { useT } from '../../../lib/i18n';
+import { useToast } from '../../../lib/toast-context';
 
 // Issue #732: payload 型は canvas store の判別可能 union に集約。`NodeProps` を
 // `Node<CardDataOf<'editor'>>` で具体化することで `data.payload` が `EditorCardPayload`
@@ -31,26 +34,56 @@ function EditorCardImpl({ id, data }: NodeProps<Node<CardDataOf<'editor'>>>): JS
     () => (relPath ? detectLanguage(relPath) === 'image' : false),
     [relPath]
   );
+  const t = useT();
+  const confirm = useNativeConfirm();
+  const { showToast } = useToast();
+  const tRef = useRef(t);
+  const showToastRef = useRef(showToast);
+  useEffect(() => {
+    tRef.current = t;
+    showToastRef.current = showToast;
+  }, [showToast, t]);
 
   const [content, setContent] = useState('');
   const [original, setOriginal] = useState('');
   const [isBinary, setIsBinary] = useState(false);
+  const [lossyEncoding, setLossyEncoding] = useState(false);
+  const [encoding, setEncoding] = useState('utf-8');
+  const [mtimeMs, setMtimeMs] = useState<number | undefined>(undefined);
+  const [sizeBytes, setSizeBytes] = useState<number | undefined>(undefined);
+  const [contentHash, setContentHash] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     if (!projectRoot || !relPath) {
+      setContent('');
+      setOriginal('');
+      setIsBinary(false);
+      setLossyEncoding(false);
+      setEncoding('utf-8');
+      setMtimeMs(undefined);
+      setSizeBytes(undefined);
+      setContentHash(undefined);
       setLoading(false);
       return;
     }
     // Issue #325: 画像ファイルは files.read を呼ばず ImagePreview に委ねる。
     // バイナリを丸ごと UTF-8 lossy で読むコストを避けるため早期 return する。
     if (isImage) {
+      setError(null);
+      setLossyEncoding(false);
       setLoading(false);
       return;
     }
     setLoading(true);
+    setError(null);
+    setLossyEncoding(false);
+    setEncoding('utf-8');
+    setMtimeMs(undefined);
+    setSizeBytes(undefined);
+    setContentHash(undefined);
     void window.api.files
       .read(projectRoot, relPath)
       .then((res) => {
@@ -58,10 +91,21 @@ function EditorCardImpl({ id, data }: NodeProps<Node<CardDataOf<'editor'>>>): JS
         if (!res.ok) {
           setError(res.error ?? 'failed to read');
         } else {
+          const lossy = res.encoding === 'lossy';
           setContent(res.content);
           setOriginal(res.content);
           setIsBinary(res.isBinary);
+          setLossyEncoding(lossy);
+          setEncoding(res.encoding || 'utf-8');
+          setMtimeMs(res.mtimeMs);
+          setSizeBytes(res.sizeBytes);
+          setContentHash(res.contentHash);
           setError(null);
+          if (lossy) {
+            showToastRef.current(tRef.current('editor.nonUtf8Warning', { path: relPath }), {
+              tone: 'warning'
+            });
+          }
         }
       })
       .catch((e) => !cancelled && setError(String(e)))
@@ -87,13 +131,69 @@ function EditorCardImpl({ id, data }: NodeProps<Node<CardDataOf<'editor'>>>): JS
 
   const onSave = useCallback(async () => {
     if (!dirty) return;
-    const res = await window.api.files.write(projectRoot, relPath, content);
-    if (res.ok) {
-      setOriginal(content);
-    } else {
-      setError(res.error ?? 'failed to save');
+    if (!projectRoot || !relPath || isBinary) return;
+    if (lossyEncoding) {
+      showToast(t('editor.nonUtf8SaveBlocked', { path: relPath }), { tone: 'warning' });
+      return;
     }
-  }, [dirty, projectRoot, relPath, content]);
+    try {
+      let res = await window.api.files.write(
+        projectRoot,
+        relPath,
+        content,
+        mtimeMs,
+        sizeBytes,
+        encoding,
+        contentHash
+      );
+      if (res.conflict) {
+        const overwrite = await confirm(t('editor.externalChangeConfirm', { path: relPath }));
+        if (!overwrite) {
+          showToast(t('editor.saveAborted', { path: relPath }), { tone: 'warning' });
+          return;
+        }
+        res = await window.api.files.write(
+          projectRoot,
+          relPath,
+          content,
+          undefined,
+          undefined,
+          encoding,
+          undefined
+        );
+      }
+      if (!res.ok) {
+        const message = res.error ?? 'failed to save';
+        setError(message);
+        showToast(t('editor.saveFailed', { error: message }), { tone: 'error' });
+        return;
+      }
+      setOriginal(content);
+      setMtimeMs(res.mtimeMs);
+      setSizeBytes(res.sizeBytes);
+      setContentHash(res.contentHash);
+      setError(null);
+      showToast(t('editor.saved', { path: relPath }), { tone: 'success' });
+    } catch (err) {
+      const message = String(err);
+      setError(message);
+      showToast(t('editor.saveFailed', { error: message }), { tone: 'error' });
+    }
+  }, [
+    dirty,
+    projectRoot,
+    relPath,
+    isBinary,
+    lossyEncoding,
+    content,
+    mtimeMs,
+    sizeBytes,
+    encoding,
+    contentHash,
+    confirm,
+    showToast,
+    t
+  ]);
 
   return (
     <>
@@ -107,6 +207,8 @@ function EditorCardImpl({ id, data }: NodeProps<Node<CardDataOf<'editor'>>>): JS
           isBinary={isBinary}
           loading={loading}
           error={error}
+          readOnly={lossyEncoding}
+          readOnlyReason={lossyEncoding ? t('editor.nonUtf8ReadOnly') : undefined}
           onChange={setContent}
           onSave={() => void onSave()}
         />

--- a/src/renderer/src/components/canvas/cards/__tests__/EditorCard.test.tsx
+++ b/src/renderer/src/components/canvas/cards/__tests__/EditorCard.test.tsx
@@ -7,7 +7,10 @@
  * 「タイトルが描画される」を最小限固定する。
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+
+const editorViewMock = vi.hoisted(() => vi.fn());
+const confirmMock = vi.hoisted(() => vi.fn(async () => true));
 
 vi.mock('@xyflow/react', () => ({
   Handle: () => null,
@@ -17,7 +20,14 @@ vi.mock('@xyflow/react', () => ({
 }));
 
 vi.mock('../../../EditorView', () => ({
-  EditorView: () => <div data-testid="editor-view-stub" />
+  EditorView: (props: unknown) => {
+    editorViewMock(props);
+    return <div data-testid="editor-view-stub" />;
+  }
+}));
+
+vi.mock('../../../../lib/use-native-confirm', () => ({
+  useNativeConfirm: () => confirmMock
 }));
 
 import EditorCard from '../EditorCard';
@@ -37,11 +47,21 @@ function installApi(): {
 } {
   const read = vi.fn(async () => ({
     ok: true,
+    path: 'src/foo.ts',
     content: 'hello',
     isBinary: false,
+    encoding: 'utf-8',
+    mtimeMs: 1000,
+    sizeBytes: 5,
+    contentHash: 'hash-1',
     error: null
   }));
-  const write = vi.fn(async () => ({ ok: true }));
+  const write = vi.fn(async () => ({
+    ok: true,
+    mtimeMs: 2000,
+    sizeBytes: 7,
+    contentHash: 'hash-2'
+  }));
   (window as TestWindow).api = {
     settings: {
       load: vi.fn(async () => DEFAULT_SETTINGS),
@@ -54,6 +74,19 @@ function installApi(): {
     files: { read, write }
   };
   return { read, write };
+}
+
+type EditorViewMockProps = {
+  content: string;
+  dirty: boolean;
+  readOnly?: boolean;
+  readOnlyReason?: string;
+  onChange: (value: string) => void;
+  onSave: () => void;
+};
+
+function latestEditorProps(): EditorViewMockProps {
+  return editorViewMock.mock.calls.at(-1)?.[0] as EditorViewMockProps;
 }
 
 function Wrapper({ children }: { children: ReactNode }): JSX.Element {
@@ -93,6 +126,9 @@ describe('EditorCard (smoke)', () => {
 
   beforeEach(() => {
     originalApi = (window as TestWindow).api;
+    editorViewMock.mockClear();
+    confirmMock.mockReset();
+    confirmMock.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -114,6 +150,116 @@ describe('EditorCard (smoke)', () => {
     expect(screen.getByTestId('editor-view-stub')).toBeInTheDocument();
     await waitFor(() => expect(api.read).toHaveBeenCalledTimes(1));
     expect(api.read).toHaveBeenCalledWith('/repo', 'src/foo.ts');
+  });
+
+  it('保存時に読み込み時の mtime / size / encoding / hash を渡す (Issue #892)', async () => {
+    const api = installApi();
+    api.read.mockResolvedValueOnce({
+      ok: true,
+      path: 'src/foo.ts',
+      content: 'hello',
+      isBinary: false,
+      encoding: 'shift_jis',
+      mtimeMs: 1234,
+      sizeBytes: 5,
+      contentHash: 'hash-before'
+    });
+
+    renderCard();
+
+    await waitFor(() => expect(latestEditorProps().content).toBe('hello'));
+    act(() => latestEditorProps().onChange('changed'));
+    await waitFor(() => expect(latestEditorProps().dirty).toBe(true));
+
+    await act(async () => {
+      latestEditorProps().onSave();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(api.write).toHaveBeenCalledTimes(1));
+    expect(api.write).toHaveBeenCalledWith(
+      '/repo',
+      'src/foo.ts',
+      'changed',
+      1234,
+      5,
+      'shift_jis',
+      'hash-before'
+    );
+  });
+
+  it('外部変更 conflict では確認後に encoding を保って強制上書きする', async () => {
+    const api = installApi();
+    api.read.mockResolvedValueOnce({
+      ok: true,
+      path: 'src/foo.ts',
+      content: 'hello',
+      isBinary: false,
+      encoding: 'shift_jis',
+      mtimeMs: 1234,
+      sizeBytes: 5,
+      contentHash: 'hash-before'
+    });
+    api.write
+      .mockResolvedValueOnce({ ok: false, conflict: true, error: 'conflict' })
+      .mockResolvedValueOnce({
+        ok: true,
+        mtimeMs: 3000,
+        sizeBytes: 7,
+        contentHash: 'hash-after'
+      });
+
+    renderCard();
+
+    await waitFor(() => expect(latestEditorProps().content).toBe('hello'));
+    act(() => latestEditorProps().onChange('changed'));
+    await waitFor(() => expect(latestEditorProps().dirty).toBe(true));
+
+    await act(async () => {
+      latestEditorProps().onSave();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(api.write).toHaveBeenCalledTimes(2));
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(api.write).toHaveBeenNthCalledWith(
+      2,
+      '/repo',
+      'src/foo.ts',
+      'changed',
+      undefined,
+      undefined,
+      'shift_jis',
+      undefined
+    );
+  });
+
+  it('lossy 読み込み時は readOnly にし、保存をブロックする', async () => {
+    const api = installApi();
+    api.read.mockResolvedValueOnce({
+      ok: true,
+      path: 'src/foo.ts',
+      content: 'hello',
+      isBinary: false,
+      encoding: 'lossy',
+      mtimeMs: 1234,
+      sizeBytes: 5,
+      contentHash: 'hash-before'
+    });
+
+    renderCard();
+
+    await waitFor(() => expect(latestEditorProps().readOnly).toBe(true));
+    expect(latestEditorProps().readOnlyReason).toBeTruthy();
+    act(() => latestEditorProps().onChange('changed'));
+    await waitFor(() => expect(latestEditorProps().dirty).toBe(true));
+
+    await act(async () => {
+      latestEditorProps().onSave();
+      await Promise.resolve();
+    });
+
+    expect(api.write).not.toHaveBeenCalled();
   });
 
   it('画像ファイルでは files.read を呼ばない (Issue #325)', async () => {


### PR DESCRIPTION
## 概要
- Canvas の EditorCard で files.read の encoding / mtime / size / contentHash を保持するようにしました
- 保存時に IDE タブと同じく expected 系と encoding を files.write に渡し、外部変更 conflict は確認後に encoding を保って上書きします
- lossy 読み込みファイルは readOnly 表示にし、保存をブロックします
- EditorCard の回帰テストを追加しました

## 検証
- npx vitest run src/renderer/src/components/canvas/cards/__tests__/EditorCard.test.tsx src/renderer/src/components/canvas/cards/__tests__/FileTreeCard.test.tsx src/renderer/src/components/canvas/cards/__tests__/DiffCard.test.tsx
- npm run typecheck
- git diff --check

Closes #892