### PR TITLE
refactor: open issues #935, #930 の 2 件をバンドル修正

### DIFF
--- a/src-tauri/src/commands/team_inject.rs
+++ b/src-tauri/src/commands/team_inject.rs
@@ -139,17 +139,18 @@ pub async fn team_send_retry_inject(
             }
             // Canvas 側 UI が「retry で配達成功」を視覚化するため team:handoff を emit する。
             // from_role は元 sender の role を保つ (UI が「誰からの message か」を再描画できるように)。
-            let payload = json!({
-                "teamId": args.team_id,
-                "fromAgentId": from_agent_id,
-                "fromRole": from_role,
-                "toAgentId": args.agent_id,
-                "toRole": "",
-                "preview": preview,
-                "messageId": args.message_id,
-                "timestamp": delivered_at,
-                "retried": true,
-            });
+            // Issue #930: payload は events.rs の名前付き struct (retried=true で再送を区別)。
+            let payload = crate::team_hub::events::HandoffEventPayload {
+                team_id: args.team_id.clone(),
+                from_agent_id: from_agent_id.clone(),
+                from_role: from_role.clone(),
+                to_agent_id: args.agent_id.clone(),
+                to_role: String::new(),
+                preview: preview.clone(),
+                message_id: args.message_id,
+                timestamp: delivered_at.clone(),
+                retried: true,
+            };
             if let Err(e) = app.emit("team:handoff", payload) {
                 tracing::warn!("[retry_inject] emit team:handoff failed: {e}");
             }

--- a/src-tauri/src/commands/team_state.rs
+++ b/src-tauri/src/commands/team_state.rs
@@ -312,11 +312,10 @@ async fn ensure_private_dir(dir: &Path) -> crate::commands::error::CommandResult
     Ok(())
 }
 
+/// Issue #935: open 判定は task_status の SSOT に委譲する (許容値リストの分裂防止)。
+/// 不明値は従来どおり open 扱い (タスクを見失わない方向に倒す)。
 fn is_open_task(status: &str) -> bool {
-    !matches!(
-        status.trim().to_ascii_lowercase().as_str(),
-        "done" | "completed" | "complete" | "cancelled" | "canceled"
-    )
+    crate::team_hub::task_status::is_open_status_str(status)
 }
 
 fn normalize(mut state: TeamOrchestrationState) -> TeamOrchestrationState {

--- a/src-tauri/src/team_hub/events.rs
+++ b/src-tauri/src/team_hub/events.rs
@@ -1,0 +1,67 @@
+//! Issue #930: Tauri イベント payload の名前付き struct 集約。
+//!
+//! 従来は emit 側ごとに `serde_json::json!` リテラルで即席組み立てされ、TS 側の受信
+//! interface と二重手書きになっていたため、同一イベントでも emit 箇所間で形状が分岐し
+//! (recruit-request の waitPolicy 有無)、TS 側のファントムフィールド
+//! (customInstructions) やフィールド欠落 (handoff の retried) を型検査で検出できなかった。
+//!
+//! 本 module の struct を emit に使い、`src/types/shared.ts` の同名 interface と
+//! `#[serde(rename_all = "camelCase")]` で同期する。新しいイベントを足すときも
+//! `json!` リテラルではなくここに struct を定義すること。
+
+use serde::Serialize;
+
+/// `team:recruit-request` の payload。shared.ts の `RecruitRequestPayload` と同期。
+///
+/// emit 箇所:
+/// - `protocol/tools/recruit.rs` (worker 採用 — waitPolicy / dynamicRole あり)
+/// - `protocol/tools/create_leader.rs` (leader 生成 — waitPolicy なし / dynamicRole は None)
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecruitRequestPayload {
+    pub team_id: String,
+    pub requester_agent_id: String,
+    pub requester_role: String,
+    pub new_agent_id: String,
+    pub role_profile_id: String,
+    pub engine: String,
+    pub agent_label_hint: String,
+    /// create_leader 経路では None (leader に wait_policy 概念が無い)。
+    /// 従来どおり「キー自体を載せない」形を保つため skip する。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wait_policy: Option<String>,
+    /// `team_recruit(role_definition=...)` の 1 ステップ採用時のみ Some。
+    /// renderer は RoleProfilesContext のメモリキャッシュに追加する。
+    pub dynamic_role: Option<RecruitRequestDynamicRole>,
+}
+
+/// recruit-request に同梱される動的ロール定義。shared.ts の `RecruitRequestDynamicRole` と同期。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecruitRequestDynamicRole {
+    pub id: String,
+    pub label: String,
+    pub description: String,
+    pub instructions: String,
+    pub instructions_ja: Option<String>,
+}
+
+/// `team:handoff` の payload。shared.ts の `HandoffPayload` と同期。
+///
+/// emit 箇所:
+/// - `protocol/tools/send.rs` (初回配送 — retried=false)
+/// - `commands/team_inject.rs` (`app_team_retry_inject` の再送成功 — retried=true)
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffEventPayload {
+    pub team_id: String,
+    pub from_agent_id: String,
+    pub from_role: String,
+    pub to_agent_id: String,
+    pub to_role: String,
+    pub preview: String,
+    pub message_id: u32,
+    pub timestamp: String,
+    /// retry 経由の配送なら true。UI が「再送で届いた」ことを区別して描画できる。
+    pub retried: bool,
+}

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -20,6 +20,8 @@ pub mod role_lint;
 // inject 本文を「summary + attached: <path>」に置換する spool 機構。
 pub mod spool;
 pub mod state;
+// Issue #935: タスク status ドメイン値の SSOT (許容値 / alias 正規化 / open・done 判定)。
+pub mod task_status;
 
 /// Issue #494: TeamHub 周辺の integration test を集約する test-only module。
 /// `protocol::permissions` の matrix 検証等を `tests/permissions.rs` に置く。

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -10,6 +10,8 @@
 
 pub mod bridge;
 pub mod error;
+// Issue #930: Tauri イベント payload の名前付き struct 集約 (shared.ts と同期)。
+pub mod events;
 // Issue #526: vibe-team の advisory file locks (worker のファイル編集衝突を warn する)。
 pub mod file_locks;
 pub mod inject;

--- a/src-tauri/src/team_hub/protocol/schema.rs
+++ b/src-tauri/src/team_hub/protocol/schema.rs
@@ -222,7 +222,11 @@ pub(super) fn tool_defs() -> Value {
                         "maximum": 4294967295u32,
                         "description": "Numeric task id from team_assign_task (must fit in a u32; missing or out-of-range values are rejected with update_task_invalid_args)."
                     },
-                    "status": { "type": "string" },
+                    "status": {
+                        "type": "string",
+                        "enum": ["pending", "in_progress", "done", "blocked", "needs_input", "failed", "cancelled"],
+                        "description": "Canonical task status (Issue #935). Legacy aliases completed/complete/canceled are still accepted and normalized server-side."
+                    },
                     "summary": { "type": "string" },
                     "blocked_reason": { "type": "string" },
                     "next_action": { "type": "string" },
@@ -232,7 +236,7 @@ pub(super) fn tool_defs() -> Value {
                     "report_kind": { "type": "string" },
                     "done_evidence": {
                         "type": "array",
-                        "description": "Required when status is done/completed/complete for tasks with done_criteria.",
+                        "description": "Required when status is done for tasks with done_criteria.",
                         "items": {
                             "type": "object",
                             "properties": {

--- a/src-tauri/src/team_hub/protocol/tools/assign_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/assign_task.rs
@@ -394,7 +394,8 @@ pub async fn team_assign_task(
             id: task_id,
             assigned_to: assignee.to_string(),
             description: description.to_string(),
-            status: "pending".into(),
+            // Issue #935: 初期 status も SSOT の canonical 値を使う
+            status: crate::team_hub::task_status::TaskStatus::Pending.as_str().into(),
             created_by: ctx.role.clone(),
             created_at: assigned_at.clone(),
             updated_at: None,

--- a/src-tauri/src/team_hub/protocol/tools/create_leader.rs
+++ b/src-tauri/src/team_hub/protocol/tools/create_leader.rs
@@ -140,16 +140,19 @@ pub async fn team_create_leader(
 
     let app = hub.app_handle.lock().await.clone();
     if let Some(app) = &app {
-        let payload = json!({
-            "teamId": ctx.team_id,
-            "requesterAgentId": ctx.agent_id,
-            "requesterRole": ctx.role,
-            "newAgentId": new_agent_id,
-            "roleProfileId": role_profile_id,
-            "engine": resolved_engine,
-            "agentLabelHint": agent_label_hint,
-            "dynamicRole": Value::Null,
-        });
+        // Issue #930: recruit.rs と同じ named struct で emit し、emit 箇所間の形状分岐を防ぐ。
+        // leader は wait_policy 概念を持たないので None (キー自体を載せない、従来互換)。
+        let payload = crate::team_hub::events::RecruitRequestPayload {
+            team_id: ctx.team_id.clone(),
+            requester_agent_id: ctx.agent_id.clone(),
+            requester_role: ctx.role.clone(),
+            new_agent_id: new_agent_id.clone(),
+            role_profile_id: role_profile_id.clone(),
+            engine: resolved_engine.clone(),
+            agent_label_hint: agent_label_hint.clone(),
+            wait_policy: None,
+            dynamic_role: None,
+        };
         if let Err(e) = app.emit("team:recruit-request", payload) {
             hub.cancel_pending_recruit(&new_agent_id).await;
             return Err(RecruitError::new(

--- a/src-tauri/src/team_hub/protocol/tools/recruit.rs
+++ b/src-tauri/src/team_hub/protocol/tools/recruit.rs
@@ -506,30 +506,30 @@ pub async fn team_recruit(
     // RoleProfilesContext のメモリキャッシュへ追加し、worker template に instructions を流し込む。
     // (team:role-created を別 emit でも届けているが、recruit-request と同梱しておくと到達順に依存しない)
     let dynamic_role_payload = match (&dynamic_role, &dynamic_match) {
-        (Some(d), _) | (_, Some(d)) => Some(json!({
-            "id": d.id,
-            "label": d.label,
-            "description": d.description,
-            "instructions": d.instructions,
-            "instructionsJa": d.instructions_ja,
-        })),
+        (Some(d), _) | (_, Some(d)) => Some(crate::team_hub::events::RecruitRequestDynamicRole {
+            id: d.id.clone(),
+            label: d.label.clone(),
+            description: d.description.clone(),
+            instructions: d.instructions.clone(),
+            instructions_ja: d.instructions_ja.clone(),
+        }),
         _ => None,
     };
 
-    // Renderer にカード生成を依頼
+    // Renderer にカード生成を依頼 (Issue #930: payload は events.rs の名前付き struct)
     let app = hub.app_handle.lock().await.clone();
     if let Some(app) = &app {
-        let payload = json!({
-            "teamId": ctx.team_id,
-            "requesterAgentId": ctx.agent_id,
-            "requesterRole": ctx.role,
-            "newAgentId": new_agent_id,
-            "roleProfileId": role_profile_id,
-            "engine": resolved_engine,
-            "agentLabelHint": agent_label_hint,
-            "waitPolicy": wait_policy.clone(),
-            "dynamicRole": dynamic_role_payload,
-        });
+        let payload = crate::team_hub::events::RecruitRequestPayload {
+            team_id: ctx.team_id.clone(),
+            requester_agent_id: ctx.agent_id.clone(),
+            requester_role: ctx.role.clone(),
+            new_agent_id: new_agent_id.clone(),
+            role_profile_id: role_profile_id.clone(),
+            engine: resolved_engine.clone(),
+            agent_label_hint: agent_label_hint.clone(),
+            wait_policy: Some(wait_policy.clone()),
+            dynamic_role: dynamic_role_payload,
+        };
         if let Err(e) = app.emit("team:recruit-request", payload) {
             hub.cancel_pending_recruit(&new_agent_id).await;
             return Err(RecruitError::new(

--- a/src-tauri/src/team_hub/protocol/tools/report.rs
+++ b/src-tauri/src/team_hub/protocol/tools/report.rs
@@ -10,6 +10,7 @@
 //! (報告自体は state に保存済みなので、`team_get_tasks` 経由で読み取れる)。
 
 use crate::commands::team_state::{TeamReportFinding, TeamReportSnapshot};
+use crate::team_hub::task_status::TaskStatus;
 use crate::team_hub::{inject, CallContext, TeamHub};
 
 use super::super::consts::MAX_TEAM_REPORTS;
@@ -17,6 +18,8 @@ use super::error::ToolError;
 use chrono::Utc;
 use serde_json::{json, Value};
 
+/// team_report が受け付ける status の部分集合 (task status SSOT = `TaskStatus` の subset)。
+/// 報告は「作業の区切り」を表すため pending / in_progress / cancelled は対象外。
 const ALLOWED_STATUSES: &[&str] = &["done", "blocked", "needs_input", "failed"];
 const ALLOWED_SEVERITIES: &[&str] = &["high", "medium", "low"];
 /// 1 レポートあたりの findings 上限 (Hub 側 OOM 防止)。
@@ -127,13 +130,16 @@ fn parse_status(args: &Value) -> Result<String, ToolError> {
         .and_then(|v| v.as_str())
         .map(str::trim)
         .ok_or_else(|| invalid_args(format!("status is required ({ALLOWED_STATUSES:?})")))?;
-    let lower = raw.to_ascii_lowercase();
-    if !ALLOWED_STATUSES.contains(&lower.as_str()) {
-        return Err(invalid_args(format!(
-            "status must be one of {ALLOWED_STATUSES:?} (got {raw:?})"
-        )));
-    }
-    Ok(lower)
+    // Issue #935: alias 正規化 ("completed" → "done" 等) は TaskStatus::parse に集約し、
+    // report ドメインの許容 subset チェックだけここで行う。
+    let status = TaskStatus::parse(raw)
+        .filter(|s| ALLOWED_STATUSES.contains(&s.as_str()))
+        .ok_or_else(|| {
+            invalid_args(format!(
+                "status must be one of {ALLOWED_STATUSES:?} (got {raw:?})"
+            ))
+        })?;
+    Ok(status.as_str().to_string())
 }
 
 fn parse_task_id(args: &Value) -> Result<(String, Option<u32>), ToolError> {

--- a/src-tauri/src/team_hub/protocol/tools/send.rs
+++ b/src-tauri/src/team_hub/protocol/tools/send.rs
@@ -720,17 +720,19 @@ async fn dispatch_injects(
                         .record_delivery(hub, &ctx.team_id, &target_aid, &delivered_at)
                         .await;
                     // Phase 3: hand-off イベントを Canvas にブロードキャスト
+                    // (Issue #930: payload は events.rs の名前付き struct。初回配送なので retried=false)
                     if let Some(app) = app {
-                        let payload = json!({
-                            "teamId": ctx.team_id,
-                            "fromAgentId": ctx.agent_id,
-                            "fromRole": ctx.role,
-                            "toAgentId": target_aid,
-                            "toRole": target_role,
-                            "preview": preview,
-                            "messageId": guard.msg_id,
-                            "timestamp": guard.timestamp,
-                        });
+                        let payload = crate::team_hub::events::HandoffEventPayload {
+                            team_id: ctx.team_id.clone(),
+                            from_agent_id: ctx.agent_id.clone(),
+                            from_role: ctx.role.clone(),
+                            to_agent_id: target_aid.clone(),
+                            to_role: target_role.clone(),
+                            preview: preview.clone(),
+                            message_id: guard.msg_id,
+                            timestamp: guard.timestamp.clone(),
+                            retried: false,
+                        };
                         if let Err(e) = app.emit("team:handoff", payload) {
                             tracing::warn!("emit team:handoff failed: {e}");
                         }

--- a/src-tauri/src/team_hub/protocol/tools/update_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/update_task.rs
@@ -3,6 +3,7 @@
 //! Issue #373 Phase 2 で `protocol.rs` から切り出し。
 
 use crate::commands::team_state::TaskDoneEvidenceSnapshot;
+use crate::team_hub::task_status::TaskStatus;
 use crate::team_hub::{CallContext, TeamHub};
 use chrono::Utc;
 use serde_json::{json, Value};
@@ -30,13 +31,6 @@ fn normalize_criterion(s: &str) -> String {
         .collect::<Vec<_>>()
         .join(" ")
         .to_ascii_lowercase()
-}
-
-fn is_done_status(status: &str) -> bool {
-    matches!(
-        status.trim().to_ascii_lowercase().as_str(),
-        "done" | "completed" | "complete"
-    )
 }
 
 fn done_evidence_invalid(message: impl Into<String>) -> ToolError {
@@ -203,7 +197,19 @@ pub async fn team_update_task(
     args: &Value,
 ) -> Result<Value, ToolError> {
     let task_id = parse_task_id(args)?;
-    let status = args.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    // Issue #935: status は受信境界で TaskStatus に parse する。旧実装は無検証で
+    // 任意文字列 (欠落時は空文字) を保存しており、消費側ごとの許容値リストと
+    // 食い違ってタスクが状態不明のまま open 滞留する事故を生んでいた。
+    let status_raw = args.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    let status = TaskStatus::parse(status_raw).ok_or_else(|| {
+        ToolError::new(
+            "update_task_invalid_status",
+            format!(
+                "status must be one of {:?} (got {status_raw:?})",
+                TaskStatus::allowed_values()
+            ),
+        )
+    })?;
     let done_evidence = parse_done_evidence(args)?;
     let summary = optional_string(args, "summary", "summary");
     let blocked_reason = optional_string(args, "blocked_reason", "blockedReason");
@@ -257,7 +263,7 @@ pub async fn team_update_task(
                 agent_id = %ctx.agent_id,
                 role = %ctx.role,
                 task_id = task_id,
-                attempted_status = %status,
+                attempted_status = %status_raw,
                 task_assigned_to = %task.assigned_to,
                 "[team_update_task] permission denied: caller is not assignee nor leader"
             );
@@ -267,7 +273,7 @@ pub async fn team_update_task(
                 "update task assigned to another agent",
             ));
         }
-        if is_done_status(status) && !task.done_criteria.is_empty() {
+        if status.is_done() && !task.done_criteria.is_empty() {
             let missing = task
                 .done_criteria
                 .iter()
@@ -284,7 +290,8 @@ pub async fn team_update_task(
                 return Err(done_evidence_missing(missing));
             }
         }
-        task.status = status.to_string();
+        // alias ("completed" 等) は parse で正規化済みなので canonical 値が保存される
+        task.status = status.as_str().to_string();
         task.updated_at = Some(now_iso.clone());
         if !done_evidence.is_empty() {
             task.done_evidence = done_evidence.clone();
@@ -322,17 +329,13 @@ pub async fn team_update_task(
                 let _ = team.next_actions.pop_front();
             }
         }
-        let status_lower = status.to_ascii_lowercase();
-        if matches!(
-            status_lower.as_str(),
-            "done" | "completed" | "complete" | "blocked"
-        ) {
+        if status.is_done() || status == TaskStatus::Blocked {
             let kind = optional_string(args, "report_kind", "reportKind")
-                .unwrap_or_else(|| status_lower.clone());
+                .unwrap_or_else(|| status.as_str().to_string());
             let report_summary = summary
                 .clone()
                 .or_else(|| task_summary.clone())
-                .unwrap_or_else(|| format!("Task #{task_id} marked {status}"));
+                .unwrap_or_else(|| format!("Task #{task_id} marked {}", status.as_str()));
             team.worker_reports
                 .push_back(crate::commands::team_state::WorkerReportSnapshot {
                     id: format!("task-{task_id}-{}", now_iso.replace([':', '.'], "-")),
@@ -370,6 +373,111 @@ mod tests {
     use crate::pty::SessionRegistry;
     use crate::team_hub::{TeamHub, TeamInfo, TeamTask};
     use std::sync::Arc;
+
+    /// Issue #935: 旧実装は status 無検証 (欠落時は空文字保存) で、タスクが状態不明の
+    /// まま open 滞留していた。受信境界で不正値・欠落を構造化エラーで拒否することを固定する。
+    #[tokio::test]
+    async fn update_task_rejects_invalid_or_missing_status() {
+        let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+        let team_id = "team-status-validation".to_string();
+        {
+            let mut state = hub.state.lock().await;
+            let team = state
+                .teams
+                .entry(team_id.clone())
+                .or_insert_with(TeamInfo::default);
+            team.tasks.push_back(TeamTask {
+                id: 1,
+                assigned_to: "worker".into(),
+                description: "validate status".into(),
+                status: "pending".into(),
+                created_by: "leader".into(),
+                created_at: "2026-06-10T10:00:00Z".into(),
+                updated_at: None,
+                summary: None,
+                blocked_reason: None,
+                next_action: None,
+                artifact_path: None,
+                blocked_by_human_gate: false,
+                required_human_decision: None,
+                target_paths: Vec::new(),
+                lock_conflicts: Vec::new(),
+                pre_approval: None,
+                done_criteria: Vec::new(),
+                done_evidence: Vec::new(),
+            });
+        }
+        let ctx = CallContext {
+            team_id: team_id.clone(),
+            role: "worker".into(),
+            agent_id: "worker-1".into(),
+        };
+
+        for args in [
+            json!({ "task_id": 1 }),                          // status 欠落
+            json!({ "task_id": 1, "status": "" }),            // 空文字
+            json!({ "task_id": 1, "status": "wip" }),         // 未知値
+        ] {
+            let err = team_update_task(&hub, &ctx, &args)
+                .await
+                .expect_err("invalid status must be rejected");
+            assert_eq!(err.code, "update_task_invalid_status", "args={args}");
+        }
+
+        // 不正リクエストで task が汚れていない (pending のまま)
+        let state = hub.state.lock().await;
+        let team = state.teams.get(&team_id).unwrap();
+        assert_eq!(team.tasks[0].status, "pending");
+    }
+
+    /// Issue #935: legacy alias は受理しつつ canonical 値へ正規化して保存する。
+    #[tokio::test]
+    async fn update_task_normalizes_legacy_status_aliases() {
+        let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+        let team_id = "team-status-alias".to_string();
+        {
+            let mut state = hub.state.lock().await;
+            let team = state
+                .teams
+                .entry(team_id.clone())
+                .or_insert_with(TeamInfo::default);
+            team.tasks.push_back(TeamTask {
+                id: 1,
+                assigned_to: "worker".into(),
+                description: "alias normalization".into(),
+                status: "in_progress".into(),
+                created_by: "leader".into(),
+                created_at: "2026-06-10T10:00:00Z".into(),
+                updated_at: None,
+                summary: None,
+                blocked_reason: None,
+                next_action: None,
+                artifact_path: None,
+                blocked_by_human_gate: false,
+                required_human_decision: None,
+                target_paths: Vec::new(),
+                lock_conflicts: Vec::new(),
+                pre_approval: None,
+                done_criteria: Vec::new(),
+                done_evidence: Vec::new(),
+            });
+        }
+        let ctx = CallContext {
+            team_id: team_id.clone(),
+            role: "worker".into(),
+            agent_id: "worker-1".into(),
+        };
+
+        team_update_task(&hub, &ctx, &json!({ "task_id": 1, "status": "Completed" }))
+            .await
+            .expect("legacy alias must be accepted");
+
+        let state = hub.state.lock().await;
+        let team = state.teams.get(&team_id).unwrap();
+        assert_eq!(team.tasks[0].status, "done", "alias must be normalized");
+        // done 扱いなので worker_reports にも report が積まれる (kind は canonical)
+        assert_eq!(team.worker_reports.back().unwrap().kind, "done");
+    }
 
     #[tokio::test]
     async fn update_task_marks_caller_as_seen_activity() {

--- a/src-tauri/src/team_hub/state/hub_state.rs
+++ b/src-tauri/src/team_hub/state/hub_state.rs
@@ -328,6 +328,10 @@ pub struct TeamTask {
     pub id: u32,
     pub assigned_to: String,
     pub description: String,
+    /// Issue #935: 通常は `task_status::TaskStatus::as_str()` の canonical 値。
+    /// 永続化済み legacy データには alias / 任意文字列が残りうるため String のまま、
+    /// 書き込みは受信境界 (update_task / assign_task) で必ず正規化する。
+    /// 判定 (open / done) は `task_status` module 経由のみとし、`matches!` を散らさない。
     pub status: String,
     pub created_by: String,
     pub created_at: String,

--- a/src-tauri/src/team_hub/task_status.rs
+++ b/src-tauri/src/team_hub/task_status.rs
@@ -1,0 +1,140 @@
+//! Issue #935: タスク status のドメイン値 SSOT。
+//!
+//! 従来は許容値リスト・alias 正規化・open/done 判定が消費側ごとにコピーされて
+//! 食い違っていた (update_task 3 語 / team_state 5 語 / report 4 語 / shared.ts の
+//! `| string` union)。本 module を唯一の定義源とし、受信境界では `TaskStatus::parse`
+//! で正規化、判定は `is_done` / `is_open` メソッド経由のみとする。
+//!
+//! wire / 永続化フォーマットは従来どおり文字列のまま (canonical な snake_case を
+//! `as_str()` で書く)。永続化済みの legacy alias ("completed" / "complete" /
+//! "canceled") は parse 側で吸収する。
+
+/// タスクの状態。shared.ts の `TeamTaskStatus` union と同期。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskStatus {
+    Pending,
+    InProgress,
+    Done,
+    Blocked,
+    NeedsInput,
+    Failed,
+    Cancelled,
+}
+
+impl TaskStatus {
+    /// canonical 文字列。永続化・IPC への書き込みには必ずこれを使う。
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::InProgress => "in_progress",
+            Self::Done => "done",
+            Self::Blocked => "blocked",
+            Self::NeedsInput => "needs_input",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    /// 受信境界・永続化読込用 parse。大文字小文字を無視し、legacy alias
+    /// ("completed"/"complete" → Done, "canceled" → Cancelled) をここ 1 箇所で正規化する。
+    /// 不明値は None (受信境界では構造化エラーに、永続化読込では従来互換の挙動に倒す)。
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "pending" => Some(Self::Pending),
+            "in_progress" => Some(Self::InProgress),
+            "done" | "completed" | "complete" => Some(Self::Done),
+            "blocked" => Some(Self::Blocked),
+            "needs_input" => Some(Self::NeedsInput),
+            "failed" => Some(Self::Failed),
+            "cancelled" | "canceled" => Some(Self::Cancelled),
+            _ => None,
+        }
+    }
+
+    /// done_evidence 検証などの「完了扱い」判定。
+    pub fn is_done(self) -> bool {
+        matches!(self, Self::Done)
+    }
+
+    /// open = まだ作業対象 (pending_tasks に出すべき)。Done / Cancelled 以外はすべて open
+    /// (Blocked / NeedsInput / Failed は人間や Leader の介入待ちであり「閉じた」わけではない)。
+    pub fn is_open(self) -> bool {
+        !matches!(self, Self::Done | Self::Cancelled)
+    }
+
+    /// エラーメッセージ・JSON schema 用の canonical 許容値一覧。
+    pub const fn allowed_values() -> &'static [&'static str] {
+        &[
+            "pending",
+            "in_progress",
+            "done",
+            "blocked",
+            "needs_input",
+            "failed",
+            "cancelled",
+        ]
+    }
+}
+
+/// 永続化済みの生 status 文字列に対する open 判定。
+/// 不明値 (古いデータ / 手書き編集) は従来挙動どおり open 扱いに倒す
+/// (勝手に closed 扱いにしてタスクを見失うより安全)。
+pub fn is_open_status_str(raw: &str) -> bool {
+    TaskStatus::parse(raw).map(TaskStatus::is_open).unwrap_or(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_values() {
+        for &s in TaskStatus::allowed_values() {
+            let parsed = TaskStatus::parse(s).expect("canonical value must parse");
+            assert_eq!(parsed.as_str(), s, "as_str must roundtrip canonical value");
+        }
+    }
+
+    #[test]
+    fn normalizes_legacy_aliases() {
+        assert_eq!(TaskStatus::parse("completed"), Some(TaskStatus::Done));
+        assert_eq!(TaskStatus::parse("complete"), Some(TaskStatus::Done));
+        assert_eq!(TaskStatus::parse("canceled"), Some(TaskStatus::Cancelled));
+        assert_eq!(TaskStatus::parse(" DONE "), Some(TaskStatus::Done));
+        assert_eq!(TaskStatus::parse("In_Progress"), Some(TaskStatus::InProgress));
+    }
+
+    #[test]
+    fn rejects_unknown_values() {
+        assert_eq!(TaskStatus::parse(""), None);
+        assert_eq!(TaskStatus::parse("wip"), None);
+        assert_eq!(TaskStatus::parse("done!"), None);
+    }
+
+    #[test]
+    fn done_and_open_judgments() {
+        assert!(TaskStatus::Done.is_done());
+        assert!(!TaskStatus::Blocked.is_done());
+        assert!(!TaskStatus::Done.is_open());
+        assert!(!TaskStatus::Cancelled.is_open());
+        for st in [
+            TaskStatus::Pending,
+            TaskStatus::InProgress,
+            TaskStatus::Blocked,
+            TaskStatus::NeedsInput,
+            TaskStatus::Failed,
+        ] {
+            assert!(st.is_open(), "{st:?} must stay open");
+        }
+    }
+
+    #[test]
+    fn raw_string_open_judgment_keeps_legacy_fallback() {
+        assert!(!is_open_status_str("completed"));
+        assert!(!is_open_status_str("Canceled"));
+        assert!(is_open_status_str("blocked"));
+        // 不明値は open 扱い (タスクを見失わない)
+        assert!(is_open_status_str("mystery-status"));
+        assert!(is_open_status_str(""));
+    }
+}

--- a/src/renderer/src/lib/use-recruit-listener.ts
+++ b/src/renderer/src/lib/use-recruit-listener.ts
@@ -29,7 +29,11 @@ import type { CardData } from '../stores/canvas';
 import { useRoleProfiles } from './role-profiles-context';
 import { ackRecruit } from './recruit-ack';
 import { findRecruitPosition } from './canvas-recruit-position';
-import type { RecruitRescuedPayload, WaitPolicy } from '../../../types/shared';
+import type {
+  RecruitRequestPayload,
+  RecruitRescuedPayload,
+  WaitPolicy
+} from '../../../types/shared';
 import { useToast } from './toast-context';
 import { useT } from './i18n';
 import {
@@ -55,26 +59,10 @@ function resolveHiddenThresholdMs(): number {
   return DEFAULT_HIDDEN_THRESHOLD_MS;
 }
 
-interface RecruitRequestPayload {
-  teamId: string;
-  requesterAgentId: string;
-  requesterRole: string;
-  newAgentId: string;
-  roleProfileId: string;
-  engine: 'claude' | 'codex';
-  agentLabelHint?: string;
-  customInstructions?: string;
-  waitPolicy?: WaitPolicy;
-  /** Leader が team_recruit(role_definition=...) で 1 ステップ採用した場合に同梱される */
-  dynamicRole?: {
-    id: string;
-    label: string;
-    description: string;
-    instructions: string;
-    instructionsJa?: string;
-  } | null;
-}
-
+// Issue #930: RecruitRequestPayload は shared.ts に移動し、Rust 側
+// team_hub/events.rs の同名 struct と同期する。旧ローカル定義にあった
+// customInstructions は Rust 側のどの emit にも存在しないファントムフィールド
+// (常に undefined) だったため削除した。
 interface DismissRequestPayload {
   teamId: string;
   agentId: string;
@@ -113,12 +101,6 @@ function waitPolicyInstructions(policy: WaitPolicy | undefined): string {
   ].join('\n');
 }
 
-function mergeCustomInstructions(
-  raw: string | undefined,
-  waitPolicy: WaitPolicy | undefined
-): string {
-  return [raw?.trim(), waitPolicyInstructions(waitPolicy)].filter(Boolean).join('\n\n');
-}
 
 export function useRecruitListener(): void {
   // 動的ロールを RoleProfilesContext に投入するためのフック関数
@@ -268,7 +250,10 @@ export function useRecruitListener(): void {
             organization: requesterOrganization,
             // Issue #117: AgentNodeCard が拾って Claude(--append-system-prompt) /
             // Codex(model_instructions_file) 両方の経路に注入する正本フィールド。
-            customInstructions: mergeCustomInstructions(p.customInstructions, p.waitPolicy),
+            // Issue #930: 旧 p.customInstructions は Rust 側に存在しないファントム
+            // フィールドで常に undefined だったため、waitPolicy 由来の指示のみを使う
+            // (実行時挙動は従来と同一)。
+            customInstructions: waitPolicyInstructions(p.waitPolicy),
             waitPolicy: p.waitPolicy ?? 'strict'
           }
         });

--- a/src/renderer/src/lib/use-team-handoff.ts
+++ b/src/renderer/src/lib/use-team-handoff.ts
@@ -1,23 +1,19 @@
 import { useEffect, useRef } from 'react';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import type { HandoffPayload } from '../../../types/shared';
 
 /**
  * Issue #158: Rust TeamHub の `team:handoff` イベントは Canvas と ActivityFeed の
  * 両方が listen しており、同じイベントに対して 2 つの Tauri リスナーが並ぶ構造になっていた。
  * 将来カウントロジック等で重複事故を起こさないよう、Tauri 側の listen を 1 本にまとめ、
  * 各購読者は in-memory の Set 経由で broadcast を受け取る方式に変更する。
+ *
+ * Issue #930: HandoffPayload は shared.ts に移動し、Rust 側 team_hub/events.rs の
+ * `HandoffEventPayload` struct と同期する (retried フィールドの欠落を解消)。
+ * 既存 importer 互換のため re-export する。
  */
 
-export interface HandoffPayload {
-  teamId: string;
-  fromAgentId: string;
-  fromRole: string;
-  toAgentId: string;
-  toRole: string;
-  preview: string;
-  messageId: number;
-  timestamp?: string;
-}
+export type { HandoffPayload } from '../../../types/shared';
 
 type Listener = (p: HandoffPayload) => void;
 const listeners = new Set<Listener>();

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1528,6 +1528,55 @@ export interface RecruitAckArgs {
   phase?: RecruitAckPhase | null;
 }
 
+/**
+ * Issue #930: `team:recruit-request` に同梱される動的ロール定義。
+ * Rust 側 `team_hub/events.rs` の `RecruitRequestDynamicRole` (camelCase) と同期。
+ */
+export interface RecruitRequestDynamicRole {
+  id: string;
+  label: string;
+  description: string;
+  instructions: string;
+  instructionsJa?: string | null;
+}
+
+/**
+ * Issue #930: `team:recruit-request` イベントの payload。
+ * Rust 側 `team_hub/events.rs` の `RecruitRequestPayload` (camelCase) と同期。
+ * emit 箇所は recruit.rs (worker 採用) と create_leader.rs (leader 生成) の 2 つで、
+ * leader 経路では waitPolicy キーが載らない。
+ */
+export interface RecruitRequestPayload {
+  teamId: string;
+  requesterAgentId: string;
+  requesterRole: string;
+  newAgentId: string;
+  roleProfileId: string;
+  engine: 'claude' | 'codex';
+  agentLabelHint?: string;
+  waitPolicy?: WaitPolicy;
+  /** Leader が team_recruit(role_definition=...) で 1 ステップ採用した場合に同梱される */
+  dynamicRole?: RecruitRequestDynamicRole | null;
+}
+
+/**
+ * Issue #930: `team:handoff` イベントの payload。
+ * Rust 側 `team_hub/events.rs` の `HandoffEventPayload` (camelCase) と同期。
+ * emit 箇所は send.rs (初回配送, retried=false) と team_inject.rs (再送, retried=true)。
+ */
+export interface HandoffPayload {
+  teamId: string;
+  fromAgentId: string;
+  fromRole: string;
+  toAgentId: string;
+  toRole: string;
+  preview: string;
+  messageId: number;
+  timestamp?: string;
+  /** retry 配送 (`app_team_retry_inject`) による再送なら true */
+  retried?: boolean;
+}
+
 // ---------- Window Effects (Issue #260) ----------
 
 /**

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -885,6 +885,21 @@ export interface TeamOrchestrationSummary {
 }
 
 /**
+ * Issue #935: タスク status の canonical 値。Rust 側 SSOT
+ * (`src-tauri/src/team_hub/task_status.rs` の `TaskStatus`) と同期する。
+ * 受信境界 (team_update_task) で legacy alias ("completed"/"complete"/"canceled")
+ * は canonical 値へ正規化されるため、新規データはこの union のみになる。
+ */
+export type TeamTaskStatus =
+  | 'pending'
+  | 'in_progress'
+  | 'done'
+  | 'blocked'
+  | 'needs_input'
+  | 'failed'
+  | 'cancelled';
+
+/**
  * Issue #514: TeamHub orchestration state の TS 投影。
  * Rust 側 `commands/team_state.rs` の `TeamOrchestrationState` (camelCase) に揃える。
  * dashboard / 履歴復元 / 統合フェーズビューなど renderer 全体で参照する。
@@ -893,6 +908,11 @@ export interface TeamTaskSnapshot {
   id: number;
   assignedTo: string;
   description: string;
+  /**
+   * 通常は `TeamTaskStatus` の canonical 値。永続化済みの古いデータには
+   * legacy alias / 当時の任意文字列が残りうるため型は string のまま
+   * (判定は Rust 側 `task_status.rs` が正規化して行う)。
+   */
   status: string;
   createdBy: string;
   createdAt: string;
@@ -1000,7 +1020,8 @@ export interface WorkerReportPayload {
  */
 export interface UpdateTaskArgs {
   taskId: number;
-  status: 'pending' | 'in_progress' | 'done' | 'completed' | 'blocked' | string;
+  /** Issue #935: trailing `| string` を撤去し canonical union のみ許可する */
+  status: TeamTaskStatus;
   summary?: string;
   blockedReason?: string;
   nextAction?: string;


### PR DESCRIPTION
## Summary
- Closes #935: タスク status のドメイン値を `team_hub/task_status.rs` の `TaskStatus` enum に SSOT 化。update_task 3 語 / team_state 5 語 / report 4 語に分裂していた許容値判定を `is_done`/`is_open` メソッドに集約し、受信境界で parse (不正値・欠落は `update_task_invalid_status` で拒否、legacy alias は canonical 値へ正規化)。MCP schema の status に enum 制約を追加、shared.ts に `TeamTaskStatus` union を追加し `UpdateTaskArgs` の trailing `| string` を撤去。永続化済みの不明値は従来どおり open 扱い (タスクを見失わない方向に fail)
- Closes #930: `team:recruit-request` / `team:handoff` の payload を `team_hub/events.rs` の named struct (serde camelCase) 化し、emit 箇所間の形状分岐を統一。TS 側ファントムフィールド `customInstructions` を削除 (実行時挙動は不変)、`retried` を `HandoffPayload` に追加して再送配達を UI から区別可能に。`RecruitRequestPayload` / `HandoffPayload` を shared.ts へ移動

残スコープは follow-up issue へ分離: #958 (自然言語キーワード推測の廃止) / #959 (json! emit の CI 禁止 + ts-rs codegen)

## Test plan
- [x] `cargo test --lib` 683 テストパス (task_status 5 件 + update_task の不正 status 拒否 / alias 正規化 2 件を新規追加)
- [x] `npx vitest run` 全 75 ファイル / 457 テストパス
- [x] `npm run typecheck` パス + `tsc -p tsconfig.web.json` で変更ファイルに型エラーなしを確認
- [x] 既存テスト (done_evidence 検証 / pending_tasks フィルタ / report subset) の挙動不変を確認