### PR TITLE
feat(api-agents): 読み取りツール(read_file/list_dir) + tool-callingループ

### DIFF
--- a/src-tauri/src/commands/api_agents.rs
+++ b/src-tauri/src/commands/api_agents.rs
@@ -13,12 +13,13 @@ use uuid::Uuid;
 
 mod providers;
 pub mod skills;
+mod tools;
 pub mod types;
 
 #[cfg(test)]
 mod tests;
 
-use self::providers::{call_provider, provider_preset};
+use self::providers::{call_provider, provider_preset, ToolRuntime};
 use self::types::*;
 use crate::state::{current_project_root, AppState};
 use tauri::State;
@@ -236,9 +237,23 @@ pub async fn api_agent_send(
     .collect::<Vec<_>>()
     .join("\n\n");
 
-    // SSE chunk が届くたびに delta を emit する。closure は req/app を借用するため、
-    // 後段で req のフィールドを move する前にブロックで drop させる。
+    // tools_enabled (= !degraded) のとき read_file / list_dir を実行する tool-loop を回す。
+    // read-only / 非対応 provider は tools=None で SSE chat に degrade。
+    // closure 群は req/app を借用するため、後段で req のフィールドを move する前に
+    // ブロックスコープで drop させる。
     let response = {
+        let mut on_tool = |name: &str, status: &str, detail: Option<&str>| {
+            emit_tool(&app, &req, name, status, detail.map(str::to_string));
+        };
+        let tools = if degraded {
+            None
+        } else {
+            Some(ToolRuntime {
+                project_root: &project_root,
+                max_turns: budget,
+                on_tool: &mut on_tool,
+            })
+        };
         let mut on_delta = |delta: &str| emit_delta(&app, &req, delta);
         call_provider(
             &provider,
@@ -246,6 +261,7 @@ pub async fn api_agent_send(
             &req.agent,
             &system_prompt,
             &session.messages,
+            tools,
             &mut on_delta,
         )
         .await

--- a/src-tauri/src/commands/api_agents/providers.rs
+++ b/src-tauri/src/commands/api_agents/providers.rs
@@ -3,8 +3,21 @@ use serde_json::{json, Value};
 
 use super::types::{ApiAgentConfig, ApiAgentMessage, ApiAgentUsage};
 
-static HTTP_CLIENT: once_cell::sync::Lazy<reqwest::Client> =
+mod agentic;
+
+pub(super) static HTTP_CLIENT: once_cell::sync::Lazy<reqwest::Client> =
     once_cell::sync::Lazy::new(reqwest::Client::new);
+
+/// tool-calling を有効にして呼ぶときのコンテキスト。`None` のときは read-only chat
+/// (SSE ストリーミング) 経路になる。
+pub(super) struct ToolRuntime<'a> {
+    /// ツールが参照する active project root (state の信頼値)。
+    pub project_root: &'a str,
+    /// 自動 tool ターンの上限。
+    pub max_turns: u32,
+    /// tool 実行状況の通知 (name, status, detail)。
+    pub on_tool: &'a mut (dyn FnMut(&str, &str, Option<&str>) + Send),
+}
 
 #[derive(Clone)]
 pub(super) struct ProviderPreset {
@@ -52,20 +65,42 @@ pub(super) fn provider_preset(
     })
 }
 
-/// provider を呼び出し、応答を SSE でストリーミングする。`on_delta` は本文 chunk が届く
-/// たびに呼ばれる。戻り値は確定後の (全文, usage, stop_reason)。
+/// provider を呼び出す。
+/// - `tools = Some(..)`: 非ストリーミングの tool-calling ループ (read_file / list_dir を実行)。
+/// - `tools = None`: read-only chat を SSE ストリーミング。
+///
+/// いずれも `on_delta` で本文を emit し、戻り値は確定後の (全文, usage, stop_reason)。
 pub(super) async fn call_provider(
     provider: &ProviderPreset,
     key: &str,
     agent: &ApiAgentConfig,
     system_prompt: &str,
     messages: &[ApiAgentMessage],
+    tools: Option<ToolRuntime<'_>>,
     on_delta: &mut (dyn FnMut(&str) + Send),
 ) -> anyhow::Result<(String, Option<ApiAgentUsage>, String)> {
-    match provider.adapter {
-        "anthropic" => call_anthropic(provider, key, agent, system_prompt, messages, on_delta).await,
-        "gemini" => call_gemini(provider, key, agent, system_prompt, messages, on_delta).await,
-        _ => call_openai_compatible(provider, key, agent, system_prompt, messages, on_delta).await,
+    match (provider.adapter, tools) {
+        ("anthropic", Some(rt)) => {
+            agentic::call_anthropic_tools(provider, key, agent, system_prompt, messages, rt, on_delta)
+                .await
+        }
+        ("gemini", Some(rt)) => {
+            agentic::call_gemini_tools(provider, key, agent, system_prompt, messages, rt, on_delta)
+                .await
+        }
+        (_, Some(rt)) => {
+            agentic::call_openai_tools(provider, key, agent, system_prompt, messages, rt, on_delta)
+                .await
+        }
+        ("anthropic", None) => {
+            call_anthropic(provider, key, agent, system_prompt, messages, on_delta).await
+        }
+        ("gemini", None) => {
+            call_gemini(provider, key, agent, system_prompt, messages, on_delta).await
+        }
+        (_, None) => {
+            call_openai_compatible(provider, key, agent, system_prompt, messages, on_delta).await
+        }
     }
 }
 
@@ -336,7 +371,7 @@ fn emit_data_line<F: FnMut(&str)>(line: &[u8], on_data: &mut F) {
     }
 }
 
-fn usage_from_value(value: &Value) -> Option<ApiAgentUsage> {
+pub(super) fn usage_from_value(value: &Value) -> Option<ApiAgentUsage> {
     if !value.is_object() {
         return None;
     }

--- a/src-tauri/src/commands/api_agents/providers/agentic.rs
+++ b/src-tauri/src/commands/api_agents/providers/agentic.rs
@@ -97,7 +97,7 @@ pub(super) async fn call_openai_tools(
         // assistant の tool_calls メッセージをそのまま会話へ (OpenAI は原文の再送が必要)。
         convo.push(msg.clone());
         for call in &calls {
-            let outcome = run_tool(&mut rt, call);
+            let outcome = run_tool(&mut rt, call).await;
             convo.push(json!({
                 "role": "tool",
                 "tool_call_id": call.id,
@@ -195,7 +195,7 @@ pub(super) async fn call_anthropic_tools(
         convo.push(json!({ "role": "assistant", "content": content }));
         let mut results = Vec::new();
         for call in &calls {
-            let (outcome, is_error) = run_tool_with_flag(&mut rt, call);
+            let (outcome, is_error) = run_tool_with_flag(&mut rt, call).await;
             results.push(json!({
                 "type": "tool_result",
                 "tool_use_id": call.id,
@@ -308,7 +308,7 @@ pub(super) async fn call_gemini_tools(
         contents.push(json!({ "role": "model", "parts": parts }));
         let mut resp_parts = Vec::new();
         for call in &calls {
-            let outcome = run_tool(&mut rt, call);
+            let outcome = run_tool(&mut rt, call).await;
             resp_parts.push(json!({
                 "functionResponse": { "name": call.name, "response": { "result": outcome } }
             }));
@@ -353,13 +353,28 @@ fn gemini_usage(v: &Value) -> Option<ApiAgentUsage> {
 // ---------- shared ----------
 
 /// tool を実行し、status イベントを emit して結果本文を返す。
-fn run_tool(rt: &mut ToolRuntime<'_>, call: &ToolCall) -> String {
-    run_tool_with_flag(rt, call).0
+async fn run_tool(rt: &mut ToolRuntime<'_>, call: &ToolCall) -> String {
+    run_tool_with_flag(rt, call).await.0
 }
 
-fn run_tool_with_flag(rt: &mut ToolRuntime<'_>, call: &ToolCall) -> (String, bool) {
+async fn run_tool_with_flag(rt: &mut ToolRuntime<'_>, call: &ToolCall) -> (String, bool) {
     (rt.on_tool)(&call.name, "started", Some(&summarize_args(&call.args)));
-    let outcome = tools::execute_tool(rt.project_root, &call.name, &call.args);
+    // ツール実行は同期ブロッキング fs (read_dir / read) を含むため、async ランタイムの
+    // worker を塞がないよう spawn_blocking へ退避する。
+    let project_root = rt.project_root.to_string();
+    let name = call.name.clone();
+    let args = call.args.clone();
+    let outcome = match tokio::task::spawn_blocking(move || {
+        tools::execute_tool(&project_root, &name, &args)
+    })
+    .await
+    {
+        Ok(o) => o,
+        Err(e) => tools::ToolOutcome {
+            content: format!("tool execution failed: {e}"),
+            is_error: true,
+        },
+    };
     (rt.on_tool)(
         &call.name,
         if outcome.is_error { "failed" } else { "completed" },

--- a/src-tauri/src/commands/api_agents/providers/agentic.rs
+++ b/src-tauri/src/commands/api_agents/providers/agentic.rs
@@ -1,0 +1,485 @@
+// providers/agentic — 非ストリーミングの tool-calling ループ (Issue #1002)。
+//
+// tools_enabled (supports_tools && toolMode != readOnly) のとき呼ばれる。tool 解決ターンは
+// SSE の差分蓄積を避けるため非ストリーミング (完全 JSON から tool_calls をパース) で回し、
+// read_file / list_dir を実行して結果を会話へ戻す。最終回答は on_delta で emit する。
+//
+// 各 provider のツール表現:
+//   - OpenAI:    request.tools[].function / response.message.tool_calls[] / role:"tool"
+//   - Anthropic: request.tools[] (input_schema) / content[type=tool_use] / content[type=tool_result]
+//   - Gemini:    tools[].functionDeclarations / parts[].functionCall / parts[].functionResponse
+
+use serde_json::{json, Value};
+
+use super::super::tools;
+use super::super::types::{ApiAgentConfig, ApiAgentMessage, ApiAgentUsage};
+use super::{usage_from_value, ProviderPreset, ToolRuntime, HTTP_CLIENT};
+
+/// 1 件の tool 呼び出し (provider 非依存に正規化したもの)。
+struct ToolCall {
+    /// OpenAI/Anthropic は id を持つ。Gemini は名前で対応づけるので空。
+    id: String,
+    name: String,
+    args: Value,
+}
+
+const BUDGET_MSG: &str = "Tool turn budget exceeded before a final answer.";
+
+// ---------- OpenAI-compatible ----------
+
+pub(super) async fn call_openai_tools(
+    provider: &ProviderPreset,
+    key: &str,
+    agent: &ApiAgentConfig,
+    system_prompt: &str,
+    messages: &[ApiAgentMessage],
+    mut rt: ToolRuntime<'_>,
+    on_delta: &mut (dyn FnMut(&str) + Send),
+) -> anyhow::Result<(String, Option<ApiAgentUsage>, String)> {
+    let specs = tools::builtin_read_tools();
+    let tool_defs: Vec<Value> = specs
+        .iter()
+        .map(|s| {
+            json!({
+                "type": "function",
+                "function": { "name": s.name, "description": s.description, "parameters": s.parameters }
+            })
+        })
+        .collect();
+
+    let mut convo: Vec<Value> = Vec::new();
+    if !system_prompt.is_empty() {
+        convo.push(json!({ "role": "system", "content": system_prompt }));
+    }
+    for m in messages {
+        if m.role == "tool" {
+            continue;
+        }
+        convo.push(json!({ "role": m.role, "content": m.content }));
+    }
+
+    let mut total_usage = None;
+    for _turn in 0..rt.max_turns {
+        let mut body = json!({
+            "model": agent.model,
+            "messages": convo,
+            "tools": tool_defs,
+            "stream": false
+        });
+        if let Some(t) = agent.temperature {
+            body["temperature"] = json!(t);
+        }
+        if let Some(max) = agent.max_output_tokens {
+            body["max_tokens"] = json!(max);
+        }
+        let v: Value = HTTP_CLIENT
+            .post(format!("{}/chat/completions", provider.base_url))
+            .bearer_auth(key)
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        accumulate_usage(&mut total_usage, usage_from_value(&v["usage"]));
+        let msg = &v["choices"][0]["message"];
+        let stop = v["choices"][0]["finish_reason"]
+            .as_str()
+            .unwrap_or("stop")
+            .to_string();
+        let (text, calls) = openai_extract(msg);
+        if calls.is_empty() {
+            if !text.is_empty() {
+                on_delta(&text);
+            }
+            return Ok((text, total_usage, stop));
+        }
+        // assistant の tool_calls メッセージをそのまま会話へ (OpenAI は原文の再送が必要)。
+        convo.push(msg.clone());
+        for call in &calls {
+            let outcome = run_tool(&mut rt, call);
+            convo.push(json!({
+                "role": "tool",
+                "tool_call_id": call.id,
+                "content": outcome
+            }));
+        }
+    }
+    Ok((BUDGET_MSG.to_string(), total_usage, "max_turns".to_string()))
+}
+
+fn openai_extract(msg: &Value) -> (String, Vec<ToolCall>) {
+    let text = msg["content"].as_str().unwrap_or("").to_string();
+    let calls = msg["tool_calls"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|tc| {
+                    let id = tc["id"].as_str()?.to_string();
+                    let name = tc["function"]["name"].as_str()?.to_string();
+                    let args_str = tc["function"]["arguments"].as_str().unwrap_or("{}");
+                    let args = serde_json::from_str(args_str).unwrap_or_else(|_| json!({}));
+                    Some(ToolCall { id, name, args })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    (text, calls)
+}
+
+// ---------- Anthropic ----------
+
+pub(super) async fn call_anthropic_tools(
+    provider: &ProviderPreset,
+    key: &str,
+    agent: &ApiAgentConfig,
+    system_prompt: &str,
+    messages: &[ApiAgentMessage],
+    mut rt: ToolRuntime<'_>,
+    on_delta: &mut (dyn FnMut(&str) + Send),
+) -> anyhow::Result<(String, Option<ApiAgentUsage>, String)> {
+    let specs = tools::builtin_read_tools();
+    let tool_defs: Vec<Value> = specs
+        .iter()
+        .map(|s| json!({ "name": s.name, "description": s.description, "input_schema": s.parameters }))
+        .collect();
+
+    let mut convo: Vec<Value> = messages
+        .iter()
+        .filter(|m| m.role == "user" || m.role == "assistant")
+        .map(|m| json!({ "role": m.role, "content": m.content }))
+        .collect();
+
+    let mut total_usage = None;
+    for _turn in 0..rt.max_turns {
+        let mut body = json!({
+            "model": agent.model,
+            "messages": convo,
+            "max_tokens": agent.max_output_tokens.unwrap_or(4096),
+            "tools": tool_defs
+        });
+        if !system_prompt.is_empty() {
+            body["system"] = json!(system_prompt);
+        }
+        if let Some(t) = agent.temperature {
+            body["temperature"] = json!(t);
+        }
+        let v: Value = HTTP_CLIENT
+            .post(format!("{}/messages", provider.base_url))
+            .header("x-api-key", key)
+            .header("anthropic-version", "2023-06-01")
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        accumulate_usage(
+            &mut total_usage,
+            Some(ApiAgentUsage {
+                input_tokens: v["usage"]["input_tokens"].as_u64().map(|n| n as u32),
+                output_tokens: v["usage"]["output_tokens"].as_u64().map(|n| n as u32),
+                total_tokens: None,
+            }),
+        );
+        let stop = v["stop_reason"].as_str().unwrap_or("end_turn").to_string();
+        let content = v["content"].as_array().cloned().unwrap_or_default();
+        let (text, calls) = anthropic_extract(&content);
+        if calls.is_empty() {
+            if !text.is_empty() {
+                on_delta(&text);
+            }
+            return Ok((text, total_usage, stop));
+        }
+        // assistant の content (tool_use 含む) をそのまま会話へ。
+        convo.push(json!({ "role": "assistant", "content": content }));
+        let mut results = Vec::new();
+        for call in &calls {
+            let (outcome, is_error) = run_tool_with_flag(&mut rt, call);
+            results.push(json!({
+                "type": "tool_result",
+                "tool_use_id": call.id,
+                "content": outcome,
+                "is_error": is_error
+            }));
+        }
+        convo.push(json!({ "role": "user", "content": results }));
+    }
+    Ok((BUDGET_MSG.to_string(), total_usage, "max_turns".to_string()))
+}
+
+fn anthropic_extract(content: &[Value]) -> (String, Vec<ToolCall>) {
+    let mut text = String::new();
+    let mut calls = Vec::new();
+    for b in content {
+        match b["type"].as_str() {
+            Some("text") => {
+                if let Some(t) = b["text"].as_str() {
+                    text.push_str(t);
+                }
+            }
+            Some("tool_use") => {
+                if let (Some(id), Some(name)) = (b["id"].as_str(), b["name"].as_str()) {
+                    calls.push(ToolCall {
+                        id: id.to_string(),
+                        name: name.to_string(),
+                        args: b["input"].clone(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    (text, calls)
+}
+
+// ---------- Gemini ----------
+
+pub(super) async fn call_gemini_tools(
+    provider: &ProviderPreset,
+    key: &str,
+    agent: &ApiAgentConfig,
+    system_prompt: &str,
+    messages: &[ApiAgentMessage],
+    mut rt: ToolRuntime<'_>,
+    on_delta: &mut (dyn FnMut(&str) + Send),
+) -> anyhow::Result<(String, Option<ApiAgentUsage>, String)> {
+    let specs = tools::builtin_read_tools();
+    let decls: Vec<Value> = specs
+        .iter()
+        .map(|s| json!({ "name": s.name, "description": s.description, "parameters": s.parameters }))
+        .collect();
+    let tools_field = json!([{ "functionDeclarations": decls }]);
+
+    let mut contents: Vec<Value> = Vec::new();
+    for m in messages {
+        if m.role == "system" || m.role == "tool" {
+            continue;
+        }
+        let role = if m.role == "assistant" { "model" } else { "user" };
+        contents.push(json!({ "role": role, "parts": [{ "text": m.content }] }));
+    }
+
+    let mut total_usage = None;
+    for _turn in 0..rt.max_turns {
+        let mut body = json!({ "contents": contents, "tools": tools_field });
+        if !system_prompt.is_empty() {
+            body["systemInstruction"] = json!({ "parts": [{ "text": system_prompt }] });
+        }
+        let mut gen = serde_json::Map::new();
+        if let Some(t) = agent.temperature {
+            gen.insert("temperature".to_string(), json!(t));
+        }
+        if let Some(max) = agent.max_output_tokens {
+            gen.insert("maxOutputTokens".to_string(), json!(max));
+        }
+        if !gen.is_empty() {
+            body["generationConfig"] = Value::Object(gen);
+        }
+        let v: Value = HTTP_CLIENT
+            .post(format!(
+                "{}/models/{}:generateContent",
+                provider.base_url, agent.model
+            ))
+            .header("x-goog-api-key", key)
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        accumulate_usage(&mut total_usage, gemini_usage(&v));
+        let stop = v["candidates"][0]["finishReason"]
+            .as_str()
+            .unwrap_or("STOP")
+            .to_string();
+        let parts = v["candidates"][0]["content"]["parts"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        let (text, calls) = gemini_extract(&parts);
+        if calls.is_empty() {
+            if !text.is_empty() {
+                on_delta(&text);
+            }
+            return Ok((text, total_usage, stop));
+        }
+        // model の parts (functionCall 含む) をそのまま会話へ。
+        contents.push(json!({ "role": "model", "parts": parts }));
+        let mut resp_parts = Vec::new();
+        for call in &calls {
+            let outcome = run_tool(&mut rt, call);
+            resp_parts.push(json!({
+                "functionResponse": { "name": call.name, "response": { "result": outcome } }
+            }));
+        }
+        contents.push(json!({ "role": "user", "parts": resp_parts }));
+    }
+    Ok((BUDGET_MSG.to_string(), total_usage, "max_turns".to_string()))
+}
+
+fn gemini_extract(parts: &[Value]) -> (String, Vec<ToolCall>) {
+    let mut text = String::new();
+    let mut calls = Vec::new();
+    for p in parts {
+        if let Some(t) = p["text"].as_str() {
+            text.push_str(t);
+        }
+        if p["functionCall"].is_object() {
+            if let Some(name) = p["functionCall"]["name"].as_str() {
+                calls.push(ToolCall {
+                    id: String::new(),
+                    name: name.to_string(),
+                    args: p["functionCall"]["args"].clone(),
+                });
+            }
+        }
+    }
+    (text, calls)
+}
+
+fn gemini_usage(v: &Value) -> Option<ApiAgentUsage> {
+    let u = &v["usageMetadata"];
+    if !u.is_object() {
+        return None;
+    }
+    Some(ApiAgentUsage {
+        input_tokens: u["promptTokenCount"].as_u64().map(|n| n as u32),
+        output_tokens: u["candidatesTokenCount"].as_u64().map(|n| n as u32),
+        total_tokens: u["totalTokenCount"].as_u64().map(|n| n as u32),
+    })
+}
+
+// ---------- shared ----------
+
+/// tool を実行し、status イベントを emit して結果本文を返す。
+fn run_tool(rt: &mut ToolRuntime<'_>, call: &ToolCall) -> String {
+    run_tool_with_flag(rt, call).0
+}
+
+fn run_tool_with_flag(rt: &mut ToolRuntime<'_>, call: &ToolCall) -> (String, bool) {
+    (rt.on_tool)(&call.name, "started", Some(&summarize_args(&call.args)));
+    let outcome = tools::execute_tool(rt.project_root, &call.name, &call.args);
+    (rt.on_tool)(
+        &call.name,
+        if outcome.is_error { "failed" } else { "completed" },
+        None,
+    );
+    (outcome.content, outcome.is_error)
+}
+
+fn summarize_args(args: &Value) -> String {
+    let s = args.to_string();
+    if s.chars().count() > 120 {
+        s.chars().take(120).collect::<String>() + "…"
+    } else {
+        s
+    }
+}
+
+fn accumulate_usage(total: &mut Option<ApiAgentUsage>, add: Option<ApiAgentUsage>) {
+    let Some(add) = add else {
+        return;
+    };
+    let t = total.get_or_insert_with(ApiAgentUsage::default);
+    t.input_tokens = sum_opt(t.input_tokens, add.input_tokens);
+    t.output_tokens = sum_opt(t.output_tokens, add.output_tokens);
+    t.total_tokens = sum_opt(t.total_tokens, add.total_tokens);
+}
+
+fn sum_opt(a: Option<u32>, b: Option<u32>) -> Option<u32> {
+    match (a, b) {
+        (None, None) => None,
+        _ => Some(a.unwrap_or(0) + b.unwrap_or(0)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openai_extract_parses_tool_calls() {
+        let msg = json!({
+            "content": null,
+            "tool_calls": [
+                { "id": "call_1", "function": { "name": "read_file", "arguments": "{\"path\":\"a.txt\"}" } }
+            ]
+        });
+        let (text, calls) = openai_extract(&msg);
+        assert_eq!(text, "");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_1");
+        assert_eq!(calls[0].name, "read_file");
+        assert_eq!(calls[0].args["path"], json!("a.txt"));
+    }
+
+    #[test]
+    fn openai_extract_final_text_has_no_calls() {
+        let msg = json!({ "content": "here is the answer" });
+        let (text, calls) = openai_extract(&msg);
+        assert_eq!(text, "here is the answer");
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn anthropic_extract_separates_text_and_tool_use() {
+        let content = vec![
+            json!({ "type": "text", "text": "let me check " }),
+            json!({ "type": "tool_use", "id": "tu_1", "name": "list_dir", "input": { "path": "." } }),
+        ];
+        let (text, calls) = anthropic_extract(&content);
+        assert_eq!(text, "let me check ");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "list_dir");
+        assert_eq!(calls[0].id, "tu_1");
+        assert_eq!(calls[0].args["path"], json!("."));
+    }
+
+    #[test]
+    fn gemini_extract_reads_function_call() {
+        let parts = vec![
+            json!({ "text": "checking" }),
+            json!({ "functionCall": { "name": "read_file", "args": { "path": "x.rs" } } }),
+        ];
+        let (text, calls) = gemini_extract(&parts);
+        assert_eq!(text, "checking");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "read_file");
+        assert_eq!(calls[0].args["path"], json!("x.rs"));
+        assert!(calls[0].id.is_empty());
+    }
+
+    #[test]
+    fn accumulate_usage_sums_across_turns() {
+        let mut total = None;
+        accumulate_usage(
+            &mut total,
+            Some(ApiAgentUsage {
+                input_tokens: Some(10),
+                output_tokens: Some(5),
+                total_tokens: None,
+            }),
+        );
+        accumulate_usage(
+            &mut total,
+            Some(ApiAgentUsage {
+                input_tokens: Some(7),
+                output_tokens: Some(3),
+                total_tokens: Some(20),
+            }),
+        );
+        let u = total.unwrap();
+        assert_eq!(u.input_tokens, Some(17));
+        assert_eq!(u.output_tokens, Some(8));
+        assert_eq!(u.total_tokens, Some(20));
+    }
+
+    #[test]
+    fn summarize_args_truncates_long_payloads() {
+        let big = json!({ "path": "a".repeat(300) });
+        let s = summarize_args(&big);
+        assert!(s.chars().count() <= 121);
+        assert!(s.ends_with('…'));
+    }
+}

--- a/src-tauri/src/commands/api_agents/tools.rs
+++ b/src-tauri/src/commands/api_agents/tools.rs
@@ -1,0 +1,286 @@
+// api_agents/tools — API エージェントがモデルに公開する読み取り専用ツール (Issue #1002)。
+//
+// v1 スコープ: read_file / list_dir のみ。書込・シェル実行は対象外。
+//
+// セキュリティ方針:
+//   - 参照は active project root (caller が state から取得した信頼値) 配下のみ。
+//   - canonicalize して root 配下に収まることを検証し、`..` traversal / symlink escape を拒否。
+//   - read_file はサイズ上限、list_dir は件数上限でキャップする。
+//
+// ツール実行は同期 fs (小さなローカル読み取りのみ) で行い、provider アダプタの非ストリーミング
+// tool-loop から `FnMut(&str, &Value) -> ToolOutcome` クロージャ経由で呼ばれる。
+
+use serde_json::{json, Value};
+use std::path::PathBuf;
+
+/// read_file が一度に返す最大バイト数。
+const MAX_READ_BYTES: u64 = 64 * 1024;
+/// list_dir が返す最大エントリ数。
+const MAX_LIST_ENTRIES: usize = 200;
+
+/// モデルへ渡すツール定義 (provider 非依存)。各アダプタが自身の関数呼び出し形式へ変換する。
+pub(super) struct ToolSpec {
+    pub name: &'static str,
+    pub description: &'static str,
+    /// JSON Schema (OpenAI function parameters 互換)。
+    pub parameters: Value,
+}
+
+/// ツール 1 回の実行結果。`is_error` のときはモデルにエラーであることを伝える。
+pub(super) struct ToolOutcome {
+    pub content: String,
+    pub is_error: bool,
+}
+
+impl ToolOutcome {
+    fn ok(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            is_error: false,
+        }
+    }
+    fn err(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            is_error: true,
+        }
+    }
+}
+
+/// v1 の読み取り専用ツール定義。
+pub(super) fn builtin_read_tools() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "read_file",
+            description: "Read a UTF-8 text file from the current project. \
+                Path is relative to the project root. Read-only.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "File path relative to the project root."
+                    }
+                },
+                "required": ["path"]
+            }),
+        },
+        ToolSpec {
+            name: "list_dir",
+            description: "List entries of a directory in the current project. \
+                Path is relative to the project root (default: project root). Read-only.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Directory path relative to the project root. Defaults to '.'."
+                    }
+                }
+            }),
+        },
+    ]
+}
+
+/// 名前でツールをディスパッチして実行する。未知ツールはエラー結果を返す。
+pub(super) fn execute_tool(project_root: &str, name: &str, args: &Value) -> ToolOutcome {
+    match name {
+        "read_file" => read_file_tool(project_root, args),
+        "list_dir" => list_dir_tool(project_root, args),
+        other => ToolOutcome::err(format!("unknown tool: {other}")),
+    }
+}
+
+/// `project_root` 配下に収まる実体パスへ解決する。canonicalize 後の実体が root 外を指す
+/// (symlink escape / traversal) 場合はエラー。
+fn resolve_within(project_root: &str, rel: &str) -> Result<PathBuf, String> {
+    let root = project_root.trim();
+    if root.is_empty() {
+        return Err("no project is open".to_string());
+    }
+    let root_canon =
+        std::fs::canonicalize(root).map_err(|e| format!("project root unavailable: {e}"))?;
+    // rel が絶対パスでも join で置換されるが、最終的な canonicalize + 封じ込めで弾く。
+    let joined = root_canon.join(rel);
+    let canon = std::fs::canonicalize(&joined).map_err(|e| format!("path not found: {rel} ({e})"))?;
+    if !canon.starts_with(&root_canon) {
+        return Err(format!("path escapes the project root: {rel}"));
+    }
+    Ok(canon)
+}
+
+fn read_file_tool(project_root: &str, args: &Value) -> ToolOutcome {
+    let Some(path) = args.get("path").and_then(Value::as_str) else {
+        return ToolOutcome::err("read_file requires a string 'path' argument");
+    };
+    let resolved = match resolve_within(project_root, path) {
+        Ok(p) => p,
+        Err(e) => return ToolOutcome::err(e),
+    };
+    let meta = match std::fs::metadata(&resolved) {
+        Ok(m) => m,
+        Err(e) => return ToolOutcome::err(format!("stat failed: {e}")),
+    };
+    if !meta.is_file() {
+        return ToolOutcome::err(format!("not a file: {path}"));
+    }
+    use std::io::Read;
+    let file = match std::fs::File::open(&resolved) {
+        Ok(f) => f,
+        Err(e) => return ToolOutcome::err(format!("open failed: {e}")),
+    };
+    let mut buf = Vec::new();
+    if let Err(e) = file.take(MAX_READ_BYTES).read_to_end(&mut buf) {
+        return ToolOutcome::err(format!("read failed: {e}"));
+    }
+    let mut text = String::from_utf8_lossy(&buf).to_string();
+    if meta.len() > MAX_READ_BYTES {
+        text.push_str("\n…(truncated; file exceeds 64KB read limit)");
+    }
+    ToolOutcome::ok(text)
+}
+
+fn list_dir_tool(project_root: &str, args: &Value) -> ToolOutcome {
+    let path = args
+        .get("path")
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or(".");
+    let resolved = match resolve_within(project_root, path) {
+        Ok(p) => p,
+        Err(e) => return ToolOutcome::err(e),
+    };
+    if !resolved.is_dir() {
+        return ToolOutcome::err(format!("not a directory: {path}"));
+    }
+    let rd = match std::fs::read_dir(&resolved) {
+        Ok(rd) => rd,
+        Err(e) => return ToolOutcome::err(format!("read_dir failed: {e}")),
+    };
+    let mut entries: Vec<String> = Vec::new();
+    for e in rd.flatten() {
+        let name = e.file_name().to_string_lossy().to_string();
+        let is_dir = e.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        entries.push(if is_dir { format!("{name}/") } else { name });
+    }
+    entries.sort();
+    let total = entries.len();
+    entries.truncate(MAX_LIST_ENTRIES);
+    let mut out = entries.join("\n");
+    if total > MAX_LIST_ENTRIES {
+        out.push_str(&format!(
+            "\n…({} more entries truncated)",
+            total - MAX_LIST_ENTRIES
+        ));
+    }
+    if out.is_empty() {
+        out.push_str("(empty directory)");
+    }
+    ToolOutcome::ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "hello world").unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        std::fs::write(dir.path().join("sub/b.txt"), "nested").unwrap();
+        dir
+    }
+
+    #[test]
+    fn read_file_reads_within_root() {
+        let dir = setup();
+        let root = dir.path().to_string_lossy().to_string();
+        let out = execute_tool(&root, "read_file", &json!({ "path": "a.txt" }));
+        assert!(!out.is_error);
+        assert_eq!(out.content, "hello world");
+        let nested = execute_tool(&root, "read_file", &json!({ "path": "sub/b.txt" }));
+        assert_eq!(nested.content, "nested");
+    }
+
+    #[test]
+    fn read_file_rejects_traversal() {
+        let dir = setup();
+        let root = dir.path().join("sub").to_string_lossy().to_string();
+        // sub の外 (../a.txt) は root=sub の外なので拒否される
+        let out = execute_tool(&root, "read_file", &json!({ "path": "../a.txt" }));
+        assert!(out.is_error);
+        assert!(out.content.contains("escapes") || out.content.contains("not found"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_file_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+        let dir = setup();
+        // project root を sub にし、secret は sub の外 (project 直下) に置く
+        let root = dir.path().join("sub");
+        let secret = dir.path().join("secret.txt");
+        std::fs::write(&secret, "TOP SECRET").unwrap();
+        symlink(&secret, root.join("leak.txt")).unwrap();
+        let out = execute_tool(
+            &root.to_string_lossy(),
+            "read_file",
+            &json!({ "path": "leak.txt" }),
+        );
+        assert!(out.is_error);
+        assert!(!out.content.contains("TOP SECRET"));
+    }
+
+    #[test]
+    fn read_file_caps_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_string_lossy().to_string();
+        let big = "x".repeat((MAX_READ_BYTES as usize) * 2);
+        std::fs::write(dir.path().join("big.txt"), &big).unwrap();
+        let out = execute_tool(&root, "read_file", &json!({ "path": "big.txt" }));
+        assert!(!out.is_error);
+        assert!(out.content.contains("truncated"));
+        assert!(out.content.len() <= MAX_READ_BYTES as usize + 100);
+    }
+
+    #[test]
+    fn list_dir_lists_entries_and_marks_dirs() {
+        let dir = setup();
+        let root = dir.path().to_string_lossy().to_string();
+        let out = execute_tool(&root, "list_dir", &json!({ "path": "." }));
+        assert!(!out.is_error);
+        assert!(out.content.contains("a.txt"));
+        assert!(out.content.contains("sub/"));
+    }
+
+    #[test]
+    fn list_dir_defaults_to_root() {
+        let dir = setup();
+        let root = dir.path().to_string_lossy().to_string();
+        let out = execute_tool(&root, "list_dir", &json!({}));
+        assert!(!out.is_error);
+        assert!(out.content.contains("a.txt"));
+    }
+
+    #[test]
+    fn unknown_tool_is_error() {
+        let dir = setup();
+        let out = execute_tool(&dir.path().to_string_lossy(), "rm_rf", &json!({}));
+        assert!(out.is_error);
+        assert!(out.content.contains("unknown tool"));
+    }
+
+    #[test]
+    fn missing_path_arg_is_error() {
+        let dir = setup();
+        let out = execute_tool(&dir.path().to_string_lossy(), "read_file", &json!({}));
+        assert!(out.is_error);
+    }
+
+    #[test]
+    fn empty_project_root_is_error() {
+        let out = execute_tool("", "list_dir", &json!({}));
+        assert!(out.is_error);
+        assert!(out.content.contains("no project"));
+    }
+}

--- a/src-tauri/src/commands/api_agents/tools.rs
+++ b/src-tauri/src/commands/api_agents/tools.rs
@@ -157,15 +157,23 @@ fn list_dir_tool(project_root: &str, args: &Value) -> ToolOutcome {
         Ok(rd) => rd,
         Err(e) => return ToolOutcome::err(format!("read_dir failed: {e}")),
     };
-    let mut entries: Vec<String> = Vec::new();
+    // bounded top-K: 全件を Vec に貯めてソートするのではなく、アルファベット順で先頭
+    // MAX_LIST_ENTRIES 件だけを max-heap で保持する。大量エントリのディレクトリでも
+    // メモリ/ソートコストを K 件に抑える (O(n log K) / O(K))。
+    use std::collections::BinaryHeap;
+    let mut heap: BinaryHeap<String> = BinaryHeap::new();
+    let mut total = 0usize;
     for e in rd.flatten() {
+        total += 1;
         let name = e.file_name().to_string_lossy().to_string();
         let is_dir = e.file_type().map(|t| t.is_dir()).unwrap_or(false);
-        entries.push(if is_dir { format!("{name}/") } else { name });
+        heap.push(if is_dir { format!("{name}/") } else { name });
+        if heap.len() > MAX_LIST_ENTRIES {
+            heap.pop(); // 最大要素を捨て、先頭 K 件 (アルファベット順) を保持
+        }
     }
+    let mut entries = heap.into_vec();
     entries.sort();
-    let total = entries.len();
-    entries.truncate(MAX_LIST_ENTRIES);
     let mut out = entries.join("\n");
     if total > MAX_LIST_ENTRIES {
         out.push_str(&format!(
@@ -260,6 +268,23 @@ mod tests {
         let out = execute_tool(&root, "list_dir", &json!({}));
         assert!(!out.is_error);
         assert!(out.content.contains("a.txt"));
+    }
+
+    #[test]
+    fn list_dir_caps_entry_count_keeping_alphabetical_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_string_lossy().to_string();
+        for i in 0..250 {
+            std::fs::write(dir.path().join(format!("f{i:04}.txt")), "x").unwrap();
+        }
+        let out = execute_tool(&root, "list_dir", &json!({ "path": "." }));
+        assert!(!out.is_error);
+        assert!(out.content.contains("more entries truncated"));
+        let entry_lines = out.content.lines().filter(|l| l.ends_with(".txt")).count();
+        assert_eq!(entry_lines, MAX_LIST_ENTRIES);
+        // アルファベット順で先頭が残り、末尾は truncate される
+        assert!(out.content.contains("f0000.txt"));
+        assert!(!out.content.contains("f0249.txt"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- API エージェントにプロジェクト**読み取りツール** (`read_file` / `list_dir`) を追加し、`tools_enabled` (`supports_tools && toolMode != readOnly`) のとき **tool-calling ループ**を回す。read-only / 非対応 provider は従来の SSE chat (#1001) に degrade。
- 計画 v1 スコープの「プロジェクト読取ツール」を実装。書込・シェル実行は対象外。

## 設計
- **tool 解決ターンは非ストリーミング**: 完全な JSON レスポンスから tool_calls をパースする。SSE の差分蓄積より単純で誤りにくい。最終回答 (tool_calls 無し) を `on_delta` で emit、tool 実行状況は `api-agent:tool` イベントで通知、`maxAutoTurnsPerChain` で停止。
- `call_provider` を `(adapter, tools)` で dispatch。`tools = Some(ToolRuntime{ project_root, max_turns, on_tool })` のとき agentic 経路、`None` のとき streaming 経路。

## セキュリティ (tools.rs)
- 参照は active project root (state の信頼値) 配下のみ。`resolve_within` が canonicalize して root 配下に収まることを検証し、`..` traversal / symlink escape を拒否。
- `read_file` は 64KB、`list_dir` は 200 件でキャップ。

## アダプタ別 (providers/agentic.rs)
| provider | request tools | tool call | tool result |
|----------|---------------|-----------|-------------|
| OpenAI互換 | `tools[].function` | `message.tool_calls[]` | `role:"tool"` |
| Anthropic | `tools[].input_schema` | `content[type=tool_use]` | `content[type=tool_result]` |
| Gemini | `functionDeclarations` | `parts[].functionCall` | `parts[].functionResponse` |

各 `*_extract` を pure 関数に切り出し、synthetic JSON で tool_call パースを単体テスト。

## ファイル分割
providers.rs を mod root 化し、tool-loop アダプタを `providers/agentic.rs` に分離 (全ファイル 500 行未満を維持)。

## Test plan
- [x] `cargo test --lib -- api_agents` (38 passed)
  - tools: 読取 / traversal 拒否 / **symlink escape 拒否** / サイズ・件数キャップ / 未知ツール
  - agentic: OpenAI / Anthropic / Gemini の tool_call パース、usage 集約、引数要約の truncation
- [x] `cargo check` 0 warnings / file-size ratchet OK
- [x] card 側は既存の `onToolReady` で tool 状況を表示 (renderer 変更なし)

## 注意
実 API キーが無いため tool-calling の**ライブ実行検証は不可**。各 provider 仕様への準拠 + 単体テスト + レビューで品質を担保している。

Closes #1002
