### PR TITLE
fix(ui): #884 toast-container に position: fixed を復元し通知を再表示

### DIFF
--- a/src/renderer/src/styles/__tests__/toast-css-contract.test.ts
+++ b/src/renderer/src/styles/__tests__/toast-css-contract.test.ts
@@ -1,0 +1,68 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const stylesDir = dirname(testDir);
+const componentsDir = join(stylesDir, 'components');
+
+function readStyleFile(pathFromStylesDir: string): string {
+  return readFileSync(join(stylesDir, pathFromStylesDir), 'utf8');
+}
+
+function readComponentCss(fileName: string): string {
+  return readFileSync(join(componentsDir, fileName), 'utf8');
+}
+
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function readZIndexToken(tokens: string, name: string): number {
+  const match = tokens.match(new RegExp(String.raw`${name}\s*:\s*(\d+)\s*;`));
+  expect(match, `tokens.css must define ${name} as a plain number`).not.toBeNull();
+  return Number(match![1]);
+}
+
+/*
+ * jsdom は CSS を適用しないため computed style では検出できない。Issue #884 では
+ * redesign 時に .toast-container の position 宣言が落ち、toast が viewport 外へ
+ * 押し出されて約 2 ヶ月間まったく表示されなかった。同型の「宣言落ち」退行を
+ * テキストレベルでガードする。
+ */
+describe('Toast CSS contract (Issue #884)', () => {
+  it('keeps .toast-container fixed-positioned so top/left/transform take effect', () => {
+    const toast = stripCssComments(readComponentCss('toast.css'));
+
+    expect(toast).toMatch(/\.toast-container\s*\{[^}]*position:\s*fixed\s*;/);
+  });
+
+  it('stacks toasts above the Canvas root but below active UI (context menu / palette)', () => {
+    const tokens = stripCssComments(readStyleFile('tokens.css'));
+
+    const zToast = readZIndexToken(tokens, '--z-toast');
+    const zToastTop = readZIndexToken(tokens, '--z-toast-top');
+    const zCanvasRoot = readZIndexToken(tokens, '--z-canvas-root');
+    const zContextMenu = readZIndexToken(tokens, '--z-context-menu');
+    const zPalette = readZIndexToken(tokens, '--z-palette');
+
+    // Canvas モード (.canvas-layout = --z-canvas-root) でも toast が視認できること
+    expect(zToast).toBeGreaterThan(zCanvasRoot);
+    expect(zToastTop).toBeGreaterThan(zCanvasRoot);
+    // 受動通知が能動 UI を覆わないこと
+    expect(zToastTop).toBeLessThan(zContextMenu);
+    expect(zToastTop).toBeLessThan(zPalette);
+  });
+
+  it('restores .toast flex layout and pointer-events lost in the redesign migration', () => {
+    const toast = stripCssComments(readComponentCss('toast.css'));
+
+    // .toast__body の flex: 1 と media query の flex-wrap は .toast の flex を前提とする
+    expect(toast).toMatch(/\.toast\s*\{[^}]*display:\s*flex\s*;/);
+    // container は pointer-events: none (クリック透過) なので本体で auto に戻す
+    expect(toast).toMatch(/\.toast\s*\{[^}]*pointer-events:\s*auto\s*;/);
+  });
+});

--- a/src/renderer/src/styles/components/toast.css
+++ b/src/renderer/src/styles/components/toast.css
@@ -1,5 +1,9 @@
 .toast-container {
-  top: 18px;
+  /* Issue #884: position 宣言が無いと top/left/transform が効かず通常フローに
+   * 置かれたまま viewport 外へ押し出される。#307 と同様に Windows 最大化時の
+   * 不可視リサイズ境界 (--wf-top) を top に加算する。 */
+  position: fixed;
+  top: calc(18px + var(--wf-top, 0px));
   right: auto;
   bottom: auto;
   left: 50%;
@@ -15,6 +19,14 @@
  * 左端 2px のロール色バーで種別 (success/warning/error) を表現。
  */
 .toast {
+  /* Issue #884: 旧 index.css 定義からの移し漏れ復元。.toast__body の flex: 1 や
+   * media query の flex-wrap は .toast が flex container であることを前提とする。
+   * container 側は pointer-events: none (クリック透過) のため、toast 本体で
+   * auto に戻さないと close ボタンが押せない。 */
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  pointer-events: auto;
   width: 100%;
   min-width: 0;
   max-width: 100%;
@@ -123,7 +135,7 @@
 
 @media (max-width: 640px) {
   .toast-container {
-    top: 12px;
+    top: calc(12px + var(--wf-top, 0px));
     width: calc(100vw - 16px);
   }
 

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -623,12 +623,16 @@ samp,
  * "画面全体に対してどの層にいるか" が問題になるものだけを集約する。
  *
  * 9000 台は Canvas モード (常時最前面) と、その上に出る body portal UI 用。
- * Canvas root より下でよい modal/toast は 1000〜3500 台に留める。
+ * Canvas root より下でよい modal は 1000〜3500 台に留める。
  *
  * Issue #356: ContextMenu は createPortal(document.body) で body 直下に出るため、
  * Canvas モード時は .canvas-layout (z-index: --z-canvas-root = 9200) と body の
  * stacking context を共有する。3500 のままでは Canvas root の後ろに完全に隠れて
  * 右クリックメニューが見えない。9500 (canvas-root + noise-overlay より上) に置く。
+ *
+ * Issue #884: toast も Canvas モードで視認が必要なため #356 と同じ理由で 9000 台
+ * (canvas-root より上) に置く。ただし受動通知が能動 UI を覆わないよう
+ * context-menu (9500) / palette (9600) よりは下に留める。
  */
 :root {
   --z-dropdown: 100;
@@ -638,8 +642,8 @@ samp,
   --z-modal: 1000;
   --z-modal-elevated: 1500;
   --z-palette: 9600;
-  --z-toast: 3000;
-  --z-toast-top: 3200;
+  --z-toast: 9300;
+  --z-toast-top: 9400;
   --z-noise-overlay: 9000;
   --z-canvas-root: 9200;
   --z-context-menu: 9500;


### PR DESCRIPTION
## Summary
- `.toast-container` に `position` 宣言が無く `top/left/transform` が効かないまま通常フローに置かれ、toast 通知が viewport 外へ押し出されて一切表示されなかった問題を修正 (redesign `116f4c7` での宣言落ち)
- `position: fixed` を復元し、#307 の前例に倣い Windows 最大化時の不可視リサイズ境界を `top: calc(18px + var(--wf-top, 0px))` で補正 (media query 内 `12px` も同様)
- 同コミットで移し漏れた `.toast` の `display: flex / align-items / gap / pointer-events: auto` を復元 (`.toast__body` の `flex: 1` と media query の `flex-wrap` は親の flex を前提、container は `pointer-events: none` のため本体で auto に戻さないと close ボタンが押せない)
- Canvas モード (`--z-canvas-root: 9200`) でも視認できるよう `--z-toast: 3000→9300` / `--z-toast-top: 3200→9400` へ引き上げ (Issue #356 ContextMenu と同じ理由)。受動通知が能動 UI を覆わないよう context-menu (9500) / palette (9600) よりは下に留める
- 同型の「宣言落ち」退行を防ぐ `toast-css-contract.test.ts` を追加 (jsdom は CSS を適用しないためテキストレベルでガード)。issue の計画では `lib/__tests__/toast-css-regression.test.ts` 案だったが、既存の `styles/__tests__/*-css-contract.test.ts` 慣例に合わせて配置・命名した

Closes #884

## Test plan
- [x] `npx vitest run` 全 448 テスト pass (新規 contract テスト 3 件含む)
- [x] `npm run typecheck` 通過
- [ ] 手動: IDE モードで「パスをコピー」→ 画面上端中央に toast 表示・× で消えること
- [ ] 手動: Canvas モード (Ctrl+Shift+M) で toast が `.canvas-layout` の上に表示されること
- [ ] 手動: コンテキストメニュー / コマンドパレット表示中は toast がその背後に出ること