### PR TITLE
fix(pty): #937 チーム解散時に team スコープの PTY を backend で回収する

### DIFF
--- a/src-tauri/src/commands/app/team_mcp.rs
+++ b/src-tauri/src/commands/app/team_mcp.rs
@@ -279,6 +279,18 @@ pub async fn app_cleanup_team_mcp(
     team_id: String,
 ) -> crate::commands::error::CommandResult<CleanupTeamMcpResult> {
     let last = state.team_hub.clear_team(&team_id).await;
+
+    // Issue #937: 従来は hub state / MCP 設定だけを消し PTY registry に触れていなかったため、
+    // チームの PTY (と claude CLI が spawn した MCP node 群) は renderer の React unmount kill
+    // 一極依存で、UI フリーズ/クラッシュ時に孤児化していた (#864 / #829)。チーム解散の所有者で
+    // ある本コマンドが backend 側でも team スコープの PTY を確実に回収する (残チーム数に依らず実行)。
+    let reclaimed = state.pty_registry.kill_team(&team_id);
+    if reclaimed > 0 {
+        tracing::info!(
+            "[cleanup_team_mcp] reclaimed {reclaimed} PTY session(s) for team {team_id}"
+        );
+    }
+
     if !last {
         return Ok(CleanupTeamMcpResult {
             ok: true,

--- a/src-tauri/src/pty/registry.rs
+++ b/src-tauri/src/pty/registry.rs
@@ -372,6 +372,57 @@ impl SessionRegistry {
             let _ = s.kill();
         }
     }
+
+    /// Issue #937: チーム解散 (`app_cleanup_team_mcp` → `clear_team`) 時に、当該 `team_id` に
+    /// 属する PTY を **backend 側で確実に回収** する。回収した session 数を返す。
+    ///
+    /// 従来 `clear_team` は hub state / MCP 設定だけを消し、`pty_registry` に一切触れて
+    /// いなかった。PTY kill は renderer の React unmount (`use-xterm-bind.ts` の `terminal.kill`)
+    /// 一極依存で、UI フリーズ/クラッシュ時にチームの PTY と claude CLI が spawn した MCP node
+    /// 群が孤児化していた (#864 / #829)。本メソッドで kill 発火点を backend にも置く。
+    ///
+    /// [`Self::remove`] と同じく by_id / by_agent / by_session_key の 3 index を同期して外し、
+    /// `kill()` (Windows は detached thread で `taskkill /T`、Unix は killer 経由) と
+    /// codex broker 掃除 (これも detached: #834) を行う。どちらも即 return するので、本メソッドは
+    /// `remove` と同じ非ブロッキング特性を持ち、async command から直接呼んでよい。
+    pub fn kill_team(&self, team_id: &str) -> usize {
+        let sessions: Vec<Arc<SessionHandle>> = {
+            let mut g = recover(self.inner.lock());
+            let ids: Vec<String> = g
+                .by_id
+                .iter()
+                .filter(|(_, s)| s.team_id.as_deref() == Some(team_id))
+                .map(|(id, _)| id.clone())
+                .collect();
+            let mut collected = Vec::with_capacity(ids.len());
+            for id in ids {
+                if let Some(handle) = g.by_id.remove(&id) {
+                    // Issue #42 と同じ index 同期: agent_id / session_key の逆引きも掃除する。
+                    if let Some(aid) = &handle.agent_id {
+                        if g.by_agent.get(aid).map(String::as_str) == Some(id.as_str()) {
+                            g.by_agent.remove(aid);
+                        }
+                    }
+                    if let Some(skey) = &handle.session_key {
+                        if g.by_session_key.get(skey).map(String::as_str) == Some(id.as_str()) {
+                            g.by_session_key.remove(skey);
+                        }
+                    }
+                    collected.push(handle);
+                }
+            }
+            collected
+        };
+        let count = sessions.len();
+        for handle in &sessions {
+            let _ = handle.kill();
+            handle.cleanup_codex_broker_after_kill();
+        }
+        if count > 0 {
+            tracing::info!("[registry] kill_team({team_id}) reclaimed {count} PTY session(s)");
+        }
+        count
+    }
 }
 
 #[cfg(test)]
@@ -609,5 +660,91 @@ mod attach_lookup_tests {
         // 片方のみ Some → false (片側のみ team 紐付けが残っている状況は cross-team risk)
         assert!(!team_ids_match(Some("team-a"), None));
         assert!(!team_ids_match(None, Some("team-b")));
+    }
+}
+
+#[cfg(test)]
+mod kill_team_tests {
+    //! Issue #937: `kill_team` がチームスコープの PTY だけを kill + index から除去し、
+    //! 他チーム / team 無し PTY を巻き込まないことを検証する。実 PTY は起動せず、
+    //! `handle.rs` の test_support の mock killer 付き handle を registry に挿入する。
+    use super::*;
+    use crate::pty::session::test_support::handle_with;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // insert_if_absent の Err 型は SessionHandle (Debug 未実装) なので `.expect` は使えない。
+    // `is_ok()` で採用成功を assert する。
+    #[test]
+    fn kill_team_reclaims_only_matching_team_and_cleans_indices() {
+        let reg = SessionRegistry::new();
+        let kills_a1 = Arc::new(AtomicUsize::new(0));
+        let kills_a2 = Arc::new(AtomicUsize::new(0));
+        let kills_b1 = Arc::new(AtomicUsize::new(0));
+
+        // team-a に 2 セッション (agent_id + session_key 付き)、team-b に 1 セッション。
+        assert!(reg
+            .insert_if_absent(
+                "s1".to_string(),
+                handle_with(Some("a1"), Some("k1"), Some("team-a"), kills_a1.clone()),
+            )
+            .is_ok());
+        assert!(reg
+            .insert_if_absent(
+                "s2".to_string(),
+                handle_with(Some("a2"), Some("k2"), Some("team-a"), kills_a2.clone()),
+            )
+            .is_ok());
+        assert!(reg
+            .insert_if_absent(
+                "s3".to_string(),
+                handle_with(Some("b1"), Some("k3"), Some("team-b"), kills_b1.clone()),
+            )
+            .is_ok());
+
+        let reclaimed = reg.kill_team("team-a");
+        assert_eq!(reclaimed, 2, "team-a の 2 セッションだけ回収されること");
+
+        // by_id から team-a の 2 件が消え、team-b は残る。
+        assert!(reg.get("s1").is_none());
+        assert!(reg.get("s2").is_none());
+        assert!(reg.get("s3").is_some());
+
+        // list_team_members も team 単位で同期されている。
+        assert!(reg.list_team_members("team-a").is_empty());
+        assert_eq!(reg.list_team_members("team-b").len(), 1);
+
+        // team-a の handle は kill() が呼ばれ (明示 kill + 最後の Arc drop 時の Drop kill で
+        // 2 回入りうる。remove と同じ冪等な二重 kill 特性)、team-b は一切呼ばれていない。
+        assert!(kills_a1.load(Ordering::SeqCst) >= 1);
+        assert!(kills_a2.load(Ordering::SeqCst) >= 1);
+        assert_eq!(kills_b1.load(Ordering::SeqCst), 0);
+
+        // by_agent / by_session_key index も掃除済み: 同じ agent_id/session_key で再 insert
+        // しても旧 entry と衝突せず採用される (stale index が残っていない証跡)。
+        assert!(
+            reg.insert_if_absent(
+                "s1b".to_string(),
+                handle_with(Some("a1"), Some("k1"), Some("team-a"), Arc::new(AtomicUsize::new(0))),
+            )
+            .is_ok(),
+            "re-insert with reclaimed agent/session key must succeed"
+        );
+        assert!(reg.get("s1b").is_some());
+    }
+
+    #[test]
+    fn kill_team_no_match_is_noop() {
+        let reg = SessionRegistry::new();
+        let kills = Arc::new(AtomicUsize::new(0));
+        assert!(reg
+            .insert_if_absent(
+                "s1".to_string(),
+                handle_with(Some("a1"), None, Some("team-a"), kills.clone()),
+            )
+            .is_ok());
+
+        assert_eq!(reg.kill_team("team-x"), 0, "未知 team は 0 件");
+        assert!(reg.get("s1").is_some(), "他チームの PTY は残る");
+        assert_eq!(kills.load(Ordering::SeqCst), 0);
     }
 }

--- a/src-tauri/src/pty/session/handle.rs
+++ b/src-tauri/src/pty/session/handle.rs
@@ -272,17 +272,23 @@ impl Drop for SessionHandle {
     }
 }
 
+/// テスト用の `SessionHandle` 構築サポート。実 PTY を起動せずに kill 回数を計数する
+/// mock killer 付き handle を作る。`handle.rs` の Drop/inject テストだけでなく、
+/// `pty::registry` の team/index 操作テスト (#937 の `kill_team`) からも再利用できるよう
+/// crate 内へ公開する (`pub(crate)`)。
 #[cfg(test)]
-mod drop_tests {
-    use super::*;
-    use portable_pty::PtySize;
+pub(crate) mod test_support {
+    use super::SessionHandle;
+    use crate::pty::scrollback::{new_scrollback, WriteBudget};
+    use portable_pty::{MasterPty, PtySize};
     use std::io::{Cursor, Read, Result as IoResult, Write};
-    use std::panic::{catch_unwind, AssertUnwindSafe};
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
 
     #[derive(Debug, Clone)]
-    struct CountingKiller {
-        kills: Arc<AtomicUsize>,
+    pub(crate) struct CountingKiller {
+        pub(crate) kills: Arc<AtomicUsize>,
     }
 
     impl portable_pty::ChildKiller for CountingKiller {
@@ -296,7 +302,7 @@ mod drop_tests {
         }
     }
 
-    struct DummyMaster;
+    pub(crate) struct DummyMaster;
 
     impl MasterPty for DummyMaster {
         fn resize(&self, _size: PtySize) -> std::result::Result<(), anyhow::Error> {
@@ -338,14 +344,20 @@ mod drop_tests {
         }
     }
 
-    fn test_handle(kills: Arc<AtomicUsize>) -> SessionHandle {
+    /// `agent_id` / `session_key` / `team_id` を指定して mock killer 付き handle を作る。
+    pub(crate) fn handle_with(
+        agent_id: Option<&str>,
+        session_key: Option<&str>,
+        team_id: Option<&str>,
+        kills: Arc<AtomicUsize>,
+    ) -> SessionHandle {
         SessionHandle {
             writer: Mutex::new(Box::new(Vec::<u8>::new())),
             master: Mutex::new(Box::new(DummyMaster)),
             killer: Mutex::new(Box::new(CountingKiller { kills })),
-            agent_id: None,
-            session_key: None,
-            team_id: None,
+            agent_id: agent_id.map(str::to_string),
+            session_key: session_key.map(str::to_string),
+            team_id: team_id.map(str::to_string),
             role: None,
             cwd: String::new(),
             is_codex: false,
@@ -355,10 +367,23 @@ mod drop_tests {
                 window_started_at: Instant::now(),
                 bytes_in_window: 0,
             }),
-            scrollback: crate::pty::scrollback::new_scrollback(),
+            scrollback: new_scrollback(),
             watcher_cancel: Arc::new(AtomicBool::new(false)),
         }
     }
+
+    /// `team_id` 等を持たない最小 handle (handle.rs の Drop/inject テスト用)。
+    pub(crate) fn test_handle(kills: Arc<AtomicUsize>) -> SessionHandle {
+        handle_with(None, None, None, kills)
+    }
+}
+
+#[cfg(test)]
+mod drop_tests {
+    use super::test_support::test_handle;
+    use super::*;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn drop_recovers_poisoned_killer_mutex_and_kills_child() {

--- a/src-tauri/src/pty/session/mod.rs
+++ b/src-tauri/src/pty/session/mod.rs
@@ -33,4 +33,9 @@ pub(crate) mod windows_resolve;
 pub use handle::{SessionHandle, UserWriteOutcome};
 pub use spawn::{resolve_valid_cwd, spawn_session, SpawnOptions, TerminalWarning};
 
+// Issue #937: registry の kill_team テスト等が mock killer 付き handle を作れるよう、
+// テスト専用の構築 helper を crate 内へ再エクスポートする (`handle` モジュール自体は private)。
+#[cfg(test)]
+pub(crate) use handle::test_support;
+
 pub(crate) use spawn::resolve_terminal_command_path_for_check;


### PR DESCRIPTION
## Summary
- `app_cleanup_team_mcp` (→ `clear_team`) は hub state と MCP 設定だけを消し、`pty_registry` に**一切触れていなかった**。PTY kill は renderer の React unmount (`use-xterm-bind.ts` の `terminal.kill`) **一極依存**で、UI フリーズ/クラッシュ時に team の PTY と claude CLI が spawn した MCP node 群が孤児化していた (#864 / #829)。
- `SessionRegistry::kill_team(team_id)` を新設。`remove` と同じく by_id / by_agent / by_session_key の 3 index を同期して外し、`kill()`（Windows は detached thread で `taskkill /T`、Unix は killer 経由）+ codex broker 掃除（detached: #834）を team 単位で実行する。どちらも即 return するため `remove` と同じ非ブロッキング特性で、チーム解散の所有者である `app_cleanup_team_mcp` から直接呼べる。
- これで PTY kill の発火点を **backend にも置く**（残チーム数に依らず実行）。renderer unmount kill は早期解放の最適化として残る。
- テスト容易化のため、mock killer 付き `SessionHandle` 構築を `handle.rs` の `#[cfg(test)] pub(crate) mod test_support` へ集約し（既存 `drop_tests` もこれに集約）、`registry` の `kill_team` テストから再利用。

## スコープ（bounded slice）
本 PR は #937 の柱3「チーム解散の所有者が PTY を回収する」のみ。**クラッシュ/強制終了時の孤児化（#864 系）は未対応**で、以下の残り柱は follow-up issue へ分離した:
- OS 寿命バインド（Job Object / setsid+killpg）→ #950
- 構造化シャットダウン（`kill_all` bounded join + `app_restart` 集約）→ #951
- 集中スーパーバイザ（watcher/cleanup/poller のキャンセル統一）→ #952

そのため本 PR は `Closes` ではなく `Refs #937`（umbrella は残置）。

## Test plan
- [x] `cargo test --lib pty::registry` — 14 件 pass（うち kill_team_tests 2 件: team 単位の回収 + index 掃除 + 他チーム非巻き込み / 未知 team は no-op）
- [x] `cargo test --lib pty::` — 既存 drop_tests 含め全 pass（test_support 集約の回帰なし）
- [x] `cargo check` 警告なし

Refs #937