### PR TITLE
chore(release): bump version to 1.6.4 (#977 fix 同梱)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-editor",
-  "version": "1.6.0",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-editor",
-      "version": "1.6.0",
+      "version": "1.6.4",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/geist-mono": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5382,7 +5382,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.6.3"
+version = "1.6.4"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",

--- a/src/renderer/src/lib/hooks/use-team-management.ts
+++ b/src/renderer/src/lib/hooks/use-team-management.ts
@@ -75,6 +75,7 @@ export interface UseTeamManagementResult {
 
   // ---- terminal launch helpers (TerminalView props にそのまま渡せる形) ----
   getTerminalArgs: (tab: TerminalTab) => string[];
+  getClaudeInstructions: (tab: TerminalTab) => string | undefined;
   getCodexInstructions: (tab: TerminalTab) => string | undefined;
   getRolePrompt: (tab: TerminalTab) => string | undefined;
   getTerminalEnv: (tab: TerminalTab) => Record<string, string> | undefined;
@@ -123,6 +124,7 @@ export function useTeamManagement(
     handleTerminalSessionId: history.handleTerminalSessionId,
     persistTerminalCustomLabel: history.persistTerminalCustomLabel,
     getTerminalArgs: launch.getTerminalArgs,
+    getClaudeInstructions: launch.getClaudeInstructions,
     getCodexInstructions: launch.getCodexInstructions,
     getRolePrompt: launch.getRolePrompt,
     getTerminalEnv: launch.getTerminalEnv,


### PR DESCRIPTION
## Summary
- バージョンを 1.6.3 → 1.6.4 に更新 (package.json / package-lock.json / tauri.conf.json / Cargo.toml / Cargo.lock)
- Closes #977: `useTeamManagement` が `getClaudeInstructions` を返却しておらず、`AppShell` の IDE モード terminal 描画 (`claudeInstructions={getClaudeInstructions(tab)}`) が実行時 TypeError になる退行を修正してリリースに同梱
- package-lock.json の version は 1.6.0 のまま過去 2 リリースで放置されていたため、本 PR で 1.6.4 に同期

## リリース手順 (本 PR merge 後)
1. merge commit に `v1.6.4` タグを付けて push → release.yml が draft release を生成
2. draft の description を編集して publish

## Test plan
- [x] `npm run typecheck` 通過 (※ #841 により実効検査は限定的)
- [x] Cargo.lock は `[[package]] vibe-editor` の version 行のみ更新 (cargo の自動同期と同一形式)
- [ ] CI (clippy / build) green