### PR TITLE
fix(test): Vitest と Rust テスト失敗を修正

### DIFF
--- a/src-tauri/src/commands/fs_watch.rs
+++ b/src-tauri/src/commands/fs_watch.rs
@@ -163,11 +163,18 @@ pub(crate) fn is_safe_watch_root(root: &Path) -> bool {
         if canon == Path::new("/") {
             return false;
         }
-        let lower = canon.to_string_lossy();
         for prefix in [
-            "/etc", "/sys", "/proc", "/dev", "/usr", "/bin", "/sbin", "/boot",
+            "/etc",
+            "/private/etc",
+            "/sys",
+            "/proc",
+            "/dev",
+            "/usr",
+            "/bin",
+            "/sbin",
+            "/boot",
         ] {
-            if lower.starts_with(prefix) {
+            if canon.starts_with(prefix) {
                 return false;
             }
         }

--- a/src/renderer/src/stores/canvas-persistence.ts
+++ b/src/renderer/src/stores/canvas-persistence.ts
@@ -1,0 +1,63 @@
+import type { PersistStorage, StorageValue } from 'zustand/middleware';
+import type { CanvasState } from './canvas';
+import {
+  toPersistedCanvasState,
+  type PersistedCardNode
+} from './canvas-card-identity';
+
+export const CANVAS_PERSIST_NAME = 'vibe-editor:canvas';
+export const CANVAS_PERSIST_VERSION = 5;
+
+type CanvasPersistState = Pick<
+  CanvasState,
+  'viewport' | 'stageView' | 'teamLocks' | 'arrangeGap'
+> & { nodes: PersistedCardNode[] };
+
+function canvasStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export const canvasPersistStorage: PersistStorage<CanvasPersistState> = {
+  getItem: (name) => {
+    const raw = canvasStorage()?.getItem(name);
+    if (!raw) return null;
+    return JSON.parse(raw) as StorageValue<CanvasPersistState>;
+  },
+  setItem: (name, value) => {
+    // Issue #864/#835: drag 中は nodes が毎フレーム変わるため、localStorage への
+    // JSON.stringify が UI スレッドを詰まらせる。drag 終了時に明示 flush する。
+    if (canvasPersistPaused()) return;
+    canvasStorage()?.setItem(name, JSON.stringify(value));
+  },
+  removeItem: (name) => {
+    canvasStorage()?.removeItem(name);
+  }
+};
+
+let isPaused = false;
+
+export function setCanvasPersistPaused(paused: boolean): void {
+  isPaused = paused;
+}
+
+export function canvasPersistPaused(): boolean {
+  return isPaused;
+}
+
+export function toCanvasPersistState(state: CanvasState): CanvasPersistState {
+  return {
+    ...toPersistedCanvasState(state)
+  };
+}
+
+export function flushCanvasPersistState(state: CanvasState): void {
+  canvasPersistStorage.setItem(CANVAS_PERSIST_NAME, {
+    state: toCanvasPersistState(state),
+    version: CANVAS_PERSIST_VERSION
+  });
+}

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -22,15 +22,22 @@ import {
   normalizeCanvasState
 } from '../lib/canvas-migrations';
 import type { AgentPayload } from '../components/canvas/cards/AgentNodeCard/types';
-import type { PersistStorage, StorageValue } from 'zustand/middleware';
 import {
   findReconcileTarget,
   makeCardNode,
   nextFallbackCardPosition,
   reconcileCardNode,
-  toPersistedCanvasState,
-  type PersistedCardNode
+  toPersistedCanvasState
 } from './canvas-card-identity';
+import {
+  CANVAS_PERSIST_NAME,
+  CANVAS_PERSIST_VERSION,
+  canvasPersistPaused,
+  canvasPersistStorage,
+  flushCanvasPersistState,
+  setCanvasPersistPaused,
+  toCanvasPersistState
+} from './canvas-persistence';
 
 export type CardType = 'terminal' | 'agent' | 'editor' | 'diff' | 'fileTree' | 'changes';
 
@@ -216,7 +223,7 @@ export function cardRoleId(data: CardData | undefined): string | undefined {
   return undefined;
 }
 
-interface CanvasState {
+export interface CanvasState {
   nodes: Node<CardData>[];
   edges: Edge[];
   viewport: Viewport;
@@ -312,39 +319,6 @@ export const NODE_MIN_H = 280;
  *  - 大量 handoff 時の保留 timer 蓄積を抑える
  */
 const pulseTimers = new Map<string, number>();
-let canvasPersistPaused = false;
-
-type CanvasPersistState = Pick<
-  CanvasState,
-  'viewport' | 'stageView' | 'teamLocks' | 'arrangeGap'
-> & { nodes: PersistedCardNode[] };
-
-function canvasStorage(): Storage | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    return window.localStorage;
-  } catch {
-    return null;
-  }
-}
-
-const canvasPersistStorage: PersistStorage<CanvasPersistState> = {
-  getItem: (name) => {
-    const raw = canvasStorage()?.getItem(name);
-    if (!raw) return null;
-    return JSON.parse(raw) as StorageValue<CanvasPersistState>;
-  },
-  setItem: (name, value) => {
-    // Issue #864/#835: drag 中は nodes が毎フレーム変わるため、localStorage への
-    // JSON.stringify が UI スレッドを詰まらせる。drag 終了時の setCanvasDragging(false)
-    // と直後の setNodes で最新状態が flush されるので、drag 中だけ丸ごと skip する。
-    if (canvasPersistPaused) return;
-    canvasStorage()?.setItem(name, JSON.stringify(value));
-  },
-  removeItem: (name) => {
-    canvasStorage()?.removeItem(name);
-  }
-};
 
 /** Issue #385: テストから直接 normalize の挙動を検証するための export。
  *  本体は zustand persist の migrate / merge から間接呼出しされるが、unit test では
@@ -382,8 +356,18 @@ export const useCanvasStore = create<CanvasState>()(
       setEdges: (edges) => set({ edges }),
       setViewport: (viewport) => set({ viewport }),
       setCanvasDragging: (isDragging) => {
-        canvasPersistPaused = isDragging;
+        if (isDragging) {
+          setCanvasPersistPaused(true);
+          set({ isDragging });
+          return;
+        }
+
+        const wasPaused = canvasPersistPaused();
         set({ isDragging });
+        setCanvasPersistPaused(false);
+        if (wasPaused) {
+          flushCanvasPersistState(get());
+        }
       },
       addCard: ({ type, title, payload, position }) => {
         const existing = get().nodes;
@@ -537,14 +521,14 @@ export const useCanvasStore = create<CanvasState>()(
         set((state) => ({ nodes: unifyTerminalSize(state.nodes) }))
     }),
     {
-      name: 'vibe-editor:canvas',
+      name: CANVAS_PERSIST_NAME,
       storage: canvasPersistStorage,
       // Issue #385: v4 で persisted state は必ず normalizeCanvasState を経由させる。
       // 同 version の rehydrate でも `merge` で再正規化するため、runtime で紛れ込んだ
       // NaN viewport / 範囲外 zoom / 壊れた node も次回起動時には掃除される。
       // Issue #497: v5 で旧既定 640x400 のカードを新既定 760x460 へ移行する
       // (>640 / >400 の手動拡大値は尊重)。詳細は `lib/canvas-migrations.ts` の v4 step。
-      version: 5,
+      version: CANVAS_PERSIST_VERSION,
       // 各 version の差分は `lib/canvas-migrations.ts` の `MIGRATION_STEPS` に集約。
       // ここでは「fromVersion → 最新」を 1 行で進めるだけ。最後に必ず normalize を通すので
       // 同 version の rehydrate でも runtime に紛れ込んだ NaN viewport / 範囲外 zoom /
@@ -563,9 +547,7 @@ export const useCanvasStore = create<CanvasState>()(
       // Issue #938: nodes は PersistedCardNode へ明示変換 (pick) してから保存する。
       // dragging / selected / measured 等の React Flow ランタイムフィールドは
       // スキーマに列挙されていないため構造的に localStorage へ到達しない (#894/#895 の恒久化)。
-      partialize: (s): CanvasPersistState => ({
-        ...toPersistedCanvasState(s)
-      })
+      partialize: toCanvasPersistState
     }
     )
   )

--- a/src/renderer/src/test-setup.ts
+++ b/src/renderer/src/test-setup.ts
@@ -1,5 +1,53 @@
 import '@testing-library/jest-dom/vitest';
 
+class MemoryStorage implements Storage {
+  private readonly items = new Map<string, string>();
+
+  get length(): number {
+    return this.items.size;
+  }
+
+  clear(): void {
+    this.items.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.items.get(String(key)) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.items.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.items.delete(String(key));
+  }
+
+  setItem(key: string, value: string): void {
+    this.items.set(String(key), String(value));
+  }
+}
+
+function defineGlobalStorage(storage: Storage): void {
+  if (storage instanceof MemoryStorage) {
+    for (const target of [globalThis, window]) {
+      Object.defineProperty(target, 'Storage', {
+        configurable: true,
+        value: MemoryStorage
+      });
+    }
+  }
+
+  for (const target of [globalThis, window]) {
+    Object.defineProperty(target, 'localStorage', {
+      configurable: true,
+      value: storage
+    });
+  }
+}
+
+defineGlobalStorage(new MemoryStorage());
+
 if (typeof HTMLCanvasElement !== 'undefined') {
   Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
     configurable: true,


### PR DESCRIPTION
## Summary
- Canvas persist の drag 中 pause/終了時 flush をテスト可能な helper に分離
- Vitest 環境に localStorage polyfill を追加して zustand persist の参照失敗を防止
- macOS で canonicalize された /private/etc も unsafe watch root として拒否

Closes #986

## Test plan
- [x] npm test
- [x] npm run typecheck
- [x] cargo test --manifest-path src-tauri/Cargo.toml