### PR TITLE
chore(release): bump version to 1.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5525,7 +5525,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.6.4"
+version = "1.6.5"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## Summary
- バージョンを 1.6.4 → 1.6.5 に bump (package.json / tauri.conf.json / Cargo.toml / Cargo.lock)
- 1.6.4 以降に main へ入った 23 件の変更をリリースする

## おもな変更点 (v1.6.4..main)
- feat(ui): #981 macOS ネイティブの信号機ウィンドウ制御ボタン (#982)
- feat(team_hub): Monitor inbox 配送を opt-in 追加 (#992)
- refactor(pty): TaskSupervisor でタスク終了を集約 (#991) / spawn telemetry を分離 (#984)
- refactor(commands): ProjectRoot ゲートを導入 (#990)
- refactor(team_hub): 状態推測を構造化フィールドへ統一 (#988) + 型生成/lint (#989)
- fix(terminal): #979 macOS GUI 起動時の PATH 未継承を補強 (#980)
- fix(test): Vitest と Rust テスト失敗を修正 (#987)
- fix(ci): typecheck を build mode に切り替え (#877)
- chore(deps): tauri / frontend / eslint ほか依存更新多数

## Test plan
- [ ] `npm run typecheck` 通過
- [ ] merge 後 v1.6.5 タグを push し release.yml で各 OS バンドルをビルド