### PR TITLE
ci(persistence): #948 永続化ファイルの生 serde parse を CI で検出し safe_load 経由を強制

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
       - name: ESLint
         run: npm run lint
 
+      # Issue #948: 永続化ファイルの生 serde parse 握り潰し (`serde_json::from_*(...).ok()`)
+      # を検出して fail させる。読込は safe_load 共通基盤 (#936) 経由を強制する。
+      # 例外は該当行直前の `// safe-load-exempt: <理由>` で明示 opt-out。
+      - name: Safe-load lint (persistence parse guard)
+        run: npm run lint:safe-load
+
       # Issue #721: renderer の単体テスト (vitest) を CI で実行する。
       # 従来は package.json に test スクリプトと vitest.config.ts があるのに
       # CI で一度も走らず、renderer のリグレッションがフリーパスだった。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: ESLint
         run: npm run lint
 
-      # Issue #948: 永続化ファイルの生 serde parse 握り潰し (`serde_json::from_*(...).ok()`)
+      # Issue #948: 永続化ファイルの生 serde parse 握りつぶし (`serde_json::from_*(...).ok()`)
       # を検出して fail させる。読込は safe_load 共通基盤 (#936) 経由を強制する。
       # 例外は該当行直前の `// safe-load-exempt: <理由>` で明示 opt-out。
       - name: Safe-load lint (persistence parse guard)

--- a/build/check-safe-load.mjs
+++ b/build/check-safe-load.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Issue #948: 永続化ファイルの「生 serde parse 握り潰し読込」を CI で検出する tripwire。
+//
+// #936 の根本原因は、新しい永続化ストアを書く開発者が `serde_json::from_*(...).ok()`
+// (parse 失敗を黙って捨てて default に倒す) を最も簡単な前例としてコピーできること。
+// この形は「破損 JSON → 黙って default 読込 → 次回 save で正常データを backup 無しに
+// 上書き消失」のデータ消失バグを既定で内包する。読み込みは必ず
+// `crate::commands::safe_load` (退避してから default に倒す共通基盤) を経由すること。
+//
+// 例外 (外部ツール所有ファイルの read-only 参照 / socket プロトコル行 など、
+// 「破損→default→上書き消失」経路が構造的に存在しないもの) は、該当行または直前行に
+//   // safe-load-exempt: <理由>
+// を書いて明示的に opt-out する。理由なしの exempt は review で弾く運用。
+//
+// 制限: 行単位 (直後 2 行まで連結) の regex 検査なので、`.ok()` を 3 行以上離して書けば
+// すり抜けられる。これは「うっかりコピーされる支配的パターン」を止める tripwire であり、
+// 完全な静的解析ではない。
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const scanRoot = join(repoRoot, 'src-tauri', 'src');
+
+// safe_load 実装自身 (doc コメントでアンチパターンを説明している) は対象外。
+const EXEMPT_FILES = new Set(['commands/safe_load.rs'.replace(/\//g, '/')]);
+
+const PATTERN = /serde_json::from_(slice|str)\b[\s\S]{0,200}?\.ok\(\)/;
+const EXEMPT_MARKER = 'safe-load-exempt';
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (name.endsWith('.rs')) out.push(p);
+  }
+  return out;
+}
+
+const violations = [];
+for (const file of walk(scanRoot)) {
+  const rel = relative(scanRoot, file).replace(/\\/g, '/');
+  if (EXEMPT_FILES.has(rel)) continue;
+  const lines = readFileSync(file, 'utf8').split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    // 複数行 statement (`from_slice::<T>(&bytes)\n    .ok()`) も拾うため直後 2 行を連結する。
+    const window = lines.slice(i, i + 3).join('\n');
+    if (!PATTERN.test(window)) continue;
+    if (!/serde_json::from_(slice|str)\b/.test(lines[i])) continue; // 起点行のみ報告
+    // exempt マーカーは該当行または直前 3 行以内 (複数行コメントで理由を書けるように)。
+    const lookback = lines.slice(Math.max(0, i - 3), i + 1).join('\n');
+    if (lookback.includes(EXEMPT_MARKER)) continue;
+    violations.push(`${rel}:${i + 1}: ${lines[i].trim()}`);
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    '[check-safe-load] 永続化ファイルの生 serde parse 握り潰し (`serde_json::from_*(...).ok()`) を検出しました。\n' +
+      '`crate::commands::safe_load::safe_load_or_quarantine` / `safe_parse_or_quarantine` を使うか、\n' +
+      '永続化ファイルの読込でない場合は該当行の直前に `// safe-load-exempt: <理由>` を書いてください (Issue #948)。\n'
+  );
+  for (const v of violations) console.error(`  ${v}`);
+  process.exit(1);
+}
+console.log('[check-safe-load] OK (no raw serde parse of persisted files)');

--- a/build/check-safe-load.mjs
+++ b/build/check-safe-load.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Issue #948: 永続化ファイルの「生 serde parse 握り潰し読込」を CI で検出する tripwire。
+// Issue #948: 永続化ファイルの「生 serde parse 握りつぶし読込」を CI で検出する tripwire。
 //
 // #936 の根本原因は、新しい永続化ストアを書く開発者が `serde_json::from_*(...).ok()`
 // (parse 失敗を黙って捨てて default に倒す) を最も簡単な前例としてコピーできること。
@@ -58,7 +58,7 @@ for (const file of walk(scanRoot)) {
 
 if (violations.length > 0) {
   console.error(
-    '[check-safe-load] 永続化ファイルの生 serde parse 握り潰し (`serde_json::from_*(...).ok()`) を検出しました。\n' +
+    '[check-safe-load] 永続化ファイルの生 serde parse 握りつぶし (`serde_json::from_*(...).ok()`) を検出しました。\n' +
       '`crate::commands::safe_load::safe_load_or_quarantine` / `safe_parse_or_quarantine` を使うか、\n' +
       '永続化ファイルの読込でない場合は該当行の直前に `// safe-load-exempt: <理由>` を書いてください (Issue #948)。\n'
   );

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run",
+    "lint:safe-load": "node build/check-safe-load.mjs",
     "test:watch": "vitest",
     "icons": "node build/generate-icons.mjs"
   },

--- a/src-tauri/src/commands/handoffs.rs
+++ b/src-tauri/src/commands/handoffs.rs
@@ -413,10 +413,13 @@ pub async fn handoffs_read(
     }
     let id = safe_segment(&handoff_id);
     let path = handoff_dir(&project_root, team_id.as_deref()).join(format!("{id}.json"));
-    let Ok(bytes) = fs::read(&path).await else {
-        return Ok(None);
-    };
-    Ok(serde_json::from_slice::<HandoffCheckpoint>(&bytes).ok())
+    // Issue #948: 生 `from_slice(...).ok()` の握り潰し読込を廃止し、safe_load 共通基盤 (#936)
+    // に統一する。破損 checkpoint は `.bak.<ts>` へ退避してから None に倒す。
+    Ok(
+        crate::commands::safe_load::safe_load_or_quarantine::<HandoffCheckpoint>(&path, None)
+            .await
+            .into_option(),
+    )
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/handoffs.rs
+++ b/src-tauri/src/commands/handoffs.rs
@@ -413,7 +413,7 @@ pub async fn handoffs_read(
     }
     let id = safe_segment(&handoff_id);
     let path = handoff_dir(&project_root, team_id.as_deref()).join(format!("{id}.json"));
-    // Issue #948: 生 `from_slice(...).ok()` の握り潰し読込を廃止し、safe_load 共通基盤 (#936)
+    // Issue #948: 生 `from_slice(...).ok()` の握りつぶし読込を廃止し、safe_load 共通基盤 (#936)
     // に統一する。破損 checkpoint は `.bak.<ts>` へ退避してから None に倒す。
     Ok(
         crate::commands::safe_load::safe_load_or_quarantine::<HandoffCheckpoint>(&path, None)

--- a/src-tauri/src/pty/codex_broker.rs
+++ b/src-tauri/src/pty/codex_broker.rs
@@ -102,6 +102,8 @@ fn cleanup_stale_in_state_dir(state_dir: &Path, is_alive: impl Fn(u32) -> bool) 
 
     let session = match std::fs::read_to_string(&broker_file)
         .ok()
+        // safe-load-exempt: Codex CLI が所有する外部ファイルの read-only 参照。vibe-editor は
+        // この path に save しないため #936 の「破損→default→上書き消失」経路が存在しない。
         .and_then(|s| serde_json::from_str::<BrokerSession>(&s).ok())
     {
         Some(session) => session,

--- a/src-tauri/src/pty/codex_watcher.rs
+++ b/src-tauri/src/pty/codex_watcher.rs
@@ -190,6 +190,8 @@ fn read_codex_session_meta(path: &Path) -> Option<(String, String)> {
     if reader.read_line(&mut first).ok()? == 0 {
         return None; // 空ファイル
     }
+    // safe-load-exempt: Codex CLI が書く rollout jsonl (外部ファイル) の read-only 参照。
+    // partial write は次イベントで recheck される設計で、退避も上書きもしない。
     let v: serde_json::Value = serde_json::from_str(first.trim()).ok()?;
     if v.get("type").and_then(|t| t.as_str()) != Some("session_meta") {
         return None;

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -824,6 +824,7 @@ mod handshake_auth_tests {
         let read_res = timeout(Duration::from_secs(5), reader.read_line(&mut line)).await;
         let outcome = match read_res {
             Ok(Ok(0)) | Ok(Err(_)) | Err(_) => None,
+            // safe-load-exempt: socket プロトコル行 (テスト) の parse。永続化ファイルではない。
             Ok(Ok(_)) => serde_json::from_str::<serde_json::Value>(line.trim()).ok(),
         };
 


### PR DESCRIPTION
## Summary
Closes #948 (#936 の再発防止ガード)。

- `build/check-safe-load.mjs` を新設。`src-tauri/src` の `serde_json::from_{slice,str}(...).ok()` (parse 失敗の握り潰し読込 = #936 の「破損→default→上書き消失」を既定で内包するパターン) を検出して fail させる
- 例外は該当行直前 3 行以内の `// safe-load-exempt: <理由>` で明示 opt-out。現状の正当な 3 件 (Codex CLI 所有ファイルの read-only 参照 2 件 / socket プロトコル行 1 件) にマーカーと理由を付与
- 検出された唯一の真の違反 `handoffs_read` の checkpoint 読込を `safe_load_or_quarantine` へ移行 (破損 checkpoint を `.bak.<ts>` 退避してから None)
- `npm run lint:safe-load` を追加し、ci.yml の ESLint 直後に step として配線
- 制限 (issue の false positive 回避方針): 行ベース regex の tripwire であり完全な静的解析ではない。`.ok()` を 3 行以上離せばすり抜け可能だが、「うっかりコピーされる支配的パターン」の阻止が目的

## Test plan
- [x] `node build/check-safe-load.mjs` がローカルで OK (違反 0)
- [x] exempt マーカーを外すと該当 3 件が検出され exit 1 になることを確認
- [x] `cargo test --lib` 683 テストパス (handoffs テスト含む)