### PR TITLE
fix(terminal): #931 Windows binary-missing の spawn 失敗を engine_binary_missing に正しく分類

### DIFF
--- a/src/renderer/src/lib/__tests__/classify-spawn-phase.test.ts
+++ b/src/renderer/src/lib/__tests__/classify-spawn-phase.test.ts
@@ -1,0 +1,42 @@
+// Issue #931: spawn 失敗エラーの binary-missing 判定 (classifySpawnPhase) の回帰テスト。
+import { describe, expect, it } from 'vitest';
+import { classifySpawnPhase } from '../use-terminal-spawn';
+
+describe('classifySpawnPhase (Issue #931)', () => {
+  it('Windows resolve のロケール非依存メッセージを engine_binary_missing に分類する', () => {
+    // pty/session/windows_resolve.rs が返す英語ハードコードメッセージ。
+    // 従来は spawn に誤分類されていた回帰を固定する。
+    expect(
+      classifySpawnPhase('command executable was not found: claude (searched 12 PATH entries)')
+    ).toBe('engine_binary_missing');
+    expect(classifySpawnPhase('command executable was not found: codex')).toBe(
+      'engine_binary_missing'
+    );
+  });
+
+  it('OS / which 由来の binary-missing メッセージも従来どおり分類する', () => {
+    for (const msg of [
+      'ENOENT: no such file or directory',
+      'No such file or directory (os error 2)',
+      'The system cannot find the file specified',
+      'cannot find binary path',
+      'program not found',
+      'command not found',
+      "'claude' is not recognized as an internal or external command",
+      '指定されたファイルが見つかりません。'
+    ]) {
+      expect(classifySpawnPhase(msg)).toBe('engine_binary_missing');
+    }
+  });
+
+  it('binary-missing でない spawn 失敗は spawn に分類する', () => {
+    for (const msg of [
+      'Access is denied (os error 5)',
+      'failed to allocate pty',
+      'permission denied',
+      'VIBE_ env filtered out a required variable'
+    ]) {
+      expect(classifySpawnPhase(msg)).toBe('spawn');
+    }
+  });
+});

--- a/src/renderer/src/lib/use-terminal-spawn.ts
+++ b/src/renderer/src/lib/use-terminal-spawn.ts
@@ -37,18 +37,26 @@ import { ackRecruit, type RecruitAckPhase } from './recruit-ack';
  *   - Unix:          "No such file or directory" / "ENOENT"
  *   - which::which:  "cannot find binary path"
  *
+ * Issue #931: Windows では binary-missing が spawn 到達前に
+ * `pty/session/windows_resolve.rs::resolve_windows_spawn_command` の段階で捕捉され、
+ * `"command executable was not found: ..."` という **Rust 側ハードコードの英語** メッセージで
+ * 返る (= OS ロケールに依存しない安定マーカー)。従来のヒューリスティックはこの文字列を
+ * 拾えず Windows の binary-missing を汎用 `spawn` に誤分類していたため、安定マーカー
+ * `"executable was not found"` を追加する。OS ロケール依存の文字列は fallback として温存。
+ *
  * 上記のいずれかにマッチすれば `engine_binary_missing` で返す。マッチしなければ
  * 汎用 `spawn` (= PTY allocation failure / 権限エラー / 環境変数 escape 失敗等)
- * として扱う。Phase 1 ではこのヒューリスティックで十分 (Rust 側で構造化エラー化
- * するのは Phase 3 のスコープ)。
+ * として扱う。Rust 側で構造化エラーコード (errorCode) を返すのは #931 の残スコープ。
  */
-function classifySpawnPhase(error: string): RecruitAckPhase {
+export function classifySpawnPhase(error: string): RecruitAckPhase {
   const e = error.toLowerCase();
   if (
     e.includes('enoent') ||
     e.includes('no such file or directory') ||
     e.includes('cannot find the file') ||
     e.includes('cannot find binary') ||
+    // Issue #931: Rust 側 resolve エラーのロケール非依存な安定マーカー
+    e.includes('executable was not found') ||
     e.includes('program not found') ||
     e.includes('command not found') ||
     e.includes('not recognized') ||


### PR DESCRIPTION
## Summary
#931 (IPC エラー契約の機械可読化) の bounded slice として、実バグを 1 件修正。

Windows で engine binary が PATH に無い場合、spawn 到達前に `windows_resolve.rs::resolve_windows_spawn_command` が `"command executable was not found: ..."` という **Rust 側ハードコードの英語** (= OS ロケール非依存の安定マーカー) で Err を返す。renderer の `classifySpawnPhase` はこの文字列を拾えず、Windows の binary-missing を汎用 `spawn` フェーズに誤分類していた (recruit 失敗時の phase 報告 `engine_binary_missing` が出ない)。

- ロケール非依存マーカー `"executable was not found"` を判定に追加
- OS ロケール依存の文字列 (ja-JP「指定された…」/ en-US「cannot find the file」) は fallback として温存 → 挙動退行なし
- `classifySpawnPhase` を export し、binary-missing / 非 binary-missing 分類の回帰テストを追加

#931 本文が掲げる「Rust 側で構造化 errorCode を IPC 契約に載せ、renderer の文字列マッチ分岐を全廃する」完全対応は引き続き #931 で追跡 (本 PR は最も明確な誤分類バグ 1 件を locale-independent に直すもの)。

## Test plan
- [x] `npx vitest run` 新規 classify-spawn-phase テスト 3 件パス
- [x] `npm run typecheck` 0 エラー