### PR TITLE
fix(pty): #951 シャットダウン/再起動を構造化し kill と exit の競合を解消

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -4,7 +4,7 @@
 // - ProjectRoot は AppState に保持し、CLI 引数 / 環境変数 / カレントディレクトリで初期化
 use crate::state::AppState;
 use serde::Serialize;
-use tauri::State;
+use tauri::{Manager, State};
 
 #[derive(Serialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -89,8 +89,26 @@ pub fn app_set_project_root(
     Ok(())
 }
 
+/// Issue #951: 旧実装は `app.restart()` を直接呼ぶだけで、in-flight inject の待機も PTY の
+/// kill も行わず、旧プロセスの子 (claude/codex + 配下 MCP) が回収されないまま新プロセスと
+/// 並走していた。CloseRequested handler (lib.rs) と同じ構造化シャットダウン
+/// (inject drain → blocking kill_all) を通してから restart する。
 #[tauri::command]
-pub fn app_restart(app: tauri::AppHandle) {
+pub async fn app_restart(app: tauri::AppHandle) {
+    let state = app.state::<crate::state::AppState>();
+    let drained = state
+        .pty_inflight
+        .wait_idle(std::time::Duration::from_secs(3))
+        .await;
+    if !drained {
+        tracing::warn!("[lifecycle] app_restart: inject drain timeout — proceeding to kill_all");
+    }
+    let registry = state.pty_registry.clone();
+    let _ = tauri::async_runtime::spawn_blocking(move || {
+        registry.kill_all_blocking(std::time::Duration::from_secs(2));
+    })
+    .await;
+    tracing::info!("[lifecycle] app_restart: PTY shutdown complete — restarting");
     app.restart();
 }
 pub(crate) mod team_mcp;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -475,7 +475,15 @@ pub fn run() {
                                     "[lifecycle] in-flight inject drain timeout — proceeding to kill_all (was={inflight_before}, remaining={remaining})"
                                 );
                             }
-                            state.pty_registry.kill_all();
+                            // Issue #951: 旧実装の kill_all() は taskkill を detached thread に
+                            // 逃がして即返るため、直後の exit(0) が taskkill より先に自プロセスを
+                            // 消して子プロセスが孤児化する競合があった。blocking 版で全 session の
+                            // process-tree kill 完了 (上限 2s) を待ってから exit する。
+                            let registry = state.pty_registry.clone();
+                            let _ = tauri::async_runtime::spawn_blocking(move || {
+                                registry.kill_all_blocking(std::time::Duration::from_secs(2));
+                            })
+                            .await;
                             // MCP エントリは残しておく (次回起動時に reclaim されるので副作用なし)
                             // team-bridge.js は ~/.vibe-editor/ に置いたまま (再利用のため)
                             app_for_drain.exit(0);

--- a/src-tauri/src/pty/registry.rs
+++ b/src-tauri/src/pty/registry.rs
@@ -373,6 +373,58 @@ impl SessionRegistry {
         }
     }
 
+    /// Issue #951: シャットダウン / 再起動経路専用の **同期** kill_all。
+    ///
+    /// `kill_all()` の `SessionHandle::kill()` は Windows で process-tree kill (taskkill) を
+    /// detached thread に逃がして即返るため、直後に `app.exit(0)` / `app.restart()` で
+    /// 自プロセスごと消えると taskkill が走り切る前に殺され、子プロセス (claude/codex +
+    /// その配下の MCP) が孤児として残る競合があった。
+    ///
+    /// 本メソッドは各 session の process-tree kill を並列 thread で実行し、全完了 (または
+    /// `timeout`) まで呼び出し thread をブロックして待つ。blocking なので async context
+    /// からは `spawn_blocking` 経由で呼ぶこと。
+    pub fn kill_all_blocking(&self, timeout: Duration) {
+        let sessions: Vec<Arc<SessionHandle>> = {
+            let mut g = recover(self.inner.lock());
+            g.by_agent.clear();
+            g.by_session_key.clear();
+            g.by_id.drain().map(|(_, s)| s).collect()
+        };
+        if sessions.is_empty() {
+            return;
+        }
+        let total = sessions.len();
+        let (tx, rx) = std::sync::mpsc::channel::<()>();
+        for s in sessions {
+            let tx = tx.clone();
+            std::thread::spawn(move || {
+                s.kill_blocking();
+                let _ = tx.send(());
+            });
+        }
+        drop(tx);
+        let deadline = Instant::now() + timeout;
+        let mut done = 0usize;
+        while done < total {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match rx.recv_timeout(remaining) {
+                Ok(()) => done += 1,
+                Err(_) => break, // timeout または全 sender drop
+            }
+        }
+        if done < total {
+            tracing::warn!(
+                "[pty] kill_all_blocking timeout: {done}/{total} sessions confirmed killed \
+                 within {timeout:?} — proceeding with shutdown"
+            );
+        } else {
+            tracing::info!("[pty] kill_all_blocking finished ({done}/{total})");
+        }
+    }
+
     /// Issue #937: チーム解散 (`app_cleanup_team_mcp` → `clear_team`) 時に、当該 `team_id` に
     /// 属する PTY を **backend 側で確実に回収** する。回収した session 数を返す。
     ///
@@ -660,6 +712,50 @@ mod attach_lookup_tests {
         // 片方のみ Some → false (片側のみ team 紐付けが残っている状況は cross-team risk)
         assert!(!team_ids_match(Some("team-a"), None));
         assert!(!team_ids_match(None, Some("team-b")));
+    }
+}
+
+#[cfg(test)]
+mod kill_all_blocking_tests {
+    //! Issue #951: `kill_all_blocking` が「返った時点で全 session の kill が完了している」
+    //! ことを検証する。detached thread に逃がす `kill_all` と違い、直後に exit(0) /
+    //! restart してもプロセス回収が走り切っている保証が欲しい経路 (シャットダウン) 用。
+    use super::*;
+    use crate::pty::session::test_support::handle_with;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn kill_all_blocking_kills_all_sessions_before_returning() {
+        let reg = SessionRegistry::new();
+        let k1 = Arc::new(AtomicUsize::new(0));
+        let k2 = Arc::new(AtomicUsize::new(0));
+        assert!(reg
+            .insert_if_absent(
+                "s1".to_string(),
+                handle_with(Some("a1"), Some("k1"), None, k1.clone()),
+            )
+            .is_ok());
+        assert!(reg
+            .insert_if_absent(
+                "s2".to_string(),
+                handle_with(Some("a2"), Some("k2"), None, k2.clone()),
+            )
+            .is_ok());
+
+        reg.kill_all_blocking(Duration::from_secs(5));
+
+        // 返った時点で各 session の killer が呼ばれている (>=1 は Drop 経由の冪等二重 kill 許容)
+        assert!(k1.load(Ordering::SeqCst) >= 1, "s1 must be killed before return");
+        assert!(k2.load(Ordering::SeqCst) >= 1, "s2 must be killed before return");
+        assert!(reg.get("s1").is_none());
+        assert!(reg.get("s2").is_none());
+    }
+
+    #[test]
+    fn kill_all_blocking_on_empty_registry_returns_immediately() {
+        let reg = SessionRegistry::new();
+        // session 0 件なら channel 待ちに入らず即返る (hang しないことの smoke)
+        reg.kill_all_blocking(Duration::from_millis(50));
     }
 }
 

--- a/src-tauri/src/pty/session/handle.rs
+++ b/src-tauri/src/pty/session/handle.rs
@@ -168,6 +168,23 @@ impl SessionHandle {
         Ok(())
     }
 
+    /// Issue #951: シャットダウン / 再起動経路専用の **同期** kill。
+    ///
+    /// `kill()` は Windows で taskkill を detached thread に逃がして即返るため、直後に
+    /// プロセスごと exit すると taskkill が走り切る前に殺され、子プロセスが孤児化する
+    /// 競合があった。本メソッドは process-tree kill を呼び出し thread 上で同期実行する。
+    /// 通常のタブ close では従来どおり `kill()` を使う (UI をブロックしないため)。
+    pub fn kill_blocking(&self) {
+        self.watcher_cancel.store(true, Ordering::Release);
+        #[cfg(windows)]
+        if let Some(pid) = self.process_id {
+            Self::kill_process_tree_best_effort(pid);
+        }
+        if let Ok(mut k) = lock_poisoned!(self.killer, "killer") {
+            let _ = k.kill();
+        }
+    }
+
     /// Issue #632: claude_watcher が共有する cancel signal。`spawn_watcher` の caller
     /// (terminal_create) はこれを clone して watcher thread に渡す。session 寿命に追従して
     /// watcher を停止できる (= 60 秒 deadline での polling 漏れ問題を解消)。


### PR DESCRIPTION
## Summary
Closes #951。

- `SessionHandle::kill_blocking` / `SessionRegistry::kill_all_blocking(timeout)` を新設。通常の `kill()` は Windows で taskkill を detached thread に逃がして即返るため、直後の `app.exit(0)` が taskkill より先に自プロセスを消し、子プロセス (claude/codex + 配下 MCP) が孤児化する競合があった。blocking 版は全 session の process-tree kill を並列 thread で実行し、mpsc + deadline で完了を待ってから返る
- CloseRequested handler: inject drain (3s, #630) → `kill_all_blocking` (2s, spawn_blocking 経由) → `exit(0)` の構造化シーケンスに変更
- `app_restart`: 旧実装は `app.restart()` 直呼びで kill すら走らず、旧プロセスの子が新プロセスと並走していた。同じ構造化シャットダウンを通してから restart するよう変更

なお #950 (クラッシュ/強制終了時の OS 寿命バインド = Windows Job Object) は別レイヤの対策として本 PR には含めない (正常終了経路の競合解消が本 issue のスコープ)。

## Test plan
- [x] `cargo test --lib` 688 テストパス (kill_all_blocking の「返った時点で kill 完了」+ 空 registry 即返の 2 テストを新規追加)
- [x] `cargo check` クリーン (Manager import 追加で async command 化)
- [x] kill_team (#937) / kill_all (#630) の既存挙動は不変 (通常タブ close は従来の非 blocking kill のまま)