### PR TITLE
fix(canvas): #938 addCard/addCards を agentId reconcile 化し永続化を宣言的スキーマに分離

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -39,6 +39,6 @@
   "src/renderer/src/lib/hooks/use-xterm-bind.ts": 889,
   "src/renderer/src/lib/i18n.ts": 1775,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
-  "src/renderer/src/stores/canvas.ts": 583,
+  "src/renderer/src/stores/canvas.ts": 577,
   "src/types/shared.ts": 1598
 }

--- a/src/renderer/src/lib/canvas-migrations.ts
+++ b/src/renderer/src/lib/canvas-migrations.ts
@@ -67,13 +67,10 @@ function clampZoom(zoom: number): number {
   return Math.min(Math.max(zoom, VIEWPORT_MIN_ZOOM), VIEWPORT_MAX_ZOOM);
 }
 
-function stripTransientNodeState(raw: Record<string, unknown>): Partial<Node<CardData>> {
-  const node: Record<string, unknown> = { ...raw };
-  delete node.dragging;
-  delete node.selected;
-  delete node.resizing;
-  return node as Partial<Node<CardData>>;
-}
+// Issue #938: 旧 `stripTransientNodeState` (raw を丸ごと spread して dragging/selected/
+// resizing を delete する除外方式) は撤廃。normalize は下の明示構築 (pick 方式) で
+// 「列挙したフィールドしか復元されない」形にし、ランタイムフィールドの取りこぼし
+// (#894/#895 の measured / width drift 等) を症状別パッチではなく構造で塞ぐ。
 
 /**
  * crypto.randomUUID() ベースの安定 ID 生成。
@@ -136,23 +133,31 @@ export function normalizeCanvasState(input: unknown): NormalizedCanvasState {
             Math.abs(rawY) > VIEWPORT_RESCUE_DISTANCE
               ? Math.floor(index / 6) * (NODE_H + 32)
               : rawY;
-          return {
-            ...stripTransientNodeState(raw),
+          // Issue #938: 明示構築 (pick)。永続化データに何が混ざっていても、
+          // ここに列挙したフィールドだけが React Flow ノードとして復元される。
+          // top-level width/height は NodeResizer の手動リサイズ値 (意図的な永続データ)
+          // なので有限値のときだけ引き継ぐ。
+          const node: Node<CardData> = {
             id: typeof raw.id === 'string' && raw.id ? raw.id : newId(type),
             type,
             position: { x: safeX, y: safeY },
             data: {
-              ...data,
               cardType: type,
               title,
               payload: data.payload
-            },
+            } as CardData,
             style: {
-              ...styleRaw,
               width: finiteOr(styleRaw.width, NODE_W),
               height: finiteOr(styleRaw.height, NODE_H)
             }
           };
+          if (typeof raw.width === 'number' && Number.isFinite(raw.width)) {
+            node.width = raw.width;
+          }
+          if (typeof raw.height === 'number' && Number.isFinite(raw.height)) {
+            node.height = raw.height;
+          }
+          return node;
         })
         .filter((n): n is Node<CardData> => n !== null)
     : [];

--- a/src/renderer/src/stores/__tests__/canvas-card-reconcile.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-card-reconcile.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Issue #938: addCard / addCards の agentId reconcile (upsert) と
+ * PersistedCardNode 明示変換のテスト。
+ *
+ * 守りたい不変条件:
+ *  - 同 type + 同 agentId のカードは何回 add しても 1 枚 (新規 spawn → registry の
+ *    旧 PTY kill (#893) の事故経路を store レベルで遮断する)
+ *  - reconcile 時は既存カードの position / size を保ち、payload は浅く merge される
+ *  - agentId を持たないカードは従来どおり常に append
+ *  - 永続化は PersistedCardNode への明示 pick で、dragging / selected / measured 等の
+ *    React Flow ランタイムフィールドが localStorage に到達しない (#894/#895 の恒久化)
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Node } from '@xyflow/react';
+import { useCanvasStore, type CardData } from '../canvas';
+import { toPersistedCardNode } from '../canvas-card-identity';
+
+const TEAM = 'team-reconcile-test';
+
+function agentSpec(agentId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'agent' as const,
+    title: `Agent ${agentId}`,
+    position: { x: 0, y: 0 },
+    payload: {
+      agent: 'claude' as const,
+      role: 'programmer',
+      roleProfileId: 'programmer',
+      teamId: TEAM,
+      teamName: 'Reconcile Test',
+      agentId,
+      cwd: 'C:/proj',
+      ...overrides
+    }
+  };
+}
+
+describe('useCanvasStore reconcile (Issue #938)', () => {
+  beforeEach(() => {
+    if (typeof localStorage !== 'undefined') localStorage.clear();
+    useCanvasStore.getState().clear();
+  });
+
+  it('同 agentId の addCards 再実行でカードが複製されない (resume 経路の #893 再生産防止)', () => {
+    const store = useCanvasStore.getState();
+    const first = store.addCards([agentSpec('programmer-0-' + TEAM)]);
+    expect(useCanvasStore.getState().nodes).toHaveLength(1);
+
+    // 稼働中チームを resume したのと同じ: 同一 agentId の spec をもう一度 addCards
+    const second = useCanvasStore
+      .getState()
+      .addCards([agentSpec('programmer-0-' + TEAM, { resumeSessionId: 'session-12345678' })]);
+
+    const nodes = useCanvasStore.getState().nodes;
+    expect(nodes).toHaveLength(1);
+    // 既存カードの id がそのまま返る (viewport フォーカス等の caller が既存カードを掴める)
+    expect(second[0]).toBe(first[0]);
+  });
+
+  it('reconcile は payload を浅く merge し position は既存値を保つ', () => {
+    const store = useCanvasStore.getState();
+    const [id] = store.addCards([agentSpec('researcher-1-' + TEAM)]);
+    // ユーザーがカードを動かした状態を再現
+    useCanvasStore.setState({
+      nodes: useCanvasStore
+        .getState()
+        .nodes.map((n) => (n.id === id ? { ...n, position: { x: 1234, y: 567 } } : n))
+    });
+
+    useCanvasStore
+      .getState()
+      .addCards([agentSpec('researcher-1-' + TEAM, { resumeSessionId: 'session-abcdefgh' })]);
+
+    const node = useCanvasStore.getState().nodes.find((n) => n.id === id);
+    expect(node?.position).toEqual({ x: 1234, y: 567 });
+    const payload = node?.data.payload as Record<string, unknown>;
+    expect(payload.resumeSessionId).toBe('session-abcdefgh');
+    expect(payload.cwd).toBe('C:/proj'); // 既存キーは保持
+  });
+
+  it('同一バッチ内の重複 agentId も 1 枚に畳まれる', () => {
+    const ids = useCanvasStore
+      .getState()
+      .addCards([agentSpec('reviewer-2-' + TEAM), agentSpec('reviewer-2-' + TEAM)]);
+    expect(useCanvasStore.getState().nodes).toHaveLength(1);
+    expect(ids[0]).toBe(ids[1]);
+  });
+
+  it('addCard (単数) も同 agentId の terminal カードを reconcile する', () => {
+    const store = useCanvasStore.getState();
+    const first = store.addCard({
+      type: 'terminal',
+      title: 'T1',
+      payload: { agentId: 'solo-agent-1', cwd: 'C:/proj' }
+    });
+    const second = useCanvasStore.getState().addCard({
+      type: 'terminal',
+      title: 'T1 (resumed)',
+      payload: { agentId: 'solo-agent-1', resumeSessionId: 'session-87654321' }
+    });
+    expect(second).toBe(first);
+    expect(useCanvasStore.getState().nodes).toHaveLength(1);
+  });
+
+  it('agentId を持たないカードは従来どおり append される', () => {
+    const store = useCanvasStore.getState();
+    store.addCard({ type: 'editor', title: 'a.ts', payload: { projectRoot: 'C:/p', relPath: 'a.ts' } });
+    useCanvasStore
+      .getState()
+      .addCard({ type: 'editor', title: 'a.ts', payload: { projectRoot: 'C:/p', relPath: 'a.ts' } });
+    expect(useCanvasStore.getState().nodes).toHaveLength(2);
+  });
+
+  it('type が異なれば同じ agentId でも reconcile しない', () => {
+    const store = useCanvasStore.getState();
+    store.addCard({ type: 'terminal', title: 'T', payload: { agentId: 'x-agent-1' } });
+    useCanvasStore.getState().addCards([agentSpec('x-agent-1')]);
+    expect(useCanvasStore.getState().nodes).toHaveLength(2);
+  });
+});
+
+describe('toPersistedCardNode (Issue #938)', () => {
+  it('ランタイムフィールド (dragging / selected / measured) は永続化スキーマに含まれない', () => {
+    const node = {
+      id: 'agent-1',
+      type: 'agent',
+      position: { x: 10, y: 20 },
+      data: { cardType: 'agent', title: 'A', payload: { agentId: 'a-1' } },
+      style: { width: 760, height: 460 },
+      dragging: true,
+      selected: true,
+      resizing: true,
+      measured: { width: 999, height: 999 },
+      zIndex: 5
+    } as unknown as Node<CardData>;
+
+    const persisted = toPersistedCardNode(node);
+    expect(persisted).toEqual({
+      id: 'agent-1',
+      type: 'agent',
+      position: { x: 10, y: 20 },
+      data: { cardType: 'agent', title: 'A', payload: { agentId: 'a-1' } },
+      style: { width: 760, height: 460 }
+    });
+    expect('dragging' in persisted).toBe(false);
+    expect('measured' in persisted).toBe(false);
+  });
+
+  it('NodeResizer の手動リサイズ値 (top-level width/height) は意図的に永続化される', () => {
+    const node = {
+      id: 'terminal-1',
+      type: 'terminal',
+      position: { x: 0, y: 0 },
+      data: { cardType: 'terminal', title: 'T', payload: undefined },
+      style: { width: 760, height: 460 },
+      width: 900,
+      height: 600
+    } as unknown as Node<CardData>;
+
+    const persisted = toPersistedCardNode(node);
+    expect(persisted.width).toBe(900);
+    expect(persisted.height).toBe(600);
+  });
+});

--- a/src/renderer/src/stores/canvas-card-identity.ts
+++ b/src/renderer/src/stores/canvas-card-identity.ts
@@ -1,0 +1,165 @@
+/**
+ * Issue #938: Canvas カードの identity (agentId) 照合と永続化スキーマ。
+ *
+ * ## カード状態の所有権規約
+ *
+ * Canvas カードの「位置・サイズ・teamId・agentId・sessionId」は複数の場所に複製されるが、
+ * 役割は次のとおり単方向に固定する:
+ *
+ *   1. **zustand store (`stores/canvas.ts`) が正本 (single source of truth)**。
+ *      カードの追加・更新は必ず `addCard` / `addCards` / `setCardPayload` 経由で行う。
+ *   2. localStorage persist は store の **キャッシュ** (`PersistedCardNode` スキーマに
+ *      明示変換してから保存。React Flow のランタイムフィールドは構造的に持ち込めない)。
+ *   3. team-history.json (Rust 経由) は store の **射影 (書込のみ)**。復元時は
+ *      `spawnTeam` が射影から `CardSpec` を組み、`addCards` の reconcile が store と照合する。
+ *   4. Rust TeamHub / PTY registry は **プロセスのランタイムレジストリ** であり、
+ *      カード identity の正本ではない (agentId で突き合わせるだけ)。
+ *
+ * `addCard` / `addCards` は agentId をキーにした **reconcile (upsert)**: 同 type かつ
+ * 同 agentId のカードが既にあれば新規カードを作らず payload を更新して既存 id を返す。
+ * これにより resume / preset / recruit 等の「カードを生やす」経路が増えても、
+ * 同一 agentId のカード複製 → 同 agent_id 再 spawn → registry の旧 PTY kill (#893)
+ * という事故経路が構造的に再生産されない。
+ */
+import type { Node } from '@xyflow/react';
+import { NODE_W, NODE_H } from '../lib/canvas-migrations';
+import type { CardData, CardPayloadMap, CardType } from './canvas';
+
+/** agentId を持ちうるカード (agent / terminal) からそれを取り出す。 */
+function nodeAgentId(data: CardData | undefined): string | undefined {
+  if (!data) return undefined;
+  if (data.cardType === 'agent' || data.cardType === 'terminal') {
+    return data.payload?.agentId;
+  }
+  return undefined;
+}
+
+/**
+ * addCard / addCards の reconcile (upsert) 対象を探す。
+ *
+ * agentId は PTY registry の識別子であり、「同 agent_id で再 spawn されると旧 PTY を
+ * kill + drop する」規約 (#42 / registry.rs) を持つ。同 type + 同 agentId のカードを
+ * 二重に生やすと稼働中 PTY の巻き添え kill (#893) になるため、identity 一致時は
+ * 新規カードを作らず既存カードへ payload を merge する。
+ *
+ * agentId を持たないカード (editor / diff / 単発 terminal 等) は対象外 (常に append)。
+ */
+export function findReconcileTarget(
+  nodes: Node<CardData>[],
+  type: CardType,
+  payload: { agentId?: string } | undefined
+): Node<CardData> | undefined {
+  if (type !== 'agent' && type !== 'terminal') return undefined;
+  const agentId = payload?.agentId;
+  if (!agentId) return undefined;
+  return nodes.find((n) => n.type === type && nodeAgentId(n.data) === agentId);
+}
+
+/**
+ * reconcile 時の既存ノード更新。position / size (= ユーザーが今いじっている配置) は
+ * 既存値を正とし、title と payload (resumeSessionId / latestHandoff 等の復元コンテキスト)
+ * だけを浅く merge する。
+ */
+export function reconcileCardNode(
+  node: Node<CardData>,
+  title: string,
+  payload: Record<string, unknown> | undefined
+): Node<CardData> {
+  const prev = (node.data.payload ?? {}) as Record<string, unknown>;
+  return {
+    ...node,
+    data: {
+      ...node.data,
+      title,
+      payload: payload ? ({ ...prev, ...payload } as CardData['payload']) : node.data.payload
+    } as CardData
+  };
+}
+
+/**
+ * `addCard` / `addCards` 共通の `Node<CardData>` 生成ヘルパ (Issue #732 から移設)。
+ * `type` と `payload` は呼び出し側 (generic / `CardSpec`) で対応付けて渡されるため、
+ * 構築する `data` は実体として `CardData` のいずれかの variant。generic `T` を union
+ * member へ静的に絞れないので `data` 構築の 1 箇所だけ cast する。
+ */
+export function makeCardNode<T extends CardType>(
+  id: string,
+  type: T,
+  position: { x: number; y: number },
+  title: string,
+  payload: CardPayloadMap[T] | undefined
+): Node<CardData> {
+  return {
+    id,
+    type,
+    position,
+    data: { cardType: type, title, payload } as CardData,
+    style: { width: NODE_W, height: NODE_H }
+  };
+}
+
+/** Issue #840: 6 列グリッド上の占有スロットを避け、最初の空き位置を返す。 */
+export function nextFallbackCardPosition(nodes: Node<CardData>[]): { x: number; y: number } {
+  const cols = 6;
+  const stepX = NODE_W + 32;
+  const stepY = NODE_H + 32;
+  const occupied = new Set(
+    nodes.map((node) => `${Math.round(node.position.x)},${Math.round(node.position.y)}`)
+  );
+
+  for (let slot = 0; slot <= nodes.length; slot++) {
+    const x = (slot % cols) * stepX;
+    const y = Math.floor(slot / cols) * stepY;
+    if (!occupied.has(`${x},${y}`)) return { x, y };
+  }
+
+  return {
+    x: ((nodes.length + 1) % cols) * stepX,
+    y: Math.floor((nodes.length + 1) / cols) * stepY
+  };
+}
+
+/**
+ * localStorage に保存するカード 1 枚分の宣言的スキーマ (Issue #938)。
+ *
+ * 旧実装は React Flow のランタイムオブジェクト (`Node<CardData>`) を丸ごと保存しており、
+ * `dragging` / `selected` / `measured` 等のランタイムフィールドが永続化境界を越えるたびに
+ * 症状別の除外パッチ (#894 / #895) を当てていた。書込側 (`toPersistedCardNode`) で
+ * このスキーマへ **明示変換 (pick)** することで、列挙されていないフィールドは型レベルで
+ * 永続化不能になる。
+ *
+ * `width` / `height` (top-level) は NodeResizer の手動リサイズ値で、`style` の既定サイズ
+ * より優先される **意図的な** 永続データなので含める。
+ */
+export interface PersistedCardNode {
+  id: string;
+  type: CardType;
+  position: { x: number; y: number };
+  /** NodeResizer の手動リサイズ値。未リサイズなら省略。 */
+  width?: number;
+  height?: number;
+  style?: { width?: number; height?: number };
+  data: CardData;
+}
+
+/** `Node<CardData>` → `PersistedCardNode` の明示変換 (Issue #938)。 */
+export function toPersistedCardNode(n: Node<CardData>): PersistedCardNode {
+  const out: PersistedCardNode = {
+    id: n.id,
+    type: (n.type ?? n.data.cardType) as CardType,
+    position: { x: n.position.x, y: n.position.y },
+    data: { cardType: n.data.cardType, title: n.data.title, payload: n.data.payload } as CardData
+  };
+  if (typeof n.width === 'number' && Number.isFinite(n.width)) out.width = n.width;
+  if (typeof n.height === 'number' && Number.isFinite(n.height)) out.height = n.height;
+  const style = n.style as { width?: unknown; height?: unknown } | undefined;
+  if (style) {
+    const s: { width?: number; height?: number } = {};
+    if (typeof style.width === 'number' && Number.isFinite(style.width)) s.width = style.width;
+    if (typeof style.height === 'number' && Number.isFinite(style.height)) {
+      s.height = style.height;
+    }
+    out.style = s;
+  }
+  return out;
+}

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -1,8 +1,9 @@
 /**
  * Canvas store — React Flow の nodes/edges を保持し localStorage 永続化する。
  *
- * Phase 2 では「Card 配置の自由レイアウト」だけを支える最小実装。
- * Phase 3 以降で agent ノード / hand-off エッジを正規化していく。
+ * Issue #938: カード状態の所有権規約 (store が正本 / persist はキャッシュ /
+ * team-history は射影 / TeamHub はランタイムレジストリ) と、agentId reconcile・
+ * `PersistedCardNode` 永続化スキーマの詳細は `stores/canvas-card-identity.ts` を参照。
  */
 import { create } from 'zustand';
 import { persist, subscribeWithSelector } from 'zustand/middleware';
@@ -22,6 +23,14 @@ import {
 } from '../lib/canvas-migrations';
 import type { AgentPayload } from '../components/canvas/cards/AgentNodeCard/types';
 import type { PersistStorage, StorageValue } from 'zustand/middleware';
+import {
+  findReconcileTarget,
+  makeCardNode,
+  nextFallbackCardPosition,
+  reconcileCardNode,
+  toPersistedCardNode,
+  type PersistedCardNode
+} from './canvas-card-identity';
 
 export type CardType = 'terminal' | 'agent' | 'editor' | 'diff' | 'fileTree' | 'changes';
 
@@ -307,8 +316,8 @@ let canvasPersistPaused = false;
 
 type CanvasPersistState = Pick<
   CanvasState,
-  'nodes' | 'viewport' | 'stageView' | 'teamLocks' | 'arrangeGap'
->;
+  'viewport' | 'stageView' | 'teamLocks' | 'arrangeGap'
+> & { nodes: PersistedCardNode[] };
 
 function canvasStorage(): Storage | null {
   if (typeof window === 'undefined') return null;
@@ -342,49 +351,6 @@ const canvasPersistStorage: PersistStorage<CanvasPersistState> = {
  *  この export を使って壊れた localStorage 入力 / 極端な viewport などの境界条件を確認する。
  *  実体は `lib/canvas-migrations.ts` 側に移し、こちらは互換維持のための re-export。 */
 export const __testables = MIGRATION_TESTABLES;
-
-/**
- * Issue #732: `addCard` / `addCards` 共通の `Node<CardData>` 生成ヘルパ。
- * `type` と `payload` は呼び出し側 (generic / `CardSpec`) で対応付けて渡されるため、
- * 構築する `data` は実体として `CardDataOf<T>` (= `CardData` のいずれかの variant)。
- * generic `T` を union member へ静的に絞れないので `data` 構築の 1 箇所だけ cast する
- * (構造は変えず、判別 tag `cardType` と payload の対応は呼び出し側の型で保証される)。
- */
-function makeCardNode<T extends CardType>(
-  id: string,
-  type: T,
-  position: { x: number; y: number },
-  title: string,
-  payload: CardPayloadMap[T] | undefined
-): Node<CardData> {
-  return {
-    id,
-    type,
-    position,
-    data: { cardType: type, title, payload } as CardData,
-    style: { width: NODE_W, height: NODE_H }
-  };
-}
-
-function nextFallbackCardPosition(nodes: Node<CardData>[]): { x: number; y: number } {
-  const cols = 6;
-  const stepX = NODE_W + 32;
-  const stepY = NODE_H + 32;
-  const occupied = new Set(
-    nodes.map((node) => `${Math.round(node.position.x)},${Math.round(node.position.y)}`)
-  );
-
-  for (let slot = 0; slot <= nodes.length; slot++) {
-    const x = (slot % cols) * stepX;
-    const y = Math.floor(slot / cols) * stepY;
-    if (!occupied.has(`${x},${y}`)) return { x, y };
-  }
-
-  return {
-    x: ((nodes.length + 1) % cols) * stepX,
-    y: Math.floor((nodes.length + 1) / cols) * stepY
-  };
-}
 
 export const useCanvasStore = create<CanvasState>()(
   /**
@@ -420,8 +386,20 @@ export const useCanvasStore = create<CanvasState>()(
         set({ isDragging });
       },
       addCard: ({ type, title, payload, position }) => {
-        const id = newId(type);
         const existing = get().nodes;
+        // Issue #938: 同 type + 同 agentId のカードがあれば append せず reconcile する。
+        const target = findReconcileTarget(existing, type, payload);
+        if (target) {
+          set({
+            nodes: existing.map((n) =>
+              n.id === target.id
+                ? reconcileCardNode(n, title, payload as Record<string, unknown> | undefined)
+                : n
+            )
+          });
+          return target.id;
+        }
+        const id = newId(type);
         let pos = position;
         if (!pos) {
           // Issue #840: 削除後に existing.length だけを見ると既存カードと座標が重なる。
@@ -435,12 +413,25 @@ export const useCanvasStore = create<CanvasState>()(
       },
       addCards: (cards) => {
         const ids: string[] = [];
-        const newNodes: Node<CardData>[] = cards.map((c) => {
-          const id = newId(c.type);
-          ids.push(id);
-          return makeCardNode(id, c.type, c.position, c.title, c.payload);
-        });
-        set({ nodes: [...get().nodes, ...newNodes] });
+        // Issue #938: working copy に対して逐次 reconcile することで、
+        // 「store 上の既存カード」とも「同一バッチ内の重複 spec」とも upsert で照合される。
+        let working = [...get().nodes];
+        for (const c of cards) {
+          const target = findReconcileTarget(working, c.type, c.payload);
+          if (target) {
+            working = working.map((n) =>
+              n.id === target.id
+                ? reconcileCardNode(n, c.title, c.payload as Record<string, unknown> | undefined)
+                : n
+            );
+            ids.push(target.id);
+          } else {
+            const id = newId(c.type);
+            working.push(makeCardNode(id, c.type, c.position, c.title, c.payload));
+            ids.push(id);
+          }
+        }
+        set({ nodes: working });
         return ids;
       },
       removeCard: (id, options) =>
@@ -569,8 +560,11 @@ export const useCanvasStore = create<CanvasState>()(
       },
       // 永続化: nodes / viewport / stageView / teamLocks / arrangeGap。
       // edges は一時的な hand-off アニメに使うので含めない。
+      // Issue #938: nodes は PersistedCardNode へ明示変換 (pick) してから保存する。
+      // dragging / selected / measured 等の React Flow ランタイムフィールドは
+      // スキーマに列挙されていないため構造的に localStorage へ到達しない (#894/#895 の恒久化)。
       partialize: (s) => ({
-        nodes: s.nodes,
+        nodes: s.nodes.map(toPersistedCardNode),
         viewport: s.viewport,
         stageView: s.stageView,
         teamLocks: s.teamLocks,


### PR DESCRIPTION
## Summary

Closes #938

Canvas カード状態が 5 箇所に複製され identity 照合の規約が無い構造問題を、store レベルで解消する。

- **agentId reconcile (upsert)**: `addCard` / `addCards` は同 type + 同 agentId のカードが既にあれば新規カードを作らず、payload を浅く merge して既存 id を返す (`stores/canvas-card-identity.ts` 新設)。position / size は既存値 (ユーザーが触っている配置) を正とする。これにより resume / preset / recruit 等の「カードを生やす」経路が今後増えても、複製カード → 同 agent_id 再 spawn → registry の旧 PTY kill (#893 型) が**構造的に再生産されない**。同一バッチ内の重複 spec も 1 枚に畳まれる
- **永続化スキーマの宣言的分離**: `PersistedCardNode = { id, type, position, width?, height?, style{width,height}, data{cardType,title,payload} }` へ partialize で**明示変換 (pick)** してから localStorage 保存。`dragging` / `selected` / `measured` 等の React Flow ランタイムフィールドはスキーマに列挙されていないため型レベルで永続化不能 (#894/#895 の症状別除外パッチの恒久化)。top-level `width`/`height` は NodeResizer の手動リサイズ値 (意図的な永続データ) なので保持
- **normalize もスプレッド廃止**: `canvas-migrations.ts` の復元側を「raw を spread して transient を delete する除外方式」から「列挙フィールドのみの明示構築」へ
- **所有権規約の明文化**: store 正本 / localStorage persist はキャッシュ / team-history.json は射影 (書込のみ・復元は reconcile で照合) / Rust TeamHub・PTY registry はランタイムレジストリ、の単方向規約を `canvas-card-identity.ts` に記載

## 再発防止

- [x] regression テスト 8 件追加 (`canvas-card-reconcile.test.ts`): 同 agentId 複製防止 / 既存 id 返却 / position 保持 + payload merge / バッチ内重複 / agentId 無しは append / type 違いは別カード / PersistedCardNode がランタイムフィールドを含まない / 手動リサイズ値は保持

## Test plan

- [x] `npm test` 468 passed (新規 8 件含む) / `npm run typecheck` / `npm run lint` 0 errors / `npm run build:vite` 成功
- [x] `npm run lint:file-size` green — canvas.ts は分割で 583 → 577 行に縮小 (baseline 引き下げ)、新設 2 ファイルは 500 行以下