### PR TITLE
fix(settings): #885 「デフォルトに戻す」で runtime 状態と customAgents を温存

### DIFF
--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowLeft, Check, Plus, Search, X } from 'lucide-react';
 import type { AgentConfig, AppSettings } from '../../../types/shared';
-import { DEFAULT_SETTINGS } from '../../../types/shared';
+import { resetPreferencesToDefaults } from '../../../types/shared';
 import { useT } from '../lib/i18n';
 import { useToast } from '../lib/toast-context';
 import { useSpringMount } from '../lib/use-animated-mount';
@@ -161,10 +161,12 @@ export function SettingsModal({
     }, 380);
   };
 
-  // Issue #28: Reset は draft だけを DEFAULT_SETTINGS に戻す。
+  // Issue #28: Reset は draft だけを既定値に戻す。
   // 永続化は Apply / Cancel のタイミングに揃える (footer の 2 ボタンと整合)。
+  // Issue #885: リセット範囲は preference キー (RESETTABLE_SETTING_KEYS) のみ。
+  // notepad / recentProjects / onboarding 等の runtime 状態と customAgents は温存する。
   const handleReset = (): void => {
-    setDraft({ ...DEFAULT_SETTINGS });
+    setDraft((d) => resetPreferencesToDefaults(d));
   };
 
   const customAgents = draft.customAgents ?? [];

--- a/src/renderer/src/components/settings/__tests__/SettingsModal.test.tsx
+++ b/src/renderer/src/components/settings/__tests__/SettingsModal.test.tsx
@@ -5,8 +5,12 @@
  *   1. open=true で「設定」見出しと General セクション (Language / Density) が描画される
  *   2. Density のラジオを切り替えると Apply 押下時に onApply に新しい draft が渡る
  *   3. Apply 押下から 380ms 後に onClose が呼ばれる (saved → close 遷移)
- *   4. Reset ボタンは draft を DEFAULT_SETTINGS に戻すが、永続化は行わない
+ *   4. Reset ボタンは draft の preference キーだけを既定値に戻すが、永続化は行わない
  *      (= onApply 未押下なので外部 onApply は呼ばれない)
+ *
+ * Issue #885: Reset は RESETTABLE_SETTING_KEYS のみ初期化し、runtime 状態
+ * (notepad / recentProjects / workspaceFolders / lastOpenedRoot /
+ * hasCompletedOnboarding) とユーザーデータ (customAgents) を温存する。
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
@@ -14,7 +18,11 @@ import type { ReactNode } from 'react';
 import { SettingsModal } from '../../SettingsModal';
 import { SettingsProvider } from '../../../lib/settings-context';
 import { ToastProvider } from '../../../lib/toast-context';
-import { DEFAULT_SETTINGS, type AppSettings } from '../../../../../types/shared';
+import {
+  DEFAULT_SETTINGS,
+  type AgentConfig,
+  type AppSettings
+} from '../../../../../types/shared';
 
 type TestWindow = Window &
   typeof globalThis & {
@@ -130,7 +138,7 @@ describe('SettingsModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('Reset は draft を DEFAULT_SETTINGS に戻すが onApply は呼ばない', async () => {
+  it('Reset は draft の preference を既定値に戻すが onApply は呼ばない', async () => {
     const onApply = vi.fn();
     const onClose = vi.fn();
     const initial: AppSettings = { ...DEFAULT_SETTINGS, density: 'comfortable' };
@@ -164,6 +172,60 @@ describe('SettingsModal', () => {
     // onApply / onClose は呼ばれない (Reset は draft 操作のみ)
     expect(onApply).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('Issue #885: Reset → Apply で runtime 状態と customAgents が温存される', async () => {
+    const onApply = vi.fn();
+    const onClose = vi.fn();
+    const agent: AgentConfig = {
+      id: 'custom-1',
+      name: 'My Agent',
+      command: 'my-agent',
+      args: '--flag'
+    };
+    const initial: AppSettings = {
+      ...DEFAULT_SETTINGS,
+      density: 'comfortable',
+      notepad: 'ターミナル間の受け渡しメモ',
+      recentProjects: ['C:\\proj-a', 'C:\\proj-b'],
+      workspaceFolders: ['C:\\proj-a\\packages'],
+      lastOpenedRoot: 'C:\\proj-a',
+      hasCompletedOnboarding: true,
+      customAgents: [agent]
+    };
+
+    render(
+      <Wrapper>
+        <SettingsModal
+          open
+          initial={initial}
+          onApply={onApply}
+          onClose={onClose}
+        />
+      </Wrapper>
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20);
+    });
+
+    // Reset → Apply
+    fireEvent.click(screen.getByRole('button', { name: /デフォルトに戻す|Reset to defaults/ }));
+    fireEvent.click(screen.getByRole('button', { name: /適用して保存|Apply & save/ }));
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    const applied = onApply.mock.calls[0][0] as AppSettings;
+
+    // preference は既定値に戻る
+    expect(applied.density).toBe(DEFAULT_SETTINGS.density);
+
+    // runtime 状態とユーザーデータは温存される
+    expect(applied.notepad).toBe('ターミナル間の受け渡しメモ');
+    expect(applied.recentProjects).toEqual(['C:\\proj-a', 'C:\\proj-b']);
+    expect(applied.workspaceFolders).toEqual(['C:\\proj-a\\packages']);
+    expect(applied.lastOpenedRoot).toBe('C:\\proj-a');
+    expect(applied.hasCompletedOnboarding).toBe(true);
+    expect(applied.customAgents).toEqual([agent]);
   });
 
   it('カスタム画像のクリアは variant も DEFAULT_SETTINGS に戻す', async () => {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -333,6 +333,53 @@ export const DEFAULT_SETTINGS: AppSettings = {
   terminalForceUtf8: true
 };
 
+/**
+ * Issue #885: 設定モーダルの「デフォルトに戻す」が初期化してよい preference キーの
+ * 単一情報源。設定 UI で編集可能なキーのみを列挙する。
+ *
+ * 設定 UI に編集可能キーを追加したらこの配列にも追加すること。
+ * runtime 状態 (`notepad` / `lastOpenedRoot` / `recentProjects` / `workspaceFolders` /
+ * `hasCompletedOnboarding` / `fileTreeExpanded` / `fileTreeCollapsedRoots` /
+ * `claudeCodePanelWidth` / `sidebarWidth`) とユーザーデータ (`customAgents`) は
+ * **入れない**。「温存キーの列挙」ではなく「リセット対象の列挙」を採るのは、
+ * 将来のキー追加漏れの失敗モードが「そのキーだけリセットされない」(安全側) になり、
+ * 新規状態キーが Reset で消える (危険側) 再発を構造的に防げるため。
+ */
+export const RESETTABLE_SETTING_KEYS = [
+  'language',
+  'theme',
+  'uiFontFamily',
+  'uiFontSize',
+  'editorFontFamily',
+  'editorFontSize',
+  'terminalFontFamily',
+  'terminalFontSize',
+  'density',
+  'statusMascotVariant',
+  'claudeCommand',
+  'claudeArgs',
+  'claudeCwd',
+  'codexCommand',
+  'codexArgs',
+  'mcpAutoSetup',
+  'terminalForceUtf8'
+] as const satisfies readonly (keyof AppSettings)[];
+
+/**
+ * Issue #885: 現在の設定のうち `RESETTABLE_SETTING_KEYS` のキーだけを
+ * `DEFAULT_SETTINGS` の値で上書きした新しいオブジェクトを返す純関数。
+ * runtime 状態とユーザーデータは `current` の値を温存する。
+ */
+export function resetPreferencesToDefaults(current: AppSettings): AppSettings {
+  const next: AppSettings = { ...current };
+  for (const key of RESETTABLE_SETTING_KEYS) {
+    // キーごとに値型が異なる union への代入は TS が静的検証できないため
+    // ここだけ Record 経由で書き込む (キー自体は keyof AppSettings に束縛済み)。
+    (next as Record<string, unknown>)[key] = DEFAULT_SETTINGS[key];
+  }
+  return next;
+}
+
 /** git status --porcelain のエントリ */
 export interface GitFileChange {
   path: string;


### PR DESCRIPTION
## Summary
- 設定モーダルの「デフォルトに戻す」(`handleReset`) が `DEFAULT_SETTINGS` 全量で draft を置換していたため、Reset → Apply で `notepad` / `recentProjects` / `workspaceFolders` / `lastOpenedRoot` / `hasCompletedOnboarding` / `fileTreeExpanded` / `fileTreeCollapsedRoots` / panel 幅 / `customAgents` まで初期化され、メモ・最近のプロジェクト・カスタムエージェントの消失とオンボーディング再表示が起きていた問題を修正
- `src/types/shared.ts` にリセット対象 preference キーの単一情報源 `RESETTABLE_SETTING_KEYS` (`as const satisfies readonly (keyof AppSettings)[]` で typo をコンパイルエラー化) と純関数 `resetPreferencesToDefaults` を追加し、`handleReset` を `setDraft((d) => resetPreferencesToDefaults(d))` に差し替え
- 「温存キーの列挙」ではなく「リセット対象の列挙」を採用 — 将来のキー追加漏れの失敗モードが「そのキーだけリセットされない」(安全側) になり、新規状態キーが Reset で消える (危険側) 再発を構造的に防ぐ
- `DEFAULT_SETTINGS` に無い optional キー (`statusMascotCustomPath` / `webviewZoom` 等) は現行どおり温存 (挙動変更なし)。Issue #28 の「Reset は draft 操作のみ・永続化は Apply/Cancel」も維持
- 既存 Reset テストを新仕様の文言に更新し、Reset → Apply で runtime 状態 + `customAgents` が温存されることを検証するテストを追加

Closes #885

## Test plan
- [x] `npx vitest run` 全 449 テスト pass (SettingsModal 5 件含む)
- [x] `npm run typecheck` 通過
- [ ] 手動: メモ・カスタムエージェント・テーマ変更ありの状態で Reset → Apply し、テーマ等は既定に戻る一方で Notes / カスタムエージェント / 最近のプロジェクトが残りオンボーディングが再表示されないこと
- [ ] 手動: Reset 後にキャンセルで閉じると何も永続化されないこと (Issue #28 維持)