### PR TITLE
fix(pty): #950 PTY child を kill-on-close Job Object に bind し OS 寿命バインドを実現

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -85,6 +85,8 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Pipes",
     "Win32_System_Threading",
     "Win32_Security",
+    # Issue #950: PTY child の kill-on-close Job Object
+    "Win32_System_JobObjects",
 ] }
 
 [dev-dependencies]

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -19,6 +19,9 @@ pub mod path_norm;
 pub mod registry;
 pub mod scrollback;
 pub mod session;
+// Issue #950: PTY child の OS 寿命バインド (Windows Job Object)。
+#[cfg(windows)]
+pub mod win_job_object;
 
 /// Issue #494: PTY (`batcher` flush 境界条件等) の integration test を集約する test-only module。
 #[cfg(test)]

--- a/src-tauri/src/pty/session/handle.rs
+++ b/src-tauri/src/pty/session/handle.rs
@@ -65,6 +65,12 @@ pub struct SessionHandle {
     /// 観測して即時 exit する。これにより「session が 1 秒で死んでも watcher が 60 秒
     /// 並走する」リソース蓄積を防ぐ。
     pub(super) watcher_cancel: Arc<AtomicBool>,
+    /// Issue #950: child プロセスツリーを bind した kill-on-close Job Object。
+    /// この handle の drop (= タブ close / kill_all / vibe-editor 異常死による OS の
+    /// handle 強制 close) で job 内の全プロセス (孫含む) が OS により kill される。
+    /// Job 作成 / assign に失敗した場合は None (taskkill 経路のみで回収)。
+    #[cfg(windows)]
+    pub(super) job: Option<crate::pty::win_job_object::KillOnCloseJob>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -369,6 +375,8 @@ pub(crate) mod test_support {
             }),
             scrollback: new_scrollback(),
             watcher_cancel: Arc::new(AtomicBool::new(false)),
+            #[cfg(windows)]
+            job: None,
         }
     }
 

--- a/src-tauri/src/pty/session/spawn.rs
+++ b/src-tauri/src/pty/session/spawn.rs
@@ -356,6 +356,15 @@ pub fn spawn_session(
     let process_id = child.process_id();
     let killer = child.clone_killer();
 
+    // Issue #950: child を kill-on-close Job Object に bind し、vibe-editor 本体の
+    // クラッシュ / 強制終了でも OS が handle close 経由で子プロセスツリーを回収できる
+    // ようにする。作成 / assign 失敗は warn のみ (従来の taskkill 経路で回収継続)。
+    #[cfg(windows)]
+    let job = process_id
+        .and_then(|pid| {
+            crate::pty::win_job_object::KillOnCloseJob::create().filter(|job| job.assign_pid(pid))
+        });
+
     // reader thread (blocking IO -> mpsc)
     let mut reader = pair.master.try_clone_reader()?;
     let mut writer = pair.master.take_writer()?;
@@ -551,6 +560,8 @@ pub fn spawn_session(
         scrollback,
         // Issue #632: watcher cancel token は session 起動と同寿命。kill() / Drop で flip。
         watcher_cancel: Arc::new(AtomicBool::new(false)),
+        #[cfg(windows)]
+        job,
     })
 }
 

--- a/src-tauri/src/pty/win_job_object.rs
+++ b/src-tauri/src/pty/win_job_object.rs
@@ -1,0 +1,148 @@
+//! Issue #950: PTY 子プロセスの OS 寿命バインド (Windows Job Object)。
+//!
+//! 従来の回収は「正常終了経路での taskkill /T」(#951 で blocking 化) のみで、
+//! vibe-editor 本体の **クラッシュ / taskkill 強制終了** では誰も taskkill を呼べず、
+//! claude/codex とその配下 (MCP node 等の孫プロセス) が孤児として残っていた。
+//!
+//! 本 module は `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` 付きの Job Object を PTY child
+//! ごとに作成して child PID を assign する。Job handle は `SessionHandle` が保持し、
+//! - handle drop (タブ close / kill_all) → CloseHandle → job 内全プロセスを OS が kill
+//! - vibe-editor 本体の異常死 → OS が全 handle を強制 close → 同様に kill
+//! の両経路で「親の寿命 = 子プロセスツリーの寿命」を OS レベルで保証する。
+//!
+//! 制限:
+//! - assign は spawn 後の後付けなので、child が assign 前に spawn した孫は job に
+//!   入らない (sub-ms の race、実用上 cmd.exe / node の初期化より十分速い)。
+//!   taskkill /T fallback (#951) は引き続き併用する (defense in depth)。
+//! - 子が `CREATE_BREAKAWAY_FROM_JOB` を明示しない限り孫は job を継承する
+//!   (Windows 8+ の nested job により、子が自前の job を作っても破綻しない)。
+
+#![cfg(windows)]
+
+use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, HANDLE};
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE};
+
+/// KILL_ON_JOB_CLOSE な Job Object の RAII wrapper。
+/// drop (= 最後の handle close) で job 内の全プロセスが OS によって kill される。
+pub struct KillOnCloseJob(HANDLE);
+
+// HANDLE は kernel object への参照で、所有権ごと thread 間を移動しても安全。
+unsafe impl Send for KillOnCloseJob {}
+unsafe impl Sync for KillOnCloseJob {}
+
+impl KillOnCloseJob {
+    /// Job Object を作成して KILL_ON_JOB_CLOSE を設定する。失敗は warn ログを残して
+    /// None (Job 無しでも従来の taskkill 経路は生きているため起動自体は止めない)。
+    pub fn create() -> Option<Self> {
+        unsafe {
+            let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if job.is_null() {
+                tracing::warn!(
+                    "[pty] CreateJobObjectW failed (err={}); child lifetime binding disabled",
+                    GetLastError()
+                );
+                return None;
+            }
+            let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            let ok = SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const core::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            );
+            if ok == 0 {
+                tracing::warn!(
+                    "[pty] SetInformationJobObject(KILL_ON_JOB_CLOSE) failed (err={})",
+                    GetLastError()
+                );
+                let _ = CloseHandle(job);
+                return None;
+            }
+            Some(Self(job))
+        }
+    }
+
+    /// `pid` のプロセスをこの job に割り当てる。以降にそのプロセスが spawn する
+    /// 子孫は自動的に job へ入る。失敗 (既に終了 / 権限) は warn を残して false。
+    pub fn assign_pid(&self, pid: u32) -> bool {
+        unsafe {
+            let process = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid);
+            if process.is_null() {
+                tracing::warn!(
+                    "[pty] OpenProcess(pid={pid}) for job assignment failed (err={})",
+                    GetLastError()
+                );
+                return false;
+            }
+            let ok = AssignProcessToJobObject(self.0, process);
+            let _ = CloseHandle(process);
+            if ok == 0 {
+                tracing::warn!(
+                    "[pty] AssignProcessToJobObject(pid={pid}) failed (err={})",
+                    GetLastError()
+                );
+                return false;
+            }
+            tracing::debug!("[pty] child pid={pid} bound to kill-on-close job object");
+            true
+        }
+    }
+}
+
+impl Drop for KillOnCloseJob {
+    fn drop(&mut self) {
+        // KILL_ON_JOB_CLOSE: この close で job 内に残る全プロセスが kill される。
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_and_drop_does_not_panic() {
+        // Job Object の作成 + KILL_ON_JOB_CLOSE 設定 + drop (CloseHandle) の往復 smoke。
+        let job = KillOnCloseJob::create();
+        assert!(job.is_some(), "job object creation should succeed on Windows");
+        drop(job);
+    }
+
+    #[test]
+    fn assigned_child_is_killed_when_job_drops() {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        // 長時間生きる無害な child (ping ループ) を spawn → job に assign → job drop で
+        // OS により kill されることを実プロセスで検証する。
+        let mut child = std::process::Command::new("ping")
+            .args(["-n", "60", "127.0.0.1"])
+            .creation_flags(CREATE_NO_WINDOW)
+            .spawn()
+            .expect("spawn ping");
+        let job = KillOnCloseJob::create().expect("create job");
+        assert!(job.assign_pid(child.id()), "assign must succeed for live child");
+        drop(job); // KILL_ON_JOB_CLOSE → child が OS に kill される
+
+        // kill 反映を少し待ってから確認 (best-effort、最大 ~2s)
+        let mut exited = false;
+        for _ in 0..40 {
+            if let Ok(Some(_)) = child.try_wait() {
+                exited = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        if !exited {
+            let _ = child.kill(); // テストの後始末 (失敗時に ping を残さない)
+        }
+        assert!(exited, "child must be killed by job close");
+    }
+}


### PR DESCRIPTION
## Summary
Closes #950。

vibe-editor 本体の**クラッシュ / taskkill 強制終了**では正常終了経路の回収 (#951 / PR #965) が走らず、claude/codex とその配下 (MCP node 等の孫プロセス) が孤児化していた。`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` 付きの Job Object を PTY child ごとに作成して spawn 直後に PID を assign し、`SessionHandle` に RAII で保持する。

- handle drop (タブ close / kill_all / 本体異常死による OS の handle 強制 close) → `CloseHandle` → job 内の全プロセス (孫含む) を OS が kill。「親の寿命 = 子プロセスツリーの寿命」を OS レベルで保証
- 既存の taskkill /T + ChildKiller 経路は defense in depth として併用 (assign 前に spawn された孫の取りこぼし対策)
- Job 作成 / assign 失敗は warn のみで PTY 起動は止めない (fail-open、従来経路で回収継続)
- Unix / macOS は `cfg(windows)` ゲートで構造ごと不在 (CI の cargo-cfg matrix で両 OS の compile を保証)
- windows-sys に `Win32_System_JobObjects` feature を追加

## Test plan
- [x] `cargo test --lib` 690 テストパス
- [x] 新規統合テスト: 実プロセス (ping) を job に assign → job drop → OS により kill されることを `try_wait` で検証 / job の create+drop smoke
- [x] `cargo check` クリーン (Windows)。Linux/macOS は cfg ゲートで該当コード不在 (CI の cargo-cfg job で検証される)