### PR TITLE
ci(backend): #939 cargo clippy を品質ゲートに追加し既存 warning 32 件を解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master @ 2026-04-26
         with:
           toolchain: stable
+          # Issue #939: clippy ゲート用。dtolnay/rust-toolchain は minimal profile なので明示する。
+          components: clippy
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
@@ -81,6 +83,12 @@ jobs:
       - name: Cargo check
         run: cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets
 
+      # Issue #939: clippy を品質ゲートに追加。warning を deny して新規の clippy lint 違反で
+      # CI を fail させる (`grep -c clippy ci.yml = 0` だった監査指摘の解消)。現時点の警告 0 件を
+      # baseline とし、許容できない lint は at-site `#[allow(...)]` + 理由コメントで明示 opt-out する。
+      - name: Cargo clippy (-D warnings)
+        run: cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+
       - name: Cargo test
         run: cargo test --locked --manifest-path src-tauri/Cargo.toml
 
@@ -129,6 +137,8 @@ jobs:
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master @ 2026-04-26
         with:
           toolchain: stable
+          # Issue #939: cfg-gated コード (win_job_object 等の #[cfg(windows)]) も clippy 検査する。
+          components: clippy
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
@@ -137,6 +147,11 @@ jobs:
 
       - name: Cargo check (cfg-gated build)
         run: cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets
+
+      # Issue #939: Linux verify job の clippy は cfg(windows)/cfg(macos) コードを検査しないため、
+      # 各 OS でも clippy を走らせて cfg-gated コードの lint 違反を捕捉する。
+      - name: Cargo clippy (cfg-gated, -D warnings)
+        run: cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 
   # Issue #745: 既存の `npm audit` / `cargo audit` は advisory DB ベースの依存脆弱性検査で、
   # 「うっかり API key / token / 暗号鍵をコミットした」を検知できない。

--- a/src-tauri/src/commands/app/updater.rs
+++ b/src-tauri/src/commands/app/updater.rs
@@ -188,8 +188,8 @@ fn parse_iso8601_to_ms(s: &str) -> Option<i64> {
     }
     let leap = is_leap_year(year);
     let mdays = [31u32, if leap { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-    for m in 0..(month - 1) as usize {
-        days += mdays[m] as i64;
+    for &md in mdays.iter().take((month - 1) as usize) {
+        days += md as i64;
     }
     days += (day as i64) - 1;
     let secs = days * 86_400 + (hour as i64) * 3600 + (minute as i64) * 60 + (second as i64);
@@ -237,7 +237,7 @@ fn decide_should_warn(now_ms: i64, last_ms: Option<i64>) -> bool {
     if now_ms <= 0 {
         return true;
     }
-    last_ms.map_or(true, |prev| {
+    last_ms.is_none_or(|prev| {
         now_ms < prev || now_ms.saturating_sub(prev) >= COOLDOWN_MS
     })
 }

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -261,6 +261,9 @@ pub async fn files_read(app: AppHandle, project_root: String, rel_path: String) 
     }
 }
 
+// Issue #939: tauri command は renderer から渡る引数を 1:1 で受けるため引数が多くなるのは
+// 構造上不可避 (引数を struct にまとめると IPC 契約 / shared.ts 側も書き換えが必要)。
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn files_write(
     app: AppHandle,

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -677,15 +677,17 @@ mod tests {
 
     #[test]
     fn custom_agent_reserved_ids_are_rejected() {
-        let mut s = Settings::default();
-        s.custom_agents = Some(vec![AgentConfig {
-            id: "claude".into(),
-            name: "Shadow Claude".into(),
-            command: "shadow".into(),
-            args: "".into(),
-            cwd: None,
-            color: None,
-        }]);
+        let s = Settings {
+            custom_agents: Some(vec![AgentConfig {
+                id: "claude".into(),
+                name: "Shadow Claude".into(),
+                command: "shadow".into(),
+                args: "".into(),
+                cwd: None,
+                color: None,
+            }]),
+            ..Settings::default()
+        };
 
         let err = validate_custom_agent_ids(&s).unwrap_err();
         assert!(err.to_string().contains("reserved"));
@@ -693,15 +695,17 @@ mod tests {
 
     #[test]
     fn custom_agent_non_reserved_ids_are_allowed() {
-        let mut s = Settings::default();
-        s.custom_agents = Some(vec![AgentConfig {
-            id: "aider".into(),
-            name: "Aider".into(),
-            command: "aider".into(),
-            args: "".into(),
-            cwd: None,
-            color: None,
-        }]);
+        let s = Settings {
+            custom_agents: Some(vec![AgentConfig {
+                id: "aider".into(),
+                name: "Aider".into(),
+                command: "aider".into(),
+                args: "".into(),
+                cwd: None,
+                color: None,
+            }]),
+            ..Settings::default()
+        };
 
         assert!(validate_custom_agent_ids(&s).is_ok());
     }

--- a/src-tauri/src/commands/terminal/command_validation.rs
+++ b/src-tauri/src/commands/terminal/command_validation.rs
@@ -59,6 +59,10 @@ fn split_command_line(input: &str) -> Vec<String> {
             }
             '\\' => {
                 let next = chars.peek().copied();
+                // Issue #939: 2 つの分岐は「同じ動作・別条件」で意図的に分けている
+                // (quote 内のエスケープ規則 vs quote 外の規則)。条件の意味が別なので
+                // `||` で潰さず分けたまま allow する (将来どちらかの動作を変える余地を残す)。
+                #[allow(clippy::if_same_then_else)]
                 if quote.is_some() && next == quote {
                     current.push(chars.next().unwrap_or(ch));
                 } else if quote.is_none() && matches!(next, Some('"') | Some('\'')) {

--- a/src-tauri/src/commands/terminal_tabs.rs
+++ b/src-tauri/src/commands/terminal_tabs.rs
@@ -304,7 +304,7 @@ async fn save_to_disk_at(path: &Path, file: &PersistedTerminalTabsFile) -> Resul
     // `~/.claude/projects/<encoded>/<uuid>.jsonl` の会話履歴に間接アクセスできるため
     // 機密ファイル扱い。`~/.claude.json` / role-profiles 等と同じく 0o600 を強制する。
     // Windows では mode は no-op (Windows ACL 強制は別 issue で対応)。
-    crate::commands::atomic_write::atomic_write_with_mode(&path, &json, Some(0o600))
+    crate::commands::atomic_write::atomic_write_with_mode(path, &json, Some(0o600))
         .await
         .map_err(|e| e.to_string())
 }
@@ -466,8 +466,10 @@ mod tests {
     async fn save_to_disk_rejects_future_incoming_schema() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("terminal-tabs.json");
-        let mut file = PersistedTerminalTabsFile::default();
-        file.schema_version = TERMINAL_TABS_SCHEMA_VERSION + 1;
+        let file = PersistedTerminalTabsFile {
+            schema_version: TERMINAL_TABS_SCHEMA_VERSION + 1,
+            ..Default::default()
+        };
 
         let err = save_to_disk_at(&path, &file).await.unwrap_err();
 

--- a/src-tauri/src/commands/tests/settings.rs
+++ b/src-tauri/src/commands/tests/settings.rs
@@ -122,15 +122,17 @@ async fn agent_config_minimal_entry_loads() {
 /// `customAgents` の `cwd` / `color` 完備バージョンも round-trip 可能。
 #[tokio::test]
 async fn agent_config_full_entry_round_trips() {
-    let mut s = Settings::default();
-    s.custom_agents = Some(vec![AgentConfig {
-        id: "claude-dev".into(),
-        name: "Claude (dev)".into(),
-        command: "claude".into(),
-        args: "--debug".into(),
-        cwd: Some("/tmp".into()),
-        color: Some("#ff0000".into()),
-    }]);
+    let s = Settings {
+        custom_agents: Some(vec![AgentConfig {
+            id: "claude-dev".into(),
+            name: "Claude (dev)".into(),
+            command: "claude".into(),
+            args: "--debug".into(),
+            cwd: Some("/tmp".into()),
+            color: Some("#ff0000".into()),
+        }]),
+        ..Settings::default()
+    };
 
     let bytes = serde_json::to_vec(&s).unwrap();
     let back: Settings = serde_json::from_slice(&bytes).unwrap();
@@ -227,9 +229,11 @@ async fn concurrent_atomic_writes_leave_valid_settings_json() {
     for i in 0..16 {
         let path_clone = path.clone();
         handles.push(tokio::spawn(async move {
-            let mut s = Settings::default();
-            s.notepad = format!("write-{i}");
-            s.ui_font_size = 14.0 + (i as f64);
+            let s = Settings {
+                notepad: format!("write-{i}"),
+                ui_font_size: 14.0 + (i as f64),
+                ..Settings::default()
+            };
             let json = serde_json::to_vec_pretty(&s).unwrap();
             atomic_write(&path_clone, &json).await.unwrap();
         }));

--- a/src-tauri/src/pty/registry.rs
+++ b/src-tauri/src/pty/registry.rs
@@ -199,6 +199,10 @@ impl SessionRegistry {
     ///   - `Ok(())`: 採用された (id は registry に登録済み)
     ///   - `Err(handle)`: 既存 PTY と id が衝突。caller の handle はそのまま返却される
     ///     ので、caller 側で `handle.kill()` してから別 id で retry する責務がある。
+    ///
+    /// Issue #939: `Err` に大きな `SessionHandle` を載せるのは「衝突時に handle を呼び出し元へ
+    /// 返して回収させる」という設計上の意図 (Box 化すると毎回ヒープ確保が増える)。許容する。
+    #[allow(clippy::result_large_err)]
     pub fn insert_if_absent(&self, id: String, handle: SessionHandle) -> Result<(), SessionHandle> {
         let mut g = recover(self.inner.lock());
         if g.by_id.contains_key(&id) {
@@ -350,39 +354,21 @@ impl SessionRegistry {
         removed
     }
 
-    /// アプリ終了 (window CloseRequested → `app.exit(0)` 直前) に全 PTY を kill する。
+    /// Issue #951: アプリ終了 (window CloseRequested → `app.exit(0)`) / 再起動経路専用の
+    /// **同期** 全 PTY kill。
     ///
-    /// Issue #834: 旧実装は各 session で `cleanup_codex_broker_after_kill()` を**同期直列**に
-    /// 呼んでおり、これが `git`/`tasklist` 子プロセス spawn + (broker 生存時) 250ms sleep を
-    /// 伴うため、codex タブ数ぶんアプリ終了がブロックされていた (#630 で inject drain を
-    /// 非同期化した狙いが相殺されていた)。
+    /// 旧 `kill_all()` (非 blocking) の `SessionHandle::kill()` は Windows で process-tree
+    /// kill (taskkill) を detached thread に逃がして即返るため、直後に `app.exit(0)` /
+    /// `app.restart()` で自プロセスごと消えると taskkill が走り切る前に殺され、子プロセス
+    /// (claude/codex + その配下の MCP) が孤児として残る競合があった。本メソッドは各 session の
+    /// process-tree kill を並列 thread で実行し、全完了 (または `timeout`) まで呼び出し thread を
+    /// ブロックして待つ。blocking なので async context からは `spawn_blocking` 経由で呼ぶこと。
+    /// (Issue #939: 非 blocking 版 `kill_all` は本メソッド導入後に呼び出し元が消えて dead code に
+    ///  なったため削除した。)
     ///
-    /// 終了経路では broker の stale state 掃除を**スキップ**する。掃除は best-effort な
-    /// state file の後始末に過ぎず、残っても次回起動時の spawn 前 cleanup
-    /// (`cleanup_codex_broker_if_stale`) で確実に回収できる。ここでは `s.kill()` による
-    /// 子プロセス停止だけを直列で確実に行い (これは速い)、即座に呼び出し元へ返す。
-    pub fn kill_all(&self) {
-        let sessions: Vec<Arc<SessionHandle>> = {
-            let mut g = recover(self.inner.lock());
-            g.by_agent.clear();
-            g.by_session_key.clear();
-            g.by_id.drain().map(|(_, s)| s).collect()
-        };
-        for s in sessions {
-            let _ = s.kill();
-        }
-    }
-
-    /// Issue #951: シャットダウン / 再起動経路専用の **同期** kill_all。
-    ///
-    /// `kill_all()` の `SessionHandle::kill()` は Windows で process-tree kill (taskkill) を
-    /// detached thread に逃がして即返るため、直後に `app.exit(0)` / `app.restart()` で
-    /// 自プロセスごと消えると taskkill が走り切る前に殺され、子プロセス (claude/codex +
-    /// その配下の MCP) が孤児として残る競合があった。
-    ///
-    /// 本メソッドは各 session の process-tree kill を並列 thread で実行し、全完了 (または
-    /// `timeout`) まで呼び出し thread をブロックして待つ。blocking なので async context
-    /// からは `spawn_blocking` 経由で呼ぶこと。
+    /// Issue #834: 終了経路では broker の stale state 掃除を**スキップ**する (掃除は best-effort で
+    /// 次回起動時の spawn 前 cleanup `cleanup_codex_broker_if_stale` で回収できる)。ここでは
+    /// process-tree kill だけを確実に行う。
     pub fn kill_all_blocking(&self, timeout: Duration) {
         let sessions: Vec<Arc<SessionHandle>> = {
             let mut g = recover(self.inner.lock());

--- a/src-tauri/src/pty/session/handle.rs
+++ b/src-tauri/src/pty/session/handle.rs
@@ -69,7 +69,12 @@ pub struct SessionHandle {
     /// この handle の drop (= タブ close / kill_all / vibe-editor 異常死による OS の
     /// handle 強制 close) で job 内の全プロセス (孫含む) が OS により kill される。
     /// Job 作成 / assign に失敗した場合は None (taskkill 経路のみで回収)。
+    ///
+    /// Issue #939: フィールドは **保持していること自体 (RAII)** が目的で、明示的に読まれる
+    /// ことはない。SessionHandle の drop で `KillOnCloseJob::drop` (= CloseHandle) が走り、
+    /// KILL_ON_JOB_CLOSE が発火する。clippy の dead-code は Drop の副作用を認識しないため allow。
     #[cfg(windows)]
+    #[allow(dead_code)]
     pub(super) job: Option<crate::pty::win_job_object::KillOnCloseJob>,
 }
 

--- a/src-tauri/src/pty/session/spawn.rs
+++ b/src-tauri/src/pty/session/spawn.rs
@@ -230,7 +230,7 @@ fn resolve_spawn_command(
 pub(crate) fn build_cmd_label(prepared: &PreparedSpawnCommand) -> String {
     let basename = prepared
         .resolved_command
-        .rsplit(|c: char| c == '/' || c == '\\')
+        .rsplit(['/', '\\'])
         .next()
         .filter(|s| !s.is_empty())
         .unwrap_or(prepared.requested_command.as_str())
@@ -348,7 +348,7 @@ pub fn spawn_session(
         Err(err) => {
             let err_string = err.to_string();
             log_spawn_outcome(&cmd_label, engine, platform, elapsed_ms, Some(&err_string));
-            return Err(err.into());
+            return Err(err);
         }
     };
     drop(pair.slave);

--- a/src-tauri/src/pty/win_job_object.rs
+++ b/src-tauri/src/pty/win_job_object.rs
@@ -8,6 +8,7 @@
 //! ごとに作成して child PID を assign する。Job handle は `SessionHandle` が保持し、
 //! - handle drop (タブ close / kill_all) → CloseHandle → job 内全プロセスを OS が kill
 //! - vibe-editor 本体の異常死 → OS が全 handle を強制 close → 同様に kill
+//!
 //! の両経路で「親の寿命 = 子プロセスツリーの寿命」を OS レベルで保証する。
 //!
 //! 制限:

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -33,7 +33,7 @@ pub struct AppState {
 /// 呼び出し側が `MutexGuard` ではなく値そのものを欲しがるパターン (`.clone()` /
 /// `.unwrap_or_default()`) しか存在しなかったため、値を直接返す形に簡素化している。
 pub fn current_project_root(slot: &ArcSwapOption<String>) -> Option<String> {
-    slot.load().as_deref().map(|s| s.clone())
+    slot.load().as_deref().cloned()
 }
 
 /// Issue #739: project_root を更新する。`Some("")` のような空文字はそのまま保持する

--- a/src-tauri/src/team_hub/inject.rs
+++ b/src-tauri/src/team_hub/inject.rs
@@ -235,6 +235,7 @@ impl std::fmt::Display for InjectError {
 ///   - 受信端末: OSC 52 (クリップボード書換) / OSC 2 (タイトル偽装) / CSI 2J (画面消去)
 ///   - LLM 側: ZWSP / RTL Override / U+2028/2029 が deny 句マッチをすり抜け、
 ///     prompt injection / lint bypass / レビュアー目視回避を成立させる
+///
 /// など、任意の端末乗っ取り / プロンプト乗っ取り経路が成立する。bracketed paste で囲んでも
 /// 内側の ESC は端末によっては解釈されてしまう (PT mode の実装差異)。
 ///

--- a/src-tauri/src/team_hub/protocol/dynamic_role.rs
+++ b/src-tauri/src/team_hub/protocol/dynamic_role.rs
@@ -201,8 +201,8 @@ pub(super) async fn validate_and_register_dynamic_role(
 /// `register_team` 経路で「該当 team_id の entry だけ」を抽出して `replay_persisted_dynamic_roles_for_team`
 /// に渡し、Hub の `dynamic_roles` map を再構成する。
 ///
-/// Issue #604 (Security): 永続化済みでも `instruction_lint::lint_all` の **deny** チェック
-/// + 長さ上限は replay 時に必ず再実行する。`role-profiles.json` は user-writable plain JSON
+/// Issue #604 (Security): 永続化済みでも `instruction_lint::lint_all` の **deny** チェックと
+/// 長さ上限は replay 時に必ず再実行する。`role-profiles.json` は user-writable plain JSON
 /// のため、攻撃者 (or 過去の緩い lint 版で書かれた entry) が手書きで deny 句入り instructions を
 /// 仕込めば worker prompt に直接注入される経路があった。Lint warn (軽微) と template
 /// validation は forward-compat 維持のため引き続き skip する (= 旧 entry を一斉に弾かない)。

--- a/src-tauri/src/team_hub/protocol/role_template.rs
+++ b/src-tauri/src/team_hub/protocol/role_template.rs
@@ -185,9 +185,9 @@ fn find_sections(text: &str) -> Vec<SectionMatch> {
             Some("Inputs")
         } else if after.starts_with("Outputs") {
             Some("Outputs")
-        } else if after.starts_with("Done Criteria") {
-            Some("Done Criteria")
-        } else if DONE_CRITERIA_ALIASES.iter().any(|a| after.starts_with(a)) {
+        } else if after.starts_with("Done Criteria")
+            || DONE_CRITERIA_ALIASES.iter().any(|a| after.starts_with(a))
+        {
             Some("Done Criteria")
         } else {
             None
@@ -203,6 +203,9 @@ fn find_sections(text: &str) -> Vec<SectionMatch> {
             .map(|&(li, _)| li)
             .unwrap_or(lines.len());
         let mut bytes = 0;
+        // Issue #939: 範囲 (line_idx+1)..next_line で `lines` を走査しつつ break 条件も持つため、
+        // index ループのほうが読みやすい (iterator 化は zip/enumerate で冗長になる)。
+        #[allow(clippy::needless_range_loop)]
         for li in (line_idx + 1)..next_line {
             // 次の H2/H1 見出しでも区切る (緩い fence)
             let lt = lines[li].trim_start();
@@ -279,9 +282,7 @@ pub fn validate_template(
         findings.push(TemplateFinding {
             level: TemplateLevel::Deny,
             category: "missing_all_sections",
-            detail: format!(
-                "instructions must contain all 4 sections (`### Responsibilities` / `### Inputs` / `### Outputs` / `### Done Criteria`); none were found"
-            ),
+            detail: "instructions must contain all 4 sections (`### Responsibilities` / `### Inputs` / `### Outputs` / `### Done Criteria`); none were found".to_string(),
         });
         // 全欠ケースも他チェックは ノイズになるので早期 return。
         return TemplateReport { findings };

--- a/src-tauri/src/team_hub/protocol/tools/status.rs
+++ b/src-tauri/src/team_hub/protocol/tools/status.rs
@@ -44,7 +44,7 @@ fn sanitize_status_text(s: &str) -> String {
                 // CSI: `ESC [ <param-bytes>... <final-byte 0x40..=0x7E>`
                 Some('[') => {
                     chars.next();
-                    while let Some(p) = chars.next() {
+                    for p in chars.by_ref() {
                         if matches!(p, '@'..='~') {
                             break;
                         }

--- a/src-tauri/src/team_hub/state/hub_state.rs
+++ b/src-tauri/src/team_hub/state/hub_state.rs
@@ -260,13 +260,9 @@ impl EnginePolicy {
     /// 違反が無ければ `Ok(())`。
     pub fn validate(&self, engine: &str) -> Result<(), String> {
         match (self.kind, engine) {
-            (EnginePolicyKind::ClaudeOnly, "codex") => Err(format!(
-                "team engine policy is ClaudeOnly, cannot recruit with engine='codex'"
-            )),
-            (EnginePolicyKind::CodexOnly, "claude") => Err(format!(
-                "team engine policy is CodexOnly, cannot recruit with engine='claude' \
-                 (this prevents accidental Claude recruitment into a Codex-only team)"
-            )),
+            (EnginePolicyKind::ClaudeOnly, "codex") => Err("team engine policy is ClaudeOnly, cannot recruit with engine='codex'".to_string()),
+            (EnginePolicyKind::CodexOnly, "claude") => Err("team engine policy is CodexOnly, cannot recruit with engine='claude' \
+                 (this prevents accidental Claude recruitment into a Codex-only team)".to_string()),
             _ => Ok(()),
         }
     }

--- a/src-tauri/src/team_hub/state/recruit.rs
+++ b/src-tauri/src/team_hub/state/recruit.rs
@@ -806,6 +806,10 @@ mod recruit_rescue_tests {
             .clone()
     }
 
+    // Issue #939: `ENV_LOCK` は env var をテスト間で直列化する std Mutex で、テスト全体を
+    // 1 つの critical section にするため意図的に await 跨ぎで保持する (current_thread flavor +
+    // 単独 test なので deadlock しない)。production の lock ではないので at-site で allow。
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test(flavor = "current_thread")]
     async fn timed_out_ack_within_grace_is_rescued_and_emits_event() {
         let _env_guard = ENV_LOCK.lock().expect("env lock poisoned");
@@ -847,6 +851,8 @@ mod recruit_rescue_tests {
         std::env::remove_var("VIBE_TEAM_RECRUIT_GRACE_MS");
     }
 
+    // Issue #939: 上記同様、env 直列化用 std Mutex を意図的に await 跨ぎ保持 (test 専用)。
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test(flavor = "current_thread")]
     async fn grace_zero_removes_pending_immediately_and_late_ack_is_not_found() {
         let _env_guard = ENV_LOCK.lock().expect("env lock poisoned");


### PR DESCRIPTION
## Summary
#939 (CI 品質ゲートが空回り) の bounded slice。監査指摘「`grep -c clippy ci.yml = 0`」を解消する。

- `cargo clippy --all-targets -- -D warnings` を **verify (Linux)** と **cargo-cfg (Windows/macOS)** の両 job に追加。cfg-gated コード (`win_job_object` 等の `#[cfg(windows)]`) も lint 対象にする。`dtolnay/rust-toolchain` は minimal profile なので `components: clippy` を明示
- ゲート有効化のため既存 clippy warning 32 件を baseline 0 に解消:
  - **`registry.rs`: dead code の `kill_all()` を削除** — #951 で `kill_all_blocking` に置換後、呼び出し元が消えて未使用化していた (#951 の cleanup 漏れ)
  - **`handle.rs`: #950 の `job` フィールド** は RAII (Drop で CloseHandle) 目的で保持し読まれないため `#[allow(dead_code)]` + 理由コメント
  - `files_write`: tauri command の引数多数は構造上不可避 → `#[allow(clippy::too_many_arguments)]`
  - `insert_if_absent`: Err に handle を返す設計意図 → `#[allow(clippy::result_large_err)]`
  - `recruit.rs` テスト 2 件: env 直列化用 std Mutex の await 跨ぎ保持は test 専用の意図的 critical section → `#[allow(clippy::await_holding_lock)]`
  - その他: `needless_range_loop` / `if_same_then_else` / `doc_lazy_continuation` / `field_reassign_with_default` / 機械的 auto-fix (`format!` 等) を解消 (挙動不変)

## スコープ
#939 の他のゲート (i18n ハードコード lint / max-lines ratchet / typecheck 実効化=#841 / DoD・regression テスト方針) は引き続き #939 で追跡。本 PR は最も明確な「clippy 不在」を埋め、副産物として #950/#951 由来の実 dead-code を 1 件除去する。

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` クリーン (Windows ローカル, cfg(windows) コード含む)
- [x] `cargo test --lib` 693 テストパス (clippy 修正は挙動不変)