### PR TITLE
security(files): #963 write 系 files_* を multi-root workspace 対応にし is_safe_watch_root の verbatim bypass も修正

### DIFF
--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -125,16 +125,21 @@ pub async fn assert_active_project_root(
     Ok(active_canon)
 }
 
-/// Issue #954: read/probe 系 IPC (`files_list` / `files_read`) 用のゲート。
+/// Issue #954 / #963: ファイル系 IPC (`files_*`) 用のゲート。
 ///
-/// write 系 (#932) の `assert_active_project_root` は active project との厳格一致だが、
-/// ファイルツリーは multi-root workspace (`settings.workspaceFolders`, Issue #4) で
-/// active 以外の追加ルートも正当に列挙・閲覧するため、厳格一致だとこの機能が壊れる。
-/// 本 helper は「active project root **または** settings.json に永続化された
-/// workspaceFolders のいずれか」に canonicalize 一致する場合のみ許可する。
+/// `assert_active_project_root` は active project との厳格一致だが、ファイルツリーは
+/// multi-root workspace (`settings.workspaceFolders`, Issue #4) で active 以外の追加
+/// ルートも正当に列挙・閲覧・編集するため、厳格一致だとこの機能が壊れる
+/// (#954 で read 側、#963 で write 側に適用)。本 helper は「active project root
+/// **または** settings.json に永続化された workspaceFolders のいずれか」に
+/// canonicalize 一致する場合のみ許可する。
 ///
 /// - workspaceFolders の参照先は **Rust 側 settings.json (SSOT)** であり、呼び出しごとの
 ///   renderer 引数ではない (renderer が任意 path を主張しても settings に無ければ reject)。
+/// - workspaceFolders 経由の許可は `fs_watch::is_safe_watch_root` (system 領域 / home /
+///   drive root の denylist) も併せて要求する (#963)。settings_save は workspaceFolders を
+///   無検証で受けるため、ここで通過させると write 系がシステム領域に届いてしまう。
+///   active root は `app_set_project_root` 入口で同検証済み (#639) なので再検証しない。
 /// - settings 読込は active 不一致のときだけ走る (primary root の通常フローでは I/O 追加なし)。
 /// - active が未設定 (起動直後) でも workspaceFolders 一致なら許可する (起動時の
 ///   追加ルート列挙を transient reject しない)。
@@ -190,8 +195,9 @@ pub async fn assert_readable_project_root(
     ))
 }
 
-/// `req_canon` (canonicalize 済み) が `folders` のいずれかと canonicalize 一致するか。
-/// 存在しない / canonicalize できない folder エントリは skip する。
+/// `req_canon` (canonicalize 済み) が `folders` のいずれかと canonicalize 一致し、かつ
+/// その folder が `is_safe_watch_root` (system 領域 / home / drive root denylist, #963)
+/// を通るか。存在しない / canonicalize できない / unsafe な folder エントリは skip する。
 ///
 /// PR #962 auto-review: canonicalize は folder ごとに blocking I/O を伴うため、NFS/SMB 等の
 /// 低速マウントで folder 数分の直列待ちにならないよう `JoinSet` で並列実行し、
@@ -204,7 +210,23 @@ async fn matches_any_workspace_folder(req_canon: &std::path::Path, folders: &[St
             continue;
         }
         let f = f.to_string();
-        set.spawn(async move { tokio::fs::canonicalize(&f).await.ok() });
+        set.spawn(async move {
+            // Issue #963: settings_save は workspaceFolders を無検証で受けるため、
+            // ゲート通過条件としてここで safe root 検証を要求する (write 系の防御)。
+            // `is_safe_watch_root` は **raw path を受け取り内部で canonicalize する**
+            // 設計 (app_set_project_root #639 と同じ呼び方)。canonicalize 済みの
+            // verbatim-prefix (`\\?\C:\...`) 付き path を渡すと Windows の denylist
+            // (`c:\windows` 前方一致) が素通りするため、raw `f` を渡すこと。
+            if !crate::commands::fs_watch::is_safe_watch_root(std::path::Path::new(&f)) {
+                tracing::warn!(
+                    folder = %clamp_for_log(&f),
+                    "[authz] workspace folder skipped by safe-root check"
+                );
+                return None;
+            }
+            // 比較は canonicalize 後の path で行う (req_canon も canonicalize 済み)。
+            tokio::fs::canonicalize(&f).await.ok()
+        });
     }
     while let Some(res) = set.join_next().await {
         if let Ok(Some(folder_canon)) = res {
@@ -389,6 +411,21 @@ mod tests {
         assert!(
             matches!(err, CommandError::Authz(ref m) if m.contains("workspace folders")),
             "got: {err}"
+        );
+    }
+
+    /// Issue #963: settings_save は workspaceFolders を無検証で受けるため、system 領域が
+    /// 登録されていてもゲートは通さない (write 系がシステム領域に届くのを防ぐ)。
+    #[tokio::test]
+    async fn workspace_folder_in_system_area_is_skipped() {
+        #[cfg(windows)]
+        let sys = "C:\\Windows";
+        #[cfg(unix)]
+        let sys = "/etc";
+        let req = std::fs::canonicalize(sys).expect("system dir must exist");
+        assert!(
+            !matches_any_workspace_folder(&req, &[sys.to_string()]).await,
+            "system-area workspace folder must be rejected by safe-root check"
         );
     }
 

--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -217,15 +217,25 @@ async fn matches_any_workspace_folder(req_canon: &std::path::Path, folders: &[St
             // 設計 (app_set_project_root #639 と同じ呼び方)。canonicalize 済みの
             // verbatim-prefix (`\\?\C:\...`) 付き path を渡すと Windows の denylist
             // (`c:\windows` 前方一致) が素通りするため、raw `f` を渡すこと。
-            if !crate::commands::fs_watch::is_safe_watch_root(std::path::Path::new(&f)) {
-                tracing::warn!(
-                    folder = %clamp_for_log(&f),
-                    "[authz] workspace folder skipped by safe-root check"
-                );
-                return None;
-            }
-            // 比較は canonicalize 後の path で行う (req_canon も canonicalize 済み)。
-            tokio::fs::canonicalize(&f).await.ok()
+            //
+            // PR #968 auto-review: `is_safe_watch_root` は同期 blocking I/O
+            // (`std::fs::canonicalize` + metadata) を含むため、Tokio ワーカースレッドを
+            // 塞がないよう spawn_blocking に逃がす。canonicalize も同 blocking task 内で
+            // 行い、async fs 呼び出しとの二重 I/O も避ける。
+            tokio::task::spawn_blocking(move || {
+                if !crate::commands::fs_watch::is_safe_watch_root(std::path::Path::new(&f)) {
+                    tracing::warn!(
+                        folder = %clamp_for_log(&f),
+                        "[authz] workspace folder skipped by safe-root check"
+                    );
+                    return None;
+                }
+                // 比較は canonicalize 後の path で行う (req_canon も canonicalize 済み)。
+                std::fs::canonicalize(&f).ok()
+            })
+            .await
+            .ok()
+            .flatten()
         });
     }
     while let Some(res) = set.join_next().await {

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -16,23 +16,20 @@ use crate::commands::error::CommandResult;
 use crate::state::AppState;
 use encoding::{detect_text_or_binary, encode_for_save};
 
-/// Issue #932: renderer 由来の `project_root` を `AppState` の active project と照合する共通ゲート。
+/// Issue #932 / #954 / #963: renderer 由来の `project_root` を検証する files_* 共通ゲート。
+///
+/// 当初 (#932) は write 系を active project との厳格一致で守っていたが、multi-root
+/// workspace (settings.workspaceFolders, Issue #4) の追加ルート内ファイル操作
+/// (新規作成 / リネーム / 削除 / 貼り付け) まで拒否してしまう退行があった (#963)。
+/// read 側 (#954) と同じ `assert_readable_project_root` (active root ∪ settings.json
+/// SSOT の workspaceFolders、workspace folder には `is_safe_watch_root` 検証を追加要求)
+/// に read/write とも統一する。
 ///
 /// async command が `State` (参照入力) を取ると Tauri が `Result` 返却を強制するため、非 `Result`
 /// を返す既存 FS コマンド契約 (renderer は構造体をそのまま受ける) を保てない。owned/'static な
 /// `AppHandle` 経由で state を引くことでこの制約を回避し、既存の戻り値型を維持したまま
-/// `assert_active_project_root` ゲートを各 mutation コマンド先頭に挿せるようにする。
-async fn assert_project_root_via(app: &AppHandle, project_root: &str) -> CommandResult<()> {
-    let state = app.state::<AppState>();
-    crate::commands::authz::assert_active_project_root(&state.project_root, project_root)
-        .await
-        .map(|_| ())
-}
-
-/// Issue #954: read/probe 系 (`files_list` / `files_read`) 用ゲート。write 系 (#932) と違い、
-/// multi-root workspace の追加ルート (settings.workspaceFolders, Issue #4) も正当な読み取り
-/// 対象なので、active 厳格一致ではなく `assert_readable_project_root` を使う。
-async fn assert_readable_project_root_via(
+/// ゲートを各コマンド先頭に挿せるようにする。
+async fn assert_workspace_project_root_via(
     app: &AppHandle,
     project_root: &str,
 ) -> CommandResult<()> {
@@ -116,7 +113,7 @@ pub struct FileWriteResult {
 #[tauri::command]
 pub async fn files_list(app: AppHandle, project_root: String, rel_path: String) -> FileListResult {
     // Issue #954: read/probe 系も project_root ゲートに通す (任意ディレクトリ列挙の阻止)。
-    if let Err(e) = assert_readable_project_root_via(&app, &project_root).await {
+    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
         return FileListResult {
             ok: false,
             error: Some(e.to_string()),
@@ -186,7 +183,7 @@ pub async fn files_list(app: AppHandle, project_root: String, rel_path: String) 
 #[tauri::command]
 pub async fn files_read(app: AppHandle, project_root: String, rel_path: String) -> FileReadResult {
     // Issue #954: read/probe 系も project_root ゲートに通す (任意ファイル読取の阻止)。
-    if let Err(e) = assert_readable_project_root_via(&app, &project_root).await {
+    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
         return FileReadResult {
             ok: false,
             error: Some(e.to_string()),
@@ -285,7 +282,7 @@ pub async fn files_write(
 ) -> FileWriteResult {
     // Issue #932: renderer 由来の project_root を active project と照合する共通ゲート。
     // 未検証だと乗っ取られた renderer が active プロジェクト外の任意ファイルを上書きできた。
-    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
         return FileWriteResult {
             ok: false,
             error: Some(e.to_string()),
@@ -586,7 +583,7 @@ pub async fn files_create(
     overwrite: Option<bool>,
 ) -> FileMutationResult {
     // Issue #932: active project と照合してから FS 操作を行う (任意ファイル作成を防ぐ)。
-    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
         return FileMutationResult::err(rel_path, e.to_string());
     }
     files_create_inner(project_root, rel_path, name, overwrite).await
@@ -635,7 +632,7 @@ pub async fn files_create_dir(
     name: String,
 ) -> FileMutationResult {
     // Issue #932: active project と照合してから FS 操作を行う (任意ディレクトリ作成を防ぐ)。
-    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
         return FileMutationResult::err(rel_path, e.to_string());
     }
     files_create_dir_inner(project_root, rel_path, name).await
@@ -686,7 +683,7 @@ pub async fn files_rename(
     overwrite: Option<bool>,
 ) -> FileMutationResult {
     // Issue #932: active project と照合してから FS 操作を行う (任意ファイル rename/move を防ぐ)。
-    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
         return FileMutationResult::err(from_rel, e.to_string());
     }
     files_rename_inner(project_root, from_rel, to_parent_rel, new_name, overwrite).await
@@ -758,7 +755,7 @@ pub async fn files_delete(
     permanent: Option<bool>,
 ) -> FileMutationResult {
     // Issue #932: active project と照合してから FS 操作を行う (任意ファイル削除を防ぐ)。
-    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
         return FileMutationResult::err(rel_path, e.to_string());
     }
     files_delete_inner(project_root, rel_path, permanent).await
@@ -817,7 +814,7 @@ pub async fn files_copy(
     overwrite: Option<bool>,
 ) -> FileMutationResult {
     // Issue #932: active project と照合してから FS 操作を行う (任意ファイル複製を防ぐ)。
-    if let Err(e) = assert_project_root_via(&app, &project_root).await {
+    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
         return FileMutationResult::err(from_rel, e.to_string());
     }
     files_copy_inner(project_root, from_rel, to_parent_rel, new_name, overwrite).await

--- a/src-tauri/src/commands/fs_watch.rs
+++ b/src-tauri/src/commands/fs_watch.rs
@@ -128,7 +128,18 @@ pub(crate) fn is_safe_watch_root(root: &Path) -> bool {
 
     #[cfg(windows)]
     {
-        let lower = canon.to_string_lossy().to_lowercase();
+        // Issue #963: `Path::canonicalize` は Windows で `\\?\C:\...` の verbatim prefix を
+        // 付ける。素の `to_string_lossy` だと denylist の `c:\windows` 前方一致が
+        // `\\?\c:\windows` に対して常に false になり、C:\Windows / ドライブルートが
+        // 「safe」と誤判定されていた (= #639 の project_root setter ガードも無効化)。
+        // verbatim prefix (`\\?\` / `\\?\UNC\`) を剥がしてから比較する。
+        let raw = canon.to_string_lossy();
+        let stripped = raw
+            .strip_prefix(r"\\?\UNC\")
+            .map(|rest| format!(r"\\{rest}"))
+            .or_else(|| raw.strip_prefix(r"\\?\").map(str::to_string))
+            .unwrap_or_else(|| raw.to_string());
+        let lower = stripped.to_lowercase();
         if lower.len() <= 3 && lower.ends_with(":\\") {
             return false;
         }
@@ -323,11 +334,46 @@ pub fn start_for_root(app: AppHandle, root: String) {
 #[cfg(test)]
 mod tests {
     use super::{
-        claim_active_for_root, current_active, file_name_is_ignored, path_is_ignored,
-        rollback_active_if_current, ACTIVE_WATCHER_GEN,
+        claim_active_for_root, current_active, file_name_is_ignored, is_safe_watch_root,
+        path_is_ignored, rollback_active_if_current, ACTIVE_WATCHER_GEN,
     };
     use once_cell::sync::Lazy;
     use std::ffi::OsStr;
+
+    /// Issue #963: canonicalize の verbatim prefix (`\\?\C:\...`) で system 領域 denylist が
+    /// 素通りしていた回帰を固定する。system ディレクトリは safe と判定してはならない。
+    #[test]
+    fn system_directories_are_not_safe_watch_roots() {
+        #[cfg(windows)]
+        for sys in ["C:\\Windows", "C:\\Program Files", "C:\\"] {
+            let p = std::path::Path::new(sys);
+            if p.exists() {
+                assert!(
+                    !is_safe_watch_root(p),
+                    "{sys} must be rejected as an unsafe watch root"
+                );
+            }
+        }
+        #[cfg(unix)]
+        for sys in ["/etc", "/usr", "/"] {
+            let p = std::path::Path::new(sys);
+            if p.exists() {
+                assert!(
+                    !is_safe_watch_root(p),
+                    "{sys} must be rejected as an unsafe watch root"
+                );
+            }
+        }
+    }
+
+    /// 通常のプロジェクトディレクトリ (tempdir) は safe と判定される。
+    #[test]
+    fn ordinary_project_dir_is_safe_watch_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("my-project");
+        std::fs::create_dir(&sub).unwrap();
+        assert!(is_safe_watch_root(&sub));
+    }
     use std::path::Path;
     use std::sync::Mutex;
 


### PR DESCRIPTION
## Summary
Closes #963 (#954 で自分が起票した、#932 の write 系ゲートの multi-root 退行)。

- #932 の write 系ゲートは active project 厳格一致で、multi-root workspace (settings.workspaceFolders, Issue #4) の追加ルート内ファイル操作 (新規作成 / リネーム / 削除 / 貼り付け) を全拒否していた。read 側 (#954) と同じ `assert_readable_project_root` に read/write を統一 (`assert_workspace_project_root_via` に集約、files_* 8 コマンドの呼び出しを移行)
- **セキュリティ強化**: settings_save は workspaceFolders を無検証で受けるため、workspace folder 経由の許可には `is_safe_watch_root` (system 領域 / home / ドライブルート denylist) を追加要求。active root は `app_set_project_root` 入口で同検証済み (#639) なので除外
- **その過程で `is_safe_watch_root` 自体の verbatim-prefix バグを発見・修正**: `Path::canonicalize` が返す `\?\C:\...` の verbatim prefix を剥がさず `to_string_lossy` していたため、Windows の denylist (`c:\windows` 前方一致 / ドライブルート判定) が常に素通りし、**C:\Windows やドライブルートが「safe」と誤判定されていた** (= #639 の project_root setter ガードも Windows で無効化されていた既存ホール)。verbatim prefix を剥がしてから比較する

## Test plan
- [x] `cargo test --lib` 689 テストパス
- [x] 回帰テスト追加: system ディレクトリ (C:\Windows / ドライブルート 等) が unsafe / 通常 tempdir が safe と判定される、workspaceFolders 経由でも system 領域は authz ゲートを通らない
- [x] `npm run typecheck` 0 エラー