### PR TITLE
fix(git): #888 not-a-repo 判定を構造化フラグ notGitRepo に置き換え

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -68,6 +68,9 @@ pub struct GitFileChange {
 pub struct GitStatus {
     pub ok: bool,
     pub error: Option<String>,
+    /// Issue #888: error が「git リポジトリではない」由来かどうかの構造化フラグ。
+    /// renderer は raw stderr の文字列推測をせず、このフラグで i18n メッセージに引き当てる。
+    pub not_git_repo: bool,
     pub repo_root: Option<String>,
     pub branch: Option<String>,
     pub files: Vec<GitFileChange>,
@@ -229,6 +232,14 @@ fn label_from_status(idx: char, wt: char) -> &'static str {
     }
 }
 
+/// Issue #888: git の stderr が「git リポジトリではない」エラーかを判定する。
+/// 典型形は `fatal: not a git repository (or any of the parent directories): .git`。
+/// 非英語ロケールでは stderr が翻訳され判定が外れうるが、その場合は従来どおり
+/// raw stderr の表示に fallback するだけで悪化はしない。
+fn is_not_git_repo_error(err: &str) -> bool {
+    err.to_ascii_lowercase().contains("not a git repository")
+}
+
 #[tauri::command]
 pub async fn git_status(project_root: String) -> GitStatus {
     // repo root
@@ -237,6 +248,7 @@ pub async fn git_status(project_root: String) -> GitStatus {
         Err(e) => {
             return GitStatus {
                 ok: false,
+                not_git_repo: is_not_git_repo_error(&e),
                 error: Some(e),
                 ..Default::default()
             }
@@ -254,6 +266,7 @@ pub async fn git_status(project_root: String) -> GitStatus {
             Err(e) => {
                 return GitStatus {
                     ok: false,
+                    not_git_repo: is_not_git_repo_error(&e),
                     error: Some(e),
                     repo_root: Some(repo_root),
                     branch,
@@ -266,6 +279,7 @@ pub async fn git_status(project_root: String) -> GitStatus {
     GitStatus {
         ok: true,
         error: None,
+        not_git_repo: false,
         repo_root: Some(repo_root),
         branch,
         files,
@@ -408,6 +422,20 @@ pub async fn git_diff(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn not_git_repo_error_detection() {
+        // Issue #888: 典型 stderr で true
+        assert!(is_not_git_repo_error(
+            "fatal: not a git repository (or any of the parent directories): .git"
+        ));
+        // 大文字小文字差でも true
+        assert!(is_not_git_repo_error("fatal: Not a Git Repository"));
+        // 別種のエラーでは false
+        assert!(!is_not_git_repo_error("fatal: bad revision 'HEAD'"));
+        assert!(!is_not_git_repo_error("failed to spawn git: program not found"));
+        assert!(!is_not_git_repo_error(""));
+    }
 
     #[test]
     fn parse_rename_record() {

--- a/src/renderer/src/components/ChangesPanel.tsx
+++ b/src/renderer/src/components/ChangesPanel.tsx
@@ -87,9 +87,7 @@ export function ChangesPanel({
 
       {!loading && status && !status.ok && (
         <p className="sidebar__note sidebar__note--error">
-          {status.error === 'Gitリポジトリではありません'
-            ? t('sidebar.notGitRepo')
-            : status.error}
+          {status.notGitRepo ? t('sidebar.notGitRepo') : status.error}
         </p>
       )}
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -396,6 +396,12 @@ export interface GitFileChange {
 export interface GitStatus {
   ok: boolean;
   error?: string;
+  /**
+   * Issue #888: error が「git リポジトリではない」由来かどうかの構造化フラグ。
+   * renderer は raw stderr の文字列推測をせず、このフラグで i18n メッセージに引き当てる。
+   * Rust 側は常にシリアライズするが、TS 側で組み立てる既存コードの後方互換のため optional。
+   */
+  notGitRepo?: boolean;
   repoRoot?: string;
   branch?: string;
   files: GitFileChange[];


### PR DESCRIPTION
## Summary
- `ChangesPanel` の固定文字列比較 (`status.error === ''Gitリポジトリではありません''`) が Rust backend の返す raw git stderr と一致せず dead branch 化しており、非 git フォルダで Canvas の ChangesCard に `fatal: not a git repository ...` がそのまま表示されていた問題を修正
- `git_status` の戻り値 `GitStatus` に構造化フラグ `not_git_repo: bool` (TS: `notGitRepo?`) を追加。rev-parse / porcelain 失敗の両経路で stderr の部分文字列判定 (`is_not_git_repo_error`、case-insensitive) によりセットし、renderer はフラグだけ見て既存 i18n キー `sidebar.notGitRepo` に引き当てる
- 既存 IPC コマンドの戻り値拡張のみで新規 invoke なし。`#[serde(rename_all = "camelCase")]` 済み構造体への追加で、`mod.rs` / `lib.rs` / `tauri-api.ts` は変更不要。TS 側は optional として後方互換を維持 (Rust 側は常にシリアライズ)
- `is_not_git_repo_error` の単体テストを追加 (典型 stderr / 大文字小文字差 / 別種エラー / 空文字)
- 非英語ロケールで git stderr が翻訳される場合は判定が外れて raw 表示に fallback するが、従来挙動と同等で悪化なし (LC_ALL=C 固定は影響範囲が広いため見送り)

Closes #888

## Test plan
- [x] `cargo test --lib commands::git` 4 件 pass (新規 `not_git_repo_error_detection` 含む)
- [x] `npm run typecheck` 通過
- [x] `npx vitest run` 全 450 テスト pass
- [ ] 手動: 非 git フォルダを開き ChangesCard / Changes パネルで「Git リポジトリではありません」(en: "Not a git repository") が表示され raw stderr が出ないこと
- [ ] 手動: 通常の git リポジトリで branch 名・変更一覧・diff が従来どおり動くこと