### PR TITLE
security(files): #954 read/probe 系 IPC を project_root ゲートに通す

### DIFF
--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -125,6 +125,88 @@ pub async fn assert_active_project_root(
     Ok(active_canon)
 }
 
+/// Issue #954: read/probe 系 IPC (`files_list` / `files_read`) 用のゲート。
+///
+/// write 系 (#932) の `assert_active_project_root` は active project との厳格一致だが、
+/// ファイルツリーは multi-root workspace (`settings.workspaceFolders`, Issue #4) で
+/// active 以外の追加ルートも正当に列挙・閲覧するため、厳格一致だとこの機能が壊れる。
+/// 本 helper は「active project root **または** settings.json に永続化された
+/// workspaceFolders のいずれか」に canonicalize 一致する場合のみ許可する。
+///
+/// - workspaceFolders の参照先は **Rust 側 settings.json (SSOT)** であり、呼び出しごとの
+///   renderer 引数ではない (renderer が任意 path を主張しても settings に無ければ reject)。
+/// - settings 読込は active 不一致のときだけ走る (primary root の通常フローでは I/O 追加なし)。
+/// - active が未設定 (起動直後) でも workspaceFolders 一致なら許可する (起動時の
+///   追加ルート列挙を transient reject しない)。
+pub async fn assert_readable_project_root(
+    project_root_slot: &ArcSwapOption<String>,
+    given: &str,
+) -> CommandResult<PathBuf> {
+    let trimmed = given.trim();
+    if trimmed.is_empty() {
+        tracing::warn!(
+            given = %clamp_for_log(given),
+            "[authz] assert_readable_project_root rejected: empty project_root"
+        );
+        return Err(CommandError::authz("project_root is empty"));
+    }
+    let req_canon = match tokio::fs::canonicalize(trimmed).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                given = %clamp_for_log(given),
+                error = %e,
+                "[authz] assert_readable_project_root rejected: canonicalize requested project_root failed"
+            );
+            return Err(CommandError::authz(format!(
+                "canonicalize requested project_root failed: {e}"
+            )));
+        }
+    };
+
+    // 1. active project root と一致するか (最頻パス、settings I/O なし)
+    let active = current_project_root(project_root_slot).unwrap_or_default();
+    if !active.trim().is_empty() {
+        if let Ok(active_canon) = tokio::fs::canonicalize(active.trim()).await {
+            if req_canon == active_canon {
+                return Ok(active_canon);
+            }
+        }
+    }
+
+    // 2. settings.workspaceFolders (Rust 側 SSOT) に含まれるか
+    if let Ok(settings) = crate::commands::settings::settings_load().await {
+        if matches_any_workspace_folder(&req_canon, &settings.workspace_folders).await {
+            return Ok(req_canon);
+        }
+    }
+
+    tracing::warn!(
+        requested = %clamp_for_log(&req_canon.to_string_lossy()),
+        "[authz] assert_readable_project_root rejected: not active project nor workspace folder"
+    );
+    Err(CommandError::authz(
+        "project_root does not match active project or workspace folders",
+    ))
+}
+
+/// `req_canon` (canonicalize 済み) が `folders` のいずれかと canonicalize 一致するか。
+/// 存在しない / canonicalize できない folder エントリは skip する。
+async fn matches_any_workspace_folder(req_canon: &std::path::Path, folders: &[String]) -> bool {
+    for folder in folders {
+        let f = folder.trim();
+        if f.is_empty() {
+            continue;
+        }
+        if let Ok(folder_canon) = tokio::fs::canonicalize(f).await {
+            if req_canon == folder_canon {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Issue #601 (Tier A-3): renderer 由来の `team_id` が `TeamHub` の active set に含まれるかを
 /// 検証する。`team_diagnostics_read` (#601) のような **renderer がリーダー視点を impersonate
 /// する** IPC で、過去 / 別プロジェクト / 任意 fabricated な team_id を probe されないように
@@ -264,6 +346,56 @@ mod tests {
         assert_eq!(
             canon,
             std::fs::canonicalize(project.path()).expect("canonicalize"),
+        );
+    }
+
+    // ---------- Issue #954: assert_readable_project_root ----------
+
+    #[tokio::test]
+    async fn readable_accepts_active_project_root() {
+        let project = tempdir().expect("project");
+        let lock = make_lock(Some(project.path().to_string_lossy().into_owned()));
+        let canon =
+            assert_readable_project_root(&lock, project.path().to_string_lossy().as_ref())
+                .await
+                .expect("active root must be readable");
+        assert_eq!(canon, std::fs::canonicalize(project.path()).unwrap());
+    }
+
+    #[tokio::test]
+    async fn readable_rejects_empty_and_foreign_paths() {
+        let active = tempdir().expect("active");
+        let foreign = tempdir().expect("foreign");
+        let lock = make_lock(Some(active.path().to_string_lossy().into_owned()));
+
+        let err = assert_readable_project_root(&lock, "").await.unwrap_err();
+        assert!(matches!(err, CommandError::Authz(ref m) if m.contains("empty")));
+
+        // active でも workspace folder でもない実在 path → reject
+        // (テスト環境の settings.json に tempdir が登録されていることはない)
+        let err = assert_readable_project_root(&lock, foreign.path().to_string_lossy().as_ref())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, CommandError::Authz(ref m) if m.contains("workspace folders")),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_folder_matching_is_canonical_and_skips_missing() {
+        let folder = tempdir().expect("folder");
+        let req = std::fs::canonicalize(folder.path()).unwrap();
+        // 実在 folder は raw 表記が違っても canonicalize 一致で許可
+        let raw = format!("{}{}", folder.path().to_string_lossy(), std::path::MAIN_SEPARATOR);
+        assert!(matches_any_workspace_folder(&req, &[raw]).await);
+        // 存在しない folder / 空文字エントリは skip され、一致しない
+        assert!(
+            !matches_any_workspace_folder(
+                &req,
+                &["".into(), "   ".into(), folder.path().join("nope").to_string_lossy().into_owned()]
+            )
+            .await
         );
     }
 

--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -192,14 +192,24 @@ pub async fn assert_readable_project_root(
 
 /// `req_canon` (canonicalize 済み) が `folders` のいずれかと canonicalize 一致するか。
 /// 存在しない / canonicalize できない folder エントリは skip する。
+///
+/// PR #962 auto-review: canonicalize は folder ごとに blocking I/O を伴うため、NFS/SMB 等の
+/// 低速マウントで folder 数分の直列待ちにならないよう `JoinSet` で並列実行し、
+/// 一致を見つけた時点で残りを打ち切る。
 async fn matches_any_workspace_folder(req_canon: &std::path::Path, folders: &[String]) -> bool {
+    let mut set = tokio::task::JoinSet::new();
     for folder in folders {
         let f = folder.trim();
         if f.is_empty() {
             continue;
         }
-        if let Ok(folder_canon) = tokio::fs::canonicalize(f).await {
-            if req_canon == folder_canon {
+        let f = f.to_string();
+        set.spawn(async move { tokio::fs::canonicalize(&f).await.ok() });
+    }
+    while let Some(res) = set.join_next().await {
+        if let Ok(Some(folder_canon)) = res {
+            if folder_canon == req_canon {
+                set.abort_all();
                 return true;
             }
         }

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -28,6 +28,19 @@ async fn assert_project_root_via(app: &AppHandle, project_root: &str) -> Command
         .await
         .map(|_| ())
 }
+
+/// Issue #954: read/probe 系 (`files_list` / `files_read`) 用ゲート。write 系 (#932) と違い、
+/// multi-root workspace の追加ルート (settings.workspaceFolders, Issue #4) も正当な読み取り
+/// 対象なので、active 厳格一致ではなく `assert_readable_project_root` を使う。
+async fn assert_readable_project_root_via(
+    app: &AppHandle,
+    project_root: &str,
+) -> CommandResult<()> {
+    let state = app.state::<AppState>();
+    crate::commands::authz::assert_readable_project_root(&state.project_root, project_root)
+        .await
+        .map(|_| ())
+}
 use hash::{mtime_ms_of, sha256_hex};
 // safe_join は外部 (commands/git.rs) からも呼ばれるので pub use で再 export する。
 pub use path_safety::safe_join;
@@ -101,7 +114,16 @@ pub struct FileWriteResult {
 }
 
 #[tauri::command]
-pub async fn files_list(project_root: String, rel_path: String) -> FileListResult {
+pub async fn files_list(app: AppHandle, project_root: String, rel_path: String) -> FileListResult {
+    // Issue #954: read/probe 系も project_root ゲートに通す (任意ディレクトリ列挙の阻止)。
+    if let Err(e) = assert_readable_project_root_via(&app, &project_root).await {
+        return FileListResult {
+            ok: false,
+            error: Some(e.to_string()),
+            dir: rel_path,
+            entries: vec![],
+        };
+    }
     let dir = safe_join(&project_root, &rel_path);
     let dir = match dir {
         Some(p) if p.is_dir() => p,
@@ -162,7 +184,16 @@ pub async fn files_list(project_root: String, rel_path: String) -> FileListResul
 }
 
 #[tauri::command]
-pub async fn files_read(project_root: String, rel_path: String) -> FileReadResult {
+pub async fn files_read(app: AppHandle, project_root: String, rel_path: String) -> FileReadResult {
+    // Issue #954: read/probe 系も project_root ゲートに通す (任意ファイル読取の阻止)。
+    if let Err(e) = assert_readable_project_root_via(&app, &project_root).await {
+        return FileReadResult {
+            ok: false,
+            error: Some(e.to_string()),
+            path: rel_path,
+            ..Default::default()
+        };
+    }
     let Some(abs) = safe_join(&project_root, &rel_path) else {
         return FileReadResult {
             ok: false,

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -7,7 +7,21 @@
 // - 既存実装は status と diff のみで、シェル呼び出しのオーバーヘッドは無視できる
 
 use serde::Serialize;
+use tauri::{AppHandle, Manager};
 use tokio::process::Command;
+
+/// Issue #954: renderer 由来の `project_root` を active project と照合する read/probe ゲート。
+/// git パネル / DiffCard は active project (primary root) のみを対象とするため、
+/// files 系と違い workspaceFolders 許可は不要で厳格一致 (`assert_active_project_root`) を使う。
+async fn assert_project_root_via(
+    app: &AppHandle,
+    project_root: &str,
+) -> crate::commands::error::CommandResult<()> {
+    let state = app.state::<crate::state::AppState>();
+    crate::commands::authz::assert_active_project_root(&state.project_root, project_root)
+        .await
+        .map(|_| ())
+}
 
 /// Windows で GUI アプリ (Tauri) からコンソールプロセス (git.exe) を起動すると、
 /// 既定では一瞬コンソールウィンドウが表示されてしまう。
@@ -241,7 +255,20 @@ fn is_not_git_repo_error(err: &str) -> bool {
 }
 
 #[tauri::command]
-pub async fn git_status(project_root: String) -> GitStatus {
+pub async fn git_status(app: AppHandle, project_root: String) -> GitStatus {
+    // Issue #954: read/probe 系も project_root ゲートに通す (任意リポジトリ probe の阻止)。
+    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+        return GitStatus {
+            ok: false,
+            error: Some(e.to_string()),
+            ..Default::default()
+        };
+    }
+    git_status_inner(project_root).await
+}
+
+/// ゲート通過後の本体 (#932 の files_write_inner と同じ分割。テストはこちらを呼ぶ)。
+pub(crate) async fn git_status_inner(project_root: String) -> GitStatus {
     // repo root
     let repo_root = match run_git(&["rev-parse", "--show-toplevel"], &project_root).await {
         Ok(s) => s.trim().to_string(),
@@ -288,10 +315,28 @@ pub async fn git_status(project_root: String) -> GitStatus {
 
 #[tauri::command]
 pub async fn git_diff(
+    app: AppHandle,
     project_root: String,
     rel_path: String,
     // Issue #19: rename の場合、HEAD 側 (移動前) のパス。UI (GitFileChange.originalPath) から渡す。
     // 未指定なら rel_path を両側に使う (通常の変更)。
+    original_rel_path: Option<String>,
+) -> GitDiffResult {
+    // Issue #954: read/probe 系も project_root ゲートに通す (任意リポジトリの差分 probe の阻止)。
+    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+        return GitDiffResult {
+            ok: false,
+            error: Some(e.to_string()),
+            ..Default::default()
+        };
+    }
+    git_diff_inner(project_root, rel_path, original_rel_path).await
+}
+
+/// ゲート通過後の本体 (#932 の files_write_inner と同じ分割。テストはこちらを呼ぶ)。
+pub(crate) async fn git_diff_inner(
+    project_root: String,
+    rel_path: String,
     original_rel_path: Option<String>,
 ) -> GitDiffResult {
     // 旧実装と同じく `git diff -- <path>` ではなく、HEAD と worktree を別々に取って

--- a/src-tauri/src/commands/tests/git.rs
+++ b/src-tauri/src/commands/tests/git.rs
@@ -7,7 +7,7 @@
 //! `git --version` を `which git` ではなく `Command::new("git").arg("--version").status()`
 //! で確認し、不在なら early return する (= "ok-skip" 扱い)。
 
-use crate::commands::git::{git_diff, git_status};
+use crate::commands::git::{git_diff_inner as git_diff, git_status_inner as git_status};
 use std::path::Path;
 use std::process::Command;
 use tempfile::tempdir;

--- a/src/renderer/src/lib/hooks/use-project-loader.ts
+++ b/src/renderer/src/lib/hooks/use-project-loader.ts
@@ -87,6 +87,18 @@ export function useProjectLoader(
       if (projectRoot && projectRoot !== root && !optsRef.current.confirmDiscardEditorTabs()) {
         return false;
       }
+      // Issue #954: backend の active project_root を先に確定させる。git_status / files_list
+      // 等の read 系 IPC は active root とのゲート照合 (#932 の read 側拡張) を通るため、
+      // 確定前に fetch を発火すると transient reject でパネルが空振りする。
+      // setProjectRoot は fs_watch 付け替え / asset scope 許可も担う既存 IPC で冪等
+      // (settings-context 側の同期 effect が後から同じ root で呼んでも無害)。
+      // 失敗 (system 領域 reject 等) 時はロード自体を中止してステータスに表示する。
+      try {
+        await window.api.app.setProjectRoot(root);
+      } catch (err) {
+        useUiStore.getState().setStatus(t('project.loadError', { error: String(err) }));
+        return false;
+      }
       setProjectRoot(root);
       useUiStore.getState().setStatus(t('project.loading'));
       setGitLoading(true);

--- a/src/renderer/src/lib/hooks/use-project-loader.ts
+++ b/src/renderer/src/lib/hooks/use-project-loader.ts
@@ -175,6 +175,18 @@ export function useProjectLoader(
           root = picked;
         }
         if (cancelled) return;
+        // Issue #954 (PR #962 auto-review): 起動復元パスも loadProject と同様に backend の
+        // active project_root を await で確定させてから git/sessions の fetch を発火する。
+        // ゲート (#932 read 側拡張) は active root 未設定時に reject するため、これが無いと
+        // 起動時の git パネルが transient reject で空振りする。
+        try {
+          await window.api.app.setProjectRoot(root);
+        } catch (err) {
+          useUiStore.getState().setStatus(t('project.initError', { error: String(err) }));
+          setGitLoading(false);
+          return;
+        }
+        if (cancelled) return;
         setProjectRoot(root);
         if (root !== lastOpenedRoot) {
           void updateSettings({ lastOpenedRoot: root });


### PR DESCRIPTION
## Summary
Closes #954 (#932 の read/probe 側拡張)。

- `files_list` / `files_read` に新設の `assert_readable_project_root` ゲートを追加。multi-root workspace (settings.workspaceFolders, Issue #4) の追加ルートは正当な読み取り対象のため、active 厳格一致ではなく「active project root または **Rust 側 settings.json (SSOT) に永続化された workspaceFolders**」の canonicalize 一致で許可する。renderer が任意 path を主張しても settings に無ければ reject。workspaceFolders 照合は active 不一致時のみ走るため、primary root の通常フローに settings I/O は追加されない
- `git_status` / `git_diff` は git パネル / DiffCard が active project のみを対象とするため `assert_active_project_root` の厳格一致。既存テスト維持のため #932 の `files_write_inner` と同じ outer (ゲート) / inner (本体) 分割
- issue 記載の timing 懸念 (active root 設定前の auto 発火が transient reject される) は、`loadProject` が `app.setProjectRoot` を **await してから** git/files の fetch を発火するよう初期化順序を修正して構造的に排除。起動復元 (lastOpenedRoot) もプロジェクト切替もこの経路を通る。`setProjectRoot` 失敗 (system 領域 reject 等) 時はロードを中止してステータス表示

## Test plan
- [x] `cargo test --lib` 686 テストパス (assert_readable_project_root の accept/reject + workspaceFolders canonicalize 照合のテスト 3 件を追加)
- [x] `npx vitest run` 457 テストパス
- [x] `tsc -p tsconfig.web.json` で変更ファイルに型エラーなし
- [x] 既存 git テストは inner 呼び出しに切替えて全パス (ゲート分は authz テストでカバー)