### PR TITLE
refactor(backend): #931 IPC エラー契約を { code, message } 構造化オブジェクトに統一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,13 @@ jobs:
       - name: File-size ratchet
         run: npm run lint:file-size
 
+      # Issue #931: #[tauri::command] の戻り値を CommandResult<T> ({ code, message } の
+      # 構造化エラー) に強制する。旧 3 流派 (Option<T> / ok+error 埋め込み) は baseline
+      # 免除で固定し、新規 command が旧流派をコピーしたら fail させる。
+      # 例外は直前行の `// command-result-exempt: <理由>` で明示 opt-out。
+      - name: CommandResult lint (IPC error contract)
+        run: npm run lint:command-result
+
       # Issue #721: renderer の単体テスト (vitest) を CI で実行する。
       # 従来は package.json に test スクリプトと vitest.config.ts があるのに
       # CI で一度も走らず、renderer のリグレッションがフリーパスだった。

--- a/build/check-command-result.mjs
+++ b/build/check-command-result.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// Issue #931: `#[tauri::command]` の戻り値型を CI で検査する tripwire。
+//
+// IPC の失敗表現は `commands/error.rs` の `CommandResult<T>` (`Err` は `{ code, message }`
+// の構造化 CommandError) に統一する。`Option<T>` (失敗とキャンセルの黙殺) や
+// `ok: bool + error: Option<String>` 埋め込みなど、過去の 3 流派が「コピーできる前例」
+// として並んでいると、新規コマンドがどれを真似ても compile が通ってしまうため、
+// CommandResult 以外の戻り値を持つ command を検出して fail させる。
+//
+// 既存の違反 (旧流派で書かれた command) は BASELINE_EXEMPT に列挙して固定する。
+// **新規 command を BASELINE_EXEMPT に足さない**こと。やむを得ない場合は該当
+// `#[tauri::command]` 行の直前に
+//   // command-result-exempt: <理由>
+// を書いて明示的に opt-out する (理由なしの exempt は review で弾く運用)。
+// BASELINE の violation を CommandResult へ移行する PR では、このリストから削る。
+//
+// 制限: 行ベースの軽量 parse なので、`fn` シグネチャが極端に変則的な場合は誤判定しうる。
+// これは「うっかり旧流派をコピーする」支配的パターンを止める tripwire であり、
+// 完全な型検査ではない (それは clippy / コンパイラの領分)。
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const scanRoot = join(repoRoot, 'src-tauri', 'src');
+const EXEMPT_MARKER = 'command-result-exempt';
+
+// Issue #931 時点の既存違反 (file::fn)。旧 3 流派で書かれた command の baseline。
+const BASELINE_EXEMPT = new Set([
+  'commands/app/team_mcp.rs::app_get_team_file_path',
+  'commands/app/window.rs::app_check_claude',
+  'commands/app/window.rs::app_set_window_effects',
+  'commands/app/window.rs::app_open_external',
+  'commands/app/window.rs::app_reveal_in_file_manager',
+  'commands/app.rs::app_get_project_root',
+  'commands/app.rs::app_restart',
+  'commands/app.rs::app_get_user_info',
+  'commands/dialog.rs::dialog_open_folder',
+  'commands/dialog.rs::dialog_open_file',
+  'commands/dialog.rs::dialog_is_folder_empty',
+  'commands/files.rs::files_list',
+  'commands/files.rs::files_read',
+  'commands/files.rs::files_write',
+  'commands/files.rs::files_create',
+  'commands/files.rs::files_create_dir',
+  'commands/files.rs::files_rename',
+  'commands/files.rs::files_delete',
+  'commands/files.rs::files_copy',
+  'commands/git.rs::git_status',
+  'commands/git.rs::git_diff',
+  'commands/mod.rs::ping',
+  'commands/role_profiles.rs::role_profiles_load',
+  'commands/sessions.rs::sessions_list',
+  'commands/team_history.rs::team_history_list',
+  'commands/team_history.rs::team_history_save',
+  'commands/team_history.rs::team_history_save_batch',
+  'commands/team_history.rs::team_history_delete',
+  'commands/team_presets.rs::team_presets_list',
+  'commands/team_presets.rs::team_presets_load',
+  'commands/team_presets.rs::team_presets_save',
+  'commands/team_presets.rs::team_presets_delete',
+  'commands/terminal.rs::terminal_save_pasted_image',
+  'commands/terminal_tabs.rs::terminal_tabs_load',
+  'commands/terminal_tabs.rs::terminal_tabs_save',
+  'commands/terminal_tabs.rs::terminal_tabs_clear'
+]);
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (name.endsWith('.rs')) out.push(p);
+  }
+  return out;
+}
+
+const violations = [];
+for (const file of walk(scanRoot)) {
+  const rel = relative(scanRoot, file).replace(/\\/g, '/');
+  const lines = readFileSync(file, 'utf8').split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^\s*#\[tauri::command/.test(lines[i])) continue;
+    // 直前 3 行以内の exempt マーカー (理由コメント付き opt-out)
+    const lookback = lines.slice(Math.max(0, i - 3), i).join('\n');
+    if (lookback.includes(EXEMPT_MARKER)) continue;
+    // attr 行から fn シグネチャの開始 `{` (または `;`) までを連結して戻り値型を見る
+    let sig = '';
+    let fnName = null;
+    for (let j = i + 1; j < Math.min(lines.length, i + 30); j++) {
+      sig += lines[j] + '\n';
+      if (fnName === null) {
+        const m = sig.match(/\bfn\s+([A-Za-z0-9_]+)/);
+        if (m) fnName = m[1];
+      }
+      if (/[{;]\s*$/.test(lines[j]) && fnName !== null) break;
+    }
+    if (fnName === null) continue; // attr の直後に fn が見つからない変則形は対象外
+    const key = `${rel}::${fnName}`;
+    if (BASELINE_EXEMPT.has(key)) continue;
+    if (!/->[\s\S]*\bCommandResult\s*</.test(sig)) {
+      violations.push(`${rel}:${i + 1}: ${fnName}`);
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error(`CommandResult 検査違反が ${violations.length} 件あります:\n`);
+  for (const v of violations) console.error(`  ${v}`);
+  console.error(`
+#[tauri::command] の戻り値は commands/error.rs の CommandResult<T> に統一してください
+(失敗は { code, message } の CommandError として renderer に届きます / Issue #931)。
+Option<T> や ok/error 埋め込みの旧流派をコピーしないこと。やむを得ない場合は
+直前行に // command-result-exempt: <理由> を書いて opt-out してください。`);
+  process.exit(1);
+}
+
+console.log('[check-command-result] OK (all #[tauri::command] return CommandResult)');

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,7 +99,33 @@ export default tseslint.config(
       'no-control-regex': 'off',
       'no-useless-escape': 'off',
       'prefer-const': 'warn',
-      'no-constant-condition': ['warn', { checkLoops: false }]
+      'no-constant-condition': ['warn', { checkLoops: false }],
+
+      // Issue #931: raw `invoke` の直叩きを禁止する。IPC 失敗の正規化
+      // (`{ code, message }` の CommandError 化) は tauri-api/command-error.ts の
+      // `invokeCommand()` に集約されており、raw invoke を使うと reject 値の型が
+      // 経路ごとに揺れてエラー種別の機械判別が壊れる (#737 の部分適用の再発防止)。
+      // `convertFileSrc` / `listen` 等 invoke 以外の import は制限しない。
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@tauri-apps/api/core',
+              importNames: ['invoke'],
+              message:
+                'raw invoke は禁止。tauri-api/command-error.ts の invokeCommand() を使うこと (Issue #931)。'
+            }
+          ]
+        }
+      ]
+    }
+  },
+  // Issue #931: invokeCommand の実装本体だけは raw invoke を import してよい。
+  {
+    files: ['src/renderer/src/lib/tauri-api/command-error.ts'],
+    rules: {
+      'no-restricted-imports': 'off'
     }
   },
   // Issue #939: i18n ハードコード検知。renderer 内の「日本語を含む文字列リテラル / JSX テキスト」

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "vitest run",
     "lint:safe-load": "node build/check-safe-load.mjs",
     "lint:file-size": "node build/check-file-size-ratchet.mjs",
+    "lint:command-result": "node build/check-command-result.mjs",
     "test:watch": "vitest",
     "icons": "node build/generate-icons.mjs"
   },

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -1,9 +1,14 @@
 //! Centralized error type for IPC commands.
 //!
-//! Renderer 側 (`src/renderer/src/lib/tauri-api.ts`) は `Err` payload を string として
-//! 受け取り続ける必要があるため、`Serialize` impl は意図的に variant tag を含めず
-//! `message` のみをシリアライズする。新規 variant を追加する際は同じ契約を維持すること。
-use serde::ser::{Serialize, Serializer};
+//! Issue #931: `Serialize` impl は `{ code, message }` の構造化オブジェクトを返す。
+//! renderer 側は `tauri-api/command-error.ts` の `invokeCommand()` が reject 値を
+//! `CommandError` (code / message を必ず持つ Error subclass) に正規化する契約。
+//! 失敗理由の機械判別は **code フィールドのみ** で行い、message (人間向け表示文字列)
+//! への `includes` / `===` / `startsWith` 分岐を書かないこと (#888 の dead branch の轍)。
+//!
+//! 旧契約 (message 文字列のみ serialize + JSON-in-string ハック) は #737 の部分適用で
+//! 止まっていたもので、本 PR で正式フィールドに昇格した。
+use serde::ser::{Serialize, SerializeStruct, Serializer};
 use std::fmt;
 
 #[derive(Debug)]
@@ -16,6 +21,10 @@ pub enum CommandError {
     /// Issue #600 (Tier A-2): authorization 失敗 (例: renderer から渡された project_root が
     /// active project_root と一致しないなど cross-project leak の阻止)。
     Authz(String),
+    /// Issue #931: variant 分類より細かい machine-readable code を明示したいエラー
+    /// (旧 `{"code":"...","message":"..."}` JSON-in-string ハックの後継)。
+    /// code は `snake_case` の安定識別子 (例: `retry_unknown_team`)。
+    Coded { code: String, message: String },
 }
 
 impl CommandError {
@@ -36,6 +45,28 @@ impl CommandError {
         Self::Authz(message.into())
     }
 
+    /// Issue #931: 明示 code 付きエラー。renderer は `err.code` で分岐する。
+    pub fn coded(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Coded {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    /// IPC 境界を越える machine-readable な失敗分類。
+    /// renderer (`command-error.ts`) はこの値を `CommandError.code` として公開する。
+    pub fn code(&self) -> &str {
+        match self {
+            Self::Io(_) => "io",
+            Self::Parse(_) => "parse",
+            Self::Validation(_) => "validation",
+            Self::NotFound(_) => "not_found",
+            Self::Internal(_) => "internal",
+            Self::Authz(_) => "authz",
+            Self::Coded { code, .. } => code,
+        }
+    }
+
     fn message(&self) -> &str {
         match self {
             Self::Io(message)
@@ -43,7 +74,8 @@ impl CommandError {
             | Self::Validation(message)
             | Self::NotFound(message)
             | Self::Internal(message)
-            | Self::Authz(message) => message,
+            | Self::Authz(message)
+            | Self::Coded { message, .. } => message,
         }
     }
 }
@@ -61,8 +93,13 @@ impl Serialize for CommandError {
     where
         S: Serializer,
     {
-        // 既存 IPC の Err payload は文字列だったため、互換性を優先して message のみ返す。
-        serializer.serialize_str(self.message())
+        // Issue #931: `{ code, message }` の構造化オブジェクト。renderer 側の
+        // `CommandError.from()` は object 形を最優先で解釈する (旧 string 形も
+        // 後方互換で parse できるが、新規コードは必ずこの形で返す)。
+        let mut s = serializer.serialize_struct("CommandError", 2)?;
+        s.serialize_field("code", self.code())?;
+        s.serialize_field("message", self.message())?;
+        s.end()
     }
 }
 

--- a/src-tauri/src/commands/team_inject.rs
+++ b/src-tauri/src/commands/team_inject.rs
@@ -18,7 +18,6 @@ use crate::state::AppState;
 use crate::team_hub::inject;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 use tauri::{AppHandle, Emitter, State};
 
 #[derive(Deserialize)]
@@ -48,15 +47,13 @@ pub struct RetryInjectResult {
     pub failed_at: Option<String>,
 }
 
-/// `team_send_retry_inject` が `Err` で返す構造化エラー (JSON object) を組み立てる。
+/// `team_send_retry_inject` が `Err` で返す構造化エラーを組み立てる。
 ///
-/// Issue #737: 戻り値を `CommandResult<RetryInjectResult>` に統一した後も、renderer に届く
-/// payload は従来どおり `{"code":"retry_*","message":"..."}` の JSON 文字列を保つ。
-/// `CommandError` の `Serialize` は message をそのまま文字列化するため、`CommandError::internal`
-/// に JSON 文字列を載せれば旧 `Err(String)` と完全同一の wire 出力になる。
+/// Issue #931: `CommandError::Coded` で `{ code: "retry_*", message }` を正式フィールドとして
+/// 返す。旧実装は `CommandError::internal` に `{"code":...}` の JSON 文字列を載せる
+/// JSON-in-string ハックだった (renderer 側 `CommandError.from()` は object 形を直接解釈する)。
 fn retry_err(code: &str, message: String) -> crate::commands::error::CommandError {
-    let payload = json!({ "code": code, "message": message });
-    crate::commands::error::CommandError::internal(payload.to_string())
+    crate::commands::error::CommandError::coded(code, message)
 }
 
 /// `team_send` の partial failure に対する手動リトライ。同じ team / message / agent を 1 件単位で再 inject する。

--- a/src/renderer/src/lib/tauri-api.ts
+++ b/src/renderer/src/lib/tauri-api.ts
@@ -3,7 +3,7 @@
  *
  * 役割:
  * - `import { api } from './tauri-api'` で namespaced な API を提供
- * - 内部では `@tauri-apps/api/core` の `invoke()` と `listen()` を呼ぶ
+ * - 内部では `@tauri-apps/api/core` の `invokeCommand()` と `listen()` を呼ぶ
  * - `window.api` にも同じインスタンスを割り当てている (旧コードパスとの互換のため)
  *
  * Phase 5 (Issue #373): 各領域の実装を `./tauri-api/<area>.ts` に分割し、本ファイルは
@@ -11,7 +11,7 @@
  * 外部 API (`api` / `Api` / `isTauri` / `RoleProfileSummary`) は 1 文字も変えない。
  */
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeCommand } from './tauri-api/command-error';
 
 import { app } from './tauri-api/app';
 import { dialog } from './tauri-api/dialog';
@@ -44,7 +44,7 @@ export { CommandError } from './tauri-api/command-error';
 // terminal.* event ハンドラ (onData / onExit / ...) からのみ参照される。
 
 export const api = {
-  ping: (): Promise<string> => invoke('ping'),
+  ping: (): Promise<string> => invokeCommand('ping'),
 
   app,
   git,

--- a/src/renderer/src/lib/tauri-api/app.ts
+++ b/src/renderer/src/lib/tauri-api/app.ts
@@ -1,6 +1,6 @@
 // tauri-api/app.ts — app.* IPC namespace (Phase 5 / Issue #373)
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeCommand } from './command-error';
 import type {
   AppUserInfo,
   ClaudeCheckResult,
@@ -9,7 +9,6 @@ import type {
   ThemeName,
   UpdaterShouldWarnResult
 } from '../../../../types/shared';
-import { invokeCommand } from './command-error';
 
 /** Tauri 側 TeamHub に同期する role profile の要約形 */
 export interface RoleProfileSummary {
@@ -58,49 +57,49 @@ interface TeamHubInfo {
 }
 
 export const app = {
-  getProjectRoot: (): Promise<string> => invoke('app_get_project_root'),
+  getProjectRoot: (): Promise<string> => invokeCommand('app_get_project_root'),
   /** Issue #29: renderer 側で project root が切り替わったとき Rust 側 state を同期する */
   setProjectRoot: (projectRoot: string): Promise<void> =>
-    invoke('app_set_project_root', { projectRoot }),
-  restart: (): Promise<void> => invoke('app_restart'),
-  setWindowTitle: (title: string): Promise<void> => invoke('app_set_window_title', { title }),
+    invokeCommand('app_set_project_root', { projectRoot }),
+  restart: (): Promise<void> => invokeCommand('app_restart'),
+  setWindowTitle: (title: string): Promise<void> => invokeCommand('app_set_window_title', { title }),
   checkClaude: (command: string): Promise<ClaudeCheckResult> =>
-    invoke('app_check_claude', { command }),
-  setZoomLevel: (level: number): Promise<void> => invoke('app_set_zoom_level', { level }),
+    invokeCommand('app_check_claude', { command }),
+  setZoomLevel: (level: number): Promise<void> => invokeCommand('app_set_zoom_level', { level }),
   /**
    * Issue #260 PR-1: テーマに応じて OS ネイティブの window effect (Windows: Acrylic /
    * macOS: vibrancy) を切り替える。Linux 等は no-op (applied=false で返る)。
    * 引数を `ThemeName` に絞ることで誤った文字列での呼び出しをコンパイル時に弾く。
    */
   setWindowEffects: (theme: ThemeName): Promise<SetWindowEffectsResult> =>
-    invoke('app_set_window_effects', { theme }),
+    invokeCommand('app_set_window_effects', { theme }),
   setupTeamMcp: (
     projectRoot: string,
     teamId: string,
     teamName: string,
     members: TeamMcpMember[]
   ): Promise<SetupTeamMcpResult> =>
-    invoke('app_setup_team_mcp', { projectRoot, teamId, teamName, members }),
+    invokeCommand('app_setup_team_mcp', { projectRoot, teamId, teamName, members }),
   cleanupTeamMcp: (projectRoot: string, teamId: string): Promise<CleanupTeamMcpResult> =>
-    invoke('app_cleanup_team_mcp', { projectRoot, teamId }),
+    invokeCommand('app_cleanup_team_mcp', { projectRoot, teamId }),
   setActiveLeader: (teamId: string, agentId?: string | null): Promise<ActiveLeaderResult> =>
-    invoke('app_set_active_leader', { teamId, agentId }),
+    invokeCommand('app_set_active_leader', { teamId, agentId }),
   getTeamFilePath: (teamId: string): Promise<string> =>
-    invoke('app_get_team_file_path', { teamId }),
-  getMcpServerPath: (): Promise<string> => invoke('app_get_mcp_server_path'),
-  getTeamHubInfo: (): Promise<TeamHubInfo> => invoke('app_get_team_hub_info'),
+    invokeCommand('app_get_team_file_path', { teamId }),
+  getMcpServerPath: (): Promise<string> => invokeCommand('app_get_mcp_server_path'),
+  getTeamHubInfo: (): Promise<TeamHubInfo> => invokeCommand('app_get_team_hub_info'),
   /** RoleProfile summary を Hub へ同期 (team_list_role_profiles / permissions 検証用) */
   setRoleProfileSummary: (summary: RoleProfileSummary[]): Promise<void> =>
-    invoke('app_set_role_profile_summary', { summary }),
+    invokeCommand('app_set_role_profile_summary', { summary }),
   /** recruit を手動キャンセル (timeout 待ち中にユーザーがカードを × で閉じた等) */
   cancelRecruit: (agentId: string): Promise<void> =>
-    invoke('app_cancel_recruit', { agentId }),
+    invokeCommand('app_cancel_recruit', { agentId }),
   /**
    * Issue #342 Phase 1 / #728: recruit-request の受領 / 失敗を Hub に通知する。
    * 引数 5 個 (newAgentId / teamId / ok / reason / phase) を flat camelCase で渡す。
    */
   recruitAck: (args: RecruitAckArgs): Promise<void> =>
-    invoke('app_recruit_ack', {
+    invokeCommand('app_recruit_ack', {
       newAgentId: args.newAgentId,
       teamId: args.teamId,
       ok: args.ok,
@@ -129,19 +128,19 @@ export const app = {
       projectRoot,
       forceOverwrite: !!forceOverwrite
     }),
-  getUserInfo: (): Promise<AppUserInfo> => invoke('app_get_user_info'),
-  openExternal: (url: string): Promise<OpenExternalResult> => invoke('app_open_external', { url }),
+  getUserInfo: (): Promise<AppUserInfo> => invokeCommand('app_get_user_info'),
+  openExternal: (url: string): Promise<OpenExternalResult> => invokeCommand('app_open_external', { url }),
   /** Issue #251: OS のファイルマネージャで親フォルダを開き該当ファイルをハイライト */
   revealInFileManager: (path: string): Promise<OpenExternalResult> =>
-    invoke('app_reveal_in_file_manager', { path }),
+    invokeCommand('app_reveal_in_file_manager', { path }),
   /**
    * Issue #609 (Security): updater の minisign 署名検証失敗を「24h に 1 度だけ」
    * ユーザーに通知するための cooldown 判定。`shouldWarn=true` のときだけ renderer は
    * toast を出し、その直後に必ず `updaterRecordSignatureWarning()` を呼ぶ。
    */
   updaterShouldWarnSignature: (): Promise<UpdaterShouldWarnResult> =>
-    invoke('app_updater_should_warn_signature'),
+    invokeCommand('app_updater_should_warn_signature'),
   /** Issue #609: 警告 toast 表示直後に最終警告 timestamp を更新する。 */
   updaterRecordSignatureWarning: (): Promise<void> =>
-    invoke('app_updater_record_signature_warning')
+    invokeCommand('app_updater_record_signature_warning')
 };

--- a/src/renderer/src/lib/tauri-api/command-error.ts
+++ b/src/renderer/src/lib/tauri-api/command-error.ts
@@ -1,19 +1,24 @@
 /**
- * tauri-api/command-error.ts — IPC エラーの共通正規化層 (Issue #737)
+ * tauri-api/command-error.ts — IPC エラーの共通正規化層 (Issue #737 / #931)
  *
- * Rust 側は `commands/error.rs` の `CommandError` を `Serialize` で **message 文字列のみ**
- * シリアライズして返す (variant tag は含めない後方互換契約)。一部の command (例:
- * `team_send_retry_inject` / `team_diagnostics_read`) は `CommandError::internal` に
- * `{"code":"...","message":"..."}` の JSON 文字列を載せて構造化情報を運ぶ。
+ * Rust 側は `commands/error.rs` の `CommandError` を `Serialize` で
+ * **`{ code, message }` の構造化オブジェクト**として返す (Issue #931 で正式契約化)。
+ * `code` は machine-readable な失敗分類 (`io` / `parse` / `validation` / `not_found` /
+ * `internal` / `authz`、または `retry_*` 等の明示 code)。失敗理由の分岐は **必ず
+ * `err.code` で行い**、`err.message` (人間向け表示文字列) への `includes` / `===` /
+ * `startsWith` 分岐を書かないこと (#888 の dead branch の轍)。
+ *
+ * 旧契約 (message 文字列のみ + `{"code":...}` JSON-in-string ハック) のペイロードも
+ * `CommandError.from()` が後方互換で解釈する。
  *
  * `@tauri-apps/api` の `invoke()` は Rust 側 `Err` を「シリアライズされた値そのもの」で
  * reject するため、これまで renderer 各所が「string で来るときと object で来るとき」を
  * 場当たり的に処理していた。本モジュールは:
- *   - `CommandError` … 全 IPC 失敗を表す共通 Error subclass。`code` (構造化されていれば)
- *     と `message` を必ず持つ。
+ *   - `CommandError` … 全 IPC 失敗を表す共通 Error subclass。`code` と `message` を必ず持つ。
  *   - `invokeCommand()` … `invoke()` の薄いラッパ。reject を `CommandError` に正規化して
  *     再 throw する。成功時の戻り値・引数は `invoke()` と完全に同一。
- * を提供し、wrapper レベルでエラー型を 1 つに統一する。
+ * を提供し、wrapper レベルでエラー型を 1 つに統一する。raw `invoke` の直接 import は
+ * eslint `no-restricted-imports` (Issue #931) によりこのファイル以外で禁止されている。
  */
 import { invoke, type InvokeArgs } from '@tauri-apps/api/core';
 

--- a/src/renderer/src/lib/tauri-api/dialog.ts
+++ b/src/renderer/src/lib/tauri-api/dialog.ts
@@ -1,14 +1,14 @@
 // tauri-api/dialog.ts — dialog.* IPC namespace (Phase 5 / Issue #373)
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeCommand } from './command-error';
 import type { DialogFileFilter } from '../../../../types/shared';
 
 export const dialog = {
   openFolder: (title?: string): Promise<string | null> =>
-    invoke('dialog_open_folder', { title }),
+    invokeCommand('dialog_open_folder', { title }),
   // Issue #820: filters で拡張子を絞り込めるようにする (省略時は従来通り全ファイル)
   openFile: (title?: string, filters?: DialogFileFilter[]): Promise<string | null> =>
-    invoke('dialog_open_file', { title, filters }),
+    invokeCommand('dialog_open_file', { title, filters }),
   isFolderEmpty: (folderPath: string): Promise<boolean> =>
-    invoke('dialog_is_folder_empty', { folderPath })
+    invokeCommand('dialog_is_folder_empty', { folderPath })
 };

--- a/src/renderer/src/lib/tauri-api/files.ts
+++ b/src/renderer/src/lib/tauri-api/files.ts
@@ -1,6 +1,6 @@
 // tauri-api/files.ts — files.* IPC namespace (Phase 5 / Issue #373)
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeCommand } from './command-error';
 import type {
   FileListResult,
   FileMutationResult,
@@ -10,9 +10,9 @@ import type {
 
 export const files = {
   list: (projectRoot: string, relPath: string): Promise<FileListResult> =>
-    invoke('files_list', { projectRoot, relPath }),
+    invokeCommand('files_list', { projectRoot, relPath }),
   read: (projectRoot: string, relPath: string): Promise<FileReadResult> =>
-    invoke('files_read', { projectRoot, relPath }),
+    invokeCommand('files_read', { projectRoot, relPath }),
   /**
    * Issue #65 / #104 / #102 / #119: external-change 検出と元 encoding の保持。
    *   - expectedMtimeMs: 開いた時点の mtime
@@ -30,7 +30,7 @@ export const files = {
     encoding?: string,
     expectedContentHash?: string
   ): Promise<FileWriteResult> =>
-    invoke('files_write', {
+    invokeCommand('files_write', {
       projectRoot,
       relPath,
       content,
@@ -49,10 +49,10 @@ export const files = {
     name: string,
     overwrite?: boolean
   ): Promise<FileMutationResult> =>
-    invoke('files_create', { projectRoot, relPath, name, overwrite }),
+    invokeCommand('files_create', { projectRoot, relPath, name, overwrite }),
   /** Issue #592: 親ディレクトリ relPath 配下に新規ディレクトリ `name` を作る。 */
   createDir: (projectRoot: string, relPath: string, name: string): Promise<FileMutationResult> =>
-    invoke('files_create_dir', { projectRoot, relPath, name }),
+    invokeCommand('files_create_dir', { projectRoot, relPath, name }),
   /**
    * Issue #592: ファイル/ディレクトリを rename もしくは同一ルート内移動する。
    * `fromRel` は既存パス、`toParentRel` は移動先親ディレクトリ、`newName` は新しい basename。
@@ -65,7 +65,7 @@ export const files = {
     newName: string,
     overwrite?: boolean
   ): Promise<FileMutationResult> =>
-    invoke('files_rename', { projectRoot, fromRel, toParentRel, newName, overwrite }),
+    invokeCommand('files_rename', { projectRoot, fromRel, toParentRel, newName, overwrite }),
   /**
    * Issue #592: ファイル/ディレクトリを削除する。
    * `permanent=false` (default) なら OS のゴミ箱、`true` なら完全削除。
@@ -75,7 +75,7 @@ export const files = {
     relPath: string,
     permanent?: boolean
   ): Promise<FileMutationResult> =>
-    invoke('files_delete', { projectRoot, relPath, permanent }),
+    invokeCommand('files_delete', { projectRoot, relPath, permanent }),
   /**
    * Issue #592: ファイル/ディレクトリを再帰コピー。Cut/Copy & Paste の Copy 経路。
    * cut の場合は呼び出し側で `rename` を使う。
@@ -87,5 +87,5 @@ export const files = {
     newName: string,
     overwrite?: boolean
   ): Promise<FileMutationResult> =>
-    invoke('files_copy', { projectRoot, fromRel, toParentRel, newName, overwrite })
+    invokeCommand('files_copy', { projectRoot, fromRel, toParentRel, newName, overwrite })
 };

--- a/src/renderer/src/lib/tauri-api/git.ts
+++ b/src/renderer/src/lib/tauri-api/git.ts
@@ -1,14 +1,14 @@
 // tauri-api/git.ts — git.* IPC namespace (Phase 5 / Issue #373)
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeCommand } from './command-error';
 import type { GitDiffResult, GitStatus } from '../../../../types/shared';
 
 export const git = {
-  status: (projectRoot: string): Promise<GitStatus> => invoke('git_status', { projectRoot }),
+  status: (projectRoot: string): Promise<GitStatus> => invokeCommand('git_status', { projectRoot }),
   diff: (
     projectRoot: string,
     relPath: string,
     originalRelPath?: string
   ): Promise<GitDiffResult> =>
-    invoke('git_diff', { projectRoot, relPath, originalRelPath })
+    invokeCommand('git_diff', { projectRoot, relPath, originalRelPath })
 };

--- a/src/renderer/src/lib/tauri-api/logs.ts
+++ b/src/renderer/src/lib/tauri-api/logs.ts
@@ -1,6 +1,6 @@
 // tauri-api/logs.ts — logs.* IPC namespace (Phase 5 / Issue #373)
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeCommand } from './command-error';
 import type { ReadLogTailResponse } from '../../../../types/shared';
 
 /** Issue #326: 設定モーダルからログを表示する用。
@@ -8,7 +8,7 @@ import type { ReadLogTailResponse } from '../../../../types/shared';
 export const logs = {
   /** ログファイル末尾の最大 maxBytes バイトを返す。省略時は 256KB。 */
   readTail: (maxBytes?: number): Promise<ReadLogTailResponse> =>
-    invoke('logs_read_tail', { maxBytes }),
+    invokeCommand('logs_read_tail', { maxBytes }),
   /** ログ格納ディレクトリを OS のファイルマネージャで開く。 */
-  openDir: (): Promise<void> => invoke('logs_open_dir')
+  openDir: (): Promise<void> => invokeCommand('logs_open_dir')
 };

--- a/src/renderer/src/lib/tauri-api/role-profiles.ts
+++ b/src/renderer/src/lib/tauri-api/role-profiles.ts
@@ -4,12 +4,11 @@
 // 呼び、reject を共通 `CommandError` に正規化する。`role_profiles_load` は失敗を `Err` では
 // なく fallback 値で表現する command なので素の `invoke` のまま。
 
-import { invoke } from '@tauri-apps/api/core';
-import type { RoleProfilesFile } from '../../../../types/shared';
 import { invokeCommand } from './command-error';
+import type { RoleProfilesFile } from '../../../../types/shared';
 
 export const roleProfiles = {
-  load: (): Promise<RoleProfilesFile | null> => invoke('role_profiles_load'),
+  load: (): Promise<RoleProfilesFile | null> => invokeCommand('role_profiles_load'),
   save: (file: RoleProfilesFile): Promise<void> =>
     invokeCommand('role_profiles_save', { file })
 };

--- a/src/renderer/src/lib/tauri-api/sessions.ts
+++ b/src/renderer/src/lib/tauri-api/sessions.ts
@@ -1,9 +1,9 @@
 // tauri-api/sessions.ts — sessions.* IPC namespace (Phase 5 / Issue #373)
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeCommand } from './command-error';
 import type { SessionInfo } from '../../../../types/shared';
 
 export const sessions = {
   list: (projectRoot: string): Promise<SessionInfo[]> =>
-    invoke('sessions_list', { projectRoot })
+    invokeCommand('sessions_list', { projectRoot })
 };

--- a/src/renderer/src/lib/tauri-api/settings.ts
+++ b/src/renderer/src/lib/tauri-api/settings.ts
@@ -1,12 +1,12 @@
 // tauri-api/settings.ts — settings.* IPC namespace (Phase 5 / Issue #373)
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeCommand } from './command-error';
 import type { AppSettings } from '../../../../types/shared';
 
 export const settings = {
   // 既定値とのマージや schemaVersion 判定は settings-migrate.ts に集約する。
   // ここで先に DEFAULT_SETTINGS を混ぜると、旧設定に現在の schemaVersion が
   // 入ってしまい、必要なマイグレーションがスキップされる。
-  load: (): Promise<unknown> => invoke('settings_load'),
-  save: (settings: AppSettings): Promise<void> => invoke('settings_save', { settings })
+  load: (): Promise<unknown> => invokeCommand('settings_load'),
+  save: (settings: AppSettings): Promise<void> => invokeCommand('settings_save', { settings })
 };

--- a/src/renderer/src/lib/tauri-api/team-history.ts
+++ b/src/renderer/src/lib/tauri-api/team-history.ts
@@ -1,6 +1,6 @@
 // tauri-api/team-history.ts — teamHistory.* IPC namespace (Phase 5 / Issue #373)
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeCommand } from './command-error';
 import type { TeamHistoryEntry } from '../../../../types/shared';
 
 interface MutationResult {
@@ -18,11 +18,11 @@ interface MutationResult {
 
 export const teamHistory = {
   list: (projectRoot: string): Promise<TeamHistoryEntry[]> =>
-    invoke('team_history_list', { projectRoot }),
+    invokeCommand('team_history_list', { projectRoot }),
   save: (entry: TeamHistoryEntry): Promise<MutationResult> =>
-    invoke('team_history_save', { entry }),
+    invokeCommand('team_history_save', { entry }),
   /** Issue #132: 複数チームを 1 IPC + 1 disk write でまとめて保存する */
   saveBatch: (entries: TeamHistoryEntry[]): Promise<MutationResult> =>
-    invoke('team_history_save_batch', { entries }),
-  delete: (id: string): Promise<MutationResult> => invoke('team_history_delete', { id })
+    invokeCommand('team_history_save_batch', { entries }),
+  delete: (id: string): Promise<MutationResult> => invokeCommand('team_history_delete', { id })
 };

--- a/src/renderer/src/lib/tauri-api/team-presets.ts
+++ b/src/renderer/src/lib/tauri-api/team-presets.ts
@@ -6,18 +6,18 @@
 //   - teamPresets = 永続化されたテンプレ (CRUD)
 // と意味が分かれるため。
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeCommand } from './command-error';
 import type {
   TeamPreset,
   TeamPresetMutationResult
 } from '../../../../types/shared';
 
 export const teamPresets = {
-  list: (): Promise<TeamPreset[]> => invoke('team_presets_list'),
+  list: (): Promise<TeamPreset[]> => invokeCommand('team_presets_list'),
   load: (id: string): Promise<TeamPreset | null> =>
-    invoke('team_presets_load', { id }),
+    invokeCommand('team_presets_load', { id }),
   save: (preset: TeamPreset): Promise<TeamPresetMutationResult> =>
-    invoke('team_presets_save', { preset }),
+    invokeCommand('team_presets_save', { preset }),
   delete: (id: string): Promise<TeamPresetMutationResult> =>
-    invoke('team_presets_delete', { id })
+    invokeCommand('team_presets_delete', { id })
 };

--- a/src/renderer/src/lib/tauri-api/terminal-tabs.ts
+++ b/src/renderer/src/lib/tauri-api/terminal-tabs.ts
@@ -4,7 +4,7 @@
 // 読込時は schemaVersion 不一致 / 未存在 / parse 失敗で `null` を返す (parse 失敗時の原本退避と
 // save 前の未来 schema guard は Rust 側が担当する)。
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeCommand } from './command-error';
 import type {
   PersistedTerminalTabsFile,
   TerminalTabsLoadResult
@@ -24,12 +24,12 @@ export const terminalTabs = {
    * `droppedSessions`) になった。invoke 名は不変。
    */
   load: async (): Promise<TerminalTabsLoadResult | null> => {
-    const result = await invoke<TerminalTabsLoadResult | null>('terminal_tabs_load');
+    const result = await invokeCommand<TerminalTabsLoadResult | null>('terminal_tabs_load');
     return result ?? null;
   },
   /** 全体を atomic 上書き。read-modify-write は呼び出し側責務。失敗は ok=false で返る。 */
   save: (file: PersistedTerminalTabsFile): Promise<MutationResult> =>
-    invoke('terminal_tabs_save', { file }),
+    invokeCommand('terminal_tabs_save', { file }),
   /** ファイルを削除して cache を空に戻す。idempotent。 */
-  clear: (): Promise<MutationResult> => invoke('terminal_tabs_clear')
+  clear: (): Promise<MutationResult> => invokeCommand('terminal_tabs_clear')
 };

--- a/src/renderer/src/lib/tauri-api/terminal.ts
+++ b/src/renderer/src/lib/tauri-api/terminal.ts
@@ -1,6 +1,6 @@
 // tauri-api/terminal.ts — terminal.* IPC namespace (Phase 5 / Issue #373)
 
-import { invoke } from '@tauri-apps/api/core';
+import { invokeCommand } from './command-error';
 import { subscribeEvent, subscribeEventReady } from '../subscribe-event';
 import type {
   TerminalCreateOptions,
@@ -16,14 +16,14 @@ interface SavePastedImageResult {
 
 export const terminal = {
   create: (opts: TerminalCreateOptions): Promise<TerminalCreateResult> =>
-    invoke('terminal_create', { opts }),
+    invokeCommand('terminal_create', { opts }),
   write: (id: string, data: string): Promise<void> =>
-    invoke('terminal_write', { id, data }),
+    invokeCommand('terminal_write', { id, data }),
   resize: (id: string, cols: number, rows: number): Promise<void> =>
-    invoke('terminal_resize', { id, cols, rows }),
-  kill: (id: string): Promise<void> => invoke('terminal_kill', { id }),
+    invokeCommand('terminal_resize', { id, cols, rows }),
+  kill: (id: string): Promise<void> => invokeCommand('terminal_kill', { id }),
   savePastedImage: (base64: string, mimeType: string): Promise<SavePastedImageResult> =>
-    invoke('terminal_save_pasted_image', { base64, mimeType }),
+    invokeCommand('terminal_save_pasted_image', { base64, mimeType }),
 
   onData: (id: string, cb: (data: string) => void): (() => void) =>
     subscribeEvent<string>(`terminal:data:${id}`, cb),


### PR DESCRIPTION
## Summary

Closes #931

IPC の「失敗の伝え方」3 流派並存と、人間向け表示文字列でしか失敗理由が運ばれない問題 (#888 の dead branch の根本原因) を構造側から解消する。

- **`CommandError` の Serialize を `{ code, message }` の構造化オブジェクトへ昇格**。variant 由来の code (`io` / `parse` / `validation` / `not_found` / `internal` / `authz`) に加え、明示 code 用の `Coded` variant を追加し、`team_send_retry_inject` の `{"code":"retry_*"}` JSON-in-string ハックを正式フィールドへ置換。renderer 側 `CommandError.from()` は object 形を最優先で解釈する既存実装のため、`err.code` 消費側 (CardInject 等) は互換
- **raw `invoke` 直叩きの残存 13 ファイルを `invokeCommand` へ統一** (#737 で 5/17 止まりだった正規化の完遂)。これにより構造化 Err payload が全経路で `CommandError` (Error subclass、`code`/`message` 保持) に正規化される
- **eslint `no-restricted-imports`**: `command-error.ts` 以外での `invoke` import を error 化し、流派の再生産を機械的に禁止
- **`build/check-command-result.mjs` + CI ステップ**: `CommandResult<T>` 以外を返す `#[tauri::command]` を検出して fail。旧 3 流派の既存 36 command は baseline 免除 (解消 PR で削っていく)、新規 command が `Option<T>` / ok+error 埋め込みをコピーすると CI が止める。やむを得ない場合は `// command-result-exempt: <理由>` で opt-out

issue 記載の残り 2 症状は対応済み: #888 (not_a_repo) は `notGitRepo` 構造化フラグで修正済み、use-terminal-spawn のロケール依存分類は #970 (`engine_binary_missing`) で修正済み。

## Test plan

- [x] `cargo test` 704 passed / `cargo clippy --all-targets -- -D warnings` clean
- [x] `npm test` 460 passed / `npm run typecheck` / `npm run lint` 0 errors / `npm run build:vite` 成功
- [x] `npm run lint:command-result` green (baseline 36 件)、新規違反 command を置くと fail することを確認
- [x] `npm run lint:file-size` / `npm run lint:safe-load` green