### PR TITLE
fix(terminal): #891 prompt一時ファイル権限を制限

### DIFF
--- a/src-tauri/src/commands/terminal/prompt_files.rs
+++ b/src-tauri/src/commands/terminal/prompt_files.rs
@@ -20,21 +20,58 @@ pub async fn prepare_claude_append_system_prompt_file(prompt: &str) -> Option<Pa
 }
 
 async fn prepare_prompt_file(dir_name: &str, prefix: &str, body: &str) -> Option<PathBuf> {
+    let root = crate::util::config_paths::vibe_root();
+    prepare_prompt_file_in_root(&root, dir_name, prefix, body).await
+}
+
+async fn prepare_prompt_file_in_root(
+    root: &Path,
+    dir_name: &str,
+    prefix: &str,
+    body: &str,
+) -> Option<PathBuf> {
     if body.trim().is_empty() {
         return None;
     }
-    let dir = crate::util::config_paths::vibe_root().join(dir_name);
+    let dir = root.join(dir_name);
     if let Err(e) = tokio::fs::create_dir_all(&dir).await {
         tracing::warn!("[terminal] prompt file dir create failed ({dir_name}): {e}");
         return None;
     }
+    enforce_private_prompt_dir(root, "vibe-root").await;
+    enforce_private_prompt_dir(&dir, dir_name).await;
     cleanup_old_prompt_files(&dir).await;
     let path = dir.join(format!("{prefix}-{}.md", Uuid::new_v4()));
-    if let Err(e) = tokio::fs::write(&path, body).await {
+    if let Err(e) =
+        crate::commands::atomic_write::atomic_write_with_mode(&path, body.as_bytes(), Some(0o600))
+            .await
+    {
         tracing::warn!("[terminal] prompt file write failed ({dir_name}): {e}");
         return None;
     }
     Some(path)
+}
+
+/// Issue #891 (security): system prompt files contain role/project context.
+/// On multi-user Unix hosts, both the prompt dir and its parent must be owner-only
+/// so other users cannot traverse to short-lived prompt files. Windows ignores POSIX modes.
+async fn enforce_private_prompt_dir(dir: &Path, label: &str) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) =
+            tokio::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).await
+        {
+            tracing::warn!(
+                "[terminal] failed to chmod 0o700 on prompt dir {label} ({}): {e}",
+                dir.display()
+            );
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (dir, label);
+    }
 }
 
 /// Issue #99 / #858: 古い prompt files を TTL で掃除 (paste-images と同じ best-effort)。
@@ -55,5 +92,110 @@ pub async fn cleanup_old_prompt_files(dir: &Path) {
         if age.as_secs() > TTL_SECS {
             let _ = tokio::fs::remove_file(entry.path()).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn empty_prompt_body_returns_none() {
+        let root = tempfile::tempdir().unwrap();
+
+        let path =
+            prepare_prompt_file_in_root(root.path(), "codex-instructions", "instr", "  ").await;
+
+        assert!(path.is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn prompt_file_and_dirs_are_private_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = prepare_prompt_file_in_root(
+            root.path(),
+            "codex-instructions",
+            "instr",
+            "secret prompt",
+        )
+        .await
+        .expect("prompt file should be created");
+
+        let root_mode = tokio::fs::metadata(root.path())
+            .await
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let dir_mode = tokio::fs::metadata(root.path().join("codex-instructions"))
+            .await
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let file_mode = tokio::fs::metadata(&path)
+            .await
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+
+        assert_eq!(root_mode, 0o700, "vibe root should be 0o700");
+        assert_eq!(dir_mode, 0o700, "prompt dir should be 0o700");
+        assert_eq!(file_mode, 0o600, "prompt file should be 0o600");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn existing_loose_prompt_dirs_are_tightened_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("claude-system-prompts");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o755))
+            .await
+            .unwrap();
+        tokio::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755))
+            .await
+            .unwrap();
+
+        let path = prepare_prompt_file_in_root(
+            root.path(),
+            "claude-system-prompts",
+            "append",
+            "secret prompt",
+        )
+        .await
+        .expect("prompt file should be created");
+
+        let root_mode = tokio::fs::metadata(root.path())
+            .await
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let dir_mode = tokio::fs::metadata(&dir)
+            .await
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let file_mode = tokio::fs::metadata(path)
+            .await
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+
+        assert_eq!(root_mode, 0o700, "existing loose root should be tightened");
+        assert_eq!(
+            dir_mode, 0o700,
+            "existing loose prompt dir should be tightened"
+        );
+        assert_eq!(file_mode, 0o600, "prompt file should be 0o600");
     }
 }


### PR DESCRIPTION
## 概要
- Codex / Claude の system prompt 一時ファイルを tomic_write_with_mode(..., Some(0o600)) で書き出すようにしました
- Unix では ~/.vibe-editor と prompt 用サブディレクトリを best-effort で 0o700 に絞ります
- tempdir 配下で private mode を確認する単体テストを追加しました

## 検証
- rustfmt --edition 2021 --check src-tauri/src/commands/terminal/prompt_files.rs
- cargo check
- npm run typecheck
- git diff --check

## 補足
- cargo test commands::terminal::prompt_files は Windows linker が atal error LNK1180: 完全なリンクを行うための十分なディスク容量がありません で停止したため、ローカルでは完走できませんでした。

Closes #891