### PR TITLE
feat(api-agents): provider呼び出しをSSEストリーミング化

### DIFF
--- a/src-tauri/src/commands/api_agents.rs
+++ b/src-tauri/src/commands/api_agents.rs
@@ -236,17 +236,23 @@ pub async fn api_agent_send(
     .collect::<Vec<_>>()
     .join("\n\n");
 
-    let response = call_provider(
-        &provider,
-        &key,
-        &req.agent,
-        &system_prompt,
-        &session.messages,
-    )
-    .await;
+    // SSE chunk が届くたびに delta を emit する。closure は req/app を借用するため、
+    // 後段で req のフィールドを move する前にブロックで drop させる。
+    let response = {
+        let mut on_delta = |delta: &str| emit_delta(&app, &req, delta);
+        call_provider(
+            &provider,
+            &key,
+            &req.agent,
+            &system_prompt,
+            &session.messages,
+            &mut on_delta,
+        )
+        .await
+    };
     match response {
         Ok((content, usage, stop_reason)) => {
-            emit_delta(&app, &req, &content);
+            // 本文は既にストリーミングで emit 済み。done イベントで全文を確定させる。
             let message = ApiAgentMessage {
                 id: Uuid::new_v4().to_string(),
                 role: "assistant".to_string(),

--- a/src-tauri/src/commands/api_agents/providers.rs
+++ b/src-tauri/src/commands/api_agents/providers.rs
@@ -52,17 +52,20 @@ pub(super) fn provider_preset(
     })
 }
 
+/// provider を呼び出し、応答を SSE でストリーミングする。`on_delta` は本文 chunk が届く
+/// たびに呼ばれる。戻り値は確定後の (全文, usage, stop_reason)。
 pub(super) async fn call_provider(
     provider: &ProviderPreset,
     key: &str,
     agent: &ApiAgentConfig,
     system_prompt: &str,
     messages: &[ApiAgentMessage],
+    on_delta: &mut (dyn FnMut(&str) + Send),
 ) -> anyhow::Result<(String, Option<ApiAgentUsage>, String)> {
     match provider.adapter {
-        "anthropic" => call_anthropic(provider, key, agent, system_prompt, messages).await,
-        "gemini" => call_gemini(provider, key, agent, system_prompt, messages).await,
-        _ => call_openai_compatible(provider, key, agent, system_prompt, messages).await,
+        "anthropic" => call_anthropic(provider, key, agent, system_prompt, messages, on_delta).await,
+        "gemini" => call_gemini(provider, key, agent, system_prompt, messages, on_delta).await,
+        _ => call_openai_compatible(provider, key, agent, system_prompt, messages, on_delta).await,
     }
 }
 
@@ -72,6 +75,7 @@ async fn call_openai_compatible(
     agent: &ApiAgentConfig,
     system_prompt: &str,
     messages: &[ApiAgentMessage],
+    on_delta: &mut (dyn FnMut(&str) + Send),
 ) -> anyhow::Result<(String, Option<ApiAgentUsage>, String)> {
     let mut req_messages = Vec::new();
     if !system_prompt.is_empty() {
@@ -86,7 +90,8 @@ async fn call_openai_compatible(
     let mut body = json!({
         "model": agent.model,
         "messages": req_messages,
-        "stream": false
+        "stream": true,
+        "stream_options": { "include_usage": true }
     });
     if let Some(t) = agent.temperature {
         body["temperature"] = json!(t);
@@ -94,24 +99,39 @@ async fn call_openai_compatible(
     if let Some(max) = agent.max_output_tokens {
         body["max_tokens"] = json!(max);
     }
-    let value: Value = HTTP_CLIENT
+    let resp = HTTP_CLIENT
         .post(format!("{}/chat/completions", provider.base_url))
         .bearer_auth(key)
         .json(&body)
         .send()
         .await?
-        .error_for_status()?
-        .json()
-        .await?;
-    let content = value["choices"][0]["message"]["content"]
-        .as_str()
-        .unwrap_or("")
-        .to_string();
-    let stop = value["choices"][0]["finish_reason"]
-        .as_str()
-        .unwrap_or("stop")
-        .to_string();
-    Ok((content, usage_from_value(&value["usage"]), stop))
+        .error_for_status()?;
+
+    let mut content = String::new();
+    let mut usage = None;
+    let mut stop = "stop".to_string();
+    for_each_sse_data(resp, |data| {
+        if data == "[DONE]" {
+            return;
+        }
+        let Ok(v) = serde_json::from_str::<Value>(data) else {
+            return;
+        };
+        if let Some(delta) = v["choices"][0]["delta"]["content"].as_str() {
+            if !delta.is_empty() {
+                content.push_str(delta);
+                on_delta(delta);
+            }
+        }
+        if let Some(fr) = v["choices"][0]["finish_reason"].as_str() {
+            stop = fr.to_string();
+        }
+        if v["usage"].is_object() {
+            usage = usage_from_value(&v["usage"]);
+        }
+    })
+    .await?;
+    Ok((content, usage, stop))
 }
 
 async fn call_anthropic(
@@ -120,6 +140,7 @@ async fn call_anthropic(
     agent: &ApiAgentConfig,
     system_prompt: &str,
     messages: &[ApiAgentMessage],
+    on_delta: &mut (dyn FnMut(&str) + Send),
 ) -> anyhow::Result<(String, Option<ApiAgentUsage>, String)> {
     let req_messages: Vec<Value> = messages
         .iter()
@@ -129,7 +150,8 @@ async fn call_anthropic(
     let mut body = json!({
         "model": agent.model,
         "messages": req_messages,
-        "max_tokens": agent.max_output_tokens.unwrap_or(4096)
+        "max_tokens": agent.max_output_tokens.unwrap_or(4096),
+        "stream": true
     });
     if !system_prompt.is_empty() {
         body["system"] = json!(system_prompt);
@@ -137,32 +159,54 @@ async fn call_anthropic(
     if let Some(t) = agent.temperature {
         body["temperature"] = json!(t);
     }
-    let value: Value = HTTP_CLIENT
+    let resp = HTTP_CLIENT
         .post(format!("{}/messages", provider.base_url))
         .header("x-api-key", key)
         .header("anthropic-version", "2023-06-01")
         .json(&body)
         .send()
         .await?
-        .error_for_status()?
-        .json()
-        .await?;
-    let content = value["content"]
-        .as_array()
-        .map(|parts| {
-            parts
-                .iter()
-                .filter_map(|p| p["text"].as_str())
-                .collect::<Vec<_>>()
-                .join("")
-        })
-        .unwrap_or_default();
+        .error_for_status()?;
+
+    let mut content = String::new();
+    let mut input_tokens = None;
+    let mut output_tokens = None;
+    let mut stop = "end_turn".to_string();
+    for_each_sse_data(resp, |data| {
+        let Ok(v) = serde_json::from_str::<Value>(data) else {
+            return;
+        };
+        match v["type"].as_str() {
+            Some("content_block_delta") => {
+                if let Some(t) = v["delta"]["text"].as_str() {
+                    if !t.is_empty() {
+                        content.push_str(t);
+                        on_delta(t);
+                    }
+                }
+            }
+            Some("message_start") => {
+                input_tokens = v["message"]["usage"]["input_tokens"]
+                    .as_u64()
+                    .map(|n| n as u32);
+            }
+            Some("message_delta") => {
+                if let Some(s) = v["delta"]["stop_reason"].as_str() {
+                    stop = s.to_string();
+                }
+                if let Some(o) = v["usage"]["output_tokens"].as_u64() {
+                    output_tokens = Some(o as u32);
+                }
+            }
+            _ => {}
+        }
+    })
+    .await?;
     let usage = Some(ApiAgentUsage {
-        input_tokens: value["usage"]["input_tokens"].as_u64().map(|n| n as u32),
-        output_tokens: value["usage"]["output_tokens"].as_u64().map(|n| n as u32),
+        input_tokens,
+        output_tokens,
         total_tokens: None,
     });
-    let stop = value["stop_reason"].as_str().unwrap_or("stop").to_string();
     Ok((content, usage, stop))
 }
 
@@ -172,61 +216,124 @@ async fn call_gemini(
     agent: &ApiAgentConfig,
     system_prompt: &str,
     messages: &[ApiAgentMessage],
+    on_delta: &mut (dyn FnMut(&str) + Send),
 ) -> anyhow::Result<(String, Option<ApiAgentUsage>, String)> {
     let mut contents = Vec::new();
     for m in messages {
-        let role = if m.role == "assistant" {
-            "model"
-        } else {
-            "user"
-        };
         if m.role == "system" || m.role == "tool" {
             continue;
         }
+        let role = if m.role == "assistant" { "model" } else { "user" };
         contents.push(json!({ "role": role, "parts": [{ "text": m.content }] }));
     }
     let mut body = json!({ "contents": contents });
     if !system_prompt.is_empty() {
         body["systemInstruction"] = json!({ "parts": [{ "text": system_prompt }] });
     }
-    let value: Value = HTTP_CLIENT
+    let mut gen = serde_json::Map::new();
+    if let Some(t) = agent.temperature {
+        gen.insert("temperature".to_string(), json!(t));
+    }
+    if let Some(max) = agent.max_output_tokens {
+        gen.insert("maxOutputTokens".to_string(), json!(max));
+    }
+    if !gen.is_empty() {
+        body["generationConfig"] = Value::Object(gen);
+    }
+    let resp = HTTP_CLIENT
         .post(format!(
-            "{}/models/{}:generateContent",
+            "{}/models/{}:streamGenerateContent?alt=sse",
             provider.base_url, agent.model
         ))
         .header("x-goog-api-key", key)
         .json(&body)
         .send()
         .await?
-        .error_for_status()?
-        .json()
-        .await?;
-    let content = value["candidates"][0]["content"]["parts"]
-        .as_array()
-        .map(|parts| {
-            parts
-                .iter()
-                .filter_map(|p| p["text"].as_str())
-                .collect::<Vec<_>>()
-                .join("")
-        })
-        .unwrap_or_default();
-    let usage = Some(ApiAgentUsage {
-        input_tokens: value["usageMetadata"]["promptTokenCount"]
-            .as_u64()
-            .map(|n| n as u32),
-        output_tokens: value["usageMetadata"]["candidatesTokenCount"]
-            .as_u64()
-            .map(|n| n as u32),
-        total_tokens: value["usageMetadata"]["totalTokenCount"]
-            .as_u64()
-            .map(|n| n as u32),
-    });
-    let stop = value["candidates"][0]["finishReason"]
-        .as_str()
-        .unwrap_or("STOP")
-        .to_string();
+        .error_for_status()?;
+
+    let mut content = String::new();
+    let mut usage = None;
+    let mut stop = "STOP".to_string();
+    for_each_sse_data(resp, |data| {
+        let Ok(v) = serde_json::from_str::<Value>(data) else {
+            return;
+        };
+        if let Some(parts) = v["candidates"][0]["content"]["parts"].as_array() {
+            for p in parts {
+                if let Some(t) = p["text"].as_str() {
+                    if !t.is_empty() {
+                        content.push_str(t);
+                        on_delta(t);
+                    }
+                }
+            }
+        }
+        if let Some(fr) = v["candidates"][0]["finishReason"].as_str() {
+            stop = fr.to_string();
+        }
+        if v["usageMetadata"].is_object() {
+            usage = Some(ApiAgentUsage {
+                input_tokens: v["usageMetadata"]["promptTokenCount"]
+                    .as_u64()
+                    .map(|n| n as u32),
+                output_tokens: v["usageMetadata"]["candidatesTokenCount"]
+                    .as_u64()
+                    .map(|n| n as u32),
+                total_tokens: v["usageMetadata"]["totalTokenCount"]
+                    .as_u64()
+                    .map(|n| n as u32),
+            });
+        }
+    })
+    .await?;
     Ok((content, usage, stop))
+}
+
+/// SSE レスポンスを読み、各 `data:` 行の値で `on_data` を呼ぶ。
+async fn for_each_sse_data<F: FnMut(&str)>(
+    mut resp: reqwest::Response,
+    mut on_data: F,
+) -> anyhow::Result<()> {
+    let mut sse = SseBuffer::default();
+    while let Some(chunk) = resp.chunk().await? {
+        sse.push(&chunk, &mut on_data);
+    }
+    sse.flush(&mut on_data);
+    Ok(())
+}
+
+/// chunk を貯めて完全な行ごとに SSE `data:` ペイロードを取り出すバッファ。
+/// マルチバイト文字が chunk 境界で割れても、行 (`\n` 区切り) 単位で decode するため壊れない
+/// (改行は UTF-8 の char 境界なので、行バイト列は常に完全な UTF-8 シーケンス)。
+#[derive(Default)]
+struct SseBuffer {
+    buf: Vec<u8>,
+}
+
+impl SseBuffer {
+    fn push<F: FnMut(&str)>(&mut self, chunk: &[u8], mut on_data: F) {
+        self.buf.extend_from_slice(chunk);
+        while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
+            let line: Vec<u8> = self.buf.drain(..=pos).collect();
+            emit_data_line(&line, &mut on_data);
+        }
+    }
+
+    /// ストリーム終端で残った (改行無し) 行を flush する。
+    fn flush<F: FnMut(&str)>(&mut self, mut on_data: F) {
+        if !self.buf.is_empty() {
+            let line = std::mem::take(&mut self.buf);
+            emit_data_line(&line, &mut on_data);
+        }
+    }
+}
+
+fn emit_data_line<F: FnMut(&str)>(line: &[u8], on_data: &mut F) {
+    let line = String::from_utf8_lossy(line);
+    let line = line.trim();
+    if let Some(rest) = line.strip_prefix("data:") {
+        on_data(rest.trim());
+    }
 }
 
 fn usage_from_value(value: &Value) -> Option<ApiAgentUsage> {
@@ -265,8 +372,8 @@ mod tests {
 
     #[test]
     fn preset_trims_trailing_slash_on_base_url() {
-        let custom = provider_preset("custom-openai-compatible", Some("https://x.example/v1/"))
-            .unwrap();
+        let custom =
+            provider_preset("custom-openai-compatible", Some("https://x.example/v1/")).unwrap();
         assert_eq!(custom.base_url, "https://x.example/v1");
         assert_eq!(custom.adapter, "openai-compatible");
     }
@@ -280,5 +387,42 @@ mod tests {
     #[test]
     fn unknown_provider_is_rejected() {
         assert!(provider_preset("does-not-exist", None).is_err());
+    }
+
+    fn collect_data(chunks: &[&[u8]]) -> Vec<String> {
+        let mut sse = SseBuffer::default();
+        let mut out = Vec::new();
+        for c in chunks {
+            sse.push(c, |d| out.push(d.to_string()));
+        }
+        sse.flush(|d| out.push(d.to_string()));
+        out
+    }
+
+    #[test]
+    fn sse_buffer_extracts_data_lines() {
+        let out = collect_data(&[b"data: hello\n", b"event: x\ndata: world\n\n"]);
+        assert_eq!(out, vec!["hello".to_string(), "world".to_string()]);
+    }
+
+    #[test]
+    fn sse_buffer_reassembles_multibyte_split_across_chunks() {
+        // "data: あ\n" を 'あ' (E3 81 82) の途中で分割。行単位 decode で壊れないこと。
+        let full = "data: あ\n".as_bytes();
+        let (a, b) = full.split_at(7); // "data: " + 'あ' の先頭 1 バイト
+        let out = collect_data(&[a, b]);
+        assert_eq!(out, vec!["あ".to_string()]);
+    }
+
+    #[test]
+    fn sse_buffer_flushes_trailing_line_without_newline() {
+        let out = collect_data(&[b"data: [DONE]"]);
+        assert_eq!(out, vec!["[DONE]".to_string()]);
+    }
+
+    #[test]
+    fn sse_buffer_ignores_non_data_lines() {
+        let out = collect_data(&[b": comment\n", b"\n", b"data: x\n"]);
+        assert_eq!(out, vec!["x".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary
- API エージェントの provider 呼び出しを `stream: false` の擬似ストリーミング (応答全文を 1 delta で送る) から、SSE による逐次 delta emit に切り替え。計画 v2 Test Plan の「streaming 表示 / event ordering」を満たす。
- 新規 crate 依存なし。`reqwest::Response::chunk()` でバイト単位に受信し、`SseBuffer` で行 (`\n` 区切り) 単位に decode。**改行は UTF-8 char 境界**なので、chunk (TCP セグメント) 境界でマルチバイト文字が割れても壊れない。
- `call_provider` に `on_delta` コールバック (`&mut (dyn FnMut(&str) + Send)`) を追加し、`api_agent_send` は chunk ごとに `emit_delta`。全文 1 回の emit を廃止 (done イベントで全文確定)。card 側は既存の差分追記ロジックでそのまま表示できるため renderer 変更なし。

## アダプタ別
- **openai-compatible**: `stream:true` + `stream_options.include_usage`。`choices[].delta.content` を逐次 emit、`finish_reason` / 終端 `usage` を集約。`[DONE]` 終端。
- **anthropic**: `stream:true`。`content_block_delta` の text を emit、`message_start` の input_tokens / `message_delta` の output_tokens・stop_reason を集約。
- **gemini**: `:streamGenerateContent?alt=sse`。`candidates[].content.parts[].text` を emit、`finishReason` / `usageMetadata` を集約。`generationConfig` で temperature / maxOutputTokens を反映。

## 設計メモ
- `&mut (dyn FnMut(&str) + Send)`: Tauri command の future は `Send` 必須。closure 自体 (`&AppHandle` / `&req` capture) は Send だが、trait object に明示 `+ Send` が必要。
- `on_delta` closure は `req` を借用するため、後段で `req` のフィールドを move する前にブロックスコープで drop させる。

## Test plan
- [x] `cargo test --lib -- api_agents::providers` (8 passed; preset マッピング + SSE 行分割 / **マルチバイト chunk 分割再構成** / 終端 flush / 非 data 行無視)
- [x] `cargo check` 通過 / file-size ratchet OK (providers.rs 428 行)
- [x] renderer 変更なし (card の差分追記ロジックが streaming をそのまま処理)

Closes #1000
