### PR TITLE
refactor(commands): ProjectRoot ゲートを導入

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -1,8 +1,8 @@
 {
   "src-tauri/src/commands/app/team_mcp.rs": 684,
-  "src-tauri/src/commands/authz.rs": 571,
-  "src-tauri/src/commands/files.rs": 1261,
-  "src-tauri/src/commands/git.rs": 518,
+  "src-tauri/src/commands/authz.rs": 618,
+  "src-tauri/src/commands/files.rs": 1274,
+  "src-tauri/src/commands/git.rs": 529,
   "src-tauri/src/commands/handoffs.rs": 513,
   "src-tauri/src/commands/settings.rs": 780,
   "src-tauri/src/commands/team_history.rs": 1239,

--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -15,13 +15,48 @@
 //! lock-free な `ArcSwapOption<String>` へ移したため、本 helper も `ArcSwapOption` を
 //! 受け取る形に追従する (deadlock 経路の構造的排除)。
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use arc_swap::ArcSwapOption;
 
 use crate::commands::error::{CommandError, CommandResult};
 use crate::state::current_project_root;
 use crate::team_hub::TeamHub;
+
+/// canonicalize 済み、かつ AppState の active project_root あるいは許可済み workspace folder と
+/// 照合済みの project root。FS helper はこの型を要求することで、renderer 由来の生文字列が
+/// authz gate を通らずにファイル操作へ届く経路を型で塞ぐ。
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectRoot {
+    canonical: PathBuf,
+    display: String,
+}
+
+impl ProjectRoot {
+    fn from_canonical(canonical: PathBuf) -> Self {
+        let display = canonical.to_string_lossy().into_owned();
+        Self { canonical, display }
+    }
+
+    pub fn as_path(&self) -> &Path {
+        &self.canonical
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.display
+    }
+
+    #[cfg(test)]
+    pub(crate) fn assume_canonical_for_test(path: PathBuf) -> Self {
+        Self::from_canonical(path)
+    }
+}
+
+impl AsRef<Path> for ProjectRoot {
+    fn as_ref(&self) -> &Path {
+        self.as_path()
+    }
+}
 
 /// 監査ログに raw path を出すときの clamp (制御文字を `?` に置換 + 240 文字で truncate)。
 /// renderer 由来の project_root に改行や ESC が混じっていても tracing 行を破壊しないようにする。
@@ -57,7 +92,7 @@ fn clamp_team_id_for_log(raw: &str) -> String {
 pub async fn assert_active_project_root(
     project_root_slot: &ArcSwapOption<String>,
     given: &str,
-) -> CommandResult<PathBuf> {
+) -> CommandResult<ProjectRoot> {
     let trimmed = given.trim();
     if trimmed.is_empty() {
         tracing::warn!(
@@ -122,7 +157,7 @@ pub async fn assert_active_project_root(
         ));
     }
 
-    Ok(active_canon)
+    Ok(ProjectRoot::from_canonical(active_canon))
 }
 
 /// Issue #954 / #963: ファイル系 IPC (`files_*`) 用のゲート。
@@ -146,7 +181,7 @@ pub async fn assert_active_project_root(
 pub async fn assert_readable_project_root(
     project_root_slot: &ArcSwapOption<String>,
     given: &str,
-) -> CommandResult<PathBuf> {
+) -> CommandResult<ProjectRoot> {
     let trimmed = given.trim();
     if trimmed.is_empty() {
         tracing::warn!(
@@ -174,7 +209,7 @@ pub async fn assert_readable_project_root(
     if !active.trim().is_empty() {
         if let Ok(active_canon) = tokio::fs::canonicalize(active.trim()).await {
             if req_canon == active_canon {
-                return Ok(active_canon);
+                return Ok(ProjectRoot::from_canonical(active_canon));
             }
         }
     }
@@ -182,7 +217,7 @@ pub async fn assert_readable_project_root(
     // 2. settings.workspaceFolders (Rust 側 SSOT) に含まれるか
     if let Ok(settings) = crate::commands::settings::settings_load().await {
         if matches_any_workspace_folder(&req_canon, &settings.workspace_folders).await {
-            return Ok(req_canon);
+            return Ok(ProjectRoot::from_canonical(req_canon));
         }
     }
 
@@ -270,9 +305,7 @@ pub async fn assert_active_team(hub: &TeamHub, team_id: &str) -> CommandResult<(
             team_id = %clamp_team_id_for_log(team_id),
             "[authz] assert_active_team rejected: empty team_id"
         );
-        return Err(CommandError::authz(
-            "team is not active or does not exist",
-        ));
+        return Err(CommandError::authz("team is not active or does not exist"));
     }
 
     let state = hub.state.lock().await;
@@ -288,9 +321,7 @@ pub async fn assert_active_team(hub: &TeamHub, team_id: &str) -> CommandResult<(
             active_count,
             "[authz] assert_active_team rejected: team_id not in active set"
         );
-        return Err(CommandError::authz(
-            "team is not active or does not exist",
-        ));
+        return Err(CommandError::authz("team is not active or does not exist"));
     }
     Ok(())
 }
@@ -308,9 +339,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_empty_given() {
         let lock = make_lock(Some("/tmp/whatever".to_string()));
-        let err = assert_active_project_root(&lock, "")
-            .await
-            .unwrap_err();
+        let err = assert_active_project_root(&lock, "").await.unwrap_err();
         assert!(
             matches!(err, CommandError::Authz(ref m) if m.contains("empty")),
             "got: {err}"
@@ -366,10 +395,9 @@ mod tests {
         let lock = make_lock(Some(project_a.path().to_string_lossy().into_owned()));
 
         // 攻撃: renderer から project_b を渡す → canonicalize 比較で reject
-        let err =
-            assert_active_project_root(&lock, project_b.path().to_string_lossy().as_ref())
-                .await
-                .unwrap_err();
+        let err = assert_active_project_root(&lock, project_b.path().to_string_lossy().as_ref())
+            .await
+            .unwrap_err();
         assert!(
             matches!(err, CommandError::Authz(ref m) if m.contains("does not match active project")),
             "got: {err}"
@@ -386,8 +414,10 @@ mod tests {
             .await
             .expect("matching paths should pass");
         assert_eq!(
-            canon,
-            std::fs::canonicalize(project.path()).expect("canonicalize"),
+            canon.as_path(),
+            std::fs::canonicalize(project.path())
+                .expect("canonicalize")
+                .as_path(),
         );
     }
 
@@ -397,11 +427,13 @@ mod tests {
     async fn readable_accepts_active_project_root() {
         let project = tempdir().expect("project");
         let lock = make_lock(Some(project.path().to_string_lossy().into_owned()));
-        let canon =
-            assert_readable_project_root(&lock, project.path().to_string_lossy().as_ref())
-                .await
-                .expect("active root must be readable");
-        assert_eq!(canon, std::fs::canonicalize(project.path()).unwrap());
+        let canon = assert_readable_project_root(&lock, project.path().to_string_lossy().as_ref())
+            .await
+            .expect("active root must be readable");
+        assert_eq!(
+            canon.as_path(),
+            std::fs::canonicalize(project.path()).unwrap().as_path()
+        );
     }
 
     #[tokio::test]
@@ -444,13 +476,21 @@ mod tests {
         let folder = tempdir().expect("folder");
         let req = std::fs::canonicalize(folder.path()).unwrap();
         // 実在 folder は raw 表記が違っても canonicalize 一致で許可
-        let raw = format!("{}{}", folder.path().to_string_lossy(), std::path::MAIN_SEPARATOR);
+        let raw = format!(
+            "{}{}",
+            folder.path().to_string_lossy(),
+            std::path::MAIN_SEPARATOR
+        );
         assert!(matches_any_workspace_folder(&req, &[raw]).await);
         // 存在しない folder / 空文字エントリは skip され、一致しない
         assert!(
             !matches_any_workspace_folder(
                 &req,
-                &["".into(), "   ".into(), folder.path().join("nope").to_string_lossy().into_owned()]
+                &[
+                    "".into(),
+                    "   ".into(),
+                    folder.path().join("nope").to_string_lossy().into_owned()
+                ]
             )
             .await
         );
@@ -471,7 +511,12 @@ mod tests {
         let canon = assert_active_project_root(&lock, &given)
             .await
             .expect("trailing separator should canonicalize equal");
-        assert_eq!(canon, std::fs::canonicalize(project.path()).expect("canon"));
+        assert_eq!(
+            canon.as_path(),
+            std::fs::canonicalize(project.path())
+                .expect("canon")
+                .as_path()
+        );
     }
 
     // ===== Issue #601 (Tier A-3): assert_active_team helper =====
@@ -521,7 +566,9 @@ mod tests {
 
             let err_empty = assert_active_team(&hub, "").await.unwrap_err();
             let err_whitespace = assert_active_team(&hub, "   ").await.unwrap_err();
-            let err_unknown = assert_active_team(&hub, "team-unknown-xyz").await.unwrap_err();
+            let err_unknown = assert_active_team(&hub, "team-unknown-xyz")
+                .await
+                .unwrap_err();
 
             // 全部同じ generic message にすることで「team_id がそもそも空」と
             // 「team_id が active set に居ない」を caller から区別できなくする。

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
 
+use crate::commands::authz::ProjectRoot;
 use crate::commands::error::CommandResult;
 use crate::state::AppState;
 use encoding::{detect_text_or_binary, encode_for_save};
@@ -32,11 +33,9 @@ use encoding::{detect_text_or_binary, encode_for_save};
 async fn assert_workspace_project_root_via(
     app: &AppHandle,
     project_root: &str,
-) -> CommandResult<()> {
+) -> CommandResult<ProjectRoot> {
     let state = app.state::<AppState>();
-    crate::commands::authz::assert_readable_project_root(&state.project_root, project_root)
-        .await
-        .map(|_| ())
+    crate::commands::authz::assert_readable_project_root(&state.project_root, project_root).await
 }
 use hash::{mtime_ms_of, sha256_hex};
 // safe_join は外部 (commands/git.rs) からも呼ばれるので pub use で再 export する。
@@ -113,14 +112,17 @@ pub struct FileWriteResult {
 #[tauri::command]
 pub async fn files_list(app: AppHandle, project_root: String, rel_path: String) -> FileListResult {
     // Issue #954: read/probe 系も project_root ゲートに通す (任意ディレクトリ列挙の阻止)。
-    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
-        return FileListResult {
-            ok: false,
-            error: Some(e.to_string()),
-            dir: rel_path,
-            entries: vec![],
-        };
-    }
+    let project_root = match assert_workspace_project_root_via(&app, &project_root).await {
+        Ok(root) => root,
+        Err(e) => {
+            return FileListResult {
+                ok: false,
+                error: Some(e.to_string()),
+                dir: rel_path,
+                entries: vec![],
+            }
+        }
+    };
     let dir = safe_join(&project_root, &rel_path);
     let dir = match dir {
         Some(p) if p.is_dir() => p,
@@ -149,10 +151,7 @@ pub async fn files_list(app: AppHandle, project_root: String, rel_path: String) 
     // prefix は raw の project_root ではなく同じく canonicalize された root を使う必要がある。
     // Windows の junction / symlink / 大文字小文字違いで raw と real が食い違うと strip_prefix
     // が失敗して entry.path が空文字に落ちる。
-    let canonical_root = Path::new(&project_root).canonicalize().ok();
-    let root_ref = canonical_root
-        .as_deref()
-        .unwrap_or_else(|| Path::new(&project_root));
+    let root_ref = project_root.as_path();
     while let Ok(Some(entry)) = rd.next_entry().await {
         let p = entry.path();
         let is_dir = p.is_dir();
@@ -183,14 +182,17 @@ pub async fn files_list(app: AppHandle, project_root: String, rel_path: String) 
 #[tauri::command]
 pub async fn files_read(app: AppHandle, project_root: String, rel_path: String) -> FileReadResult {
     // Issue #954: read/probe 系も project_root ゲートに通す (任意ファイル読取の阻止)。
-    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
-        return FileReadResult {
-            ok: false,
-            error: Some(e.to_string()),
-            path: rel_path,
-            ..Default::default()
-        };
-    }
+    let project_root = match assert_workspace_project_root_via(&app, &project_root).await {
+        Ok(root) => root,
+        Err(e) => {
+            return FileReadResult {
+                ok: false,
+                error: Some(e.to_string()),
+                path: rel_path,
+                ..Default::default()
+            }
+        }
+    };
     let Some(abs) = safe_join(&project_root, &rel_path) else {
         return FileReadResult {
             ok: false,
@@ -285,13 +287,16 @@ pub async fn files_write(
 ) -> FileWriteResult {
     // Issue #932: renderer 由来の project_root を active project と照合する共通ゲート。
     // 未検証だと乗っ取られた renderer が active プロジェクト外の任意ファイルを上書きできた。
-    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
-        return FileWriteResult {
-            ok: false,
-            error: Some(e.to_string()),
-            ..Default::default()
-        };
-    }
+    let project_root = match assert_workspace_project_root_via(&app, &project_root).await {
+        Ok(root) => root,
+        Err(e) => {
+            return FileWriteResult {
+                ok: false,
+                error: Some(e.to_string()),
+                ..Default::default()
+            }
+        }
+    };
     files_write_inner(
         project_root,
         rel_path,
@@ -305,7 +310,7 @@ pub async fn files_write(
 }
 
 async fn files_write_inner(
-    project_root: String,
+    project_root: ProjectRoot,
     rel_path: String,
     content: String,
     expected_mtime_ms: Option<u64>,
@@ -539,8 +544,8 @@ fn validate_basename(name: &str) -> Result<(), String> {
         .map_or(name, |(stem, _)| stem)
         .to_uppercase();
     const RESERVED: &[&str] = &[
-        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
-        "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+        "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
     ];
     if RESERVED.iter().any(|r| *r == stem_upper) {
         return Err(format!("'{name}' is a reserved name on Windows"));
@@ -553,7 +558,7 @@ fn validate_basename(name: &str) -> Result<(), String> {
 
 /// 親ディレクトリ rel_path 配下に basename を足した絶対パスを `safe_join` で得る。
 /// basename invalid もしくは safe_join 失敗 (= ルート脱出 / canonicalize 不能) で None。
-fn join_child(project_root: &str, parent_rel: &str, name: &str) -> Option<PathBuf> {
+fn join_child(project_root: &ProjectRoot, parent_rel: &str, name: &str) -> Option<PathBuf> {
     validate_basename(name).ok()?;
     let combined = if parent_rel.is_empty() {
         name.to_string()
@@ -565,12 +570,8 @@ fn join_child(project_root: &str, parent_rel: &str, name: &str) -> Option<PathBu
 
 /// canonicalize 済みの project_root から見た相対パス (POSIX 区切り) を返す。
 /// frontend のキャッシュキー (FileNode.path) と整合させるための helper。
-fn rel_from_abs(project_root: &str, abs: &Path) -> String {
-    let canonical_root = match Path::new(project_root).canonicalize() {
-        Ok(p) => p,
-        Err(_) => return abs.to_string_lossy().into_owned(),
-    };
-    abs.strip_prefix(&canonical_root)
+fn rel_from_abs(project_root: &ProjectRoot, abs: &Path) -> String {
+    abs.strip_prefix(project_root.as_path())
         .map(|r| r.to_string_lossy().replace('\\', "/"))
         .unwrap_or_default()
 }
@@ -586,14 +587,15 @@ pub async fn files_create(
     overwrite: Option<bool>,
 ) -> FileMutationResult {
     // Issue #932: active project と照合してから FS 操作を行う (任意ファイル作成を防ぐ)。
-    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
-        return FileMutationResult::err(rel_path, e.to_string());
-    }
+    let project_root = match assert_workspace_project_root_via(&app, &project_root).await {
+        Ok(root) => root,
+        Err(e) => return FileMutationResult::err(rel_path, e.to_string()),
+    };
     files_create_inner(project_root, rel_path, name, overwrite).await
 }
 
 async fn files_create_inner(
-    project_root: String,
+    project_root: ProjectRoot,
     rel_path: String,
     name: String,
     overwrite: Option<bool>,
@@ -635,14 +637,15 @@ pub async fn files_create_dir(
     name: String,
 ) -> FileMutationResult {
     // Issue #932: active project と照合してから FS 操作を行う (任意ディレクトリ作成を防ぐ)。
-    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
-        return FileMutationResult::err(rel_path, e.to_string());
-    }
+    let project_root = match assert_workspace_project_root_via(&app, &project_root).await {
+        Ok(root) => root,
+        Err(e) => return FileMutationResult::err(rel_path, e.to_string()),
+    };
     files_create_dir_inner(project_root, rel_path, name).await
 }
 
 async fn files_create_dir_inner(
-    project_root: String,
+    project_root: ProjectRoot,
     rel_path: String,
     name: String,
 ) -> FileMutationResult {
@@ -686,14 +689,15 @@ pub async fn files_rename(
     overwrite: Option<bool>,
 ) -> FileMutationResult {
     // Issue #932: active project と照合してから FS 操作を行う (任意ファイル rename/move を防ぐ)。
-    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
-        return FileMutationResult::err(from_rel, e.to_string());
-    }
+    let project_root = match assert_workspace_project_root_via(&app, &project_root).await {
+        Ok(root) => root,
+        Err(e) => return FileMutationResult::err(from_rel, e.to_string()),
+    };
     files_rename_inner(project_root, from_rel, to_parent_rel, new_name, overwrite).await
 }
 
 async fn files_rename_inner(
-    project_root: String,
+    project_root: ProjectRoot,
     from_rel: String,
     to_parent_rel: String,
     new_name: String,
@@ -758,14 +762,15 @@ pub async fn files_delete(
     permanent: Option<bool>,
 ) -> FileMutationResult {
     // Issue #932: active project と照合してから FS 操作を行う (任意ファイル削除を防ぐ)。
-    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
-        return FileMutationResult::err(rel_path, e.to_string());
-    }
+    let project_root = match assert_workspace_project_root_via(&app, &project_root).await {
+        Ok(root) => root,
+        Err(e) => return FileMutationResult::err(rel_path, e.to_string()),
+    };
     files_delete_inner(project_root, rel_path, permanent).await
 }
 
 async fn files_delete_inner(
-    project_root: String,
+    project_root: ProjectRoot,
     rel_path: String,
     permanent: Option<bool>,
 ) -> FileMutationResult {
@@ -817,14 +822,15 @@ pub async fn files_copy(
     overwrite: Option<bool>,
 ) -> FileMutationResult {
     // Issue #932: active project と照合してから FS 操作を行う (任意ファイル複製を防ぐ)。
-    if let Err(e) = assert_workspace_project_root_via(&app, &project_root).await {
-        return FileMutationResult::err(from_rel, e.to_string());
-    }
+    let project_root = match assert_workspace_project_root_via(&app, &project_root).await {
+        Ok(root) => root,
+        Err(e) => return FileMutationResult::err(from_rel, e.to_string()),
+    };
     files_copy_inner(project_root, from_rel, to_parent_rel, new_name, overwrite).await
 }
 
 async fn files_copy_inner(
-    project_root: String,
+    project_root: ProjectRoot,
     from_rel: String,
     to_parent_rel: String,
     new_name: String,
@@ -857,10 +863,7 @@ async fn files_copy_inner(
         return FileMutationResult::err(from_rel, "destination escapes parent directory");
     }
     if to_abs.starts_with(&from_abs) {
-        return FileMutationResult::err(
-            from_rel,
-            "cannot copy into the source or its descendant",
-        );
+        return FileMutationResult::err(from_rel, "cannot copy into the source or its descendant");
     }
     if !overwrite && tokio::fs::metadata(&to_abs).await.is_ok() {
         return FileMutationResult::err(
@@ -947,12 +950,8 @@ mod issue_592_tests {
     use super::*;
     use tempfile::tempdir;
 
-    fn root_str(td: &tempfile::TempDir) -> String {
-        td.path()
-            .canonicalize()
-            .unwrap()
-            .to_string_lossy()
-            .into_owned()
+    fn root_str(td: &tempfile::TempDir) -> ProjectRoot {
+        ProjectRoot::assume_canonical_for_test(td.path().canonicalize().unwrap())
     }
 
     #[test]
@@ -1021,8 +1020,14 @@ mod issue_592_tests {
         let td = tempdir().unwrap();
         let root = root_str(&td);
         files_create_inner(root.clone(), "".into(), "a.txt".into(), None).await;
-        let res =
-            files_rename_inner(root.clone(), "a.txt".into(), "".into(), "b.txt".into(), None).await;
+        let res = files_rename_inner(
+            root.clone(),
+            "a.txt".into(),
+            "".into(),
+            "b.txt".into(),
+            None,
+        )
+        .await;
         assert!(res.ok, "{:?}", res.error);
         assert!(!td.path().join("a.txt").exists());
         assert!(td.path().join("b.txt").exists());
@@ -1072,7 +1077,10 @@ mod issue_592_tests {
         std::fs::write(td.path().join("src").join("nested").join("b.txt"), b"b").unwrap();
         let res = files_copy_inner(root.clone(), "src".into(), "".into(), "dst".into(), None).await;
         assert!(res.ok, "{:?}", res.error);
-        assert_eq!(std::fs::read(td.path().join("dst").join("a.txt")).unwrap(), b"a");
+        assert_eq!(
+            std::fs::read(td.path().join("dst").join("a.txt")).unwrap(),
+            b"a"
+        );
         assert_eq!(
             std::fs::read(td.path().join("dst").join("nested").join("b.txt")).unwrap(),
             b"b"
@@ -1084,7 +1092,8 @@ mod issue_592_tests {
         let td = tempdir().unwrap();
         let root = root_str(&td);
         files_create_dir_inner(root.clone(), "".into(), "a".into()).await;
-        let res = files_copy_inner(root.clone(), "a".into(), "a".into(), "inside".into(), None).await;
+        let res =
+            files_copy_inner(root.clone(), "a".into(), "a".into(), "inside".into(), None).await;
         assert!(!res.ok);
     }
 
@@ -1109,10 +1118,15 @@ mod issue_592_tests {
         let res = files_copy_inner(root.clone(), "src".into(), "".into(), "dst".into(), None).await;
         assert!(res.ok, "{:?}", res.error);
         // 通常ファイルはコピーされる
-        assert_eq!(std::fs::read(td.path().join("dst").join("normal.txt")).unwrap(), b"ok");
+        assert_eq!(
+            std::fs::read(td.path().join("dst").join("normal.txt")).unwrap(),
+            b"ok"
+        );
         // symlink 経由の機密ファイルは dst 配下に複製されてはならない
-        assert!(!td.path().join("dst").join("link-to-secret").exists(),
-                "symlink (or its target) must NOT be copied into the project");
+        assert!(
+            !td.path().join("dst").join("link-to-secret").exists(),
+            "symlink (or its target) must NOT be copied into the project"
+        );
     }
 
     /// PR #695 review (Correctness): symlink cycle (a -> b, b -> a) を含む directory を
@@ -1165,12 +1179,8 @@ mod issue_828_tests {
     use super::*;
     use tempfile::tempdir;
 
-    fn root_str(td: &tempfile::TempDir) -> String {
-        td.path()
-            .canonicalize()
-            .unwrap()
-            .to_string_lossy()
-            .into_owned()
+    fn root_str(td: &tempfile::TempDir) -> ProjectRoot {
+        ProjectRoot::assume_canonical_for_test(td.path().canonicalize().unwrap())
     }
 
     /// save 直前にディスク上のファイルが 50MB を超えている場合、hash 全読込せず
@@ -1191,14 +1201,17 @@ mod issue_828_tests {
             root,
             "huge.txt".into(),
             "new content".into(),
-            None,                      // expected_mtime_ms
-            None,                      // expected_size_bytes
-            None,                      // encoding
-            Some("deadbeef".into()),   // expected_content_hash
+            None,                    // expected_mtime_ms
+            None,                    // expected_size_bytes
+            None,                    // encoding
+            Some("deadbeef".into()), // expected_content_hash
         )
         .await;
 
-        assert!(!res.ok, "oversized file must not be written via hash-check path");
+        assert!(
+            !res.ok,
+            "oversized file must not be written via hash-check path"
+        );
         assert!(
             res.conflict,
             "oversized-at-save file must be reported as conflict"

--- a/src-tauri/src/commands/files/path_safety.rs
+++ b/src-tauri/src/commands/files/path_safety.rs
@@ -5,6 +5,8 @@
 
 use std::path::{Component, Path, PathBuf};
 
+use crate::commands::authz::ProjectRoot;
+
 /// 相対パスを root 配下に閉じ込める形で解決する。
 ///
 /// 旧実装は `joined.canonicalize()` が失敗 (= 未作成ファイル) したとき `joined` をそのまま
@@ -22,8 +24,8 @@ use std::path::{Component, Path, PathBuf};
 /// 多段ネストした未作成パス」で親 (`link/new-dir`) が canonicalize 失敗 → raw path の
 /// starts_with だけで素通りしていた。本実装では「存在する最深祖先」まで遡って canonicalize し、
 /// 祖先解決後のパスが root 配下かどうかで判定する。
-pub fn safe_join(root: &str, rel: &str) -> Option<PathBuf> {
-    let root = Path::new(root).canonicalize().ok()?;
+pub fn safe_join(root: &ProjectRoot, rel: &str) -> Option<PathBuf> {
+    let root = root.as_path();
     let rel_path = Path::new(rel);
 
     // (1) 絶対パス混入を拒否
@@ -47,14 +49,14 @@ pub fn safe_join(root: &str, rel: &str) -> Option<PathBuf> {
     }
 
     // 正規化後の joined パス (fs 実体は未作成かもしれない)
-    let mut joined = root.clone();
+    let mut joined = root.to_path_buf();
     for c in &stack {
         joined.push(c);
     }
 
     // (3) 可能なら symlink 展開後も root 配下であることを再確認
     if let Ok(canonical) = joined.canonicalize() {
-        if canonical.starts_with(&root) {
+        if canonical.starts_with(root) {
             return Some(canonical);
         }
         return None;
@@ -69,7 +71,7 @@ pub fn safe_join(root: &str, rel: &str) -> Option<PathBuf> {
     loop {
         match probe.canonicalize() {
             Ok(canonical) => {
-                if !canonical.starts_with(&root) {
+                if !canonical.starts_with(root) {
                     return None;
                 }
                 let mut result = canonical;
@@ -99,38 +101,35 @@ mod safe_join_tests {
     use super::*;
     use std::fs;
 
-    fn tempdir() -> PathBuf {
+    fn temp_root() -> ProjectRoot {
         let d = std::env::temp_dir().join(format!("vibe-safe-join-{}", std::process::id()));
         let _ = fs::create_dir_all(&d);
-        d.canonicalize().unwrap()
+        ProjectRoot::assume_canonical_for_test(d.canonicalize().unwrap())
     }
 
     #[test]
     fn rejects_parent_escape() {
-        let root = tempdir();
-        let root_str = root.to_string_lossy();
-        assert!(safe_join(&root_str, "../outside.txt").is_none());
-        assert!(safe_join(&root_str, "a/../../outside.txt").is_none());
+        let root = temp_root();
+        assert!(safe_join(&root, "../outside.txt").is_none());
+        assert!(safe_join(&root, "a/../../outside.txt").is_none());
     }
 
     #[test]
     fn rejects_absolute() {
-        let root = tempdir();
-        let root_str = root.to_string_lossy();
+        let root = temp_root();
         if cfg!(windows) {
-            assert!(safe_join(&root_str, "C:\\Windows\\notepad.exe").is_none());
+            assert!(safe_join(&root, "C:\\Windows\\notepad.exe").is_none());
         } else {
-            assert!(safe_join(&root_str, "/etc/passwd").is_none());
+            assert!(safe_join(&root, "/etc/passwd").is_none());
         }
     }
 
     #[test]
     fn allows_inside() {
-        let root = tempdir();
-        let root_str = root.to_string_lossy();
-        assert!(safe_join(&root_str, "sub/file.txt").is_some());
-        assert!(safe_join(&root_str, "a/../b.txt").is_some()); // 中間の .. は OK
-        assert!(safe_join(&root_str, "./nested/./file.txt").is_some());
+        let root = temp_root();
+        assert!(safe_join(&root, "sub/file.txt").is_some());
+        assert!(safe_join(&root, "a/../b.txt").is_some()); // 中間の .. は OK
+        assert!(safe_join(&root, "./nested/./file.txt").is_some());
     }
 
     /// Issue #101: symlink 配下にある「未作成」のネストパスが、symlink 先 (= 外部)
@@ -140,14 +139,10 @@ mod safe_join_tests {
     fn rejects_uncreated_path_under_symlink_to_outside() {
         use std::os::unix::fs::symlink as unix_symlink;
 
-        let root = std::env::temp_dir().join(format!(
-            "vibe-safe-join-symlink-{}",
-            std::process::id()
-        ));
-        let outside = std::env::temp_dir().join(format!(
-            "vibe-safe-join-outside-{}",
-            std::process::id()
-        ));
+        let root =
+            std::env::temp_dir().join(format!("vibe-safe-join-symlink-{}", std::process::id()));
+        let outside =
+            std::env::temp_dir().join(format!("vibe-safe-join-outside-{}", std::process::id()));
         let _ = fs::remove_dir_all(&root);
         let _ = fs::remove_dir_all(&outside);
         fs::create_dir_all(&root).unwrap();
@@ -157,12 +152,12 @@ mod safe_join_tests {
         let link = root.join("link");
         unix_symlink(&outside, &link).unwrap();
 
-        let root_str = root.canonicalize().unwrap().to_string_lossy().into_owned();
+        let root = ProjectRoot::assume_canonical_for_test(root.canonicalize().unwrap());
 
         // link は外部を指すので link/new-dir/file.txt は拒否されるべき
-        assert!(safe_join(&root_str, "link/new-dir/file.txt").is_none());
+        assert!(safe_join(&root, "link/new-dir/file.txt").is_none());
         // link 自体も外部解決されるので拒否
-        assert!(safe_join(&root_str, "link/file.txt").is_none());
+        assert!(safe_join(&root, "link/file.txt").is_none());
 
         let _ = fs::remove_dir_all(&root);
         let _ = fs::remove_dir_all(&outside);
@@ -171,9 +166,8 @@ mod safe_join_tests {
     /// 多段ネストの未作成パスが root 配下なら通ること (Issue #101 修正の non-regression)。
     #[test]
     fn allows_uncreated_nested_path_inside_root() {
-        let root = tempdir();
-        let root_str = root.to_string_lossy();
+        let root = temp_root();
         // root 配下に未作成のディレクトリ階層を含むパス
-        assert!(safe_join(&root_str, "a/b/c/file.txt").is_some());
+        assert!(safe_join(&root, "a/b/c/file.txt").is_some());
     }
 }

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -10,17 +10,17 @@ use serde::Serialize;
 use tauri::{AppHandle, Manager};
 use tokio::process::Command;
 
+use crate::commands::authz::ProjectRoot;
+
 /// Issue #954: renderer 由来の `project_root` を active project と照合する read/probe ゲート。
 /// git パネル / DiffCard は active project (primary root) のみを対象とするため、
 /// files 系と違い workspaceFolders 許可は不要で厳格一致 (`assert_active_project_root`) を使う。
 async fn assert_project_root_via(
     app: &AppHandle,
     project_root: &str,
-) -> crate::commands::error::CommandResult<()> {
+) -> crate::commands::error::CommandResult<ProjectRoot> {
     let state = app.state::<crate::state::AppState>();
-    crate::commands::authz::assert_active_project_root(&state.project_root, project_root)
-        .await
-        .map(|_| ())
+    crate::commands::authz::assert_active_project_root(&state.project_root, project_root).await
 }
 
 /// Windows で GUI アプリ (Tauri) からコンソールプロセス (git.exe) を起動すると、
@@ -257,20 +257,23 @@ fn is_not_git_repo_error(err: &str) -> bool {
 #[tauri::command]
 pub async fn git_status(app: AppHandle, project_root: String) -> GitStatus {
     // Issue #954: read/probe 系も project_root ゲートに通す (任意リポジトリ probe の阻止)。
-    if let Err(e) = assert_project_root_via(&app, &project_root).await {
-        return GitStatus {
-            ok: false,
-            error: Some(e.to_string()),
-            ..Default::default()
-        };
-    }
+    let project_root = match assert_project_root_via(&app, &project_root).await {
+        Ok(root) => root,
+        Err(e) => {
+            return GitStatus {
+                ok: false,
+                error: Some(e.to_string()),
+                ..Default::default()
+            }
+        }
+    };
     git_status_inner(project_root).await
 }
 
 /// ゲート通過後の本体 (#932 の files_write_inner と同じ分割。テストはこちらを呼ぶ)。
-pub(crate) async fn git_status_inner(project_root: String) -> GitStatus {
+pub(crate) async fn git_status_inner(project_root: ProjectRoot) -> GitStatus {
     // repo root
-    let repo_root = match run_git(&["rev-parse", "--show-toplevel"], &project_root).await {
+    let repo_root = match run_git(&["rev-parse", "--show-toplevel"], project_root.as_str()).await {
         Ok(s) => s.trim().to_string(),
         Err(e) => {
             return GitStatus {
@@ -281,14 +284,17 @@ pub(crate) async fn git_status_inner(project_root: String) -> GitStatus {
             }
         }
     };
-    let branch = run_git(&["rev-parse", "--abbrev-ref", "HEAD"], &project_root)
-        .await
-        .ok()
-        .map(|s| s.trim().to_string());
+    let branch = run_git(
+        &["rev-parse", "--abbrev-ref", "HEAD"],
+        project_root.as_str(),
+    )
+    .await
+    .ok()
+    .map(|s| s.trim().to_string());
     // Issue #19: -z (NUL 区切り) を使わないと rename が "old -> new" の 1 行として返り
     //            parser が解釈できない。`--porcelain=v1 -z` でバイト単位にパースする。
     let porcelain_bytes =
-        match run_git_bytes(&["status", "--porcelain=v1", "-z"], &project_root).await {
+        match run_git_bytes(&["status", "--porcelain=v1", "-z"], project_root.as_str()).await {
             Ok(b) => b,
             Err(e) => {
                 return GitStatus {
@@ -323,19 +329,22 @@ pub async fn git_diff(
     original_rel_path: Option<String>,
 ) -> GitDiffResult {
     // Issue #954: read/probe 系も project_root ゲートに通す (任意リポジトリの差分 probe の阻止)。
-    if let Err(e) = assert_project_root_via(&app, &project_root).await {
-        return GitDiffResult {
-            ok: false,
-            error: Some(e.to_string()),
-            ..Default::default()
-        };
-    }
+    let project_root = match assert_project_root_via(&app, &project_root).await {
+        Ok(root) => root,
+        Err(e) => {
+            return GitDiffResult {
+                ok: false,
+                error: Some(e.to_string()),
+                ..Default::default()
+            }
+        }
+    };
     git_diff_inner(project_root, rel_path, original_rel_path).await
 }
 
 /// ゲート通過後の本体 (#932 の files_write_inner と同じ分割。テストはこちらを呼ぶ)。
 pub(crate) async fn git_diff_inner(
-    project_root: String,
+    project_root: ProjectRoot,
     rel_path: String,
     original_rel_path: Option<String>,
 ) -> GitDiffResult {
@@ -380,10 +389,10 @@ pub(crate) async fn git_diff_inner(
     // Issue #154 #1: project_root が submodule / worktree 内のとき、cwd を project_root に
     // して `git show HEAD:` を回すと git は親リポを見て head_path 不在として誤判定する。
     // `git rev-parse --show-toplevel` で「このリポの本物のトップ」を求めて cwd にする。
-    let repo_root = run_git(&["rev-parse", "--show-toplevel"], &project_root)
+    let repo_root = run_git(&["rev-parse", "--show-toplevel"], project_root.as_str())
         .await
         .map(|s| s.trim().to_string())
-        .unwrap_or_else(|_| project_root.clone());
+        .unwrap_or_else(|_| project_root.as_str().to_string());
 
     // git の HEAD blob path は repo_root 相対なので、project_root → repo_root の差分を埋める。
     // safe_join 後に repo_root に含まれるかどうかを確認し、相対化する。
@@ -478,7 +487,9 @@ mod tests {
         assert!(is_not_git_repo_error("fatal: Not a Git Repository"));
         // 別種のエラーでは false
         assert!(!is_not_git_repo_error("fatal: bad revision 'HEAD'"));
-        assert!(!is_not_git_repo_error("failed to spawn git: program not found"));
+        assert!(!is_not_git_repo_error(
+            "failed to spawn git: program not found"
+        ));
         assert!(!is_not_git_repo_error(""));
     }
 

--- a/src-tauri/src/commands/tests/git.rs
+++ b/src-tauri/src/commands/tests/git.rs
@@ -7,6 +7,7 @@
 //! `git --version` を `which git` ではなく `Command::new("git").arg("--version").status()`
 //! で確認し、不在なら early return する (= "ok-skip" 扱い)。
 
+use crate::commands::authz::ProjectRoot;
 use crate::commands::git::{git_diff_inner as git_diff, git_status_inner as git_status};
 use std::path::Path;
 use std::process::Command;
@@ -37,6 +38,10 @@ fn init_fixture_repo(dir: &Path) {
     run(&["config", "user.name", "Test"]);
     run(&["config", "commit.gpgsign", "false"]);
     run(&["config", "tag.gpgsign", "false"]);
+}
+
+fn project_root(dir: &Path) -> ProjectRoot {
+    ProjectRoot::assume_canonical_for_test(dir.canonicalize().unwrap())
 }
 
 fn commit_all(dir: &Path, message: &str) {
@@ -75,8 +80,7 @@ async fn git_status_reports_modified_and_untracked_files() {
         .await
         .unwrap();
 
-    let project_root = dir.path().to_string_lossy().to_string();
-    let status = git_status(project_root).await;
+    let status = git_status(project_root(dir.path())).await;
     assert!(status.ok, "git_status failed: {:?}", status.error);
     assert!(status.repo_root.is_some());
     assert_eq!(status.branch.as_deref(), Some("main"));
@@ -105,12 +109,7 @@ async fn git_diff_returns_head_and_worktree_for_modified_file() {
         .await
         .unwrap();
 
-    let res = git_diff(
-        dir.path().to_string_lossy().to_string(),
-        "README.md".into(),
-        None,
-    )
-    .await;
+    let res = git_diff(project_root(dir.path()), "README.md".into(), None).await;
     assert!(res.ok);
     assert!(!res.is_new);
     assert!(!res.is_deleted);
@@ -137,12 +136,7 @@ async fn git_diff_marks_new_file_as_is_new() {
         .await
         .unwrap();
 
-    let res = git_diff(
-        dir.path().to_string_lossy().to_string(),
-        "new.txt".into(),
-        None,
-    )
-    .await;
+    let res = git_diff(project_root(dir.path()), "new.txt".into(), None).await;
     assert!(res.ok);
     assert!(res.is_new, "untracked file must be marked is_new");
     // is_new の場合 head は "(skipped: file too large or new)" になり original は空文字
@@ -163,12 +157,7 @@ async fn git_diff_rejects_path_traversal_attempt() {
     commit_all(dir.path(), "init");
 
     // Issue #134 で塞いだ traversal 攻撃 (rel_path = "../../.env" 等) を再現。
-    let res = git_diff(
-        dir.path().to_string_lossy().to_string(),
-        "../etc/passwd".into(),
-        None,
-    )
-    .await;
+    let res = git_diff(project_root(dir.path()), "../etc/passwd".into(), None).await;
     assert!(!res.ok, "traversal must reject");
     assert!(res.error.unwrap().contains("invalid"));
 }
@@ -187,7 +176,7 @@ async fn git_diff_rejects_head_path_starting_with_dash() {
 
     // CLI option 偽装: original_rel_path が "-foo" のようなとき early reject。
     let res = git_diff(
-        dir.path().to_string_lossy().to_string(),
+        project_root(dir.path()),
         "a.txt".into(),
         Some("-foo".into()),
     )
@@ -203,8 +192,7 @@ async fn git_status_returns_ok_false_on_non_repo_directory() {
     }
     // git init していない tempdir → rev-parse --show-toplevel が失敗するはず
     let dir = tempdir().unwrap();
-    let project_root = dir.path().to_string_lossy().to_string();
-    let status = git_status(project_root).await;
+    let status = git_status(project_root(dir.path())).await;
     assert!(!status.ok);
     assert!(status.error.is_some());
 }


### PR DESCRIPTION
## 概要
- `authz::ProjectRoot` newtype を追加し、active / readable project_root gate の戻り値を検証済み root に変更
- `safe_join` を `ProjectRoot` 専用にして、renderer 由来の生 `String` から直接呼べないように変更
- files/git の command 本体とテストを ProjectRoot 経由に統一
- file-size baseline を今回の構造変更後の行数に同期

Closes #955

## 検証
- `cargo check --manifest-path src-tauri/Cargo.toml --all-targets`
- `cargo test --manifest-path src-tauri/Cargo.toml commands::files -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml commands::tests::git -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml commands::authz -- --nocapture`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `npm run typecheck`
- `node build/check-file-size-ratchet.mjs`
- touched Rust files の `rustfmt --check`
