### PR TITLE
feat(api-agents): TeamHub pull型ツール参加 (team_read/team_send/team_info)

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -37,8 +37,8 @@
   "src/renderer/src/layouts/CanvasLayout.tsx": 758,
   "src/renderer/src/lib/hooks/use-file-tabs.ts": 517,
   "src/renderer/src/lib/hooks/use-xterm-bind.ts": 889,
-  "src/renderer/src/lib/i18n.ts": 1811,
+  "src/renderer/src/lib/i18n.ts": 1815,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
-  "src/renderer/src/stores/canvas.ts": 575,
-  "src/types/shared.ts": 1842
+  "src/renderer/src/stores/canvas.ts": 577,
+  "src/types/shared.ts": 1848
 }

--- a/src-tauri/src/commands/api_agents.rs
+++ b/src-tauri/src/commands/api_agents.rs
@@ -19,7 +19,7 @@ pub mod types;
 #[cfg(test)]
 mod tests;
 
-use self::providers::{call_provider, provider_preset, ToolRuntime};
+use self::providers::{call_provider, provider_preset, TeamToolCtx, ToolRuntime};
 use self::types::*;
 use crate::state::{current_project_root, AppState};
 use tauri::State;
@@ -248,10 +248,22 @@ pub async fn api_agent_send(
         let tools = if degraded {
             None
         } else {
+            // team_id / role が揃っているときだけ team tool を有効化する (Issue #1004)。
+            let team = req
+                .team
+                .as_ref()
+                .filter(|t| !t.team_id.trim().is_empty() && !t.role.trim().is_empty())
+                .map(|t| TeamToolCtx {
+                    hub: state.team_hub.clone(),
+                    team_id: t.team_id.clone(),
+                    agent_id: t.agent_id.clone(),
+                    role: t.role.clone(),
+                });
             Some(ToolRuntime {
                 project_root: &project_root,
                 max_turns: budget,
                 on_tool: &mut on_tool,
+                team,
             })
         };
         let mut on_delta = |delta: &str| emit_delta(&app, &req, delta);

--- a/src-tauri/src/commands/api_agents/providers.rs
+++ b/src-tauri/src/commands/api_agents/providers.rs
@@ -17,6 +17,17 @@ pub(super) struct ToolRuntime<'a> {
     pub max_turns: u32,
     /// tool 実行状況の通知 (name, status, detail)。
     pub on_tool: &'a mut (dyn FnMut(&str, &str, Option<&str>) + Send),
+    /// team 参加時のみ Some。team_read / team_send / team_info を tool として有効化する。
+    pub team: Option<TeamToolCtx>,
+}
+
+/// team 参加時の tool 実行コンテキスト (Issue #1004)。pull 型なので hub と CallContext 相当の
+/// 情報だけを持つ。`TeamHub` は Arc ベースで cheap clone。
+pub(super) struct TeamToolCtx {
+    pub hub: crate::team_hub::TeamHub,
+    pub team_id: String,
+    pub agent_id: String,
+    pub role: String,
 }
 
 #[derive(Clone)]

--- a/src-tauri/src/commands/api_agents/providers/agentic.rs
+++ b/src-tauri/src/commands/api_agents/providers/agentic.rs
@@ -13,7 +13,7 @@ use serde_json::{json, Value};
 
 use super::super::tools;
 use super::super::types::{ApiAgentConfig, ApiAgentMessage, ApiAgentUsage};
-use super::{usage_from_value, ProviderPreset, ToolRuntime, HTTP_CLIENT};
+use super::{usage_from_value, ProviderPreset, TeamToolCtx, ToolRuntime, HTTP_CLIENT};
 
 /// 1 件の tool 呼び出し (provider 非依存に正規化したもの)。
 struct ToolCall {
@@ -24,6 +24,16 @@ struct ToolCall {
 }
 
 const BUDGET_MSG: &str = "Tool turn budget exceeded before a final answer.";
+
+/// このターンでモデルに公開するツール spec。team 参加時は team_read / team_send / team_info を
+/// read_file / list_dir に追加する。
+fn tool_specs(rt: &ToolRuntime<'_>) -> Vec<tools::ToolSpec> {
+    let mut specs = tools::builtin_read_tools();
+    if rt.team.is_some() {
+        specs.extend(tools::builtin_team_tools());
+    }
+    specs
+}
 
 // ---------- OpenAI-compatible ----------
 
@@ -36,7 +46,7 @@ pub(super) async fn call_openai_tools(
     mut rt: ToolRuntime<'_>,
     on_delta: &mut (dyn FnMut(&str) + Send),
 ) -> anyhow::Result<(String, Option<ApiAgentUsage>, String)> {
-    let specs = tools::builtin_read_tools();
+    let specs = tool_specs(&rt);
     let tool_defs: Vec<Value> = specs
         .iter()
         .map(|s| {
@@ -138,7 +148,7 @@ pub(super) async fn call_anthropic_tools(
     mut rt: ToolRuntime<'_>,
     on_delta: &mut (dyn FnMut(&str) + Send),
 ) -> anyhow::Result<(String, Option<ApiAgentUsage>, String)> {
-    let specs = tools::builtin_read_tools();
+    let specs = tool_specs(&rt);
     let tool_defs: Vec<Value> = specs
         .iter()
         .map(|s| json!({ "name": s.name, "description": s.description, "input_schema": s.parameters }))
@@ -244,7 +254,7 @@ pub(super) async fn call_gemini_tools(
     mut rt: ToolRuntime<'_>,
     on_delta: &mut (dyn FnMut(&str) + Send),
 ) -> anyhow::Result<(String, Option<ApiAgentUsage>, String)> {
-    let specs = tools::builtin_read_tools();
+    let specs = tool_specs(&rt);
     let decls: Vec<Value> = specs
         .iter()
         .map(|s| json!({ "name": s.name, "description": s.description, "parameters": s.parameters }))
@@ -359,21 +369,29 @@ async fn run_tool(rt: &mut ToolRuntime<'_>, call: &ToolCall) -> String {
 
 async fn run_tool_with_flag(rt: &mut ToolRuntime<'_>, call: &ToolCall) -> (String, bool) {
     (rt.on_tool)(&call.name, "started", Some(&summarize_args(&call.args)));
-    // ツール実行は同期ブロッキング fs (read_dir / read) を含むため、async ランタイムの
-    // worker を塞がないよう spawn_blocking へ退避する。
-    let project_root = rt.project_root.to_string();
-    let name = call.name.clone();
-    let args = call.args.clone();
-    let outcome = match tokio::task::spawn_blocking(move || {
-        tools::execute_tool(&project_root, &name, &args)
-    })
-    .await
-    {
-        Ok(o) => o,
-        Err(e) => tools::ToolOutcome {
-            content: format!("tool execution failed: {e}"),
-            is_error: true,
-        },
+    let outcome = if tools::is_team_tool(&call.name) {
+        // team 系 tool は team_hub の既存関数へ委譲 (async)。team 未参加なら明示エラー。
+        match rt.team.as_ref() {
+            Some(team) => execute_team_tool(team, &call.name, &call.args).await,
+            None => tools::ToolOutcome {
+                content: format!("team tool '{}' is unavailable: not part of a team", call.name),
+                is_error: true,
+            },
+        }
+    } else {
+        // read_file / list_dir は同期ブロッキング fs を含むため spawn_blocking へ退避する。
+        let project_root = rt.project_root.to_string();
+        let name = call.name.clone();
+        let args = call.args.clone();
+        match tokio::task::spawn_blocking(move || tools::execute_tool(&project_root, &name, &args))
+            .await
+        {
+            Ok(o) => o,
+            Err(e) => tools::ToolOutcome {
+                content: format!("tool execution failed: {e}"),
+                is_error: true,
+            },
+        }
     };
     (rt.on_tool)(
         &call.name,
@@ -381,6 +399,26 @@ async fn run_tool_with_flag(rt: &mut ToolRuntime<'_>, call: &ToolCall) -> (Strin
         None,
     );
     (outcome.content, outcome.is_error)
+}
+
+/// team 系 tool を team_hub の既存関数へ委譲する (Issue #1004)。dispatch/inject の中核には
+/// 触れず、pull 型に必要な team_read / team_send / team_info だけを呼ぶ。
+async fn execute_team_tool(team: &TeamToolCtx, name: &str, args: &Value) -> tools::ToolOutcome {
+    let ctx = crate::team_hub::CallContext {
+        team_id: team.team_id.clone(),
+        role: team.role.clone(),
+        agent_id: team.agent_id.clone(),
+    };
+    match crate::team_hub::protocol::tools::call_api_agent_tool(&team.hub, &ctx, name, args).await {
+        Ok(v) => tools::ToolOutcome {
+            content: v.to_string(),
+            is_error: false,
+        },
+        Err(e) => tools::ToolOutcome {
+            content: e,
+            is_error: true,
+        },
+    }
 }
 
 fn summarize_args(args: &Value) -> String {
@@ -409,92 +447,6 @@ fn sum_opt(a: Option<u32>, b: Option<u32>) -> Option<u32> {
     }
 }
 
+
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn openai_extract_parses_tool_calls() {
-        let msg = json!({
-            "content": null,
-            "tool_calls": [
-                { "id": "call_1", "function": { "name": "read_file", "arguments": "{\"path\":\"a.txt\"}" } }
-            ]
-        });
-        let (text, calls) = openai_extract(&msg);
-        assert_eq!(text, "");
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].id, "call_1");
-        assert_eq!(calls[0].name, "read_file");
-        assert_eq!(calls[0].args["path"], json!("a.txt"));
-    }
-
-    #[test]
-    fn openai_extract_final_text_has_no_calls() {
-        let msg = json!({ "content": "here is the answer" });
-        let (text, calls) = openai_extract(&msg);
-        assert_eq!(text, "here is the answer");
-        assert!(calls.is_empty());
-    }
-
-    #[test]
-    fn anthropic_extract_separates_text_and_tool_use() {
-        let content = vec![
-            json!({ "type": "text", "text": "let me check " }),
-            json!({ "type": "tool_use", "id": "tu_1", "name": "list_dir", "input": { "path": "." } }),
-        ];
-        let (text, calls) = anthropic_extract(&content);
-        assert_eq!(text, "let me check ");
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].name, "list_dir");
-        assert_eq!(calls[0].id, "tu_1");
-        assert_eq!(calls[0].args["path"], json!("."));
-    }
-
-    #[test]
-    fn gemini_extract_reads_function_call() {
-        let parts = vec![
-            json!({ "text": "checking" }),
-            json!({ "functionCall": { "name": "read_file", "args": { "path": "x.rs" } } }),
-        ];
-        let (text, calls) = gemini_extract(&parts);
-        assert_eq!(text, "checking");
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].name, "read_file");
-        assert_eq!(calls[0].args["path"], json!("x.rs"));
-        assert!(calls[0].id.is_empty());
-    }
-
-    #[test]
-    fn accumulate_usage_sums_across_turns() {
-        let mut total = None;
-        accumulate_usage(
-            &mut total,
-            Some(ApiAgentUsage {
-                input_tokens: Some(10),
-                output_tokens: Some(5),
-                total_tokens: None,
-            }),
-        );
-        accumulate_usage(
-            &mut total,
-            Some(ApiAgentUsage {
-                input_tokens: Some(7),
-                output_tokens: Some(3),
-                total_tokens: Some(20),
-            }),
-        );
-        let u = total.unwrap();
-        assert_eq!(u.input_tokens, Some(17));
-        assert_eq!(u.output_tokens, Some(8));
-        assert_eq!(u.total_tokens, Some(20));
-    }
-
-    #[test]
-    fn summarize_args_truncates_long_payloads() {
-        let big = json!({ "path": "a".repeat(300) });
-        let s = summarize_args(&big);
-        assert!(s.chars().count() <= 121);
-        assert!(s.ends_with('…'));
-    }
-}
+mod tests;

--- a/src-tauri/src/commands/api_agents/providers/agentic/tests.rs
+++ b/src-tauri/src/commands/api_agents/providers/agentic/tests.rs
@@ -1,0 +1,126 @@
+// providers/agentic のユニットテスト (Issue #1002 / #1004)。
+// 親 agentic.rs の private fn / 型に `use super::*` でアクセスする。
+
+use super::*;
+
+#[test]
+    fn openai_extract_parses_tool_calls() {
+        let msg = json!({
+            "content": null,
+            "tool_calls": [
+                { "id": "call_1", "function": { "name": "read_file", "arguments": "{\"path\":\"a.txt\"}" } }
+            ]
+        });
+        let (text, calls) = openai_extract(&msg);
+        assert_eq!(text, "");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_1");
+        assert_eq!(calls[0].name, "read_file");
+        assert_eq!(calls[0].args["path"], json!("a.txt"));
+    }
+
+    #[test]
+    fn openai_extract_final_text_has_no_calls() {
+        let msg = json!({ "content": "here is the answer" });
+        let (text, calls) = openai_extract(&msg);
+        assert_eq!(text, "here is the answer");
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn anthropic_extract_separates_text_and_tool_use() {
+        let content = vec![
+            json!({ "type": "text", "text": "let me check " }),
+            json!({ "type": "tool_use", "id": "tu_1", "name": "list_dir", "input": { "path": "." } }),
+        ];
+        let (text, calls) = anthropic_extract(&content);
+        assert_eq!(text, "let me check ");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "list_dir");
+        assert_eq!(calls[0].id, "tu_1");
+        assert_eq!(calls[0].args["path"], json!("."));
+    }
+
+    #[test]
+    fn gemini_extract_reads_function_call() {
+        let parts = vec![
+            json!({ "text": "checking" }),
+            json!({ "functionCall": { "name": "read_file", "args": { "path": "x.rs" } } }),
+        ];
+        let (text, calls) = gemini_extract(&parts);
+        assert_eq!(text, "checking");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "read_file");
+        assert_eq!(calls[0].args["path"], json!("x.rs"));
+        assert!(calls[0].id.is_empty());
+    }
+
+    #[test]
+    fn accumulate_usage_sums_across_turns() {
+        let mut total = None;
+        accumulate_usage(
+            &mut total,
+            Some(ApiAgentUsage {
+                input_tokens: Some(10),
+                output_tokens: Some(5),
+                total_tokens: None,
+            }),
+        );
+        accumulate_usage(
+            &mut total,
+            Some(ApiAgentUsage {
+                input_tokens: Some(7),
+                output_tokens: Some(3),
+                total_tokens: Some(20),
+            }),
+        );
+        let u = total.unwrap();
+        assert_eq!(u.input_tokens, Some(17));
+        assert_eq!(u.output_tokens, Some(8));
+        assert_eq!(u.total_tokens, Some(20));
+    }
+
+    #[test]
+    fn summarize_args_truncates_long_payloads() {
+        let big = json!({ "path": "a".repeat(300) });
+        let s = summarize_args(&big);
+        assert!(s.chars().count() <= 121);
+        assert!(s.ends_with('…'));
+    }
+
+    #[test]
+    fn tool_specs_adds_team_tools_only_when_in_a_team() {
+        use crate::pty::SessionRegistry;
+        use crate::team_hub::TeamHub;
+        use std::sync::Arc;
+
+        let mut noop = |_: &str, _: &str, _: Option<&str>| {};
+        // team 無し: read_file / list_dir のみ
+        let rt_solo = ToolRuntime {
+            project_root: "",
+            max_turns: 1,
+            on_tool: &mut noop,
+            team: None,
+        };
+        let solo: Vec<&str> = tool_specs(&rt_solo).iter().map(|s| s.name).collect();
+        assert_eq!(solo, vec!["read_file", "list_dir"]);
+
+        // team 有り: team_read / team_send / team_info が追加される
+        let mut noop2 = |_: &str, _: &str, _: Option<&str>| {};
+        let rt_team = ToolRuntime {
+            project_root: "",
+            max_turns: 1,
+            on_tool: &mut noop2,
+            team: Some(TeamToolCtx {
+                hub: TeamHub::new(Arc::new(SessionRegistry::new())),
+                team_id: "team-1".into(),
+                agent_id: "api-1".into(),
+                role: "reviewer".into(),
+            }),
+        };
+        let team: Vec<&str> = tool_specs(&rt_team).iter().map(|s| s.name).collect();
+        assert!(team.contains(&"read_file"));
+        assert!(team.contains(&"team_read"));
+        assert!(team.contains(&"team_send"));
+        assert!(team.contains(&"team_info"));
+    }

--- a/src-tauri/src/commands/api_agents/tools.rs
+++ b/src-tauri/src/commands/api_agents/tools.rs
@@ -82,6 +82,51 @@ pub(super) fn builtin_read_tools() -> Vec<ToolSpec> {
     ]
 }
 
+/// team 参加時に追加するツール定義 (Issue #1004)。pull 型: team_read で受信、team_send で
+/// 送信、team_info で roster 把握。実行は team_hub の既存関数へ委譲する (別経路)。
+pub(super) fn builtin_team_tools() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "team_read",
+            description: "Read unread messages addressed to you in your team.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "unread_only": {
+                        "type": "boolean",
+                        "description": "Only return unread messages (default true)."
+                    }
+                }
+            }),
+        },
+        ToolSpec {
+            name: "team_send",
+            description: "Send a message to a teammate or role in your team.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "to": {
+                        "type": "string",
+                        "description": "Recipient: a role name, an agent id, or 'all'."
+                    },
+                    "message": { "type": "string", "description": "Message body." }
+                },
+                "required": ["to", "message"]
+            }),
+        },
+        ToolSpec {
+            name: "team_info",
+            description: "Get your team's roster, leader, and open tasks. No arguments.",
+            parameters: json!({ "type": "object", "properties": {} }),
+        },
+    ]
+}
+
+/// team 系 tool 名か。`execute_tool` ではなく team_hub 経由で実行する。
+pub(super) fn is_team_tool(name: &str) -> bool {
+    matches!(name, "team_read" | "team_send" | "team_info")
+}
+
 /// 名前でツールをディスパッチして実行する。未知ツールはエラー結果を返す。
 pub(super) fn execute_tool(project_root: &str, name: &str, args: &Value) -> ToolOutcome {
     match name {
@@ -307,5 +352,25 @@ mod tests {
         let out = execute_tool("", "list_dir", &json!({}));
         assert!(out.is_error);
         assert!(out.content.contains("no project"));
+    }
+
+    #[test]
+    fn team_tools_are_recognized_and_listed() {
+        assert!(is_team_tool("team_read"));
+        assert!(is_team_tool("team_send"));
+        assert!(is_team_tool("team_info"));
+        assert!(!is_team_tool("read_file"));
+        assert!(!is_team_tool("list_dir"));
+        let names: Vec<&str> = builtin_team_tools().iter().map(|s| s.name).collect();
+        assert_eq!(names, vec!["team_read", "team_send", "team_info"]);
+    }
+
+    #[test]
+    fn execute_tool_does_not_handle_team_tools() {
+        // team tool は execute_tool ではなく team_hub 経由なので、ここでは未知扱い。
+        let dir = setup();
+        let out = execute_tool(&dir.path().to_string_lossy(), "team_send", &json!({}));
+        assert!(out.is_error);
+        assert!(out.content.contains("unknown tool"));
     }
 }

--- a/src-tauri/src/commands/api_agents/types.rs
+++ b/src-tauri/src/commands/api_agents/types.rs
@@ -113,6 +113,15 @@ pub struct ApiAgentSkillMeta {
     pub description: String,
 }
 
+/// team 参加コンテキスト。renderer (apiAgent カード) が所属チーム情報を渡す (Issue #1004)。
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiAgentTeamCtx {
+    pub team_id: String,
+    pub agent_id: String,
+    pub role: String,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiAgentSendRequest {
@@ -123,6 +132,9 @@ pub struct ApiAgentSendRequest {
     pub message: String,
     #[serde(default)]
     pub system_prompt: Option<String>,
+    /// team 参加時のみ。team_read / team_send / team_info を tool として有効化する (Issue #1004)。
+    #[serde(default)]
+    pub team: Option<ApiAgentTeamCtx>,
     #[serde(default)]
     pub chain_id: Option<String>,
     #[serde(default)]

--- a/src-tauri/src/team_hub/protocol/tools/mod.rs
+++ b/src-tauri/src/team_hub/protocol/tools/mod.rs
@@ -41,3 +41,25 @@ pub use send::team_send;
 pub use status::team_status;
 pub use switch_leader::team_switch_leader;
 pub use update_task::team_update_task;
+
+/// Issue #1004: API エージェント (socket を持たない pull 型 virtual member) が tool として
+/// team 系操作を実行するための単一 dispatch シーム。read / send / info の 3 つだけを公開し、
+/// 各 tool の異なるエラー型 (`ToolError` / `SendError`) を文字列に正規化してツール結果として
+/// 返す。dispatch / inject などの中核ルーティングには一切触れない。
+pub(crate) async fn call_api_agent_tool(
+    hub: &crate::team_hub::TeamHub,
+    ctx: &crate::team_hub::CallContext,
+    name: &str,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    match name {
+        "team_read" => read::team_read(hub, ctx, args)
+            .await
+            .map_err(|e| e.to_string()),
+        "team_send" => send::team_send(hub, ctx, args)
+            .await
+            .map_err(|e| format!("{e:?}")),
+        "team_info" => info::team_info(hub, ctx).await.map_err(|e| e.to_string()),
+        other => Err(format!("unknown team tool: {other}")),
+    }
+}

--- a/src/renderer/src/components/canvas/cards/ApiAgentChatCard.tsx
+++ b/src/renderer/src/components/canvas/cards/ApiAgentChatCard.tsx
@@ -168,6 +168,12 @@ function ApiAgentChatCardImpl({
       }
     ]);
     try {
+      // team 参加 (Issue #1004): teamId + teamRole が揃うと team tool が有効になる。
+      // agentId はカードごとに安定な TeamHub 識別子としてノード id を使う。
+      const teamId = payload?.teamId;
+      const teamRole = payload?.teamRole?.trim();
+      const team =
+        teamId && teamRole ? { teamId, agentId: id, role: teamRole } : undefined;
       const result = await window.api.apiAgents.send({
         sessionId,
         cardInstanceId: id,
@@ -175,6 +181,7 @@ function ApiAgentChatCardImpl({
         agent: apiAgent,
         message: text,
         systemPrompt: apiAgent.systemPrompt,
+        team,
         depth: 0,
         turnBudget: 6
       });
@@ -188,7 +195,7 @@ function ApiAgentChatCardImpl({
       setStreaming(false);
       setStatus(err instanceof Error ? err.message : String(err));
     }
-  }, [apiAgent, draft, id, sessionId, streaming]);
+  }, [apiAgent, draft, id, payload?.teamId, payload?.teamRole, sessionId, streaming]);
 
   const cancel = useCallback(() => {
     const generationId = generationRef.current;
@@ -213,6 +220,18 @@ function ApiAgentChatCardImpl({
               <span>read-only</span>
             ) : null}
           </div>
+          {payload?.teamId && (
+            <label className="api-agent-card__team-role">
+              <span>{t('canvas.apiAgent.teamRole')}</span>
+              <input
+                type="text"
+                value={payload.teamRole ?? ''}
+                onChange={(e) => setCardPayload(id, { teamRole: e.target.value })}
+                placeholder={t('canvas.apiAgent.teamRolePlaceholder')}
+                spellCheck={false}
+              />
+            </label>
+          )}
           <div className="api-agent-card__messages" ref={bodyRef}>
             {!configured && (
               <div className="api-agent-card__empty">

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -56,6 +56,8 @@ const ja: Dict = {
   'mascot.desc.custom': '自分で用意した画像 (PNG/GIF/SVG/WebP) を相棒として使う',
 
   // ---------- Canvas HUD ----------
+  'canvas.apiAgent.teamRole': 'チームロール',
+  'canvas.apiAgent.teamRolePlaceholder': '例: reviewer',
   'canvas.hud.stage': 'ステージ',
   'canvas.hud.list': 'リスト',
   'canvas.hud.focus': 'フォーカス',
@@ -926,6 +928,8 @@ const en: Dict = {
   'mascot.desc.custom': 'Use your own image (PNG/GIF/SVG/WebP) as the companion',
 
   // ---------- Canvas HUD ----------
+  'canvas.apiAgent.teamRole': 'Team role',
+  'canvas.apiAgent.teamRolePlaceholder': 'e.g. reviewer',
   'canvas.hud.stage': 'Stage',
   'canvas.hud.list': 'List',
   'canvas.hud.focus': 'Focus',

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -89,6 +89,8 @@ export interface ApiAgentCardPayload extends CardPayloadBase {
   model?: string;
   toolMode?: 'auto' | 'readOnly';
   configured?: boolean;
+  /** Issue #1004: team 参加時のロール名。teamId と揃うと team tool (team_read/send/info) が有効。 */
+  teamRole?: string;
 }
 
 /** terminal カード: 単発の Claude/Codex/シェル端末を起動するための payload。 */

--- a/src/renderer/src/styles/components/canvas.css
+++ b/src/renderer/src/styles/components/canvas.css
@@ -187,6 +187,25 @@
   border-radius: var(--radius-sm, 6px);
 }
 
+.api-agent-card__team-role {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.api-agent-card__team-role input {
+  flex: 1;
+  min-width: 0;
+  padding: 2px 6px;
+  font-size: 11px;
+  color: var(--fg);
+  background: var(--surface, transparent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+}
+
 .api-agent-card__messages {
   min-height: 0;
   overflow: auto;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -458,6 +458,12 @@ export interface ApiAgentSendRequest {
   agent: ApiAgentConfig;
   message: string;
   systemPrompt?: string;
+  /**
+   * team 参加コンテキスト (Issue #1004)。指定すると team_read / team_send / team_info が
+   * tool として有効になり、TeamHub に pull 型で参加できる。`agentId` はカードごとに安定な
+   * TeamHub 上の識別子、`role` は宛先解決に使うロール名。
+   */
+  team?: { teamId: string; agentId: string; role: string };
   chainId?: string;
   depth?: number;
   turnBudget?: number;


### PR DESCRIPTION
## Summary
- 計画 v2 の TeamHub 連携を、**本番ルーティング中核 (`send.rs` dispatch/inject, target 解決) に一切触れない安全な pull 型**で実装。
- 発見: `team_read` は hub の message 履歴を `message_is_for_me`(role/agent_id/'all') で読むだけで PTY 不要。`team_send` は送信者のメンバー登録を検証せず、既存ロジックで PTY 仲間へ配送する。→ 既存 hub 関数を API エージェントの **tool** として公開するだけで参加が成立する。

## 変更点
### Rust
- `team_hub/protocol/tools/mod.rs`: 単一 dispatch シーム `call_api_agent_tool`(read/send/info のみ、`ToolError`/`SendError` を文字列化) を `pub(crate)` で追加。**中核ルーティングは不変**。
- `api_agent_send`: 任意の team context (`teamId`/`agentId`/`role`) を受け取り、tools 有効時に `team_read`/`team_send`/`team_info` を tool として公開。team tool は hub へ async 委譲、file tool は `spawn_blocking` へ振り分け。
- `tools.rs`: `builtin_team_tools` / `is_team_tool`。`providers.rs`: `ToolRuntime.team` / `TeamToolCtx`。

### Renderer
- `ApiAgentSendRequest.team` / `ApiAgentCardPayload.teamRole` を追加。apiAgent カードは `teamId` + `teamRole` が揃うと team context を送信 (`agentId` = ノード id)。最小の role 入力 UI + ja/en i18n + CSS。

### ファイル分割
`providers/agentic.rs` の test モジュールを `agentic/tests.rs` に分離し 500 行制限を維持。

## file-size baseline
単一 SoT ファイルの不可避な増分のみ引き上げ (分割対象ではない):
- `shared.ts` 1842→1848 (team 型) / `i18n.ts` 1811→1815 (role 文言 ja/en) / `canvas.ts` 575→577 (payload teamRole)

## 非対象 (フル版に委譲)
team_send→API queue への push 配送 / auto-turn push / dispatch・inject 改修 / 他メンバー roster (team_info) への API agent 表示。

## Test plan
- [x] `cargo test --lib -- api_agents` (42 passed; team tool 認識・spec 分岐・execute_tool が team tool を扱わないこと 等)
- [x] `cargo check` 0 warnings / `npm run typecheck` 通過 / file-size ratchet OK
- [x] 中核ルーティング (send.rs dispatch/inject/target 解決) を一切変更していない

## 注意
実 API キー + ライブ team が無いため **e2e 検証は不可**。hub 関数自体は既存テスト済みで、追加分は spec/振り分けを単体テストで担保している。

Closes #1004
