### PR TITLE
fix(i18n): #887 セッション復帰 toast とサイドバー tooltip のハードコードを翻訳キー化

### DIFF
--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -290,10 +290,12 @@ export function AppShell({
   const handleResumeSession = useCallback(
     (session: SessionInfo) => {
       setActiveSessionId(session.id);
-      showToast(`セッションに復帰: ${session.title.slice(0, 40)}`, { tone: 'info' });
+      showToast(t('toast.sessionResumed', { title: session.title.slice(0, 40) }), {
+        tone: 'info'
+      });
       addTerminalTab({ resumeSessionId: session.id });
     },
-    [showToast, addTerminalTab]
+    [showToast, addTerminalTab, t]
   );
 
   // Phase 1-9 (Issue #373): コマンドパレット用 Command[] 構築は lib/app-commands.ts に集約。

--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -605,7 +605,7 @@ export function CanvasLayout(): JSX.Element {
             className="resize-handle resize-handle--sidebar"
             onMouseDown={onSidebarResizeStart}
             onDoubleClick={onSidebarResizeDouble}
-            title="ドラッグでサイドバー幅を調整 / ダブルクリックでリセット"
+            title={t('layout.sidebarResizeTitle')}
             role="separator"
             aria-orientation="vertical"
           />

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -626,6 +626,7 @@ const ja: Dict = {
 
   // ---------- Toast ----------
   'toast.reviewRequested': '差分レビューを依頼: {path}',
+  'toast.sessionResumed': 'セッションに復帰: {title}',
   'toast.pathCopied': 'パスをクリップボードにコピー',
   'toast.copyFailed': 'クリップボードへのコピーに失敗しました',
   'toast.revealFailed': 'ファイルマネージャでの表示に失敗しました',
@@ -1478,6 +1479,7 @@ const en: Dict = {
 
   // ---------- Toast ----------
   'toast.reviewRequested': 'Review requested: {path}',
+  'toast.sessionResumed': 'Resumed session: {title}',
   'toast.pathCopied': 'Path copied to clipboard',
   'toast.copyFailed': 'Failed to copy to clipboard',
   'toast.revealFailed': 'Failed to reveal in file manager',


### PR DESCRIPTION
## Summary
- AppShell のセッション復帰 toast (`セッションに復帰: ...`) が日本語ハードコードのままで `language=en` に追従しなかった問題を修正。`toast.sessionResumed` キー (`{title}` 補間付き) を ja/en 両辞書の Toast セクションに追加し、`t()` 経由に置換。`handleResumeSession` の useCallback 依存配列に `t` を追加 (既存の `handleFileContextMenu` と同パターン)
- issue 起票時に挙げられていた AppShell のリサイズハンドル tooltip 2 箇所は、最新 main では既に `layout.sidebarResizeTitle` / `layout.idePanelResizeTitle` で i18n 化済みだったため変更なし
- 同一文言がハードコードで残っていた CanvasLayout のサイドバーリサイズハンドル tooltip を既存キー `layout.sidebarResizeTitle` に乗せ替え (1 行、新規キー不要)
- AppShell 内の残りの日本語はコメントとエージェント向けレビュー依頼プロンプトのみで、UI 表示文字列のハードコードは解消

Closes #887

## Test plan
- [x] `npx vitest run` 全 450 テスト pass
- [x] `npm run typecheck` 通過
- [ ] 手動: Language=English で History からセッション Resume → "Resumed session: <title>" が表示されること
- [ ] 手動: Canvas モードのサイドバーハンドル hover で英語 tooltip が出ること
- [ ] 手動: 日本語設定で従来文言に退行がないこと