### PR TITLE
refactor(backend): #959 team:inject_failed の event payload を名前付き struct 化

### DIFF
--- a/src-tauri/src/commands/team_inject.rs
+++ b/src-tauri/src/commands/team_inject.rs
@@ -172,18 +172,19 @@ pub async fn team_send_retry_inject(
                 reason_message
             );
             // 再失敗時も `team:inject_failed` を emit して UI が state 更新できるようにする。
-            let payload = json!({
-                "teamId": args.team_id,
-                "fromAgentId": from_agent_id,
-                "fromRole": from_role,
-                "toAgentId": args.agent_id,
-                "toRole": "",
-                "messageId": args.message_id,
-                "reasonCode": reason_code,
-                "reasonMessage": reason_message,
-                "failedAt": failed_at,
-                "retried": true,
-            });
+            // Issue #959/#930: payload は events.rs の named struct (retried=true で再失敗を区別)。
+            let payload = crate::team_hub::events::InjectFailedEventPayload {
+                team_id: args.team_id.clone(),
+                from_agent_id: from_agent_id.clone(),
+                from_role: from_role.clone(),
+                to_agent_id: args.agent_id.clone(),
+                to_role: String::new(),
+                message_id: args.message_id,
+                reason_code: reason_code.to_string(),
+                reason_message: reason_message.clone(),
+                failed_at: failed_at.clone(),
+                retried: true,
+            };
             if let Err(e) = app.emit("team:inject_failed", payload) {
                 tracing::warn!("[retry_inject] emit team:inject_failed failed: {e}");
             }

--- a/src-tauri/src/team_hub/events.rs
+++ b/src-tauri/src/team_hub/events.rs
@@ -65,3 +65,26 @@ pub struct HandoffEventPayload {
     /// retry 経由の配送なら true。UI が「再送で届いた」ことを区別して描画できる。
     pub retried: bool,
 }
+
+/// `team:inject_failed` の payload。shared.ts の `TeamInjectFailedEvent` と同期。
+///
+/// emit 箇所:
+/// - `protocol/tools/send.rs` (初回配送の inject 失敗 — retried フィールド無し)
+/// - `commands/team_inject.rs` (`app_team_retry_inject` の再失敗 — retried=true)
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InjectFailedEventPayload {
+    pub team_id: String,
+    pub from_agent_id: String,
+    pub from_role: String,
+    pub to_agent_id: String,
+    pub to_role: String,
+    pub message_id: u32,
+    pub reason_code: String,
+    pub reason_message: String,
+    pub failed_at: String,
+    /// retry IPC 経由の再失敗なら true。初回配送 (send.rs) では false。
+    /// TS 側 `TeamInjectFailedEvent.retried` は optional だが、struct 化に伴い常に
+    /// 明示送出する (false も載る) ことで emit 箇所間の形状を統一する。
+    pub retried: bool,
+}

--- a/src-tauri/src/team_hub/protocol/tools/send.rs
+++ b/src-tauri/src/team_hub/protocol/tools/send.rs
@@ -776,17 +776,20 @@ async fn dispatch_injects(
                     // skill の guidelines 参照): inject_failed は send 後にしか来ないため、
                     // listener 登録前に emit が走る race は構造的に発生しない。
                     if let Some(app) = app {
-                        let payload = json!({
-                            "teamId": ctx.team_id,
-                            "fromAgentId": ctx.agent_id,
-                            "fromRole": ctx.role,
-                            "toAgentId": target_aid,
-                            "toRole": target_role,
-                            "messageId": guard.msg_id,
-                            "reasonCode": reason_code,
-                            "reasonMessage": reason_message,
-                            "failedAt": failed_at,
-                        });
+                        // Issue #959/#930: payload は events.rs の named struct。初回配送の
+                        // inject 失敗なので retried=false で team_inject.rs と形状を統一。
+                        let payload = crate::team_hub::events::InjectFailedEventPayload {
+                            team_id: ctx.team_id.clone(),
+                            from_agent_id: ctx.agent_id.clone(),
+                            from_role: ctx.role.clone(),
+                            to_agent_id: target_aid.clone(),
+                            to_role: target_role.clone(),
+                            message_id: guard.msg_id,
+                            reason_code: reason_code.to_string(),
+                            reason_message: reason_message.clone(),
+                            failed_at: failed_at.clone(),
+                            retried: false,
+                        };
                         if let Err(e) = app.emit("team:inject_failed", payload) {
                             tracing::warn!("emit team:inject_failed failed: {e}");
                         }


### PR DESCRIPTION
## Summary
#959 / #930 を前進させる focused 変更。

`team:inject_failed` の payload を json! リテラルから `team_hub/events.rs` の `InjectFailedEventPayload` (serde camelCase) へ移行する。#930 で recruit-request / handoff に適用したのと同じ named-struct 化。

- 2 つの emit 箇所 (`send.rs` の初回配送 inject 失敗 / `team_inject.rs` の retry 再失敗) で payload 形状が分岐していたのを単一 struct に統一
- `retried` フィールドを両経路で常に明示送出 (初回=false / retry=true)。TS 側 `TeamInjectFailedEvent.retried` は optional だが、emit 箇所間の形状差をなくす
- shared.ts の既存 `TeamInjectFailedEvent` と camelCase 同期

## スコープについて
#959 の完全クローズには (a) 全イベント payload の struct 化、(b) json! emit を禁止する CI lint、(c) ts-rs/tauri-specta による型自動生成 が必要だが、(c) は大型・(b) は残存 json! emit (role-created / role-lint-warning / file-lock-conflict / inbox_read 等、tool レスポンスの json! と静的に区別しづらい) の grandfather が大量に必要なため、本 PR では多重 emit イベントの struct 化を 1 件進めるに留め、残りは #959 で追跡する。

## Test plan
- [x] `cargo test --lib` 693 テストパス
- [x] `cargo check` クリーン
- [x] `npm run typecheck` 0 エラー (TeamInjectFailedEvent と互換)