### PR TITLE
security(terminal): #890 immediate-exec 拒否を前置短縮形・連結短オプションに拡張

### DIFF
--- a/src-tauri/src/commands/terminal/command_validation.rs
+++ b/src-tauri/src/commands/terminal/command_validation.rs
@@ -284,6 +284,57 @@ pub fn reject_danger_flags(args: &[String], sanctioned: &HashSet<String>) -> Opt
     None
 }
 
+/// token 先頭の dash 類 (ASCII `-` `/` および Unicode ダッシュ) を全て剥がした小文字 stem を返す。
+/// `canonical_danger_flag` と同じ dash 集合を使い、PowerShell の `/command` 形式に対応するため
+/// `/` も剥がす。
+fn flag_stem(token: &str) -> String {
+    token
+        .trim()
+        .to_ascii_lowercase()
+        .trim_start_matches(|c: char| {
+            c == '-'
+                || c == '/'
+                || matches!(
+                    c,
+                    '\u{2010}'..='\u{2015}' | '\u{2212}' | '\u{FE58}' | '\u{FE63}' | '\u{FF0D}'
+                )
+        })
+        .to_string()
+}
+
+/// Issue #890: PowerShell の即時実行フラグ (`-Command` / `-EncodedCommand` / `-File`) を、
+/// 前置短縮形 (`-c`/`-co`/`-com`、`-e`/`-en`/`-enc`、`-f`/`-fil` 等) まで含めて検出する。
+/// `-ec` は EncodedCommand の文書化済み短縮形なので別途許可。`-nop`/`-ep`/`-con` 等の
+/// 対話起動フラグは前置一致しないため誤検知しない。
+fn is_powershell_immediate_exec_arg(token: &str) -> bool {
+    let stem = flag_stem(token);
+    if stem.is_empty() {
+        return false;
+    }
+    if stem == "ec" {
+        return true;
+    }
+    ["command", "encodedcommand", "file"]
+        .iter()
+        .any(|name| name.starts_with(&stem))
+}
+
+/// Issue #890: POSIX shell の即時実行フラグを検出する。
+/// `--command` / `--commands` の長形式に加え、連結短オプションクラスタ (`-cx`/`-xc`/`-cl`/`-lc`)
+/// に `c` が含まれれば true。`-i`/`-l`/`--login`/`--`/`-` は素通りさせる。
+fn is_posix_immediate_exec_arg(token: &str) -> bool {
+    let lower = token.trim().to_ascii_lowercase();
+    if lower == "--command" || lower == "--commands" {
+        return true;
+    }
+    // `--` 始まりの長形式 (上記以外) と素の `-` / `--` は対象外。
+    if lower.starts_with("--") || !lower.starts_with('-') || lower.len() < 2 {
+        return false;
+    }
+    let cluster = &lower[1..];
+    cluster.chars().all(|c| c.is_ascii_alphabetic()) && cluster.contains('c')
+}
+
 pub fn reject_immediate_exec_args(command: &str, args: &[String]) -> Option<&'static str> {
     let basename = command_basename(command);
     let lower_args: Vec<String> = args.iter().map(|a| a.trim().to_ascii_lowercase()).collect();
@@ -294,15 +345,15 @@ pub fn reject_immediate_exec_args(command: &str, args: &[String]) -> Option<&'st
     };
     match basename.as_str() {
         "bash" | "sh" | "zsh" | "fish" => {
-            if has_any(&["-c", "-lc"]) {
-                Some("shell immediate-exec flags (-c / -lc) are blocked")
+            if args.iter().any(|a| is_posix_immediate_exec_arg(a)) {
+                Some("shell immediate-exec flags (-c / -lc / connected short clusters) are blocked")
             } else {
                 None
             }
         }
         "pwsh" | "powershell" => {
-            if has_any(&["-c", "-command", "/command", "-encodedcommand", "-file"]) {
-                Some("PowerShell immediate-exec flags (-Command / -EncodedCommand / -File) are blocked")
+            if args.iter().any(|a| is_powershell_immediate_exec_arg(a)) {
+                Some("PowerShell immediate-exec flags (-Command / -EncodedCommand / -File, including prefix abbreviations) are blocked")
             } else {
                 None
             }
@@ -712,6 +763,97 @@ mod command_normalization_tests {
             reject_immediate_exec_args(&command, &args),
             Some("cmd immediate-exec flags (/c /k) are blocked")
         );
+    }
+
+    // Issue #890: PowerShell 前置短縮形による immediate-exec バイパスを塞ぐ
+    #[test]
+    fn rejects_powershell_command_prefix_abbreviations() {
+        for arg in [
+            "-e",
+            "-ec",
+            "-en",
+            "-enc",
+            "-encodedcommand",
+            "-c",
+            "-co",
+            "-com",
+            "-comm",
+            "-command",
+            "-f",
+            "-fil",
+            "-file",
+        ] {
+            let args = vec![arg.to_string(), "payload".to_string()];
+            assert!(
+                reject_immediate_exec_args("powershell", &args).is_some(),
+                "expected {arg} to be blocked"
+            );
+        }
+        // パス形式の command でも basename 正規化されて検出される
+        assert!(reject_immediate_exec_args(
+            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            &["-e".to_string(), "payload".to_string()]
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn allows_powershell_interactive_flags() {
+        for arg in [
+            "-nop",
+            "-noprofile",
+            "-nologo",
+            "-ep",
+            "-executionpolicy",
+            "-con",
+        ] {
+            let args = vec![arg.to_string(), "value".to_string()];
+            assert!(
+                reject_immediate_exec_args("powershell", &args).is_none(),
+                "expected {arg} to be allowed"
+            );
+        }
+        // 引数なしの対話起動も許可
+        assert!(reject_immediate_exec_args("powershell", &[]).is_none());
+    }
+
+    // Issue #890: POSIX 連結短オプションによる immediate-exec バイパスを塞ぐ
+    #[test]
+    fn rejects_posix_connected_short_clusters() {
+        for arg in ["-c", "-lc", "-cl", "-cx", "-xc", "-ic"] {
+            let args = vec![arg.to_string(), "evil".to_string()];
+            assert!(
+                reject_immediate_exec_args("bash", &args).is_some(),
+                "expected {arg} to be blocked"
+            );
+        }
+        // fish の長形式
+        assert!(reject_immediate_exec_args(
+            "fish",
+            &["--command".to_string(), "evil".to_string()]
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn allows_posix_interactive_flags() {
+        for arg in ["-i", "-l", "--login", "--", "-"] {
+            let args = vec![arg.to_string()];
+            assert!(
+                reject_immediate_exec_args("bash", &args).is_none(),
+                "expected {arg} to be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn preserves_nu_immediate_exec_rejection() {
+        assert!(reject_immediate_exec_args("nu", &["-c".to_string(), "x".to_string()]).is_some());
+        assert!(reject_immediate_exec_args(
+            "nu",
+            &["--commands".to_string(), "x".to_string()]
+        )
+        .is_some());
     }
 
     // Issue #743: --dangerously-* フラグの拒否

--- a/src-tauri/src/commands/terminal/command_validation.rs
+++ b/src-tauri/src/commands/terminal/command_validation.rs
@@ -328,11 +328,14 @@ fn is_posix_immediate_exec_arg(token: &str) -> bool {
     let lower = token.trim().to_ascii_lowercase();
     // `--command=evil` の値分離形式に対応するため `=` の前で切る (fish のバイパス経路)。
     let head = lower.split('=').next().unwrap_or(&lower);
-    if head == "--command" || head == "--commands" {
-        return true;
+    if let Some(long) = head.strip_prefix("--") {
+        // `--command` / `--commands` への前置一致 (fish の wgetopt_long が受理する
+        // `--c`/`--co`/`--com` 等の unique prefix 略形を含む)。`--config` 等は一致しない。
+        return !long.is_empty()
+            && ("command".starts_with(long) || "commands".starts_with(long));
     }
-    // `--` 始まりの長形式 (上記以外) と素の `-` / `--` は対象外。
-    if head.starts_with("--") || !head.starts_with('-') || head.len() < 2 {
+    // 素の `-` / `--` (上で処理済み) と非 dash は対象外。
+    if !head.starts_with('-') || head.len() < 2 {
         return false;
     }
     let cluster = &head[1..];
@@ -865,6 +868,31 @@ mod command_normalization_tests {
             reject_immediate_exec_args("bash", &["--config=x".to_string()]).is_none(),
             "bash --config=x must be allowed"
         );
+    }
+
+    // Issue #890 三次レビュー: fish の wgetopt_long が受理する `--command` の unique prefix
+    // 略形 (`--c`/`--co`/`--com` 等) を素通りさせていたバイパスを塞ぐ。
+    #[test]
+    fn rejects_fish_long_prefix_abbreviations() {
+        // `--command` への前置一致になる略形はすべてブロック
+        for arg in ["--c", "--co", "--com", "--comm", "--comman", "--commands"] {
+            assert!(
+                reject_immediate_exec_args("fish", &[arg.to_string(), "evil".to_string()]).is_some(),
+                "expected {arg} to be blocked"
+            );
+        }
+        // 値分離形式の略形も塞ぐ
+        assert!(
+            reject_immediate_exec_args("fish", &["--com=evil".to_string()]).is_some(),
+            "fish --com=evil must be blocked"
+        );
+        // 前置一致しない長形式は誤検知させない
+        for arg in ["--config", "--login", "--no-config", "--init"] {
+            assert!(
+                reject_immediate_exec_args("fish", &[arg.to_string()]).is_none(),
+                "expected {arg} to be allowed"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/terminal/command_validation.rs
+++ b/src-tauri/src/commands/terminal/command_validation.rs
@@ -308,6 +308,8 @@ fn flag_stem(token: &str) -> String {
 /// 対話起動フラグは前置一致しないため誤検知しない。
 fn is_powershell_immediate_exec_arg(token: &str) -> bool {
     let stem = flag_stem(token);
+    // `-Command:value` / `-Command=value` の値分離形式に対応するため区切り前で切る。
+    let stem = stem.split([':', '=']).next().unwrap_or(&stem);
     if stem.is_empty() {
         return false;
     }
@@ -316,7 +318,7 @@ fn is_powershell_immediate_exec_arg(token: &str) -> bool {
     }
     ["command", "encodedcommand", "file"]
         .iter()
-        .any(|name| name.starts_with(&stem))
+        .any(|name| name.starts_with(stem))
 }
 
 /// Issue #890: POSIX shell の即時実行フラグを検出する。
@@ -324,14 +326,16 @@ fn is_powershell_immediate_exec_arg(token: &str) -> bool {
 /// に `c` が含まれれば true。`-i`/`-l`/`--login`/`--`/`-` は素通りさせる。
 fn is_posix_immediate_exec_arg(token: &str) -> bool {
     let lower = token.trim().to_ascii_lowercase();
-    if lower == "--command" || lower == "--commands" {
+    // `--command=evil` の値分離形式に対応するため `=` の前で切る (fish のバイパス経路)。
+    let head = lower.split('=').next().unwrap_or(&lower);
+    if head == "--command" || head == "--commands" {
         return true;
     }
     // `--` 始まりの長形式 (上記以外) と素の `-` / `--` は対象外。
-    if lower.starts_with("--") || !lower.starts_with('-') || lower.len() < 2 {
+    if head.starts_with("--") || !head.starts_with('-') || head.len() < 2 {
         return false;
     }
-    let cluster = &lower[1..];
+    let cluster = &head[1..];
     cluster.chars().all(|c| c.is_ascii_alphabetic()) && cluster.contains('c')
 }
 
@@ -833,6 +837,34 @@ mod command_normalization_tests {
             &["--command".to_string(), "evil".to_string()]
         )
         .is_some());
+    }
+
+    // Issue #890 二次レビュー: `=` / `:` 値分離形式のバイパスを塞ぐ
+    #[test]
+    fn rejects_value_separated_immediate_exec_args() {
+        // fish の `--command=evil` / `--commands=evil`
+        assert!(
+            reject_immediate_exec_args("fish", &["--command=evil".to_string()]).is_some(),
+            "fish --command=evil must be blocked"
+        );
+        assert!(
+            reject_immediate_exec_args("fish", &["--commands=evil".to_string()]).is_some(),
+            "fish --commands=evil must be blocked"
+        );
+        // PowerShell の `-Command:value` / `-Com=value`
+        assert!(
+            reject_immediate_exec_args("powershell", &["-command:iex".to_string()]).is_some(),
+            "powershell -command:value must be blocked"
+        );
+        assert!(
+            reject_immediate_exec_args("powershell", &["-com=iex".to_string()]).is_some(),
+            "powershell -com=value must be blocked"
+        );
+        // 誤検知ガード: `--config=x` は immediate-exec ではない
+        assert!(
+            reject_immediate_exec_args("bash", &["--config=x".to_string()]).is_none(),
+            "bash --config=x must be allowed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `reject_immediate_exec_args` の完全一致 blocklist が PowerShell 前置短縮形 (`-e`/`-ec`/`-com`/`-f` 等) と POSIX 連結短オプション (`-cx`/`-xc`/`-cl`) を取りこぼし、allowlist 内シェル (powershell / bash) で immediate-exec バイパス → 任意コマンド即時実行を許していた脆弱性を修正
- 引数正規化 + 前置一致 / クラスタ検出に置き換える純関数を追加:
  - `flag_stem` — 先頭の dash 類 (`-` `/` + Unicode ダッシュ) を剥がし小文字 stem を返す
  - `is_powershell_immediate_exec_arg` — `command`/`encodedcommand`/`file` への前置一致 + `-ec` 短縮形を検出
  - `is_posix_immediate_exec_arg` — `--command`/`--commands` 長形式 + `c` を含む英字短オプションクラスタを検出
- PowerShell / POSIX branch をヘルパ呼び出しに差し替え。`-nop`/`-ep`/`-con` や `-i`/`-l`/`--login`/`--`/`-` 等の対話起動フラグは前置一致せず誤検知しない
- `cmd` branch・`nu` branch・既存エラー文字列 (`cmd immediate-exec flags (/c /k) are blocked`) は不変 (既存テスト互換)。IPC 5 点同期は対象外 (private 関数の追加と分岐差し替えのみ)
- 回帰テスト 5 件を追加 (PowerShell 短縮形拒否 / PowerShell 対話フラグ許可 / POSIX クラスタ拒否 / POSIX 対話フラグ許可 / nu 維持)

Closes #890

## Test plan
- [x] `cargo test --lib command_validation` 55 件 pass (新規 5 件含む)
- [x] `cargo fmt --check` / `cargo clippy` で変更ファイルに違反・警告なし (updater.rs の既存 fmt 崩れは本 PR スコープ外)
- [ ] 手動: 開発ビルドで `powershell -e <base64>` 起動を試み `terminal_create` が `ok:false` を返し spawn されないこと