### PR TITLE
feat(settings): settings.json parse失敗時にv11フォールバック復旧 + api_agent runtimeテスト

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -4,7 +4,7 @@
   "src-tauri/src/commands/files.rs": 1274,
   "src-tauri/src/commands/git.rs": 529,
   "src-tauri/src/commands/handoffs.rs": 513,
-  "src-tauri/src/commands/settings.rs": 857,
+  "src-tauri/src/commands/settings.rs": 841,
   "src-tauri/src/commands/team_history.rs": 1239,
   "src-tauri/src/commands/team_state.rs": 593,
   "src-tauri/src/commands/terminal.rs": 1002,

--- a/src-tauri/src/commands/api_agents.rs
+++ b/src-tauri/src/commands/api_agents.rs
@@ -14,6 +14,9 @@ use uuid::Uuid;
 mod providers;
 pub mod types;
 
+#[cfg(test)]
+mod tests;
+
 use self::providers::{call_provider, provider_preset};
 use self::types::*;
 

--- a/src-tauri/src/commands/api_agents/providers.rs
+++ b/src-tauri/src/commands/api_agents/providers.rs
@@ -239,3 +239,46 @@ fn usage_from_value(value: &Value) -> Option<ApiAgentUsage> {
         total_tokens: value["total_tokens"].as_u64().map(|n| n as u32),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preset_maps_known_providers_to_adapter_and_base_url() {
+        let openai = provider_preset("openai", None).unwrap();
+        assert_eq!(openai.adapter, "openai-compatible");
+        assert_eq!(openai.base_url, "https://api.openai.com/v1");
+        assert!(openai.supports_tools);
+
+        let anthropic = provider_preset("anthropic", None).unwrap();
+        assert_eq!(anthropic.adapter, "anthropic");
+        assert!(anthropic.supports_tools);
+
+        let gemini = provider_preset("gemini", None).unwrap();
+        assert_eq!(gemini.adapter, "gemini");
+
+        // tool calling 非対応として扱う preset
+        let groq = provider_preset("groq", None).unwrap();
+        assert!(!groq.supports_tools);
+    }
+
+    #[test]
+    fn preset_trims_trailing_slash_on_base_url() {
+        let custom = provider_preset("custom-openai-compatible", Some("https://x.example/v1/"))
+            .unwrap();
+        assert_eq!(custom.base_url, "https://x.example/v1");
+        assert_eq!(custom.adapter, "openai-compatible");
+    }
+
+    #[test]
+    fn custom_provider_requires_base_url() {
+        assert!(provider_preset("custom-openai-compatible", None).is_err());
+        assert!(provider_preset("custom-openai-compatible", Some("   ")).is_err());
+    }
+
+    #[test]
+    fn unknown_provider_is_rejected() {
+        assert!(provider_preset("does-not-exist", None).is_err());
+    }
+}

--- a/src-tauri/src/commands/api_agents/tests.rs
+++ b/src-tauri/src/commands/api_agents/tests.rs
@@ -1,0 +1,131 @@
+// api_agents runtime のユニットテスト (Issue #996)。
+//
+// 子モジュールなので `api_agents.rs` の private fn (validate_id / sanitize_provider_id /
+// session_path / build_skills_context) に直接アクセスできる。可視性を緩めずにテストする。
+
+use super::types::*;
+use super::*;
+
+#[test]
+fn validate_id_accepts_safe_ids() {
+    assert!(validate_id("sessionId", "abc-123_XYZ").is_ok());
+    assert!(validate_id("sessionId", "session:gen:card").is_ok());
+    // ちょうど 128 文字は許可
+    assert!(validate_id("sessionId", &"a".repeat(128)).is_ok());
+}
+
+#[test]
+fn validate_id_rejects_unsafe_ids() {
+    assert!(validate_id("sessionId", "").is_err());
+    assert!(validate_id("sessionId", "../etc/passwd").is_err());
+    assert!(validate_id("sessionId", "has space").is_err());
+    assert!(validate_id("sessionId", "slash/inside").is_err());
+    // 129 文字は拒否
+    assert!(validate_id("sessionId", &"a".repeat(129)).is_err());
+}
+
+#[test]
+fn sanitize_provider_id_lowercases_and_rejects_whitespace() {
+    // validate_id が trim より前に走るため、空白を含む id は弾かれる。
+    assert_eq!(sanitize_provider_id("OpenAI").unwrap(), "openai");
+    assert!(sanitize_provider_id("bad id").is_err());
+    assert!(sanitize_provider_id("  spaced  ").is_err());
+}
+
+#[test]
+fn session_path_rejects_traversal_ids() {
+    assert!(session_path("../escape").is_err());
+    let ok = session_path("safe-session-1").unwrap();
+    assert!(ok.ends_with("safe-session-1.json"));
+}
+
+#[test]
+fn build_skills_context_truncates_to_budget_and_stays_utf8() {
+    // MAX_SKILL_BYTES を大きく超えるマルチバイト本文でも panic せず、
+    // 出力は valid UTF-8 で概ね予算内に収まる。
+    let big = "あ".repeat(MAX_SKILL_BYTES); // 3 bytes/char → 3 * MAX
+    let skills = vec![ApiAgentSkill {
+        id: "big".to_string(),
+        name: "Big".to_string(),
+        body: big,
+    }];
+    let out = build_skills_context(&skills);
+    assert!(out.contains("## Skill: Big (big)"));
+    // 予算 + ヘッダ + 1 文字分の overshoot 程度に収まる
+    assert!(out.len() <= MAX_SKILL_BYTES + 256);
+    // char 境界を割らずにスライスできている
+    assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+}
+
+#[test]
+fn build_skills_context_emits_each_selected_skill() {
+    let skills = vec![
+        ApiAgentSkill {
+            id: "a".to_string(),
+            name: "Alpha".to_string(),
+            body: "alpha-body".to_string(),
+        },
+        ApiAgentSkill {
+            id: "b".to_string(),
+            name: "Beta".to_string(),
+            body: "beta-body".to_string(),
+        },
+    ];
+    let out = build_skills_context(&skills);
+    assert!(out.contains("## Skill: Alpha (a)"));
+    assert!(out.contains("alpha-body"));
+    assert!(out.contains("## Skill: Beta (b)"));
+    assert!(out.contains("beta-body"));
+}
+
+#[test]
+fn session_round_trips_through_serde_with_camel_case() {
+    let session = ApiAgentSession {
+        schema_version: SESSION_SCHEMA_VERSION,
+        session_id: "s1".to_string(),
+        agent_id: "agent-1".to_string(),
+        provider_id: "openai".to_string(),
+        model: "gpt-4.1".to_string(),
+        title: Some("Chat".to_string()),
+        created_at: "2026-06-14T00:00:00Z".to_string(),
+        updated_at: "2026-06-14T00:01:00Z".to_string(),
+        messages: vec![ApiAgentMessage {
+            id: "m1".to_string(),
+            role: "user".to_string(),
+            content: "hi".to_string(),
+            created_at: "2026-06-14T00:00:30Z".to_string(),
+            tool_name: None,
+        }],
+        turn_logs: vec![ApiAgentTurnLog {
+            generation_id: "g1".to_string(),
+            chain_id: Some("c1".to_string()),
+            depth: 0,
+            turn_number: 1,
+            stop_reason: "stop".to_string(),
+            usage: Some(ApiAgentUsage {
+                input_tokens: Some(10),
+                output_tokens: Some(5),
+                total_tokens: Some(15),
+            }),
+            created_at: "2026-06-14T00:01:00Z".to_string(),
+        }],
+        tool_mode: "auto".to_string(),
+    };
+    let json = serde_json::to_value(&session).unwrap();
+    // camelCase で serialize される
+    assert_eq!(
+        json["schemaVersion"],
+        serde_json::json!(SESSION_SCHEMA_VERSION)
+    );
+    assert_eq!(json["sessionId"], serde_json::json!("s1"));
+    assert_eq!(json["turnLogs"][0]["generationId"], serde_json::json!("g1"));
+    assert_eq!(json["toolMode"], serde_json::json!("auto"));
+    // round-trip で等価
+    let back: ApiAgentSession = serde_json::from_value(json).unwrap();
+    assert_eq!(back.session_id, session.session_id);
+    assert_eq!(back.messages.len(), 1);
+    assert_eq!(
+        back.turn_logs[0].usage.as_ref().unwrap().total_tokens,
+        Some(15)
+    );
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -23,6 +23,8 @@ pub mod safe_load;
 pub mod schema_version;
 pub mod sessions;
 pub mod settings;
+// Issue #996: settings.json parse 失敗時の原本退避 + v11 スナップショット復旧。
+pub mod settings_recovery;
 pub mod team_diagnostics;
 pub mod team_history;
 pub mod team_inject;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -16,7 +16,6 @@
 
 use crate::commands::atomic_write::atomic_write;
 use crate::commands::error::{CommandError, CommandResult};
-use crate::util::backup::write_timestamped_backup;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path, time::Duration};
@@ -374,26 +373,11 @@ pub async fn settings_load() -> CommandResult<Settings> {
     backup_pre_v12_settings_snapshot(&path, &bytes).await;
     match serde_json::from_slice::<Settings>(&bytes) {
         Ok(v) => Ok(v),
-        Err(e) => {
-            // Issue #170: 旧実装は parse 失敗時に黙って Null を返し、次の save で
-            // ユーザー設定が完全消失する事故が起きていた。.bak に元ファイルを退避してから
-            // default を返すことで、ユーザーが手動で復元できるようにする。
-            // Issue #493: strong-typing 後も `.bak` 退避は同じ流儀で維持する。
-            // Issue #644: 旧実装は単一 `.bak` を都度上書きしていたため、連続破損保存で
-            // 健全な原本が 1 ステップで失われていた。タイムスタンプ付き backup +
-            // 世代回転 (5 世代) に変更し、過去 5 ステップ分の原本に戻れるようにする。
-            tracing::error!(
-                "[settings] parse failed ({}), backing up to {}.bak.<ts>",
-                e,
-                path.display()
-            );
-            // best-effort: バックアップが取れなくても続行
-            match write_timestamped_backup(&path, &bytes, None).await {
-                Ok(bak) => tracing::info!("[settings] wrote timestamped backup: {}", bak.display()),
-                Err(berr) => tracing::warn!("[settings] backup write failed: {berr}"),
-            }
-            Ok(Settings::default())
-        }
+        // Issue #170 / #493 / #644 / #996: parse 失敗時の原本退避 + v11 スナップショット復旧は
+        // `settings_recovery` に集約 (settings.rs の肥大化を避ける)。
+        Err(e) => Ok(
+            crate::commands::settings_recovery::recover_after_parse_failure(&path, &bytes, e).await,
+        ),
     }
 }
 

--- a/src-tauri/src/commands/settings_recovery.rs
+++ b/src-tauri/src/commands/settings_recovery.rs
@@ -1,0 +1,146 @@
+// settings_recovery — settings.json の parse 失敗時の復旧経路 (Issue #996)。
+//
+// 背景:
+//   - settings_load は `~/.vibe-editor/settings.v11.bak` (pre-v12 スナップショット) を
+//     書き出すが、v12 への migration / 保存が settings.json を壊した場合に、その健全な
+//     スナップショットを読み戻さず default を返していた。計画 v2 の
+//     「migration 失敗時は旧 settings を保持して v11 として読み続ける」を満たすため、
+//     parse 失敗時の処理 (原本退避 + v11 復旧 + default) を本モジュールへ集約する。
+//   - settings.rs は既に god-file (file-size baseline 免除) なので、復旧ロジックは
+//     ここに分離して settings.rs を肥大化させない。
+
+use super::settings::Settings;
+use crate::util::backup::write_timestamped_backup;
+use std::path::Path;
+use tokio::fs;
+
+/// settings.json の deserialize 失敗時の復旧。
+///
+/// 1. 破損した原本をタイムスタンプ付き backup へ退避 (Issue #644: 世代回転で過去 5 ステップ
+///    分の原本に戻れる)。
+/// 2. 直前の健全な v11 スナップショット (`settings.v11.bak`) があれば読み戻す (Issue #996)。
+/// 3. どちらも不可なら `Settings::default()` を返す (Issue #170/#493: 旧実装の「silent Null +
+///    次 save で全消失」を防ぐ)。
+pub(crate) async fn recover_after_parse_failure(
+    path: &Path,
+    bytes: &[u8],
+    err: serde_json::Error,
+) -> Settings {
+    tracing::error!(
+        "[settings] parse failed ({}), backing up to {}.bak.<ts>",
+        err,
+        path.display()
+    );
+    // best-effort: バックアップが取れなくても続行
+    match write_timestamped_backup(path, bytes, None).await {
+        Ok(bak) => tracing::info!("[settings] wrote timestamped backup: {}", bak.display()),
+        Err(berr) => tracing::warn!("[settings] backup write failed: {berr}"),
+    }
+    if let Some(recovered) = try_recover_from_v11_backup(path).await {
+        tracing::warn!("[settings] recovered settings from v11 snapshot after parse failure");
+        return recovered;
+    }
+    Settings::default()
+}
+
+/// 隣接する `settings.v11.bak` を読み戻す。バックアップが無い / 読めない / それ自体も
+/// parse 不能なら `None` を返し、caller は default にフォールバックする。
+///
+/// `settings_path` を引数で受け取ることで、グローバル `config_paths` に依存せず tempdir で
+/// ユニットテストできる。
+async fn try_recover_from_v11_backup(settings_path: &Path) -> Option<Settings> {
+    let backup = settings_path.parent()?.join("settings.v11.bak");
+    let bytes = fs::read(&backup).await.ok()?;
+    match serde_json::from_slice::<Settings>(&bytes) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            tracing::warn!(
+                "[settings] v11 snapshot {} also failed to parse: {e}",
+                backup.display()
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// parse 可能な v11 スナップショットがあれば、その設定値を読み戻す。
+    #[tokio::test]
+    async fn recover_from_v11_backup_loads_valid_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let backup = dir.path().join("settings.v11.bak");
+        let snapshot = json!({
+            "schemaVersion": 11,
+            "language": "en",
+            "theme": "midnight",
+            "claudeCwd": "/home/u/proj",
+        });
+        tokio::fs::write(&backup, serde_json::to_vec(&snapshot).unwrap())
+            .await
+            .unwrap();
+        let recovered = try_recover_from_v11_backup(&settings_path)
+            .await
+            .expect("should recover from v11 snapshot");
+        assert_eq!(recovered.schema_version, Some(11));
+        assert_eq!(recovered.language, "en");
+        assert_eq!(recovered.theme, "midnight");
+        assert_eq!(recovered.claude_cwd, "/home/u/proj");
+    }
+
+    /// バックアップが存在しなければ `None` を返す (caller は default にフォールバック)。
+    #[tokio::test]
+    async fn recover_from_v11_backup_returns_none_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        assert!(try_recover_from_v11_backup(&settings_path).await.is_none());
+    }
+
+    /// バックアップ自体が壊れている (= 非 JSON) 場合も `None` を返し、panic しない。
+    #[tokio::test]
+    async fn recover_from_v11_backup_returns_none_for_corrupt_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let backup = dir.path().join("settings.v11.bak");
+        tokio::fs::write(&backup, b"{ this is not json").await.unwrap();
+        assert!(try_recover_from_v11_backup(&settings_path).await.is_none());
+    }
+
+    /// 復旧フルパス: 破損原本は退避され、v11 スナップショットの値が返る。
+    #[tokio::test]
+    async fn recover_after_parse_failure_prefers_v11_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let corrupt = b"{ broken json";
+        tokio::fs::write(&path, corrupt).await.unwrap();
+        let snapshot = json!({ "schemaVersion": 11, "theme": "light" });
+        tokio::fs::write(
+            dir.path().join("settings.v11.bak"),
+            serde_json::to_vec(&snapshot).unwrap(),
+        )
+        .await
+        .unwrap();
+        let err = serde_json::from_slice::<Settings>(corrupt).unwrap_err();
+        let recovered = recover_after_parse_failure(&path, corrupt, err).await;
+        assert_eq!(recovered.schema_version, Some(11));
+        assert_eq!(recovered.theme, "light");
+    }
+
+    /// v11 スナップショットが無ければ default にフォールバックする。
+    #[tokio::test]
+    async fn recover_after_parse_failure_falls_back_to_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let corrupt = b"not json at all";
+        tokio::fs::write(&path, corrupt).await.unwrap();
+        let err = serde_json::from_slice::<Settings>(corrupt).unwrap_err();
+        let recovered = recover_after_parse_failure(&path, corrupt, err).await;
+        // default 値
+        assert_eq!(recovered.theme, "claude-dark");
+        assert_eq!(recovered.language, "ja");
+    }
+}


### PR DESCRIPTION
## Summary
- `settings_load` の deserialize 失敗時に、隣接する `settings.v11.bak` (pre-v12 スナップショット) が存在し parse 可能ならそれを読み戻すフォールバック復旧を追加。無ければ従来どおり `Settings::default()`。
- 計画 v2 の「migration 前に v11.bak を作成し、migration 失敗時は旧 settings を保持して v11 として読み続ける」を満たす。これまでは v11.bak を書き出すだけで、破損保存時に読み戻さず default に落ちていた。
- 復旧ロジック (原本タイムスタンプ退避 + v11 復旧 + default フォールバック) を新モジュール `commands/settings_recovery.rs` に分離。`settings.rs` は既に god-file (file-size baseline 免除) のため、ロジック移設で **857 → 841 行へ縮小**し baseline も引き下げ。
- API エージェント runtime のテストが皆無だったので、計画 v2 Test Plan が要求する pure 関数検証 / persistence round-trip を追加。private fn は子 `tests` モジュールから検証し、可視性は一切緩めていない。

## 変更点
- `commands/settings_recovery.rs` (新規): `recover_after_parse_failure` / `try_recover_from_v11_backup` + 5 tests。`settings_path` を引数化して tempdir でユニットテスト可能。
- `commands/settings.rs`: parse 失敗時の Err 分岐を `settings_recovery` へ委譲 (肥大化回避)。
- `commands/api_agents/tests.rs` (新規): `validate_id` 境界 / path traversal 拒否、`sanitize_provider_id`、`build_skills_context` の UTF-8 安全な truncation、`ApiAgentSession` serde round-trip。
- `commands/api_agents/providers.rs`: provider preset の adapter/base_url マッピング、trailing slash 除去、custom base URL 必須、unknown provider 拒否のテスト。

## Test plan
- [x] `cargo test --lib -- api_agent settings_recovery` (16 passed)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 通過
- [x] `node build/check-file-size-ratchet.mjs` OK (settings.rs baseline 引き下げ)
- [x] 既存ユーザーの正常 settings.json の load 挙動は不変 (parse 成功パスは未変更)

Closes #996
