### PR TITLE
feat(ui): #981 macOS でネイティブの信号機ウィンドウ制御ボタンを使う

### DIFF
--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "title": "vibe-editor",
+        "width": 1440,
+        "height": 900,
+        "minWidth": 1100,
+        "minHeight": 640,
+        "resizable": true,
+        "decorations": true,
+        "transparent": false,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "backgroundColor": "#0A0A1A",
+        "fullscreen": false
+      }
+    ]
+  }
+}

--- a/src/renderer/src/components/shell/Topbar.tsx
+++ b/src/renderer/src/components/shell/Topbar.tsx
@@ -6,6 +6,7 @@ import type { StatusMascotState } from '../../lib/status-mascot';
 import type { AvailableUpdateInfo } from '../../lib/updater-check';
 import { StatusMascot } from './StatusMascot';
 import { WindowControls } from './WindowControls';
+import { isMacOS } from '../../lib/platform';
 
 interface TopbarProps {
   projectRoot: string;
@@ -151,8 +152,10 @@ export function Topbar({
         </div>
       ) : null}
 
-      {/* Issue #260 PR-2: カスタムタイトルバーのウィンドウ制御 (decorations: false の代替) */}
-      <WindowControls />
+      {/* Issue #260 PR-2: カスタムタイトルバーのウィンドウ制御 (decorations: false の代替)。
+          Issue #981: macOS は OS ネイティブの信号機ボタン (titleBarStyle: Overlay) を
+          使うため、自前の Windows 風ボタンは描画しない。 */}
+      {!isMacOS && <WindowControls />}
 
       {mascotState ? (
         <span

--- a/src/renderer/src/lib/platform.ts
+++ b/src/renderer/src/lib/platform.ts
@@ -1,0 +1,31 @@
+/**
+ * Issue #981: レンダラー側で OS プラットフォームを判定する単一窓口。
+ *
+ * Tauri の WebView では `navigator.userAgent` / `navigator.platform` に OS 名が
+ * 入る。従来は各所 (`path-norm` / `updater-check` / `use-window-frame-insets` 等)
+ * で個別に正規表現判定していたため、ここに集約して表記揺れを防ぐ。
+ *
+ * SSR / 非ブラウザ環境を考慮し `navigator` 未定義でも落ちないようにする。
+ */
+
+const ua: string =
+  typeof navigator !== 'undefined'
+    ? `${navigator.platform ?? ''} ${navigator.userAgent ?? ''}`
+    : '';
+
+/** macOS (Tauri の userAgent は "Macintosh; ... Mac OS X" を含む) */
+export const isMacOS: boolean = /Mac/i.test(ua);
+
+/** Windows */
+export const isWindows: boolean = /Win/i.test(ua);
+
+/** Linux (Android を除く。vibe-editor は desktop のみ対象) */
+export const isLinux: boolean = /Linux/i.test(ua) && !/Android/i.test(ua);
+
+/** tokens.css / shell.css の `:root[data-platform='…']` と一致する識別子。 */
+export function platformId(): 'macos' | 'windows' | 'linux' | 'other' {
+  if (isWindows) return 'windows';
+  if (isMacOS) return 'macos';
+  if (isLinux) return 'linux';
+  return 'other';
+}

--- a/src/renderer/src/lib/use-window-frame-insets.ts
+++ b/src/renderer/src/lib/use-window-frame-insets.ts
@@ -11,8 +11,8 @@
  */
 import { useEffect } from 'react';
 import { getCurrentWindow } from '@tauri-apps/api/window';
+import { isWindows, platformId } from './platform';
 
-const isWindows = /Windows/i.test(navigator.userAgent);
 type TauriWindowHandle = ReturnType<typeof getCurrentWindow>;
 
 function getSafeCurrentWindow(): TauriWindowHandle | null {
@@ -26,9 +26,12 @@ function getSafeCurrentWindow(): TauriWindowHandle | null {
 
 export function useWindowFrameInsets(): void {
   useEffect(() => {
-    if (!isWindows) return;
     const root = document.documentElement;
-    root.dataset.platform = 'windows';
+    // Issue #981: macOS のネイティブ信号機ボタン (titleBarStyle: Overlay) 分の
+    // 左 inset を CSS 側で当てるため、全プラットフォームで data-platform を出力する。
+    root.dataset.platform = platformId();
+    // 以降の不可視リサイズ境界補正は Windows のフレームレス最大化時のみ必要。
+    if (!isWindows) return;
     // 初期値を即時セットして flash を最小化
     root.dataset.windowMaximized = 'false';
     const win = getSafeCurrentWindow();

--- a/src/renderer/src/styles/components/shell.css
+++ b/src/renderer/src/styles/components/shell.css
@@ -138,7 +138,9 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 0 18px 0 16px;
+  /* Issue #981: macOS は左の信号機ボタン分を `--titlebar-traffic-inset` で確保。
+     他プラットフォームでは 0px なので従来どおり 16px。 */
+  padding: 0 18px 0 calc(16px + var(--titlebar-traffic-inset, 0px));
   border-bottom: 1px solid var(--border);
   background: var(--bg-toolbar);
   position: relative;

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -735,6 +735,13 @@ samp,
   --wf-top: 0px;
   --wf-bottom: 0px;
   --wf-x: 0px;
+  /* Issue #981: macOS のネイティブ信号機ボタン (close/min/zoom) を左上に表示する
+   * (titleBarStyle: Overlay)。topbar 左端のブランドロゴが信号機の下に潜らないよう、
+   * macOS のみ左 inset を確保する。Windows/Linux では 0。 */
+  --titlebar-traffic-inset: 0px;
+}
+:root[data-platform='macos'] {
+  --titlebar-traffic-inset: 78px;
 }
 :root[data-platform='windows'][data-window-maximized='true'] {
   --wf-top: 8px;


### PR DESCRIPTION
## Summary
- macOS で自前の Windows 風ウィンドウ制御ボタン (— □ ×, `WindowControls`) を出さず、OS ネイティブの信号機ボタン (close/min/zoom, 左上) を使うようにする。
- Windows / Linux は現状維持 (`decorations: false` + カスタム `WindowControls`)。
- 関連 issue: Closes #981

## 変更点
- **`src-tauri/tauri.macos.conf.json` を新設** — Tauri 2 のプラットフォーム別 config merge を利用し、macOS の window を `decorations: true` + `titleBarStyle: "Overlay"` + `hiddenTitle: true` に上書き。これでネイティブ信号機ボタンが表示され、webview コンテンツが titlebar の下まで広がる (overlay)。base config (Windows/Linux) は `decorations: false` のまま不変。
- **`src/renderer/src/lib/platform.ts` を新設** — 散在していた `navigator.userAgent` 正規表現判定を集約 (`isMacOS` / `isWindows` / `isLinux` / `platformId`)。
- **`Topbar.tsx`** — macOS では `WindowControls` を描画しない (`{!isMacOS && <WindowControls />}`)。
- **`use-window-frame-insets.ts`** — 全プラットフォームで `data-platform` を出力 (従来は Windows のみ)。Windows の最大化リサイズ境界補正ロジックは不変。
- **`tokens.css` / `shell.css`** — macOS のみ `.topbar` 左端に信号機分の inset (`--titlebar-traffic-inset: 78px`) を確保し、ブランドロゴが信号機の下に潜らないようにする。他 OS では 0px で従来どおり。

## 設計メモ
- `Topbar` は IDE (`AppShell`) と Canvas (`CanvasLayout`) の両モードで最上段に置かれる共通要素なので、`.topbar` への inset 適用だけで両モードをカバーできる。
- `data-platform` は CSS では今回追加した 2 ルールでしか参照されず、全 OS で出力しても既存挙動 (`[data-platform='windows'][data-window-maximized='true']`) に影響しない。

## Test plan
- [x] `npm run typecheck` 通過
- [x] `eslint` (変更ファイル) 通過
- [x] `drag-region-css-contract` テスト通過
- [x] `tauri.macos.conf.json` JSON 妥当性確認
- [ ] macOS で `npm run dev` 起動し、左上にネイティブ信号機ボタンが出て右側のカスタムボタンが消えること、ブランドロゴが信号機と重ならないことを目視確認
- [ ] Windows でカスタム `WindowControls` が従来どおり右上に出ることを確認 (リグレッション無し)