### PR TITLE
security(files): #932 ファイル変更系 IPC を active project ゲートに通す

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -10,8 +10,24 @@ mod path_safety;
 
 use serde::Serialize;
 use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager};
 
+use crate::commands::error::CommandResult;
+use crate::state::AppState;
 use encoding::{detect_text_or_binary, encode_for_save};
+
+/// Issue #932: renderer 由来の `project_root` を `AppState` の active project と照合する共通ゲート。
+///
+/// async command が `State` (参照入力) を取ると Tauri が `Result` 返却を強制するため、非 `Result`
+/// を返す既存 FS コマンド契約 (renderer は構造体をそのまま受ける) を保てない。owned/'static な
+/// `AppHandle` 経由で state を引くことでこの制約を回避し、既存の戻り値型を維持したまま
+/// `assert_active_project_root` ゲートを各 mutation コマンド先頭に挿せるようにする。
+async fn assert_project_root_via(app: &AppHandle, project_root: &str) -> CommandResult<()> {
+    let state = app.state::<AppState>();
+    crate::commands::authz::assert_active_project_root(&state.project_root, project_root)
+        .await
+        .map(|_| ())
+}
 use hash::{mtime_ms_of, sha256_hex};
 // safe_join は外部 (commands/git.rs) からも呼ばれるので pub use で再 export する。
 pub use path_safety::safe_join;
@@ -219,6 +235,7 @@ pub async fn files_read(project_root: String, rel_path: String) -> FileReadResul
 
 #[tauri::command]
 pub async fn files_write(
+    app: AppHandle,
     project_root: String,
     rel_path: String,
     content: String,
@@ -233,6 +250,36 @@ pub async fn files_write(
     encoding: Option<String>,
     // Issue #119: 前回 read 時の SHA-256 (hex)。指定時は save 直前に現在ファイルの hash と比較し、
     // mtime/size を見逃した「同サイズ・1 秒以内」変更でも conflict を確定する。
+    expected_content_hash: Option<String>,
+) -> FileWriteResult {
+    // Issue #932: renderer 由来の project_root を active project と照合する共通ゲート。
+    // 未検証だと乗っ取られた renderer が active プロジェクト外の任意ファイルを上書きできた。
+    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+        return FileWriteResult {
+            ok: false,
+            error: Some(e.to_string()),
+            ..Default::default()
+        };
+    }
+    files_write_inner(
+        project_root,
+        rel_path,
+        content,
+        expected_mtime_ms,
+        expected_size_bytes,
+        encoding,
+        expected_content_hash,
+    )
+    .await
+}
+
+async fn files_write_inner(
+    project_root: String,
+    rel_path: String,
+    content: String,
+    expected_mtime_ms: Option<u64>,
+    expected_size_bytes: Option<u64>,
+    encoding: Option<String>,
     expected_content_hash: Option<String>,
 ) -> FileWriteResult {
     let Some(abs) = safe_join(&project_root, &rel_path) else {
@@ -501,6 +548,20 @@ fn rel_from_abs(project_root: &str, abs: &Path) -> String {
 /// `name` は basename。`overwrite=false` のとき既存ファイルがあれば失敗を返す。
 #[tauri::command]
 pub async fn files_create(
+    app: AppHandle,
+    project_root: String,
+    rel_path: String,
+    name: String,
+    overwrite: Option<bool>,
+) -> FileMutationResult {
+    // Issue #932: active project と照合してから FS 操作を行う (任意ファイル作成を防ぐ)。
+    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+        return FileMutationResult::err(rel_path, e.to_string());
+    }
+    files_create_inner(project_root, rel_path, name, overwrite).await
+}
+
+async fn files_create_inner(
     project_root: String,
     rel_path: String,
     name: String,
@@ -537,6 +598,19 @@ pub async fn files_create(
 /// Issue #592: 新規ディレクトリを作成する。親ディレクトリは存在している必要がある。
 #[tauri::command]
 pub async fn files_create_dir(
+    app: AppHandle,
+    project_root: String,
+    rel_path: String,
+    name: String,
+) -> FileMutationResult {
+    // Issue #932: active project と照合してから FS 操作を行う (任意ディレクトリ作成を防ぐ)。
+    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+        return FileMutationResult::err(rel_path, e.to_string());
+    }
+    files_create_dir_inner(project_root, rel_path, name).await
+}
+
+async fn files_create_dir_inner(
     project_root: String,
     rel_path: String,
     name: String,
@@ -573,6 +647,21 @@ pub async fn files_create_dir(
 /// 既存パス上書きは `overwrite=true` のときのみ許可。
 #[tauri::command]
 pub async fn files_rename(
+    app: AppHandle,
+    project_root: String,
+    from_rel: String,
+    to_parent_rel: String,
+    new_name: String,
+    overwrite: Option<bool>,
+) -> FileMutationResult {
+    // Issue #932: active project と照合してから FS 操作を行う (任意ファイル rename/move を防ぐ)。
+    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+        return FileMutationResult::err(from_rel, e.to_string());
+    }
+    files_rename_inner(project_root, from_rel, to_parent_rel, new_name, overwrite).await
+}
+
+async fn files_rename_inner(
     project_root: String,
     from_rel: String,
     to_parent_rel: String,
@@ -632,6 +721,19 @@ pub async fn files_rename(
 /// `permanent=false` (default) は OS のゴミ箱に送り、`true` なら完全削除する。
 #[tauri::command]
 pub async fn files_delete(
+    app: AppHandle,
+    project_root: String,
+    rel_path: String,
+    permanent: Option<bool>,
+) -> FileMutationResult {
+    // Issue #932: active project と照合してから FS 操作を行う (任意ファイル削除を防ぐ)。
+    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+        return FileMutationResult::err(rel_path, e.to_string());
+    }
+    files_delete_inner(project_root, rel_path, permanent).await
+}
+
+async fn files_delete_inner(
     project_root: String,
     rel_path: String,
     permanent: Option<bool>,
@@ -676,6 +778,21 @@ pub async fn files_delete(
 /// `from_rel` 既存パス、`to_parent_rel` コピー先親ディレクトリ、`new_name` 新しい basename。
 #[tauri::command]
 pub async fn files_copy(
+    app: AppHandle,
+    project_root: String,
+    from_rel: String,
+    to_parent_rel: String,
+    new_name: String,
+    overwrite: Option<bool>,
+) -> FileMutationResult {
+    // Issue #932: active project と照合してから FS 操作を行う (任意ファイル複製を防ぐ)。
+    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+        return FileMutationResult::err(from_rel, e.to_string());
+    }
+    files_copy_inner(project_root, from_rel, to_parent_rel, new_name, overwrite).await
+}
+
+async fn files_copy_inner(
     project_root: String,
     from_rel: String,
     to_parent_rel: String,
@@ -836,7 +953,7 @@ mod issue_592_tests {
     async fn files_create_creates_file_in_root() {
         let td = tempdir().unwrap();
         let root = root_str(&td);
-        let res = files_create(root.clone(), "".into(), "hello.txt".into(), None).await;
+        let res = files_create_inner(root.clone(), "".into(), "hello.txt".into(), None).await;
         assert!(res.ok, "{:?}", res.error);
         assert!(td.path().join("hello.txt").exists());
     }
@@ -845,7 +962,7 @@ mod issue_592_tests {
     async fn files_create_rejects_path_traversal_via_name() {
         let td = tempdir().unwrap();
         let root = root_str(&td);
-        let res = files_create(root, "".into(), "../escape.txt".into(), None).await;
+        let res = files_create_inner(root, "".into(), "../escape.txt".into(), None).await;
         assert!(!res.ok);
     }
 
@@ -853,9 +970,9 @@ mod issue_592_tests {
     async fn files_create_rejects_existing_without_overwrite() {
         let td = tempdir().unwrap();
         let root = root_str(&td);
-        let r1 = files_create(root.clone(), "".into(), "x.txt".into(), None).await;
+        let r1 = files_create_inner(root.clone(), "".into(), "x.txt".into(), None).await;
         assert!(r1.ok);
-        let r2 = files_create(root.clone(), "".into(), "x.txt".into(), Some(false)).await;
+        let r2 = files_create_inner(root.clone(), "".into(), "x.txt".into(), Some(false)).await;
         assert!(!r2.ok);
     }
 
@@ -863,7 +980,7 @@ mod issue_592_tests {
     async fn files_create_dir_creates_subdir() {
         let td = tempdir().unwrap();
         let root = root_str(&td);
-        let res = files_create_dir(root, "".into(), "subdir".into()).await;
+        let res = files_create_dir_inner(root, "".into(), "subdir".into()).await;
         assert!(res.ok, "{:?}", res.error);
         assert!(td.path().join("subdir").is_dir());
     }
@@ -872,9 +989,9 @@ mod issue_592_tests {
     async fn files_rename_moves_file() {
         let td = tempdir().unwrap();
         let root = root_str(&td);
-        files_create(root.clone(), "".into(), "a.txt".into(), None).await;
+        files_create_inner(root.clone(), "".into(), "a.txt".into(), None).await;
         let res =
-            files_rename(root.clone(), "a.txt".into(), "".into(), "b.txt".into(), None).await;
+            files_rename_inner(root.clone(), "a.txt".into(), "".into(), "b.txt".into(), None).await;
         assert!(res.ok, "{:?}", res.error);
         assert!(!td.path().join("a.txt").exists());
         assert!(td.path().join("b.txt").exists());
@@ -884,8 +1001,8 @@ mod issue_592_tests {
     async fn files_rename_rejects_self_into_descendant() {
         let td = tempdir().unwrap();
         let root = root_str(&td);
-        files_create_dir(root.clone(), "".into(), "dir1".into()).await;
-        let res = files_rename(
+        files_create_dir_inner(root.clone(), "".into(), "dir1".into()).await;
+        let res = files_rename_inner(
             root.clone(),
             "dir1".into(),
             "dir1".into(),
@@ -900,9 +1017,9 @@ mod issue_592_tests {
     async fn files_copy_clones_file() {
         let td = tempdir().unwrap();
         let root = root_str(&td);
-        files_create(root.clone(), "".into(), "a.txt".into(), None).await;
+        files_create_inner(root.clone(), "".into(), "a.txt".into(), None).await;
         std::fs::write(td.path().join("a.txt"), b"hi").unwrap();
-        let res = files_copy(
+        let res = files_copy_inner(
             root.clone(),
             "a.txt".into(),
             "".into(),
@@ -918,11 +1035,11 @@ mod issue_592_tests {
     async fn files_copy_recurses_directory() {
         let td = tempdir().unwrap();
         let root = root_str(&td);
-        files_create_dir(root.clone(), "".into(), "src".into()).await;
+        files_create_dir_inner(root.clone(), "".into(), "src".into()).await;
         std::fs::write(td.path().join("src").join("a.txt"), b"a").unwrap();
         std::fs::create_dir(td.path().join("src").join("nested")).unwrap();
         std::fs::write(td.path().join("src").join("nested").join("b.txt"), b"b").unwrap();
-        let res = files_copy(root.clone(), "src".into(), "".into(), "dst".into(), None).await;
+        let res = files_copy_inner(root.clone(), "src".into(), "".into(), "dst".into(), None).await;
         assert!(res.ok, "{:?}", res.error);
         assert_eq!(std::fs::read(td.path().join("dst").join("a.txt")).unwrap(), b"a");
         assert_eq!(
@@ -935,8 +1052,8 @@ mod issue_592_tests {
     async fn files_copy_rejects_into_descendant() {
         let td = tempdir().unwrap();
         let root = root_str(&td);
-        files_create_dir(root.clone(), "".into(), "a".into()).await;
-        let res = files_copy(root.clone(), "a".into(), "a".into(), "inside".into(), None).await;
+        files_create_dir_inner(root.clone(), "".into(), "a".into()).await;
+        let res = files_copy_inner(root.clone(), "a".into(), "a".into(), "inside".into(), None).await;
         assert!(!res.ok);
     }
 
@@ -954,11 +1071,11 @@ mod issue_592_tests {
         let secret = outside.path().join("secret.txt");
         std::fs::write(&secret, b"TOP-SECRET").unwrap();
         // src/ ディレクトリに secret への symlink を仕込む (planted symlink 攻撃の再現)。
-        files_create_dir(root.clone(), "".into(), "src".into()).await;
+        files_create_dir_inner(root.clone(), "".into(), "src".into()).await;
         std::fs::write(td.path().join("src").join("normal.txt"), b"ok").unwrap();
         symlink(&secret, td.path().join("src").join("link-to-secret")).unwrap();
         // copy 実行
-        let res = files_copy(root.clone(), "src".into(), "".into(), "dst".into(), None).await;
+        let res = files_copy_inner(root.clone(), "src".into(), "".into(), "dst".into(), None).await;
         assert!(res.ok, "{:?}", res.error);
         // 通常ファイルはコピーされる
         assert_eq!(std::fs::read(td.path().join("dst").join("normal.txt")).unwrap(), b"ok");
@@ -975,13 +1092,13 @@ mod issue_592_tests {
         use std::os::unix::fs::symlink;
         let td = tempdir().unwrap();
         let root = root_str(&td);
-        files_create_dir(root.clone(), "".into(), "src".into()).await;
+        files_create_dir_inner(root.clone(), "".into(), "src".into()).await;
         let src = td.path().join("src");
         // a -> b, b -> a の symlink cycle を仕込む。
         symlink(src.join("b"), src.join("a")).unwrap();
         symlink(src.join("a"), src.join("b")).unwrap();
         // 無限ループにならず copy 完了することを timeout 付きで検証する。
-        let copy_fut = files_copy(root.clone(), "src".into(), "".into(), "dst".into(), None);
+        let copy_fut = files_copy_inner(root.clone(), "src".into(), "".into(), "dst".into(), None);
         let res = tokio::time::timeout(std::time::Duration::from_secs(5), copy_fut)
             .await
             .expect("copy_dir_recursive must terminate even with symlink cycle");
@@ -995,8 +1112,8 @@ mod issue_592_tests {
     async fn files_delete_permanent_removes_file() {
         let td = tempdir().unwrap();
         let root = root_str(&td);
-        files_create(root.clone(), "".into(), "g.txt".into(), None).await;
-        let res = files_delete(root.clone(), "g.txt".into(), Some(true)).await;
+        files_create_inner(root.clone(), "".into(), "g.txt".into(), None).await;
+        let res = files_delete_inner(root.clone(), "g.txt".into(), Some(true)).await;
         assert!(res.ok, "{:?}", res.error);
         assert!(!td.path().join("g.txt").exists());
     }
@@ -1005,7 +1122,7 @@ mod issue_592_tests {
     async fn files_delete_rejects_root() {
         let td = tempdir().unwrap();
         let root = root_str(&td);
-        let res = files_delete(root, "".into(), Some(true)).await;
+        let res = files_delete_inner(root, "".into(), Some(true)).await;
         assert!(!res.ok);
     }
 }
@@ -1039,7 +1156,7 @@ mod issue_828_tests {
         drop(f);
 
         // expected_content_hash のみ渡し、mtime/size 検証はスキップさせて hash 経路に入れる。
-        let res = files_write(
+        let res = files_write_inner(
             root,
             "huge.txt".into(),
             "new content".into(),
@@ -1069,7 +1186,7 @@ mod issue_828_tests {
         let path = td.path().join("s.txt");
         std::fs::write(&path, b"original").unwrap();
 
-        let res = files_write(
+        let res = files_write_inner(
             root,
             "s.txt".into(),
             "updated".into(),
@@ -1095,7 +1212,7 @@ mod issue_828_tests {
         std::fs::write(&path, b"original").unwrap();
         let expected = sha256_hex(b"original");
 
-        let res = files_write(
+        let res = files_write_inner(
             root,
             "s.txt".into(),
             "updated".into(),


### PR DESCRIPTION
## Summary
- renderer 由来の `project_root` を信頼境界外として検証する共通入口が無く、`files_write` / `files_create` / `files_create_dir` / `files_rename` / `files_delete` / `files_copy` が renderer 指定の任意 root をそのまま `safe_join` していた。
- **攻撃**: XSS / prompt-injection で乗っ取られた renderer が `project_root = C:\Users\victim\.ssh` 等を渡せば、active プロジェクト外の任意ファイルを write/create/delete/copy 可能 (#600 と同型の信頼境界欠落)。
- 各 mutation コマンドを **「薄い `#[tauri::command]` ラッパ(`assert_active_project_root` ゲートのみ) + テスト可能な `*_inner`(FS ロジック)」** に分離。active project と canonicalize 一致するまで FS 操作を実行しない。
- async command が `State`(参照入力) を取ると Tauri が `Result` 返却を強制するため、非 `Result` 契約(renderer は構造体をそのまま受ける)を維持できるよう owned/'static な `AppHandle` 経由で state を引く。

## スコープ（bounded slice）
最も深刻な **write/delete/create/copy 系のみ**。理由付きで以下を分離:
- **read/probe 系**(`files_read` / `files_list` / `git_status` / `git_diff`): file tree / git パネルのマウント時に auto 発火し、active root 設定前(起動 setup タスク + fire-and-forget な `app.setProjectRoot`)に走ると transient reject で空振りしうる。startup timing を整えてからの対応として → #954
- **型レベル強制**(`ProjectRoot` 型でゲート必須化、authz 貼り忘れを構造的に排除) → #955

そのため `Closes` ではなく `Refs #932`。

## Test plan
- [x] `cargo test --lib commands::files` — 30 件 pass(既存テストは `*_inner` 経由で全て緑、wrapper/inner 分離の回帰なし)
- [x] `cargo check` 警告なし
- [x] ゲート本体 `assert_active_project_root` は `commands::authz` で単体テスト済み(空 root / active 未設定 / 不一致 / 一致 / canonical 差異)

Refs #932