### PR TITLE
security(pty): #889 renderer 由来 opts.env を VIBE_* allowlist で濾過

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -527,6 +527,11 @@ pub async fn terminal_create(
 
     // チーム所属端末なら TeamHub の socket/token と team/agent/role を env に注入
     let mut env = opts.env.unwrap_or_default();
+    // Issue #889: renderer (信頼境界外) 由来の env は VIBE_* のみ許可。
+    // NODE_OPTIONS / LD_PRELOAD 等の注入による command allowlist 迂回を遮断する。
+    // この直後に Rust が信頼境界内で insert する VIBE_TEAM_* / VIBE_AGENT_ID と、
+    // spawn 側の TERM/COLORTERM 注入には影響しない。
+    env.retain(|k, _| crate::pty::session::env_allowlist::is_safe_renderer_env_key(k));
     if let Some(team_id) = &opts.team_id {
         let (socket, token, _) = state.team_hub.info().await;
         env.insert("VIBE_TEAM_SOCKET".into(), socket);

--- a/src-tauri/src/pty/session/env_allowlist.rs
+++ b/src-tauri/src/pty/session/env_allowlist.rs
@@ -5,7 +5,8 @@
 
 /// Issue #211:
 /// 親プロセス env を denylist ではなく allowlist で継承する。
-/// TeamHub 用の内部 env は `opts.env` から明示注入されたものだけが後段で渡る。
+/// renderer 由来の `opts.env` は信頼境界 (`commands/terminal.rs` の terminal_create) で
+/// `is_safe_renderer_env_key` により濾過され、通過したものだけが後段で渡る (Issue #889)。
 pub(crate) fn should_inherit_env(key: &str) -> bool {
     let upper = key.to_ascii_uppercase();
     if upper.starts_with("LC_") || upper.starts_with("XDG_") {
@@ -51,4 +52,14 @@ pub(crate) fn should_inherit_env(key: &str) -> bool {
             | "WSLENV"
             | "WSL_DISTRO_NAME"
     )
+}
+
+/// Issue #889: renderer (信頼境界外) が `opts.env` 経由で子プロセスへ渡してよいキーか。
+/// TeamHub 用の `VIBE_*` のみ許可する allowlist。`NODE_OPTIONS` / `LD_PRELOAD` /
+/// `DYLD_INSERT_LIBRARIES` 等の任意コード実行に繋がる env を一律ブロックする。
+/// Windows の env 名は case 非依存のため大文字化して判定する。
+/// 将来 renderer が `VIBE_*` 以外の env を正規に渡したくなった場合は、ここへ
+/// 明示追加する (denylist 化はしない)。
+pub(crate) fn is_safe_renderer_env_key(key: &str) -> bool {
+    key.to_ascii_uppercase().starts_with("VIBE_")
 }

--- a/src-tauri/src/pty/tests/session_env.rs
+++ b/src-tauri/src/pty/tests/session_env.rs
@@ -2,7 +2,7 @@
 //!
 //! 旧 `session.rs` 内 `env_strip_tests` をそのまま移設したもの。判定対象・期待値は不変。
 
-use crate::pty::session::env_allowlist::should_inherit_env;
+use crate::pty::session::env_allowlist::{is_safe_renderer_env_key, should_inherit_env};
 
 #[test]
 fn blocks_internal_team_env_from_parent_process() {
@@ -31,4 +31,45 @@ fn keeps_ordinary_env() {
     assert!(should_inherit_env("TERM"));
     assert!(should_inherit_env("LC_ALL"));
     assert!(should_inherit_env("XDG_RUNTIME_DIR"));
+}
+
+// ---------- Issue #889: renderer 由来 opts.env の allowlist ----------
+
+#[test]
+fn renderer_env_allows_vibe_team_keys() {
+    // TeamHub 起動が壊れないこと (renderer が正規に渡す 5 キー)
+    assert!(is_safe_renderer_env_key("VIBE_TEAM_SOCKET"));
+    assert!(is_safe_renderer_env_key("VIBE_TEAM_TOKEN"));
+    assert!(is_safe_renderer_env_key("VIBE_TEAM_ID"));
+    assert!(is_safe_renderer_env_key("VIBE_TEAM_ROLE"));
+    assert!(is_safe_renderer_env_key("VIBE_AGENT_ID"));
+}
+
+#[test]
+fn renderer_env_blocks_code_injection_vectors() {
+    assert!(!is_safe_renderer_env_key("NODE_OPTIONS"));
+    assert!(!is_safe_renderer_env_key("LD_PRELOAD"));
+    assert!(!is_safe_renderer_env_key("DYLD_INSERT_LIBRARIES"));
+    assert!(!is_safe_renderer_env_key("BROWSER"));
+    assert!(!is_safe_renderer_env_key("PYTHONSTARTUP"));
+    assert!(!is_safe_renderer_env_key("PERL5OPT"));
+    assert!(!is_safe_renderer_env_key("ELECTRON_RUN_AS_NODE"));
+}
+
+#[test]
+fn renderer_env_blocks_case_variants() {
+    // Windows の env 名は case 非依存なので小文字・混在も拒否されること
+    assert!(!is_safe_renderer_env_key("node_options"));
+    assert!(!is_safe_renderer_env_key("Node_Options"));
+    assert!(!is_safe_renderer_env_key("ld_preload"));
+    // VIBE_ prefix は case 揺れでも許可 (同じ理由で大文字化判定)
+    assert!(is_safe_renderer_env_key("vibe_team_socket"));
+}
+
+#[test]
+fn renderer_env_blocks_adjacent_prefixes() {
+    // "VIBE_" で始まらない隣接名は拒否
+    assert!(!is_safe_renderer_env_key("VIBEFAKE"));
+    assert!(!is_safe_renderer_env_key("VIBE"));
+    assert!(!is_safe_renderer_env_key(""));
 }


### PR DESCRIPTION
## Summary
- renderer (信頼境界外) が `terminal_create` の `opts.env` に任意の環境変数を渡せたため、`NODE_OPTIONS` / `LD_PRELOAD` / `DYLD_INSERT_LIBRARIES` 等の注入で command allowlist を迂回した任意コード実行 (RCE) が可能だった脆弱性を修正
- env ポリシーを集約する `env_allowlist.rs` に純関数 `is_safe_renderer_env_key` を追加 (TeamHub 用の `VIBE_*` prefix のみ許可。Windows の env 名 case 非依存に対応するため大文字化判定)
- 信頼境界である `terminal.rs` の `terminal_create` で、Rust が VIBE_TEAM_* を insert する前に `env.retain(...)` で renderer 由来キーを濾過。Rust が信頼境界内で注入する `VIBE_TEAM_*` / `VIBE_AGENT_ID` と spawn 側の TERM/COLORTERM 注入には影響しない
- IPC shape (`shared.ts` の `env?` / `tauri-api`) は不変、新規 invoke なし。`should_inherit_env` の誤解を招くコメントも #889 の濾過に言及するよう修正
- ユニットテスト 4 件追加 (VIBE_* 許可 / 注入ベクタ拒否 / case 揺れ拒否 / 隣接 prefix `VIBEFAKE` 拒否)

Closes #889

## Test plan
- [x] `cargo test --lib session_env` 7 件 pass (新規 4 件含む)
- [x] `npm run typecheck` 通過 (TS 無変更)
- [ ] 手動: 修正前は DevTools から `window.api.terminal.create({ ..., env: { NODE_OPTIONS: ''--require=...'' } })` で POC が発火、修正後は発火しないこと
- [ ] 手動: TeamHub team 端末を通常起動し VIBE_TEAM_* が渡り handshake / recruit が従来どおり動くこと