### PR TITLE
refactor(persistence): #947 既存 4 ストアの破損退避を safe_load 共通基盤へ統一

### DIFF
--- a/src-tauri/src/commands/role_profiles.rs
+++ b/src-tauri/src/commands/role_profiles.rs
@@ -4,47 +4,28 @@
 // 形式の検証は renderer 側の TS で行う想定なので、ここでは raw JSON を扱うだけ。
 
 use crate::commands::atomic_write::atomic_write_with_mode;
-use crate::util::backup::write_timestamped_backup;
+use crate::commands::safe_load::{safe_load_or_quarantine, LoadOutcome};
 use once_cell::sync::Lazy;
 use serde_json::Value;
-use tokio::fs;
+use std::path::Path;
 use tokio::sync::Mutex;
 
 static SAVE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
+/// Issue #947: 読み込みは safe_load 共通基盤に統一する。
+/// parse 失敗時の挙動 (default に倒す前に `.bak.<ts>` へコピー退避、0o600、5 世代回転 —
+/// #170 / #644 / #608 の積み上げ) は safe_load 側に集約済みで等価。
+async fn role_profiles_load_at(path: &Path) -> Value {
+    match safe_load_or_quarantine::<Value>(path, Some(0o600)).await {
+        LoadOutcome::Loaded(v) => v,
+        LoadOutcome::Absent | LoadOutcome::Corrupted => Value::Null,
+    }
+}
+
 #[tauri::command]
 pub async fn role_profiles_load() -> Value {
     let path = crate::util::config_paths::role_profiles_path();
-    let Ok(bytes) = fs::read(&path).await else {
-        return Value::Null;
-    };
-    match serde_json::from_slice::<Value>(&bytes) {
-        Ok(v) => v,
-        Err(e) => {
-            // Issue #170: 旧実装は parse 失敗で黙って Null を返し、次の save で
-            // 役割プロファイルが完全消失していた。.bak 退避してから Null を返す。
-            // Issue #644: 旧実装は単一 `.bak` を都度上書きしていたため、連続破損保存で
-            // 健全な原本が 1 ステップで失われていた。タイムスタンプ付き backup +
-            // 世代回転 (5 世代) に変更。
-            // Issue #608 (Security): role profile instructions は injection-prone な
-            // ユーザー定義 prompt を含むため、バックアップも 0o600 で書く。
-            tracing::error!(
-                "[role-profiles] parse failed ({}), backing up to {}.bak.<ts>",
-                e,
-                path.display()
-            );
-            match write_timestamped_backup(&path, &bytes, Some(0o600)).await {
-                Ok(bak) => tracing::info!(
-                    "[role-profiles] wrote timestamped backup: {}",
-                    bak.display()
-                ),
-                Err(berr) => {
-                    tracing::warn!("[role-profiles] backup write failed: {berr}")
-                }
-            }
-            Value::Null
-        }
-    }
+    role_profiles_load_at(&path).await
 }
 
 #[tauri::command]
@@ -58,4 +39,55 @@ pub async fn role_profiles_save(file: Value) -> crate::commands::error::CommandR
     Ok(atomic_write_with_mode(&path, &json, Some(0o600))
         .await
         .map_err(|e| e.to_string())?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio::fs;
+
+    #[tokio::test]
+    async fn load_at_returns_null_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("role-profiles.json");
+        assert_eq!(role_profiles_load_at(&path).await, Value::Null);
+    }
+
+    #[tokio::test]
+    async fn load_at_parses_valid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("role-profiles.json");
+        fs::write(&path, br#"{"profiles":[{"id":"leader"}]}"#)
+            .await
+            .unwrap();
+        assert_eq!(
+            role_profiles_load_at(&path).await,
+            json!({"profiles":[{"id":"leader"}]})
+        );
+    }
+
+    /// Issue #947 (元 #170/#644): 破損 JSON は Null に倒す前に `.bak.<ts>` へ退避され、
+    /// 原本はコピー退避なので残置される (次回 save が上書きする)。
+    #[tokio::test]
+    async fn load_at_quarantines_corrupt_json_before_null() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("role-profiles.json");
+        let corrupt = b"{ broken json";
+        fs::write(&path, corrupt).await.unwrap();
+
+        assert_eq!(role_profiles_load_at(&path).await, Value::Null);
+        assert!(path.exists(), "copy-style backup must leave the original");
+
+        let mut rd = fs::read_dir(dir.path()).await.unwrap();
+        let mut found = false;
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with("role-profiles.json.bak.") {
+                assert_eq!(fs::read(entry.path()).await.unwrap(), corrupt);
+                found = true;
+            }
+        }
+        assert!(found, "timestamped backup of the corrupt file must exist");
+    }
 }

--- a/src-tauri/src/commands/safe_load.rs
+++ b/src-tauri/src/commands/safe_load.rs
@@ -70,7 +70,20 @@ pub async fn safe_load_or_quarantine<T: DeserializeOwned>(
             return LoadOutcome::Absent;
         }
     };
-    match serde_json::from_slice::<T>(&bytes) {
+    safe_parse_or_quarantine(path, &bytes, backup_mode).await
+}
+
+/// Issue #947: 既に読み込んだ bytes を `T` へ parse する variant。
+/// 呼び出し側が同じ bytes を fingerprint 計算 (#642 の外部変更検出) 等にも使うストア
+/// (team-history / team-state) 向け。`safe_load_or_quarantine` を使うと read が二重になり、
+/// fingerprint と parse が別スナップショットを見る race が生まれるため、こちらを使う。
+/// 退避の不変条件 (default に倒す前に `.bak.<ts>` へコピー退避) は同一。
+pub async fn safe_parse_or_quarantine<T: DeserializeOwned>(
+    path: &Path,
+    bytes: &[u8],
+    backup_mode: Option<u32>,
+) -> LoadOutcome<T> {
+    match serde_json::from_slice::<T>(bytes) {
         Ok(v) => LoadOutcome::Loaded(v),
         Err(e) => {
             tracing::error!(
@@ -80,7 +93,7 @@ pub async fn safe_load_or_quarantine<T: DeserializeOwned>(
             );
             // #936 の core invariant: default に倒す前に必ず退避する。コピー退避なので
             // 原本 path を触らず、並行 save の valid file を巻き込まない (#853 の TOCTOU 回避)。
-            match crate::util::backup::write_timestamped_backup(path, &bytes, backup_mode).await {
+            match crate::util::backup::write_timestamped_backup(path, bytes, backup_mode).await {
                 Ok(bak) => {
                     tracing::info!("[safe_load] wrote corrupt backup: {}", bak.display())
                 }

--- a/src-tauri/src/commands/team_history.rs
+++ b/src-tauri/src/commands/team_history.rs
@@ -6,7 +6,6 @@
 use crate::commands::files::hash::{mtime_ms_of, sha256_hex};
 use crate::commands::team_state::TeamOrchestrationSummary;
 use crate::pty::path_norm::normalize_project_root;
-use crate::util::backup::write_timestamped_backup;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -230,25 +229,25 @@ async fn fingerprint_from_bytes(path: &Path, bytes: &[u8]) -> DiskFingerprint {
     }
 }
 
+/// Issue #947: parse 失敗時の退避は safe_load 共通基盤 (#936) に委譲する。
+/// fingerprint (#642) と同じ bytes を見る必要があるため bytes ベースの
+/// `safe_parse_or_quarantine` を使う (退避規約は従来と同一で挙動等価)。
 async fn parse_entries_or_backup(
     path: &Path,
     bytes: &[u8],
     context: &str,
 ) -> Vec<TeamHistoryEntry> {
-    match serde_json::from_slice::<Vec<TeamHistoryEntry>>(bytes) {
-        Ok(entries) => entries,
-        Err(e) => {
+    use crate::commands::safe_load::{safe_parse_or_quarantine, LoadOutcome};
+    match safe_parse_or_quarantine::<Vec<TeamHistoryEntry>>(path, bytes, Some(0o600)).await {
+        LoadOutcome::Loaded(entries) => entries,
+        LoadOutcome::Corrupted => {
             tracing::warn!(
-                "[team_history] parse failed during {context} (backing up then using empty history): {e}"
+                "[team_history] parse failed during {context}; falling back to empty history"
             );
-            match write_timestamped_backup(path, bytes, Some(0o600)).await {
-                Ok(bak) => {
-                    tracing::info!("[team_history] wrote timestamped backup: {}", bak.display())
-                }
-                Err(berr) => tracing::warn!("[team_history] backup write failed: {berr}"),
-            }
             Vec::new()
         }
+        // bytes は読込済みなので Absent は到達しないが、enum の網羅性のため empty に倒す
+        LoadOutcome::Absent => Vec::new(),
     }
 }
 

--- a/src-tauri/src/commands/team_state.rs
+++ b/src-tauri/src/commands/team_state.rs
@@ -348,27 +348,19 @@ pub async fn load_orchestration_state(
 /// handoff・open task・human gate 状態がすべて **silent に消失** していた (最も発見が難しい
 /// 類の障害)。fail-safe にするため:
 ///   - read 失敗は NotFound (= 未保存 / 初回起動) を silent に、それ以外の IO エラーは warn。
-///   - parse 失敗は warn + 破損ファイルを `.corrupt` へ best-effort 退避する (後から調査・
-///     手動復旧でき、退避後の原本は次回 save で健全な状態に上書きされる)。
+///   - parse 失敗は warn + 破損ファイルを `.bak.<ts>` へ best-effort コピー退避する (#947 で
+///     safe_load 共通基盤へ統一。後から調査・手動復旧でき、原本は次回 save で上書きされる)。
 ///   - 読み込んだ schema_version が現行と異なる場合は warn (`normalize` が無条件で上書きする
 ///     前に検知する。将来の migration 判定の足場)。
 async fn load_orchestration_state_from_path(path: &Path) -> Option<TeamOrchestrationState> {
-    let bytes = match fs::read(path).await {
-        Ok(b) => b,
-        Err(e) => {
-            // NotFound は通常状態 (team-state 未保存 / 初回起動) なので silent。
-            // それ以外の IO エラー (権限 / I/O 障害) は痕跡を残す。
-            if e.kind() != std::io::ErrorKind::NotFound {
-                tracing::warn!(
-                    "[team_state] failed to read orchestration state at {}: {e}",
-                    path.display()
-                );
-            }
-            return None;
-        }
-    };
-    match serde_json::from_slice::<TeamOrchestrationState>(&bytes) {
-        Ok(state) => {
+    use crate::commands::safe_load::{safe_load_or_quarantine, LoadOutcome};
+    // Issue #947: 個別の `.corrupt` rename 退避を safe_load 共通基盤 (#936) の
+    // `.bak.<ts>` コピー退避へ統一する。挙動差は「原本が rename で消える」→「原本残置 +
+    // 次回 save が上書き」だが、復旧可能性 (forensic 用 backup が残る) は同等で、
+    // コピー退避は原本 path を一切触らないため、#853 の TOCTOU (並行 save が置いた
+    // valid file を `.corrupt` へ追い出す race) が再検証ロジック無しで構造的に消える。
+    match safe_load_or_quarantine::<TeamOrchestrationState>(path, None).await {
+        LoadOutcome::Loaded(state) => {
             if state.schema_version != TEAM_STATE_SCHEMA_VERSION {
                 tracing::warn!(
                     "[team_state] orchestration state at {} has schema_version {} (expected {}); \
@@ -380,106 +372,17 @@ async fn load_orchestration_state_from_path(path: &Path) -> Option<TeamOrchestra
             }
             Some(normalize(state))
         }
-        Err(e) => {
+        LoadOutcome::Absent => None,
+        LoadOutcome::Corrupted => {
             tracing::warn!(
-                "[team_state] failed to parse orchestration state at {}: {e}; backing up corrupt \
-                 file and skipping restore (task/handoff/human-gate state will be recreated on next save)",
+                "[team_state] failed to parse orchestration state at {}; corrupt original was \
+                 quarantined to .bak.<ts> and restore is skipped (task/handoff/human-gate state \
+                 will be recreated on next save)",
                 path.display()
             );
-            // Issue #853: load 時に読んだ破損 bytes を渡し、退避直前に再 read して
-            // 内容が変化していない (= まだ破損したまま) ときだけ退避する。並行 save が
-            // valid file を置いていれば bytes が変化しているので退避を skip し、valid state を
-            // `.corrupt` へ巻き込まない (TOCTOU の解消)。
-            backup_corrupt_state_file(path, &bytes).await;
             None
         }
     }
-}
-
-/// Issue #830: 破損した team-state JSON を `<file>.corrupt` (衝突時は `.corrupt.1` ..
-/// `.corrupt.9`) に best-effort で退避する。退避できれば原本は消えるので、次回
-/// `save_orchestration_state` が健全な状態で上書きできる。退避失敗 (rename 不可 / backup
-/// が増え過ぎ) は warn に留め、load 自体は失敗させない。
-///
-/// Issue #853 (TOCTOU 修正): `corrupt_bytes` は load 時に読んで parse に失敗した原本の bytes。
-/// rename は lock 外で走るため、その間に並行 `save_orchestration_state` (atomic_write) が
-/// **valid な file** を同 path に置き換えうる。素朴に rename するとこの valid file を
-/// `.corrupt` へ追い出し、save 直後の健全な state を失う race があった。退避の直前に現在の
-/// file bytes を再 read し、`corrupt_bytes` と **完全一致するときだけ** 退避する。一致しない
-/// (= 並行 save で内容が変わった / 既に他経路で退避され消えた) 場合は退避を skip し、active
-/// path を温存する。これで「valid file を退避しない」不変条件を保証する。
-async fn backup_corrupt_state_file(path: &Path, corrupt_bytes: &[u8]) {
-    let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
-        tracing::warn!(
-            "[team_state] cannot derive file name for corrupt backup of {}",
-            path.display()
-        );
-        return;
-    };
-    let Some(parent) = path.parent() else {
-        tracing::warn!(
-            "[team_state] cannot derive parent dir for corrupt backup of {}",
-            path.display()
-        );
-        return;
-    };
-    // Issue #853: 退避直前の再検証。並行 save が割り込んで file が valid に置き換わって
-    // いれば bytes が変化しているので退避せずに抜ける (valid state を巻き込まない)。
-    // read 失敗 (並行退避で消えた等) も退避対象が消えたとみなし skip する。
-    match fs::read(path).await {
-        Ok(current) if current == corrupt_bytes => {
-            // 依然として load 時の破損 bytes と同一。退避を続行する。
-        }
-        Ok(_) => {
-            tracing::info!(
-                "[team_state] corrupt backup skipped: {} changed since load (likely a concurrent \
-                 valid save); not evicting the active file",
-                path.display()
-            );
-            return;
-        }
-        Err(e) => {
-            tracing::info!(
-                "[team_state] corrupt backup skipped: cannot re-read {} ({e}); file may have been \
-                 replaced or removed by a concurrent save",
-                path.display()
-            );
-            return;
-        }
-    }
-    // 既存 backup を上書きしない (forensic 情報を保持する) ため、空きスロットを探す。
-    for idx in 0..=9u32 {
-        let candidate_name = if idx == 0 {
-            format!("{file_name}.corrupt")
-        } else {
-            format!("{file_name}.corrupt.{idx}")
-        };
-        let candidate = parent.join(&candidate_name);
-        if fs::metadata(&candidate).await.is_ok() {
-            continue;
-        }
-        match fs::rename(path, &candidate).await {
-            Ok(()) => {
-                tracing::warn!(
-                    "[team_state] moved corrupt orchestration state to {}",
-                    candidate.display()
-                );
-                return;
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "[team_state] failed to move corrupt state {} -> {}: {e}",
-                    path.display(),
-                    candidate.display()
-                );
-                return;
-            }
-        }
-    }
-    tracing::warn!(
-        "[team_state] too many corrupt backups already exist for {}; leaving file in place",
-        path.display()
-    );
 }
 
 pub async fn save_orchestration_state(
@@ -602,6 +505,23 @@ mod tests {
         assert_eq!(state.pending_tasks[0].id, 2);
     }
 
+    /// tempdir 内の `<name>.bak.<ts>` 退避ファイル一覧を返すテストヘルパ。
+    async fn list_bak_files(dir: &std::path::Path, name: &str) -> Vec<std::path::PathBuf> {
+        let prefix = format!("{name}.bak.");
+        let mut out = Vec::new();
+        let mut rd = fs::read_dir(dir).await.unwrap();
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            if entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(&prefix)
+            {
+                out.push(entry.path());
+            }
+        }
+        out
+    }
+
     /// Issue #830: 未保存 (ファイル不在) は silent に None を返し、退避ファイルも作らない。
     #[tokio::test]
     async fn load_from_path_returns_none_for_missing_file() {
@@ -609,10 +529,8 @@ mod tests {
         let path = dir.path().join("missing.json");
         assert!(load_orchestration_state_from_path(&path).await.is_none());
         assert!(
-            fs::metadata(dir.path().join("missing.json.corrupt"))
-                .await
-                .is_err(),
-            "missing file must not produce a corrupt backup"
+            list_bak_files(dir.path(), "missing.json").await.is_empty(),
+            "missing file must not produce a quarantine backup"
         );
     }
 
@@ -641,10 +559,14 @@ mod tests {
         assert_eq!(loaded.pending_tasks.len(), 1);
     }
 
-    /// Issue #830 (core): 破損 JSON は silent に捨てず、`.corrupt` に退避してから None を返す。
-    /// 退避後は原本が消えるので、次回 save が健全な状態で上書きできる。
+    /// Issue #830 (core) + #947: 破損 JSON は silent に捨てず、`.bak.<ts>` へコピー退避して
+    /// から None を返す。コピー退避なので原本は残置され、次回 save が上書きする。
+    ///
+    /// Issue #853 (TOCTOU) の不変条件「並行 save が置いた valid file を退避で巻き込まない」は、
+    /// コピー退避が原本 path を一切触らない (rename しない) ことで構造的に保証される
+    /// (旧実装は rename だったため退避直前の bytes 再検証が必要だった)。
     #[tokio::test]
-    async fn load_from_path_backs_up_corrupt_json() {
+    async fn load_from_path_quarantines_corrupt_json_without_touching_original() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("team.json");
         let corrupt = b"{ this is not valid json ]";
@@ -653,101 +575,16 @@ mod tests {
         let loaded = load_orchestration_state_from_path(&path).await;
         assert!(loaded.is_none(), "corrupt JSON must not silently load");
 
-        // 原本は退避されて消え、`.corrupt` に同じ内容が残っている。
-        assert!(
-            fs::metadata(&path).await.is_err(),
-            "corrupt original should be moved away"
-        );
-        let backup = dir.path().join("team.json.corrupt");
-        let backup_bytes = fs::read(&backup).await.expect("corrupt backup must exist");
-        assert_eq!(backup_bytes, corrupt);
-    }
-
-    /// Issue #830: 既に `.corrupt` がある場合は上書きせず `.corrupt.1` に退避する (forensic 保持)。
-    #[tokio::test]
-    async fn backup_corrupt_state_file_does_not_clobber_existing_backup() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("team.json");
-        fs::write(&path, b"corrupt-2").await.unwrap();
-        fs::write(dir.path().join("team.json.corrupt"), b"corrupt-1")
-            .await
-            .unwrap();
-
-        // Issue #853: 退避直前に再 read される bytes が load 時の破損 bytes と一致するので退避続行。
-        backup_corrupt_state_file(&path, b"corrupt-2").await;
-
-        // 既存 backup は不変、新 backup は `.corrupt.1` に置かれる。
+        // #853: 原本 path は退避処理に一切触られず残置される (並行 save の valid file を
+        // 追い出す余地が無い)。
         assert_eq!(
-            fs::read(dir.path().join("team.json.corrupt"))
-                .await
-                .unwrap(),
-            b"corrupt-1"
+            fs::read(&path).await.expect("original must remain in place"),
+            corrupt
         );
-        assert_eq!(
-            fs::read(dir.path().join("team.json.corrupt.1"))
-                .await
-                .unwrap(),
-            b"corrupt-2"
-        );
-        assert!(fs::metadata(&path).await.is_err());
-    }
 
-    /// Issue #853 (TOCTOU 回帰テスト): load が破損 bytes を読んだ後、退避が走る前に並行 save が
-    /// **valid な内容** で同 path を置き換えた場合、退避はその valid file を `.corrupt` へ追い出して
-    /// はならない。`backup_corrupt_state_file` に load 時の破損 bytes を渡し、退避直前の再 read で
-    /// 内容が変化していれば skip することを検証する。
-    ///
-    /// 修正前 (素の rename) はここで active file (valid) が `.corrupt` に移動して save 直後の
-    /// 健全な state を失うため、この assert は fail する。修正後は valid file が原 path に温存される。
-    #[tokio::test]
-    async fn backup_corrupt_state_file_does_not_evict_concurrently_saved_valid_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("team.json");
-
-        // load 時に読んだ破損 bytes。
-        let corrupt_bytes = b"{ this is not valid json ]".to_vec();
-
-        // 退避が走る前に並行 save が valid file を置いた状況を再現する
-        // (file は corrupt_bytes とは異なる valid な内容になっている)。
-        let valid_bytes = br#"{"schemaVersion":1,"teamId":"t","projectRoot":"/p"}"#.to_vec();
-        fs::write(&path, &valid_bytes).await.unwrap();
-
-        backup_corrupt_state_file(&path, &corrupt_bytes).await;
-
-        // valid file は原 path にそのまま残り、`.corrupt` には退避されていない。
-        assert_eq!(
-            fs::read(&path).await.expect("valid file must remain at the active path"),
-            valid_bytes,
-            "concurrently saved valid state must not be evicted from the active path"
-        );
-        assert!(
-            fs::metadata(dir.path().join("team.json.corrupt"))
-                .await
-                .is_err(),
-            "no corrupt backup should be created when the file changed to a valid one"
-        );
-    }
-
-    /// Issue #853: 破損 bytes が退避直前まで変化していない (= 並行 save が無い) 通常ケースでは
-    /// 従来どおり `.corrupt` へ退避し、原本を消す。再検証の追加で正常系が壊れていないことを確認。
-    #[tokio::test]
-    async fn backup_corrupt_state_file_still_backs_up_unchanged_corrupt_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("team.json");
-        let corrupt_bytes = b"{ broken json".to_vec();
-        fs::write(&path, &corrupt_bytes).await.unwrap();
-
-        backup_corrupt_state_file(&path, &corrupt_bytes).await;
-
-        assert!(
-            fs::metadata(&path).await.is_err(),
-            "unchanged corrupt file should still be moved away"
-        );
-        assert_eq!(
-            fs::read(dir.path().join("team.json.corrupt"))
-                .await
-                .expect("corrupt backup must exist"),
-            corrupt_bytes
-        );
+        // `.bak.<ts>` に破損原本のコピーが残っている (forensic 用)。
+        let baks = list_bak_files(dir.path(), "team.json").await;
+        assert_eq!(baks.len(), 1, "exactly one quarantine backup must exist");
+        assert_eq!(fs::read(&baks[0]).await.unwrap(), corrupt);
     }
 }

--- a/src-tauri/src/commands/terminal_tabs.rs
+++ b/src-tauri/src/commands/terminal_tabs.rs
@@ -11,7 +11,6 @@
 
 use crate::commands::schema_version::SchemaVersion;
 use crate::commands::team_history::MutationResult;
-use crate::util::backup::write_timestamped_backup;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -108,33 +107,16 @@ async fn load_from_disk() -> Option<PersistedTerminalTabsFile> {
 }
 
 /// disk からロードする。schemaVersion 不一致は `None` を返して旧データを無視する。
+///
+/// Issue #947: parse 失敗時の退避 (default に倒す前に `.bak.<ts>` へコピー) は
+/// safe_load 共通基盤 (#936) に委譲する。退避規約は従来と同一で挙動等価。
+/// schemaVersion チェックは terminal_tabs 固有の関心事なので従来どおりここで行う。
 async fn load_from_disk_at(path: &Path) -> Option<PersistedTerminalTabsFile> {
-    let bytes = match fs::read(path).await {
-        Ok(bytes) => bytes,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
-        Err(e) => {
-            tracing::warn!(
-                "[terminal_tabs] read failed (treating as missing): {}: {e}",
-                path.display()
-            );
-            return None;
-        }
-    };
-    let file: PersistedTerminalTabsFile = match serde_json::from_slice(&bytes) {
-        Ok(f) => f,
-        Err(e) => {
-            tracing::warn!(
-                "[terminal_tabs] parse failed (backing up then treating as missing): {e}"
-            );
-            match write_timestamped_backup(path, &bytes, Some(0o600)).await {
-                Ok(bak) => tracing::info!(
-                    "[terminal_tabs] wrote timestamped backup: {}",
-                    bak.display()
-                ),
-                Err(berr) => tracing::warn!("[terminal_tabs] backup write failed: {berr}"),
-            }
-            return None;
-        }
+    use crate::commands::safe_load::{safe_load_or_quarantine, LoadOutcome};
+    let file = match safe_load_or_quarantine::<PersistedTerminalTabsFile>(path, Some(0o600)).await
+    {
+        LoadOutcome::Loaded(f) => f,
+        LoadOutcome::Absent | LoadOutcome::Corrupted => return None,
     };
     if file.schema_version != TERMINAL_TABS_SCHEMA_VERSION {
         tracing::info!(


### PR DESCRIPTION
## Summary
Closes #947 (#936 の残スコープ)。既に個別の退避ロジックを持っていた動作中ストアを `safe_load_or_quarantine` 共通基盤へ統一し、`.corrupt` rename 系と `.bak.<ts>` copy 系に二重化していた規約を copy 系へ収束させる。issue の指示どおり 1 ストア = 1 commit で分割。

- `role_profiles.rs`: `write_timestamped_backup` 直叩きを safe_load へ置換 (挙動等価)。テスト無しだったため不在/正常/破損退避の 3 ケースを追加
- `terminal_tabs.rs`: read/parse/退避を safe_load へ置換。schemaVersion チェックはストア固有の関心事として従来どおり load 後に維持
- `team_history.rs`: fingerprint (#642) と同じ bytes を parse する必要があるため、safe_load に bytes ベースの `safe_parse_or_quarantine` を追加して移行 (read 二重化による fingerprint/parse の別スナップショット race を回避)
- `team_state.rs`: `.corrupt` rename 退避 (+ #853 の退避直前 bytes 再検証) を `.bak.<ts>` copy 退避へ統一。**挙動差**: rename=原本消滅 → copy=原本残置 (次回 save が上書き)。#853 の「並行 save の valid file を退避で巻き込まない」不変条件は、copy 退避が原本 path を一切触らないことで再検証ロジック無しに構造的に保証される

`mcp_config/claude.rs` は対象外とした: `~/.claude.json` は他アプリと共有するファイルで、parse 失敗時は「default に倒して上書き」ではなく「Err を返して上書き拒否」が正しい設計 (#597 の意図) のため、safe_load の不変条件 (default に倒す前に退避) が適用される構造ではない。

## Test plan
- [x] `cargo test --lib` 683 テストパス
- [x] role_profiles に退避テスト 3 件を新規追加、team_state の #853 回帰テストを copy 前提に書き換え
- [x] 既存の破損退避テスト (terminal_tabs / team_history / safe_load) で回帰なしを確認