### PR TITLE
refactor(team_hub): 状態推測を構造化フィールドへ統一

### DIFF
--- a/src-tauri/src/team_hub/protocol/schema.rs
+++ b/src-tauri/src/team_hub/protocol/schema.rs
@@ -44,7 +44,7 @@ pub(super) fn tool_defs() -> Value {
                         "type": "string",
                         "enum": ["advisory", "request", "report"],
                         "default": "advisory",
-                        "description": "Message intent. advisory = peer consultation, request = formal task/request and is automatically CCed to the active Leader, report = completion/progress report."
+                        "description": "Message intent. advisory = peer consultation, request = formal task/request and is automatically CCed to the active Leader, report = completion/progress report. The Hub uses this field for report bookkeeping; it does not infer reports from message text."
                     },
                     "handoff_id": {
                         "type": "string",
@@ -231,9 +231,18 @@ pub(super) fn tool_defs() -> Value {
                     "blocked_reason": { "type": "string" },
                     "next_action": { "type": "string" },
                     "artifact_path": { "type": "string" },
-                    "blocked_by_human_gate": { "type": "boolean" },
-                    "required_human_decision": { "type": "string" },
-                    "report_kind": { "type": "string" },
+                    "blocked_by_human_gate": {
+                        "type": "boolean",
+                        "description": "Explicitly mark this blocked task as waiting on a human/leader decision. The Hub does not infer this from blocked_reason text."
+                    },
+                    "required_human_decision": {
+                        "type": "string",
+                        "description": "Structured description of the decision needed. Providing this also marks the task as a human gate."
+                    },
+                    "report_kind": {
+                        "type": "string",
+                        "description": "Optional structured worker report kind; defaults to the canonical task status."
+                    },
                     "done_evidence": {
                         "type": "array",
                         "description": "Required when status is done for tasks with done_criteria.",

--- a/src-tauri/src/team_hub/protocol/tools/assign_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/assign_task.rs
@@ -651,12 +651,12 @@ pub(super) fn build_task_notification(
     format!(
         "[Task #{task_id}]\n{description_fenced}{file_lock_section}{pre_approval_section}{done_section}\n\n\
          [Standard response protocol — follow even if not repeated in the task body]\n\
-         1. Reply immediately with `team_send(\"leader\", \"ACK: Task #{task_id} received, starting...\")`.\n\
-         2. Call `team_update_task({task_id}, \"in_progress\")`.\n\
-         3. For long-running steps, call `team_status(\"...short progress line...\")` every meaningful step \
+        1. Reply immediately with `team_send({{\"to\":\"leader\",\"kind\":\"report\",\"message\":\"ACK: Task #{task_id} received, starting...\"}})`.\n\
+        2. Call `team_update_task({{\"task_id\":{task_id},\"status\":\"in_progress\"}})`.\n\
+        3. For long-running steps, call `team_status({{\"status\":\"...short progress line...\"}})` every meaningful step \
          so the Leader can see you are alive via team_diagnostics.\n\
-         4. When done, send a `team_send(\"leader\", \"完了報告: ...\")` and call \
-         `team_update_task({task_id}, \"done\")` (or `\"blocked\"` if you cannot finish)."
+        4. When done, send `team_send({{\"to\":\"leader\",\"kind\":\"report\",\"message\":\"完了報告: ...\"}})` and call \
+        `team_update_task({{\"task_id\":{task_id},\"status\":\"done\",\"done_evidence\":{done_evidence_json}}})` (or status `\"blocked\"` if you cannot finish)."
     )
 }
 
@@ -681,9 +681,9 @@ mod tests {
         // プロトコル節 4 項目が含まれる
         assert!(msg.contains("Standard response protocol"));
         assert!(msg.contains("ACK: Task #42 received"));
-        assert!(msg.contains("team_update_task(42, \"in_progress\")"));
-        assert!(msg.contains("team_status("));
-        assert!(msg.contains("team_update_task(42, \"done\")"));
+        assert!(msg.contains(r#"team_update_task({"task_id":42,"status":"in_progress"})"#));
+        assert!(msg.contains(r#"team_status({"status":"#));
+        assert!(msg.contains(r#"team_update_task({"task_id":42,"status":"done""#));
         assert!(msg.contains("\"blocked\""));
     }
 

--- a/src-tauri/src/team_hub/protocol/tools/send.rs
+++ b/src-tauri/src/team_hub/protocol/tools/send.rs
@@ -155,39 +155,16 @@ fn optional_string(args: &Value, snake: &str, camel: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-fn is_leader_report(to: &str, message: &str, sender_role: &str) -> bool {
-    if sender_role == "leader" || to.trim() != "leader" {
-        return false;
-    }
-    let lower = message.to_ascii_lowercase();
-    message.contains("完了報告")
-        || lower.contains("completion report")
-        || lower.contains("done:")
-        || lower.contains("blocked")
-        || message.contains("ブロック")
-}
-
-fn report_kind(message: &str) -> &'static str {
-    let lower = message.to_ascii_lowercase();
-    if lower.contains("blocked") || message.contains("ブロック") {
-        "blocked"
-    } else {
-        "message"
-    }
-}
-
 fn is_leader_role(role: &str) -> bool {
     role.trim().eq_ignore_ascii_case("leader")
 }
 
 fn should_record_leader_summary_feed(
-    raw_to: &str,
-    message: &str,
     from_role: &str,
     targets: &[(String, String)],
     message_kind: MessageKind,
 ) -> bool {
-    if is_leader_report(raw_to, message, from_role) || message_kind == MessageKind::Report {
+    if message_kind == MessageKind::Report {
         return true;
     }
 
@@ -198,14 +175,8 @@ fn should_record_leader_summary_feed(
         && !targets.iter().any(|(_, role)| is_leader_role(role))
 }
 
-fn leader_summary_kind(message_kind: MessageKind, message: &str) -> String {
-    if message_kind == MessageKind::Advisory {
-        "advisory".to_string()
-    } else if message_kind == MessageKind::Report {
-        "report".to_string()
-    } else {
-        report_kind(message).to_string()
-    }
+fn leader_summary_kind(message_kind: MessageKind) -> String {
+    message_kind.as_str().to_string()
 }
 
 fn resolve_targets_with_request_cc(
@@ -503,8 +474,6 @@ async fn insert_team_message(
     // メッセージ履歴に追加
     let timestamp = Utc::now().to_rfc3339();
     let should_record_summary_feed = should_record_leader_summary_feed(
-        to,
-        message,
         &ctx.role,
         &targets.targets,
         message_kind,
@@ -557,7 +526,7 @@ async fn insert_team_message(
                 task_id: None,
                 from_role: ctx.role.clone(),
                 from_agent_id: ctx.agent_id.clone(),
-                kind: leader_summary_kind(message_kind, message),
+                kind: leader_summary_kind(message_kind),
                 summary,
                 blocked_reason: None,
                 next_action: None,
@@ -1085,16 +1054,11 @@ mod tests {
         let targets = vec![("reviewer-1".to_string(), "reviewer".to_string())];
 
         assert!(should_record_leader_summary_feed(
-            "reviewer",
-            "この設計でよいか相談です",
             "programmer",
             &targets,
             MessageKind::Advisory
         ));
-        assert_eq!(
-            leader_summary_kind(MessageKind::Advisory, "相談"),
-            "advisory"
-        );
+        assert_eq!(leader_summary_kind(MessageKind::Advisory), "advisory");
     }
 
     #[test]
@@ -1103,19 +1067,32 @@ mod tests {
         let worker_target = vec![("worker-1".to_string(), "worker".to_string())];
 
         assert!(!should_record_leader_summary_feed(
-            "leader",
-            "相談です",
             "programmer",
             &leader_target,
             MessageKind::Advisory
         ));
         assert!(!should_record_leader_summary_feed(
-            "programmer",
-            "作業してください",
             "leader",
             &worker_target,
             MessageKind::Advisory
         ));
+    }
+
+    #[test]
+    fn leader_summary_feed_does_not_infer_report_from_text() {
+        let leader_target = vec![("leader-1".to_string(), "leader".to_string())];
+
+        assert!(!should_record_leader_summary_feed(
+            "programmer",
+            &leader_target,
+            MessageKind::Advisory
+        ));
+        assert!(should_record_leader_summary_feed(
+            "programmer",
+            &leader_target,
+            MessageKind::Report
+        ));
+        assert_eq!(leader_summary_kind(MessageKind::Report), "report");
     }
 
     #[test]

--- a/src-tauri/src/team_hub/protocol/tools/update_task.rs
+++ b/src-tauri/src/team_hub/protocol/tools/update_task.rs
@@ -143,16 +143,6 @@ fn optional_report_payload(
     })
 }
 
-fn looks_like_human_gate(text: &str) -> bool {
-    let lower = text.to_ascii_lowercase();
-    lower.contains("human")
-        || lower.contains("approval")
-        || lower.contains("approve")
-        || text.contains("承認")
-        || text.contains("人間")
-        || text.contains("判断")
-}
-
 /// Issue #833: `task_id` を厳格に `u32` へ解釈する。
 ///
 /// 旧実装は `args.get("task_id").and_then(|v| v.as_u64()).unwrap_or(0) as u32` で、
@@ -227,12 +217,7 @@ pub async fn team_update_task(
         optional_string(args, "required_human_decision", "requiredHumanDecision");
     let explicit_human_gate =
         optional_bool(args, "blocked_by_human_gate", "blockedByHumanGate").unwrap_or(false);
-    let blocked_by_human_gate = explicit_human_gate
-        || blocked_reason
-            .as_deref()
-            .map(looks_like_human_gate)
-            .unwrap_or(false)
-        || required_human_decision.is_some();
+    let blocked_by_human_gate = explicit_human_gate || required_human_decision.is_some();
     let now_iso = Utc::now().to_rfc3339();
     let mut state = hub.state.lock().await;
     {
@@ -593,6 +578,65 @@ mod tests {
             team.next_actions.back().map(String::as_str),
             Some("Wait for QA")
         );
+    }
+
+    #[tokio::test]
+    async fn update_task_does_not_infer_human_gate_from_blocked_reason_text() {
+        let hub = TeamHub::new(Arc::new(SessionRegistry::new()));
+        let team_id = "team-human-gate-no-infer".to_string();
+        {
+            let mut state = hub.state.lock().await;
+            let team = state
+                .teams
+                .entry(team_id.clone())
+                .or_insert_with(TeamInfo::default);
+            team.tasks.push_back(TeamTask {
+                id: 8,
+                assigned_to: "worker".into(),
+                description: "ambiguous approval text".into(),
+                status: "pending".into(),
+                created_by: "leader".into(),
+                created_at: "2026-06-13T10:00:00Z".into(),
+                updated_at: None,
+                summary: None,
+                blocked_reason: None,
+                next_action: None,
+                artifact_path: None,
+                blocked_by_human_gate: false,
+                required_human_decision: None,
+                target_paths: Vec::new(),
+                lock_conflicts: Vec::new(),
+                pre_approval: None,
+                done_criteria: Vec::new(),
+                done_evidence: Vec::new(),
+            });
+        }
+
+        let ctx = CallContext {
+            team_id: team_id.clone(),
+            role: "worker".into(),
+            agent_id: "worker-8".into(),
+        };
+
+        team_update_task(
+            &hub,
+            &ctx,
+            &json!({
+                "task_id": 8,
+                "status": "blocked",
+                "summary": "Blocked on wording",
+                "blocked_reason": "approval wording appears in copied notes, but no decision is required"
+            }),
+        )
+        .await
+        .expect("team_update_task ok");
+
+        let state = hub.state.lock().await;
+        let team = state.teams.get(&team_id).unwrap();
+        let task = team.tasks.iter().find(|task| task.id == 8).unwrap();
+        assert!(!task.blocked_by_human_gate);
+        assert!(!team.human_gate.blocked);
+        assert_eq!(team.worker_reports.len(), 1);
     }
 
     /// Issue #516: `report_payload` (findings/proposal/risks/next_action/artifacts[]) を渡したとき


### PR DESCRIPTION
## Summary
- team_send の worker report 判定を kind=report / advisory の構造化値だけに統一
- team_update_task の human gate 判定から blocked_reason 本文のキーワード推測を撤去
- MCP schema と task 通知テンプレートを構造化フィールド前提の説明へ更新

Closes #958

## Test plan
- [x] cargo test --manifest-path src-tauri/Cargo.toml team_hub::protocol::tools::send::tests
- [x] cargo test --manifest-path src-tauri/Cargo.toml team_hub::protocol::tools::update_task::tests
- [x] cargo test --manifest-path src-tauri/Cargo.toml team_hub::protocol::tools::assign_task::tests::notification_embeds_standard_response_protocol
- [x] cargo check --manifest-path src-tauri/Cargo.toml
- [x] npm run typecheck

## Notes
- cargo fmt はこの環境の stable toolchain に rustfmt が入っていないため未実行です。