### PR TITLE
fix: open issues #820, #852, #908 の 3 件をバンドル修正

### DIFF
--- a/src-tauri/src/commands/dialog.rs
+++ b/src-tauri/src/commands/dialog.rs
@@ -2,9 +2,19 @@
 //
 // tauri-plugin-dialog でファイル/フォルダ選択、自前で空フォルダ判定。
 
+use serde::Deserialize;
 use tauri::AppHandle;
 use tauri_plugin_dialog::DialogExt;
 use tokio::sync::oneshot;
+
+/// Issue #820: renderer から渡される拡張子フィルタ。
+/// `extensions` はドット無し (例: ["png", "jpg"])。shared.ts の `DialogFileFilter` と同期。
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DialogFileFilter {
+    pub name: String,
+    pub extensions: Vec<String>,
+}
 
 #[tauri::command]
 pub async fn dialog_open_folder(app: AppHandle, title: Option<String>) -> Option<String> {
@@ -20,11 +30,19 @@ pub async fn dialog_open_folder(app: AppHandle, title: Option<String>) -> Option
 }
 
 #[tauri::command]
-pub async fn dialog_open_file(app: AppHandle, title: Option<String>) -> Option<String> {
+pub async fn dialog_open_file(
+    app: AppHandle,
+    title: Option<String>,
+    filters: Option<Vec<DialogFileFilter>>,
+) -> Option<String> {
     let (tx, rx) = oneshot::channel();
     let mut builder = app.dialog().file();
     if let Some(t) = title {
         builder = builder.set_title(&t);
+    }
+    for filter in filters.unwrap_or_default() {
+        let exts: Vec<&str> = filter.extensions.iter().map(String::as_str).collect();
+        builder = builder.add_filter(&filter.name, &exts);
     }
     builder.pick_file(move |result| {
         let _ = tx.send(result.map(|p| p.to_string()));

--- a/src/renderer/src/components/FileTreePanel.tsx
+++ b/src/renderer/src/components/FileTreePanel.tsx
@@ -2,6 +2,7 @@ import {
   useEffect,
   useId,
   useMemo,
+  useRef,
   useState,
   useCallback
 } from 'react';
@@ -508,6 +509,105 @@ export function FileTreePanel({
   );
 
   /** ルートディレクトリ右クリックメニュー。ワークスペースから外す + 新規ファイル/フォルダ + paste。 */
+  // ---------- Issue #908: WAI-ARIA tree (roving tabindex + 矢印キー移動) ----------
+  // 行は全て tabIndex=-1 で render される (FileTreeNode 参照)。「どの行が tab stop か」は
+  // React state にせず DOM 直接操作で管理する。state にすると focus 移動のたびに
+  // ツリー全体が再レンダーされ、Issue #129 の memo 最適化が無効化されるため。
+  const treeBodyRef = useRef<HTMLDivElement | null>(null);
+
+  const getTreeRows = useCallback((): HTMLButtonElement[] => {
+    const body = treeBodyRef.current;
+    if (!body) return [];
+    return Array.from(body.querySelectorAll<HTMLButtonElement>('[role="treeitem"]'));
+  }, []);
+
+  // focus を受けた行を唯一の tab stop にする (クリック / 矢印キー / Tab 進入の全経路)。
+  // focus event は bubble しないが React の onFocus は focusin 相当で container に届く。
+  const handleTreeFocus = useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      const row = (e.target as HTMLElement).closest<HTMLButtonElement>('[role="treeitem"]');
+      if (!row) return;
+      for (const r of getTreeRows()) {
+        if (r !== row && r.tabIndex === 0) r.tabIndex = -1;
+      }
+      row.tabIndex = 0;
+    },
+    [getTreeRows]
+  );
+
+  const handleTreeKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      // rename / 新規作成 input 内の矢印キーは奪わない (input は treeitem の外)
+      const target = (e.target as HTMLElement).closest<HTMLButtonElement>('[role="treeitem"]');
+      if (!target) return;
+      const rows = getTreeRows();
+      const idx = rows.indexOf(target);
+      if (idx < 0) return;
+      const levelOf = (el: HTMLElement): number => Number(el.getAttribute('aria-level') ?? '1');
+      const focusRow = (row: HTMLButtonElement | undefined): void => {
+        row?.focus(); // tabindex の付け替えは handleTreeFocus が行う
+      };
+      switch (e.key) {
+        case 'ArrowDown':
+          focusRow(rows[idx + 1]);
+          break;
+        case 'ArrowUp':
+          focusRow(rows[idx - 1]);
+          break;
+        case 'Home':
+          focusRow(rows[0]);
+          break;
+        case 'End':
+          focusRow(rows[rows.length - 1]);
+          break;
+        case 'ArrowRight': {
+          // 折りたたみ dir → 展開 / 展開済み dir → 最初の子へ / ファイル → no-op
+          const expandedAttr = target.getAttribute('aria-expanded');
+          if (expandedAttr === 'false') {
+            target.click();
+          } else if (expandedAttr === 'true') {
+            const next = rows[idx + 1];
+            if (next && levelOf(next) > levelOf(target)) focusRow(next);
+          }
+          break;
+        }
+        case 'ArrowLeft': {
+          // 展開済み dir → 折りたたみ / それ以外 → 親 dir へ
+          if (target.getAttribute('aria-expanded') === 'true') {
+            target.click();
+          } else {
+            const lv = levelOf(target);
+            for (let i = idx - 1; i >= 0; i--) {
+              if (levelOf(rows[i]) < lv) {
+                focusRow(rows[i]);
+                break;
+              }
+            }
+          }
+          break;
+        }
+        default:
+          return; // Enter/Space は <button> ネイティブ挙動 (click) に任せる
+      }
+      e.preventDefault();
+      e.stopPropagation();
+    },
+    [getTreeRows]
+  );
+
+  // roving tabindex の不変式「treeitem のうち丁度 1 行が tabIndex=0」を維持する。
+  // 行は tabIndex=-1 で mount されるため、初回表示・tab stop 行の unmount (折りたたみ /
+  // リネーム置換 / refresh) 後にここで復元する。active 行があればそれを優先する。
+  useEffect(() => {
+    const rows = getTreeRows();
+    if (rows.length === 0) return;
+    const stops = rows.filter((r) => r.tabIndex === 0);
+    if (stops.length === 1) return;
+    for (const r of stops) r.tabIndex = -1;
+    const preferred = rows.find((r) => r.classList.contains('is-active')) ?? rows[0];
+    preferred.tabIndex = 0;
+  });
+
   const handleRootContextMenu = useCallback(
     (e: React.MouseEvent, rootPath: string) => {
       e.preventDefault();
@@ -581,7 +681,15 @@ export function FileTreePanel({
           <RefreshCw size={12} strokeWidth={1.75} />
         </button>
       </div>
-      <div className="filetree__body">
+      <div
+        className="filetree__body"
+        // Issue #908: WAI-ARIA tree。行 (treeitem) は FileTreeNode 側で付与。
+        role="tree"
+        aria-label={t('filetree.treeLabel')}
+        ref={treeBodyRef}
+        onFocus={handleTreeFocus}
+        onKeyDown={handleTreeKeyDown}
+      >
         {roots.length === 0 && (
           <div className="filetree__empty" style={{ paddingLeft: 12 }}>
             —

--- a/src/renderer/src/components/__tests__/FileTreePanel-aria.test.tsx
+++ b/src/renderer/src/components/__tests__/FileTreePanel-aria.test.tsx
@@ -1,0 +1,155 @@
+// Issue #908: filetree の WAI-ARIA tree パターン (role / aria-* / roving tabindex /
+// 矢印キー移動) の回帰テスト。
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { FileNode } from '../../../../types/shared';
+
+vi.mock('../../lib/i18n', () => ({
+  useT: () => (key: string) => key
+}));
+vi.mock('../../lib/toast-context', () => ({
+  useToast: () => ({ showToast: vi.fn(), dismissToast: vi.fn() })
+}));
+vi.mock('../../lib/use-native-confirm', () => ({
+  useNativeConfirm: () => vi.fn()
+}));
+vi.mock('../../lib/tauri-api', () => ({
+  api: { files: {} }
+}));
+
+const hoisted = vi.hoisted(() => ({
+  state: null as unknown as Record<string, unknown>
+}));
+
+vi.mock('../../lib/filetree-state-context', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../lib/filetree-state-context')>();
+  return {
+    ...orig,
+    useFileTreeState: () => hoisted.state
+  };
+});
+
+import { dirKey, type DirState } from '../../lib/filetree-state-context';
+import { FileTreePanel } from '../FileTreePanel';
+
+const ROOT = '/proj';
+
+const node = (name: string, path: string, isDir: boolean): FileNode => ({ name, path, isDir });
+
+const dirState = (entries: FileNode[]): DirState => ({ loading: false, error: null, entries });
+
+let toggleDir: ReturnType<typeof vi.fn>;
+
+function setupState(): void {
+  toggleDir = vi.fn();
+  const dirs = new Map<string, DirState>([
+    [dirKey(ROOT, ''), dirState([node('src', 'src', true), node('README.md', 'README.md', false)])],
+    [dirKey(ROOT, 'src'), dirState([node('main.ts', 'src/main.ts', false)])]
+  ]);
+  hoisted.state = {
+    expanded: new Set([dirKey(ROOT, 'src')]),
+    collapsedRoots: new Set<string>(),
+    dirs,
+    toggleDir,
+    toggleRoot: vi.fn(),
+    loadDir: vi.fn().mockResolvedValue(undefined),
+    refreshAll: vi.fn(),
+    registerRoots: vi.fn(),
+    unregisterRoots: vi.fn()
+  };
+}
+
+function renderPanel(activeFilePath: string | null = 'README.md') {
+  return render(
+    <FileTreePanel
+      primaryRoot={ROOT}
+      extraRoots={[]}
+      activeFilePath={activeFilePath}
+      onOpenFile={vi.fn()}
+      onAddWorkspaceFolder={vi.fn()}
+      onRemoveWorkspaceFolder={vi.fn()}
+    />
+  );
+}
+
+beforeEach(() => {
+  setupState();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('FileTreePanel ARIA tree (Issue #908)', () => {
+  it('role=tree コンテナと role=treeitem の行が描画される', () => {
+    renderPanel();
+    expect(screen.getByRole('tree')).toBeInTheDocument();
+    // src (dir, 展開済み) / src/main.ts / README.md の 3 行
+    const items = screen.getAllByRole('treeitem');
+    expect(items).toHaveLength(3);
+  });
+
+  it('ディレクトリ行に aria-expanded、ファイル行に aria-selected、全行に aria-level が付く', () => {
+    renderPanel();
+    const [srcRow, mainRow, readmeRow] = screen.getAllByRole('treeitem');
+    expect(srcRow).toHaveAttribute('aria-expanded', 'true');
+    expect(srcRow).toHaveAttribute('aria-level', '1');
+    expect(srcRow).not.toHaveAttribute('aria-selected');
+    expect(mainRow).toHaveAttribute('aria-level', '2');
+    expect(mainRow).toHaveAttribute('aria-selected', 'false');
+    expect(mainRow).not.toHaveAttribute('aria-expanded');
+    expect(readmeRow).toHaveAttribute('aria-level', '1');
+    expect(readmeRow).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('roving tabindex: tab stop は丁度 1 行で active 行が優先される', () => {
+    renderPanel('README.md');
+    const items = screen.getAllByRole('treeitem');
+    const stops = items.filter((el) => el.tabIndex === 0);
+    expect(stops).toHaveLength(1);
+    expect(stops[0]).toHaveTextContent('README.md');
+  });
+
+  it('ArrowDown / ArrowUp で前後の行へ focus が移り tab stop も移動する', () => {
+    renderPanel();
+    const [srcRow, mainRow] = screen.getAllByRole('treeitem');
+    srcRow!.focus();
+    fireEvent.keyDown(srcRow!, { key: 'ArrowDown' });
+    expect(mainRow).toHaveFocus();
+    expect(mainRow!.tabIndex).toBe(0);
+    expect(srcRow!.tabIndex).toBe(-1);
+    fireEvent.keyDown(mainRow!, { key: 'ArrowUp' });
+    expect(srcRow).toHaveFocus();
+  });
+
+  it('Home / End で先頭・末尾の行へ focus が移る', () => {
+    renderPanel();
+    const items = screen.getAllByRole('treeitem');
+    items[1]!.focus();
+    fireEvent.keyDown(items[1]!, { key: 'End' });
+    expect(items[items.length - 1]).toHaveFocus();
+    fireEvent.keyDown(items[items.length - 1]!, { key: 'Home' });
+    expect(items[0]).toHaveFocus();
+  });
+
+  it('ArrowRight: 展開済み dir では最初の子へ focus、ArrowLeft: 展開済み dir では折りたたみ', () => {
+    renderPanel();
+    const [srcRow, mainRow] = screen.getAllByRole('treeitem');
+    srcRow!.focus();
+    fireEvent.keyDown(srcRow!, { key: 'ArrowRight' });
+    expect(mainRow).toHaveFocus();
+
+    srcRow!.focus();
+    fireEvent.keyDown(srcRow!, { key: 'ArrowLeft' });
+    expect(toggleDir).toHaveBeenCalledWith(ROOT, 'src');
+  });
+
+  it('ArrowLeft: ファイル行 (子) では親 dir へ focus が移る', () => {
+    renderPanel();
+    const [srcRow, mainRow] = screen.getAllByRole('treeitem');
+    mainRow!.focus();
+    fireEvent.keyDown(mainRow!, { key: 'ArrowLeft' });
+    expect(srcRow).toHaveFocus();
+  });
+});

--- a/src/renderer/src/components/filetree/FileTreeNode.tsx
+++ b/src/renderer/src/components/filetree/FileTreeNode.tsx
@@ -55,6 +55,14 @@ function FileTreeNodeImpl({
     <>
       <button
         type="button"
+        // Issue #908: WAI-ARIA tree パターン。ツリー全体で 1 tab stop にするため
+        // 行は常に tabIndex=-1 で render し、roving tabindex (どの行を 0 にするか) は
+        // FileTreePanel 側が DOM 直接操作で管理する (memo 構造を壊さないため)。
+        role="treeitem"
+        aria-level={depth + 1}
+        aria-expanded={node.isDir ? isOpen : undefined}
+        aria-selected={node.isDir ? undefined : isActive}
+        tabIndex={-1}
         className={`filetree__row${isActive ? ' is-active' : ''}`}
         style={fileTreeGuideStyle(depth)}
         onClick={handleClick}
@@ -66,6 +74,7 @@ function FileTreeNodeImpl({
               size={13}
               strokeWidth={2.25}
               className={`filetree__chevron${isOpen ? ' is-open' : ''}`}
+              aria-hidden
             />
             <folderDef.Icon
               size={14}

--- a/src/renderer/src/components/settings/MascotSection.tsx
+++ b/src/renderer/src/components/settings/MascotSection.tsx
@@ -15,7 +15,14 @@ export function MascotSection({ draft, update }: Props): JSX.Element {
   const customPath = draft.statusMascotCustomPath ?? '';
 
   const pickCustomImage = async (): Promise<void> => {
-    const picked = await window.api.dialog.openFile(t('settings.mascot.pickTitle'));
+    // Issue #820: Rust 側 is_allowed_mascot_path の画像ホワイトリストと同期した filter を
+    // picker に渡し、非画像選択 → silent reject の UX を防ぐ
+    const picked = await window.api.dialog.openFile(t('settings.mascot.pickTitle'), [
+      {
+        name: t('settings.mascot.imageFilterName'),
+        extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'bmp', 'ico', 'svg', 'apng']
+      }
+    ]);
     if (!picked) return;
     update('statusMascotCustomPath', picked);
     if (selected !== 'custom') update('statusMascotVariant', 'custom');

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -164,6 +164,7 @@ const ja: Dict = {
 
   // ---------- File tree / Editor ----------
   'filetree.refresh': '再読込',
+  'filetree.treeLabel': 'ファイルツリー',
   'diff.loading': 'diff を読み込み中…',
   'diff.selectFile': '差分を表示するファイルを選択してください',
   'diff.error': 'エラー: {error}',
@@ -1015,6 +1016,7 @@ const en: Dict = {
 
   // ---------- File tree / Editor ----------
   'filetree.refresh': 'Reload',
+  'filetree.treeLabel': 'File tree',
   'diff.loading': 'Loading diff…',
   'diff.selectFile': 'Select a file to view its diff',
   'diff.error': 'Error: {error}',

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -44,6 +44,7 @@ const ja: Dict = {
   // Issue #729: MascotSection の isJa 三項 / settings-options.ts hardcode を i18n.ts に集約
   'settings.mascot.title': 'キャラクター',
   'settings.mascot.pickTitle': '相棒にする画像を選択',
+  'settings.mascot.imageFilterName': '画像',
   'settings.mascot.choose': '画像を選ぶ…',
   'settings.mascot.clear': 'クリア',
   'settings.mascot.hint':
@@ -894,6 +895,7 @@ const en: Dict = {
   // Issue #729: MascotSection isJa ternaries / settings-options.ts hardcode -> centralised in i18n.ts
   'settings.mascot.title': 'Character',
   'settings.mascot.pickTitle': 'Pick a mascot image',
+  'settings.mascot.imageFilterName': 'Images',
   'settings.mascot.choose': 'Choose image…',
   'settings.mascot.clear': 'Clear',
   'settings.mascot.hint':

--- a/src/renderer/src/lib/tauri-api/dialog.ts
+++ b/src/renderer/src/lib/tauri-api/dialog.ts
@@ -1,11 +1,14 @@
 // tauri-api/dialog.ts — dialog.* IPC namespace (Phase 5 / Issue #373)
 
 import { invoke } from '@tauri-apps/api/core';
+import type { DialogFileFilter } from '../../../../types/shared';
 
 export const dialog = {
   openFolder: (title?: string): Promise<string | null> =>
     invoke('dialog_open_folder', { title }),
-  openFile: (title?: string): Promise<string | null> => invoke('dialog_open_file', { title }),
+  // Issue #820: filters で拡張子を絞り込めるようにする (省略時は従来通り全ファイル)
+  openFile: (title?: string, filters?: DialogFileFilter[]): Promise<string | null> =>
+    invoke('dialog_open_file', { title, filters }),
   isFolderEmpty: (folderPath: string): Promise<boolean> =>
     invoke('dialog_is_folder_empty', { folderPath })
 };

--- a/src/renderer/src/lib/toast-context.tsx
+++ b/src/renderer/src/lib/toast-context.tsx
@@ -35,6 +35,12 @@ export interface ToastOptions {
   action?: ToastAction;
   /** 種別: 情報/成功/警告/エラー（色分け） */
   tone?: 'info' | 'success' | 'warning' | 'error';
+  /**
+   * Issue #852: ユーザー操作 (close ボタン / action クリック) で閉じられたときだけ
+   * 呼ばれる callback。自動消滅 (duration 経過) やコードからの dismissToast() では
+   * 呼ばれない。「ユーザーが toast を認知した」ことを要求する通知 (署名警告等) に使う。
+   */
+  onUserDismiss?: () => void;
 }
 
 export interface Toast {
@@ -216,6 +222,7 @@ function ToastItem({
           className="toast__action"
           onClick={() => {
             toast.options.action?.onClick();
+            toast.options.onUserDismiss?.();
             onDismiss();
           }}
         >
@@ -225,7 +232,10 @@ function ToastItem({
       <button
         type="button"
         className="toast__close"
-        onClick={onDismiss}
+        onClick={() => {
+          toast.options.onUserDismiss?.();
+          onDismiss();
+        }}
         aria-label={t('common.close')}
       >
         <X size={14} strokeWidth={2} />

--- a/src/renderer/src/lib/updater-check.ts
+++ b/src/renderer/src/lib/updater-check.ts
@@ -25,14 +25,12 @@
  *   - network / その他 error は静かに skip。
  */
 import type { Language } from '../../../types/shared';
+import type { ToastOptions } from './toast-context';
 import { translate } from './i18n';
 
 export interface UpdaterDeps {
   language: Language;
-  showToast: (
-    message: string,
-    options?: { duration?: number; tone?: 'info' | 'success' | 'warning' | 'error' }
-  ) => number;
+  showToast: (message: string, options?: ToastOptions) => number;
   dismissToast?: (id: number) => void;
   /** コマンドパレット / ヘルプメニューからの手動チェック。最新時の通知や失敗 toast を出す。 */
   manual?: boolean;
@@ -159,7 +157,16 @@ function isSigningEnabled(): boolean {
  * Issue #609: signature 系 error を 24h に 1 度だけ toast で通知する。
  * cooldown は Rust 側 `~/.vibe-editor/updater-warned.json` に永続化されている。
  * deps が無い (preview / test) ときは toast を出さず終わる。
+ *
+ * Issue #852: cooldown の record は「toast を表示した時点」ではなく「ユーザーが
+ * toast を閉じた (= 明示的に認知した) 時点」で行う。表示しただけで record すると、
+ * ユーザーが画面を離れている間に署名警告が出て消えた場合でも 24h 抑止され、
+ * 改竄の可能性を一度も認知しないまま警告が止まるため。未認知のまま終了した場合は
+ * record されず、次回起動で再警告される。あわせて自動消滅を実質無効化する長い
+ * duration を与え、ユーザー操作でのみ閉じられる持続表示にする。
  */
+const SIGNATURE_WARNING_TOAST_MS = 86_400_000; // 24h ≒ 実質持続表示 (自動消滅させない)
+
 async function maybeWarnSignatureFailure(deps?: SilentCheckDeps): Promise<void> {
   if (!deps) return;
   if (!isSigningEnabled()) {
@@ -185,9 +192,14 @@ async function maybeWarnSignatureFailure(deps?: SilentCheckDeps): Promise<void> 
     }
     deps.showToast(translate(deps.language, 'updater.signatureFailed'), {
       tone: 'warning',
-      duration: 12_000
+      duration: SIGNATURE_WARNING_TOAST_MS,
+      onUserDismiss: () => {
+        // ユーザーが閉じた = 認知したときだけ cooldown を記録する (Issue #852)
+        void recordFn().catch((e) => {
+          console.debug('[updater] signature warning record failed:', e);
+        });
+      }
     });
-    await recordFn();
   } catch (e) {
     console.debug('[updater] signature warning gate failed:', e);
   }
@@ -197,10 +209,7 @@ async function maybeWarnSignatureFailure(deps?: SilentCheckDeps): Promise<void> 
  *  (test / 旧来の hook) では undefined を渡す。 */
 export interface SilentCheckDeps {
   language: Language;
-  showToast: (
-    message: string,
-    options?: { duration?: number; tone?: 'info' | 'success' | 'warning' | 'error' }
-  ) => number;
+  showToast: (message: string, options?: ToastOptions) => number;
 }
 
 /**

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -15,6 +15,15 @@ export type Language = 'ja' | 'en';
 export type StatusMascotVariant = 'vibe' | 'spark' | 'mono' | 'coder' | 'custom';
 
 /**
+ * Issue #820: dialog_open_file に渡す拡張子フィルタ。
+ * extensions はドット無しの拡張子 (例: ['png', 'jpg'])。
+ */
+export interface DialogFileFilter {
+  name: string;
+  extensions: string[];
+}
+
+/**
  * Issue #75: AppSettings の現在スキーマ。
  * Issue #449 で claudeArgs / codexArgs / customAgents[].args の Unicode dash (U+2013 等)
  * を ASCII '-' に正規化する migration を追加し v10。


### PR DESCRIPTION
## Summary
- Closes #820: `dialog_open_file` に拡張子フィルタ (`DialogFileFilter[]`) を追加。マスコット画像 picker は Rust 側 `is_allowed_mascot_path` の画像ホワイトリストと同期した filter を渡し、非画像選択 → silent reject の UX を解消 (IPC 5 点同期: shared.ts / dialog.rs / tauri-api/dialog.ts / MascotSection / i18n)
- Closes #852: updater 署名警告の 24h cooldown を「toast 表示時」ではなく「ユーザーが toast を閉じた (= 明示的に認知した) 時」に記録するよう変更。`ToastOptions.onUserDismiss` (ユーザー操作 dismiss のみ発火) を新設し、署名警告 toast は自動消滅しない持続表示に変更。未認知なら次回起動で再警告される
- Closes #908: filetree に WAI-ARIA tree パターンを実装。`role=tree`/`treeitem`、`aria-level`、ディレクトリ行に `aria-expanded`、ファイル行に `aria-selected`、roving tabindex でツリー全体を 1 tab stop 化、ArrowUp/Down/Left/Right + Home/End のキーボード操作に対応。focus 管理は DOM 直接操作で行い Issue #129 の memo 最適化を維持

## Test plan
- [x] `npx vitest run` 全 75 ファイル / 457 テストパス (新規 FileTreePanel-aria.test.tsx 7 件含む)
- [x] `cargo check` パス (dialog.rs)
- [x] `npm run typecheck` パス + `tsc -p tsconfig.web.json` で変更ファイルに型エラーなしを確認
- [x] rename / 新規作成 inline input 内の矢印キーがツリー navigation に奪われないことをテストで固定