### PR TITLE
fix(ui): #886 glass の tab-create-menu / team-close-confirm を overlay 高濃度に揃える

### DIFF
--- a/src/renderer/src/styles/__tests__/glass-css-contract.test.ts
+++ b/src/renderer/src/styles/__tests__/glass-css-contract.test.ts
@@ -166,6 +166,27 @@ describe('Glass CSS contract', () => {
     }
   });
 
+  it('Issue #806/#886: every glass overlay surface opts into the high-density background', () => {
+    const glass = stripCssComments(readComponentCss('glass.css'));
+
+    // overlay 高濃度ルール (rgba(15,18,28,0.92)) のセレクタリストを取り出す。
+    // 新しい overlay を追加したらこのリスト (glass.css) と本テストの両方に足すこと。
+    const overlayRule = glass.match(/([^{}]+)\{[^{}]*background:\s*rgba\(15,\s*18,\s*28,\s*0\.92\)/);
+    expect(overlayRule, 'glass.css must keep the #806 overlay density rule').not.toBeNull();
+
+    for (const selector of [
+      '.menubar__dropdown',
+      '.app-menu__dropdown',
+      '.user-menu__dropdown',
+      '.context-menu',
+      '.canvas-popover',
+      '.tab-create-menu',
+      '.team-close-confirm'
+    ]) {
+      expect(overlayRule![1]).toContain(`:root[data-theme='glass'] ${selector}`);
+    }
+  });
+
   it('index.css does not keep the legacy Issue #16 Glass surface whitelist', () => {
     const indexCss = stripCssComments(readRendererFile('index.css'));
 

--- a/src/renderer/src/styles/components/glass.css
+++ b/src/renderer/src/styles/components/glass.css
@@ -76,9 +76,10 @@
 
 /*
  * Glass テーマでも UI overlay 系 (menubar dropdown / app-menu dropdown / context menu /
- * canvas のチーム起動 popover) は読みやすさを優先して bg を高めに保つ。tokens.css の
- * `--bg-panel` (alpha ~0.52) のままだと背後の壁紙やドットグリッドが透けてラベルが
- * 読めない (Issue #806)。
+ * canvas のチーム起動 popover / タブ作成メニュー / Leader 閉じ確認バー) は読みやすさを
+ * 優先して bg を高めに保つ。tokens.css の `--bg-panel` (alpha ~0.52) のままだと背後の
+ * 壁紙やドットグリッド、xterm のターミナル文字が透けてラベルが読めない
+ * (Issue #806 / #886)。
  *   - 不透明度 0.92 の濃いブルーグレーで「読み物として成立する」濃度に。
  *   - backdrop-filter は当てて、テーマの一体感は維持。
  *   - border / shadow も glass 系トークンに揃えて浮かせる。
@@ -89,7 +90,9 @@
 :root[data-theme='glass'] .app-menu__dropdown,
 :root[data-theme='glass'] .user-menu__dropdown,
 :root[data-theme='glass'] .context-menu,
-:root[data-theme='glass'] .canvas-popover {
+:root[data-theme='glass'] .canvas-popover,
+:root[data-theme='glass'] .tab-create-menu,
+:root[data-theme='glass'] .team-close-confirm {
   background: rgba(15, 18, 28, 0.92);
   border-color: var(--glass-border, rgba(255, 255, 255, 0.10));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))


### PR DESCRIPTION
## Summary
- glass テーマで `.tab-create-menu` (タブ作成ドロップダウン) と `.team-close-confirm` (Leader 閉じ確認バー) が `--bg-panel` (α~0.52) のまま #806 の overlay 高濃度ルールから漏れており、背後の xterm ターミナル文字が透けてラベルが判読できなかった問題を修正
- `glass.css` の既存 overlay ルール (`rgba(15, 18, 28, 0.92)` + backdrop-filter + glass 系 border/shadow) のセレクタリストに 2 セレクタを追記 (新規ルールは追加せず 1 箇所で集中管理を維持)
- 説明コメントの対象列挙にも追記し、overlay リストの漏れを検出する contract テストを `glass-css-contract.test.ts` に追加
- milky 化退行 (#16/#367/#445/#709→#803) 対策: layout/surface の α (~0.52)、`--glass-brightness` / `--glass-saturate` には一切触れていない

Closes #886

## Test plan
- [x] `npx vitest run` 全 450 テスト pass (glass contract 新規 1 件含む)
- [x] `npm run typecheck` 通過
- [ ] 手動: glass テーマ + 高コントラストなターミナル出力の上で「+」メニューと Leader 閉じ確認バーの文字が透けず判読できること
- [ ] 手動: claude-dark / light / midnight で両 UI の見た目が変わらないこと
- [ ] 手動: 既存 #806 対象 (menubar dropdown / context menu / canvas popover) の濃度が従来どおりであること