### PR TITLE
refactor(pty): #983 spawn の telemetry ヘルパを spawn_metrics.rs へ分離

### DIFF
--- a/src-tauri/src/pty/session/mod.rs
+++ b/src-tauri/src/pty/session/mod.rs
@@ -24,6 +24,7 @@ mod handle;
 mod injecting_guard;
 mod lock;
 pub(crate) mod spawn;
+pub(crate) mod spawn_metrics;
 #[cfg(not(windows))]
 pub(crate) mod unix_path;
 #[cfg(windows)]

--- a/src-tauri/src/pty/session/spawn.rs
+++ b/src-tauri/src/pty/session/spawn.rs
@@ -24,6 +24,7 @@ use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::mpsc;
 
 use super::handle::{SessionHandle, TerminalExitInfo};
+use super::spawn_metrics::{build_cmd_label, engine_label, log_spawn_outcome, platform_label};
 
 /// Issue #818: ターミナル spawn 時の警告 (cwd フォールバック等) を renderer 側に
 /// 言語非依存で渡すための構造体。`message_key` は `src/renderer/src/lib/i18n.ts`
@@ -228,74 +229,6 @@ fn resolve_spawn_command(
     env: &HashMap<String, String>,
 ) -> Result<PreparedSpawnCommand> {
     super::windows_resolve::resolve_windows_spawn_command(command, args, env)
-}
-
-/// Issue #579: spawn ログ用に「漏洩しない短い command ラベル」を作る。
-///
-/// resolved_command はフルパス (例: `C:\Users\foo\AppData\Roaming\npm\claude.cmd`) を
-/// 持ちうるので、basename だけ取り出してさらに `redact_home` を通す。`Path::file_name`
-/// は Unix 上で Windows 区切り `\` を解釈しないため、cross-platform に動かすには
-/// 両方の区切りで rsplit する。
-pub(crate) fn build_cmd_label(prepared: &PreparedSpawnCommand) -> String {
-    let basename = prepared
-        .resolved_command
-        .rsplit(['/', '\\'])
-        .next()
-        .filter(|s| !s.is_empty())
-        .unwrap_or(prepared.requested_command.as_str())
-        .to_string();
-    redact_home(&basename)
-}
-
-pub(crate) fn engine_label(is_codex: bool) -> &'static str {
-    if is_codex {
-        "codex"
-    } else {
-        "claude"
-    }
-}
-
-pub(crate) fn platform_label() -> &'static str {
-    if cfg!(target_os = "windows") {
-        "windows"
-    } else if cfg!(target_os = "macos") {
-        "macos"
-    } else if cfg!(target_os = "linux") {
-        "linux"
-    } else {
-        "other"
-    }
-}
-
-/// Issue #579: PTY spawn の所要時間 + 結果を tracing で記録する。
-/// 集計は `target=pty` + メッセージ `[pty] spawn ok` / `[pty] spawn failed` で grep する想定。
-/// 詳細は `tasks/issue-579/notes.md` を参照。
-pub(crate) fn log_spawn_outcome(
-    cmd_label: &str,
-    engine: &str,
-    platform: &str,
-    elapsed_ms: u64,
-    error: Option<&str>,
-) {
-    match error {
-        None => tracing::info!(
-            target: "pty",
-            command = %cmd_label,
-            engine = %engine,
-            platform = %platform,
-            elapsed_ms = elapsed_ms,
-            "[pty] spawn ok"
-        ),
-        Some(err) => tracing::warn!(
-            target: "pty",
-            command = %cmd_label,
-            engine = %engine,
-            platform = %platform,
-            elapsed_ms = elapsed_ms,
-            error = %err,
-            "[pty] spawn failed"
-        ),
-    }
 }
 
 pub fn spawn_session(

--- a/src-tauri/src/pty/session/spawn_metrics.rs
+++ b/src-tauri/src/pty/session/spawn_metrics.rs
@@ -1,0 +1,78 @@
+//! Issue #983: spawn の telemetry / ラベル付けヘルパを `spawn.rs` から分離。
+//!
+//! `build_cmd_label` / `engine_label` / `platform_label` / `log_spawn_outcome` は
+//! spawn の所要時間・結果ログを整形するための純粋関数群で、spawn 本体の制御フロー
+//! (PTY open / reader thread / exit watcher) からは独立している。状態を持たないため
+//! 所有権の境界も発生しない。挙動・ログフォーマットは spawn.rs にあった頃から一切
+//! 変えていない (純粋な move)。
+
+use super::spawn::PreparedSpawnCommand;
+use crate::util::log_redact::redact_home;
+
+/// Issue #579: spawn ログ用に「漏洩しない短い command ラベル」を作る。
+///
+/// resolved_command はフルパス (例: `C:\Users\foo\AppData\Roaming\npm\claude.cmd`) を
+/// 持ちうるので、basename だけ取り出してさらに `redact_home` を通す。`Path::file_name`
+/// は Unix 上で Windows 区切り `\` を解釈しないため、cross-platform に動かすには
+/// 両方の区切りで rsplit する。
+pub(crate) fn build_cmd_label(prepared: &PreparedSpawnCommand) -> String {
+    let basename = prepared
+        .resolved_command
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(prepared.requested_command.as_str())
+        .to_string();
+    redact_home(&basename)
+}
+
+pub(crate) fn engine_label(is_codex: bool) -> &'static str {
+    if is_codex {
+        "codex"
+    } else {
+        "claude"
+    }
+}
+
+pub(crate) fn platform_label() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "windows"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else {
+        "other"
+    }
+}
+
+/// Issue #579: PTY spawn の所要時間 + 結果を tracing で記録する。
+/// 集計は `target=pty` + メッセージ `[pty] spawn ok` / `[pty] spawn failed` で grep する想定。
+/// 詳細は `tasks/issue-579/notes.md` を参照。
+pub(crate) fn log_spawn_outcome(
+    cmd_label: &str,
+    engine: &str,
+    platform: &str,
+    elapsed_ms: u64,
+    error: Option<&str>,
+) {
+    match error {
+        None => tracing::info!(
+            target: "pty",
+            command = %cmd_label,
+            engine = %engine,
+            platform = %platform,
+            elapsed_ms = elapsed_ms,
+            "[pty] spawn ok"
+        ),
+        Some(err) => tracing::warn!(
+            target: "pty",
+            command = %cmd_label,
+            engine = %engine,
+            platform = %platform,
+            elapsed_ms = elapsed_ms,
+            error = %err,
+            "[pty] spawn failed"
+        ),
+    }
+}

--- a/src-tauri/src/pty/tests/session_spawn.rs
+++ b/src-tauri/src/pty/tests/session_spawn.rs
@@ -8,8 +8,9 @@
 //! こちらの subscriber は `target: "pty"` を自分の crate filter で弾かない
 //! (test ローカルに `with_default` で全 target を拾う) ため。
 
-use crate::pty::session::spawn::{
-    build_cmd_label, engine_label, log_spawn_outcome, platform_label, PreparedSpawnCommand,
+use crate::pty::session::spawn::PreparedSpawnCommand;
+use crate::pty::session::spawn_metrics::{
+    build_cmd_label, engine_label, log_spawn_outcome, platform_label,
 };
 use std::io::Write;
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
## Summary
- `spawn.rs` が file-size baseline (785 行) を **797 行**で超過し、CI の **File-size ratchet** が main 上で失敗していた (#980 の macOS PATH 継承補強で増加)。これにより main をベースに rebase された全 PR の `verify` が連鎖的に red になっていた。
- CLAUDE.md rule #7 に従い baseline 引き上げではなく**分割**で対処。spawn 本体の制御フローから独立した純粋関数群 (`build_cmd_label` / `engine_label` / `platform_label` / `log_spawn_outcome`) を新規 `spawn_metrics.rs` へ移設し、`spawn.rs` を **730 行**に縮小。
- 挙動・ログフォーマットは一切変更なし (純粋な move)。状態を持たない関数群のため所有権の境界も発生しない。
- 関連 issue: #983

## Test plan
- [x] `npm run lint:file-size` green (spawn.rs 730 < 785)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` green
- [x] `cargo test session_spawn` green (7 passed)
- [ ] CI: clippy / cargo-cfg (windows/macos) / verify