### PR TITLE
fix(persistence): #936 破損永続化ファイルの安全読込共通基盤を追加

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -16,6 +16,8 @@ pub mod git;
 pub mod handoffs;
 pub mod logs;
 pub mod role_profiles;
+// Issue #936: 永続化ファイルの安全読み込み (破損時は default 前に原本退避) 共通基盤。
+pub mod safe_load;
 // Issue #739: 永続化 schema バージョン定数 + 互換性ガードの集約モジュール。
 pub mod schema_version;
 pub mod sessions;

--- a/src-tauri/src/commands/safe_load.rs
+++ b/src-tauri/src/commands/safe_load.rs
@@ -1,0 +1,171 @@
+//! Issue #936: 永続化ファイルの「安全な読み込み」共通基盤。
+//!
+//! # 背景
+//!
+//! 書き込み側は [`crate::commands::atomic_write`] が共通プリミティブとして存在するが、
+//! 読み込み側には共通基盤が無く、各ストアが `serde_json::from_slice(...).ok()?` 等で
+//! parse 失敗を握り潰していた。その結果「破損 JSON → 黙ってデフォルト読込 → 次回 save で
+//! 正常データを backup 無しに上書き消失」という **同型のデータ消失バグ** が各ストアで再発し、
+//! 個別に起票・修正されてきた (#902 / #903 / #905 / #901 / #830 / #853 / #836)。
+//!
+//! 本モジュールは「**default に倒す前に必ず原本を退避する**」という不変条件を 1 か所に集約する。
+//!
+//! # 退避戦略
+//!
+//! 退避は [`crate::util::backup::write_timestamped_backup`] (`<file>.bak.<ts>` への
+//! コピー + 5 世代回転) を用いる。これは role-profiles.json / settings.json /
+//! terminal-tabs.json / team-history.json が既に採用している支配的な規約であり、
+//! - 原本 path を **一切触らない** (コピーのみ) ため、退避中に並行 `atomic_write` が valid な
+//!   file を置いても巻き込まない。team_state の `.corrupt` rename 退避が抱えていた TOCTOU
+//!   eviction (#853) が **原理的に発生しない**。
+//! - 連続破損でも世代回転で最後の砦が残る (#644)。
+//!
+//! という二点で安全側に倒れる。
+
+use serde::de::DeserializeOwned;
+use std::path::Path;
+
+/// 永続化ファイル読み込みの結果。
+#[derive(Debug)]
+pub enum LoadOutcome<T> {
+    /// 正常に parse できた。
+    Loaded(T),
+    /// ファイルが存在しない (初回起動 / 未保存)。呼び出し側は default を使ってよい。
+    Absent,
+    /// parse 失敗。原本は best-effort で退避済みなので、呼び出し側は default に倒してよい
+    /// (次回 save で正常データを失わない)。
+    Corrupted,
+}
+
+impl<T> LoadOutcome<T> {
+    /// [`LoadOutcome::Loaded`] のときだけ `Some`。`Absent` / `Corrupted` は `None`。
+    /// 「破損も不在も None でよい」既存ストア (例: `team_presets_load`) の移行用ショートカット。
+    pub fn into_option(self) -> Option<T> {
+        match self {
+            LoadOutcome::Loaded(v) => Some(v),
+            LoadOutcome::Absent | LoadOutcome::Corrupted => None,
+        }
+    }
+}
+
+/// `path` を読み `T` へ deserialize する。**parse 失敗時は default を返す前に原本を退避** し、
+/// [`LoadOutcome::Corrupted`] を返す。ファイル不在は [`LoadOutcome::Absent`]。
+///
+/// - `backup_mode`: 退避ファイルの Unix permission。injection-prone な instructions を含む
+///   機密ファイル (role-profiles / preset 等) は `Some(0o600)`、それ以外は `None`。
+///   Windows では no-op。
+///
+/// IO エラー (NotFound 以外) も `Absent` に倒すが、痕跡として warn ログを残す。
+pub async fn safe_load_or_quarantine<T: DeserializeOwned>(
+    path: &Path,
+    backup_mode: Option<u32>,
+) -> LoadOutcome<T> {
+    let bytes = match tokio::fs::read(path).await {
+        Ok(b) => b,
+        Err(e) => {
+            // NotFound は通常状態 (未保存 / 初回起動) なので silent。それ以外は痕跡を残す。
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!("[safe_load] read failed for {}: {e}", path.display());
+            }
+            return LoadOutcome::Absent;
+        }
+    };
+    match serde_json::from_slice::<T>(&bytes) {
+        Ok(v) => LoadOutcome::Loaded(v),
+        Err(e) => {
+            tracing::error!(
+                "[safe_load] parse failed for {} ({e}); backing up corrupt original before \
+                 falling back to default",
+                path.display()
+            );
+            // #936 の core invariant: default に倒す前に必ず退避する。コピー退避なので
+            // 原本 path を触らず、並行 save の valid file を巻き込まない (#853 の TOCTOU 回避)。
+            match crate::util::backup::write_timestamped_backup(path, &bytes, backup_mode).await {
+                Ok(bak) => {
+                    tracing::info!("[safe_load] wrote corrupt backup: {}", bak.display())
+                }
+                Err(berr) => tracing::warn!(
+                    "[safe_load] corrupt backup failed for {}: {berr}",
+                    path.display()
+                ),
+            }
+            LoadOutcome::Corrupted
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use tokio::fs;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Sample {
+        a: u32,
+        b: String,
+    }
+
+    #[tokio::test]
+    async fn loads_valid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sample.json");
+        fs::write(&path, br#"{"a":7,"b":"hi"}"#).await.unwrap();
+
+        let outcome = safe_load_or_quarantine::<Sample>(&path, None).await;
+        match outcome {
+            LoadOutcome::Loaded(v) => {
+                assert_eq!(v, Sample { a: 7, b: "hi".to_string() })
+            }
+            other => panic!("expected Loaded, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_absent_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.json");
+
+        let outcome = safe_load_or_quarantine::<Sample>(&path, None).await;
+        assert!(matches!(outcome, LoadOutcome::Absent));
+        assert!(outcome.into_option().is_none());
+    }
+
+    #[tokio::test]
+    async fn quarantines_corrupt_file_before_returning_corrupted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corrupt.json");
+        let corrupt = b"{ this is not valid json";
+        fs::write(&path, corrupt).await.unwrap();
+
+        let outcome = safe_load_or_quarantine::<Sample>(&path, None).await;
+        assert!(matches!(outcome, LoadOutcome::Corrupted));
+
+        // 原本 path はコピー退避なので残置される (次回 save で上書きされる前提)。
+        assert!(path.exists(), "original is left in place for copy-style backup");
+
+        // `<file>.bak.<ts>` が作られ、破損原本の bytes を保持していること。
+        let mut rd = fs::read_dir(dir.path()).await.unwrap();
+        let mut found_backup: Option<std::path::PathBuf> = None;
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with("corrupt.json.bak.") {
+                found_backup = Some(entry.path());
+            }
+        }
+        let bak = found_backup.expect("a timestamped backup of the corrupt file must exist");
+        let bak_bytes = fs::read(&bak).await.unwrap();
+        assert_eq!(&bak_bytes, corrupt, "backup must preserve the corrupt original bytes");
+    }
+
+    #[tokio::test]
+    async fn into_option_maps_loaded_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sample.json");
+        fs::write(&path, br#"{"a":1,"b":"x"}"#).await.unwrap();
+        let got = safe_load_or_quarantine::<Sample>(&path, None)
+            .await
+            .into_option();
+        assert_eq!(got, Some(Sample { a: 1, b: "x".to_string() }));
+    }
+}

--- a/src-tauri/src/commands/team_presets.rs
+++ b/src-tauri/src/commands/team_presets.rs
@@ -156,8 +156,14 @@ pub async fn team_presets_load(id: String) -> Option<TeamPreset> {
     }
     let _g = LOCK.lock().await;
     let path = preset_path(&id);
-    let bytes = fs::read(&path).await.ok()?;
-    let preset: TeamPreset = serde_json::from_slice(&bytes).ok()?;
+    // Issue #936: 旧実装は `fs::read(...).ok()?` + `from_slice(...).ok()?` で破損も不在も
+    // 黙って None に丸め、次回 save で正常データを backup 無しに上書き消失させていた。
+    // 共通ヘルパで「default に倒す前に必ず原本を退避」する。instructions は injection-prone
+    // なので退避も 0o600 (save 側 atomic_write_with_mode と同じ)。
+    let preset: TeamPreset =
+        crate::commands::safe_load::safe_load_or_quarantine(&path, Some(0o600))
+            .await
+            .into_option()?;
     if preset.id != id {
         return None;
     }

--- a/src-tauri/src/team_hub/state/persistence.rs
+++ b/src-tauri/src/team_hub/state/persistence.rs
@@ -326,19 +326,17 @@ async fn load_persisted_dynamic_for_team(
         return Vec::new();
     }
     let path = crate::util::config_paths::role_profiles_path();
-    let bytes = match tokio::fs::read(&path).await {
-        Ok(b) => b,
-        Err(_) => return Vec::new(), // file 不在は normal (初回起動 / 動的ロールを使わない運用)
-    };
-    let value: serde_json::Value = match serde_json::from_slice(&bytes) {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!(
-                "[register_team] role-profiles.json parse failed when loading dynamic[]: {e}"
-            );
-            return Vec::new();
-        }
-    };
+    // Issue #936: 旧実装は parse 失敗時に warn だけ出して空配列で続行し、破損 role-profiles.json
+    // を退避していなかった。共通ヘルパ経由にして「default (空) に倒す前に原本を退避」する。
+    // 退避は主オーナー role_profiles_load と同じ write_timestamped_backup・0o600 規約で、コピー
+    // 退避ゆえ並行 role_profiles_save の valid file を巻き込まない。
+    let value: serde_json::Value =
+        match crate::commands::safe_load::safe_load_or_quarantine(&path, Some(0o600)).await {
+            crate::commands::safe_load::LoadOutcome::Loaded(v) => v,
+            // 不在は normal (初回起動 / 動的ロール未使用)。破損は退避済みなので空で続行。
+            crate::commands::safe_load::LoadOutcome::Absent
+            | crate::commands::safe_load::LoadOutcome::Corrupted => return Vec::new(),
+        };
     let Some(arr) = value.get("dynamic").and_then(|v| v.as_array()) else {
         // 古い JSON (dynamic フィールドなし) は no-op で OK。新規 save 時に renderer が追加する。
         return Vec::new();


### PR DESCRIPTION
## Summary
- 永続化ファイルの読み込みに共通基盤が無く、各ストアが `from_slice(...).ok()?` で parse 失敗を握り潰して「破損 JSON → 黙ってデフォルト読込 → 次回 save で正常データを backup 無しに上書き消失」という同型データ消失バグを再発させていた (#902/#903/#905/#901/#830/#853/#836 はすべて同根)。
- `src-tauri/src/commands/safe_load.rs` に `safe_load_or_quarantine<T>(path, backup_mode) -> LoadOutcome<T>` を新設。**parse 失敗時は default に倒す前に必ず原本を退避**する不変条件を 1 か所へ集約した。
- 退避は既存の支配的規約 `write_timestamped_backup`（`.bak.<ts>` コピー + 5 世代回転 + 0o600 対応）を利用。コピー退避ゆえ原本 path を触らず、並行 `atomic_write` の valid file を巻き込まない（team_state の `.corrupt` rename が抱えた #853 の TOCTOU eviction が原理的に発生しない）。
- **未修正だった 2 ストアのみ移行**（ユーザー合意の最小根治スコープ）:
  - `team_presets_load` — 破損 preset を黙って `None` にしていた
  - `load_persisted_dynamic_for_team` — 破損 role-profiles.json を空配列で続行していた

## スコープ外（follow-up issue 化済み）
- 既に動作中の退避ロジックを持つストア（team_history / team_state / terminal_tabs / role_profiles / mcp claude）の共通基盤への統一 → #947
- 生 serde parse での永続化ファイル読込を CI/lint で禁止 → #948

## Test plan
- [x] `cargo test --lib safe_load` — 4 件 pass（valid 読込 / 不在 Absent / 破損時に原本退避 + Corrupted / into_option マッピング）
- [x] `cargo test --lib team_presets` — 4 件 pass
- [x] `cargo check` 警告なし

Closes #936