### PR TITLE
feat(api-agents): vibe-editor専用skillフォルダ + Claude/Codex skillのimport

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -11,7 +11,7 @@
   "src-tauri/src/commands/terminal/command_validation.rs": 916,
   "src-tauri/src/commands/terminal_tabs.rs": 817,
   "src-tauri/src/commands/voice.rs": 550,
-  "src-tauri/src/lib.rs": 516,
+  "src-tauri/src/lib.rs": 519,
   "src-tauri/src/pty/claude_watcher.rs": 609,
   "src-tauri/src/pty/codex_broker.rs": 506,
   "src-tauri/src/pty/codex_watcher.rs": 626,
@@ -37,8 +37,8 @@
   "src/renderer/src/layouts/CanvasLayout.tsx": 758,
   "src/renderer/src/lib/hooks/use-file-tabs.ts": 517,
   "src/renderer/src/lib/hooks/use-xterm-bind.ts": 889,
-  "src/renderer/src/lib/i18n.ts": 1815,
+  "src/renderer/src/lib/i18n.ts": 1830,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
   "src/renderer/src/stores/canvas.ts": 577,
-  "src/types/shared.ts": 1848
+  "src/types/shared.ts": 1866
 }

--- a/src-tauri/src/commands/api_agents.rs
+++ b/src-tauri/src/commands/api_agents.rs
@@ -222,10 +222,11 @@ pub async fn api_agent_send(
     }
 
     let key = read_key(&req.agent.provider_id).await?;
-    // Issue #998: 選択 skill + 自動 vibe-team の SKILL.md 本文をサーバ側で読み込む。
+    // project_root は team の read_file / list_dir tool が参照する (Issue #1004)。
     let project_root = current_project_root(&state.project_root).unwrap_or_default();
+    // Issue #998/#1017: 選択 skill + 自動 vibe-team の本文を vibe-editor 専用フォルダから読む。
     let loaded_skills =
-        skills::load_skill_bodies(&project_root, req.agent.skill_ids.as_deref().unwrap_or(&[])).await;
+        skills::load_skill_bodies(req.agent.skill_ids.as_deref().unwrap_or(&[])).await;
     let skills_text = build_skills_context(&loaded_skills);
     let system_prompt = [
         req.system_prompt.as_deref().unwrap_or("").trim(),

--- a/src-tauri/src/commands/api_agents/skills.rs
+++ b/src-tauri/src/commands/api_agents/skills.rs
@@ -1,64 +1,185 @@
-// api_agents/skills — SKILL.md の列挙と読み込み (Issue #998)。
+// api_agents/skills — vibe-editor 専用 skill フォルダの列挙/読み込みと、Claude/Codex skill の
+// import (Issue #998 / #1017)。
+//
+// 構成:
+//   - API エージェントが読む skill ソースは vibe-editor 専用フォルダ `~/.vibe-editor/skills`。
+//   - import 元は Claude (`~/.claude/skills`, `<project>/.claude/skills`) と
+//     Codex (`~/.agents/skills`, `<project>/.agents/skills`)。設定からコピー (snapshot) する。
 //
 // セキュリティ方針:
-//   - 参照するのは active project root (`state` の信頼値) 配下の `.claude/skills/<id>/SKILL.md`
-//     のみ。renderer からパスを受け取らない。
-//   - skill id は `is_valid_id_segment` で検証し、`..` / `/` を含む traversal を拒否する。
-//   - SKILL.md 読み込みはサイズ上限でキャップする (巨大ファイルでの OOM 回避)。
+//   - skill id は `is_valid_id_segment` で検証し、`..` / `/` を含む traversal を拒否。
+//   - 各 skills root を canonicalize し、SKILL.md の実体が root 配下に収まることを検証して
+//     symlink escape を拒否 (canonicalize 後の実体パスを read するため TOCTOU も回避)。
+//   - SKILL.md 読み込みはサイズ上限でキャップ (巨大ファイルでの OOM 回避)。
 
+use crate::commands::atomic_write::atomic_write;
 use crate::commands::error::{CommandError, CommandResult};
 use crate::commands::validation::is_valid_id_segment;
 use crate::state::{current_project_root, AppState};
+use crate::util::config_paths;
 use std::path::{Path, PathBuf};
 use tauri::State;
 use tokio::fs;
 
-use super::types::{ApiAgentSkill, ApiAgentSkillMeta};
+use super::types::{ApiAgentSkill, ApiAgentSkillMeta, ImportSkillRequest, ImportableSkill};
 
-/// 1 つの SKILL.md から読み込む最大バイト数。context budget (`MAX_SKILL_BYTES`) とは別で、
-/// ここでは「異常に巨大なファイルを丸読みしない」ための I/O 上限。
+/// 1 つの SKILL.md から読み込む最大バイト数。
 const MAX_SKILL_FILE_BYTES: usize = 256 * 1024;
 
 /// TeamHub 参加時に自動追加する skill。
 pub(super) const VIBE_TEAM_SKILL_ID: &str = "vibe-team";
 
-fn skills_root(project_root: &str) -> PathBuf {
-    Path::new(project_root).join(".claude").join("skills")
+// ============================================================
+// 専用フォルダ (API エージェントが読む skill ソース)
+// ============================================================
+
+/// vibe-editor 専用 skill フォルダ (`~/.vibe-editor/skills`) の skill 一覧を返す。
+#[tauri::command]
+pub async fn api_agent_skill_list() -> CommandResult<Vec<ApiAgentSkillMeta>> {
+    Ok(list_skills_in(&config_paths::vibe_skills_dir()).await)
 }
 
-/// active project の `.claude/skills/*/SKILL.md` を列挙し、選択可能な skill 一覧を返す。
-/// プロジェクト未選択 / skills ディレクトリ無しのときは空配列。
-#[tauri::command]
-pub async fn api_agent_skill_list(
-    state: State<'_, AppState>,
-) -> CommandResult<Vec<ApiAgentSkillMeta>> {
-    let root = current_project_root(&state.project_root).unwrap_or_default();
-    let root = root.trim();
-    if root.is_empty() {
-        return Ok(Vec::new());
+/// `api_agent_send` から呼ぶ内部ヘルパ。選択された `skill_ids` + 自動 `vibe-team` の本文を、
+/// 専用フォルダから読み込んで返す。無効 id / 不在ファイルはスキップ。`vibe-team` だけは
+/// ファイルが無ければバンドル本文へフォールバックする。
+pub(super) async fn load_skill_bodies(skill_ids: &[String]) -> Vec<ApiAgentSkill> {
+    load_skill_bodies_from(&config_paths::vibe_skills_dir(), skill_ids).await
+}
+
+// ============================================================
+// import 元 (Claude / Codex) の列挙と import / remove
+// ============================================================
+
+/// import 候補の skills root を (source, scope, path) で返す。project root が空ならユーザー
+/// スコープのみ。project を user より先に並べて「project 優先」の重複排除を可能にする。
+fn source_roots(project_root: &str) -> Vec<(&'static str, &'static str, PathBuf)> {
+    let home = config_paths::home_dir();
+    let pr = project_root.trim();
+    let mut roots: Vec<(&'static str, &'static str, PathBuf)> = Vec::new();
+    if !pr.is_empty() {
+        roots.push(("claude", "project", Path::new(pr).join(".claude").join("skills")));
+        roots.push(("codex", "project", Path::new(pr).join(".agents").join("skills")));
     }
-    let dir = skills_root(root);
-    // symlink escape を防ぐため skills root を canonicalize し、配下封じ込めの基準にする。
-    let dir_canon = match fs::canonicalize(&dir).await {
-        Ok(p) => p,
-        Err(_) => return Ok(Vec::new()), // skills ディレクトリが無い
+    roots.push(("claude", "user", home.join(".claude").join("skills")));
+    roots.push(("codex", "user", home.join(".agents").join("skills")));
+    roots
+}
+
+/// Claude / Codex の取り込み元 skill を列挙する。(source, id) で重複排除 (project 優先)。
+#[tauri::command]
+pub async fn api_agent_skill_sources_list(
+    state: State<'_, AppState>,
+) -> CommandResult<Vec<ImportableSkill>> {
+    let project_root = current_project_root(&state.project_root).unwrap_or_default();
+    let imported: std::collections::HashSet<String> =
+        list_skills_in(&config_paths::vibe_skills_dir())
+            .await
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+
+    let mut out: Vec<ImportableSkill> = Vec::new();
+    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    for (source, scope, root) in source_roots(&project_root) {
+        for meta in list_skills_in(&root).await {
+            let key = (source.to_string(), meta.id.clone());
+            if !seen.insert(key) {
+                continue; // 同 (source, id) は project を優先済み
+            }
+            out.push(ImportableSkill {
+                imported: imported.contains(&meta.id),
+                id: meta.id,
+                name: meta.name,
+                description: meta.description,
+                source: source.to_string(),
+                scope: scope.to_string(),
+            });
+        }
+    }
+    out.sort_by(|a, b| (a.source.clone(), a.id.clone()).cmp(&(b.source.clone(), b.id.clone())));
+    Ok(out)
+}
+
+/// 指定 skill を取り込み元から専用フォルダへコピー (snapshot) する。
+#[tauri::command]
+pub async fn api_agent_skill_import(
+    state: State<'_, AppState>,
+    req: ImportSkillRequest,
+) -> CommandResult<ApiAgentSkillMeta> {
+    if !is_valid_id_segment(&req.id) {
+        return Err(CommandError::validation("invalid skill id"));
+    }
+    if req.source != "claude" && req.source != "codex" {
+        return Err(CommandError::validation("invalid source"));
+    }
+    let project_root = current_project_root(&state.project_root).unwrap_or_default();
+
+    // source の各 root を project 優先で走査し、最初に見つかった SKILL.md を採用する。
+    let mut body: Option<String> = None;
+    for (source, _scope, root) in source_roots(&project_root) {
+        if source != req.source {
+            continue;
+        }
+        let Ok(root_canon) = fs::canonicalize(&root).await else {
+            continue;
+        };
+        let md = root.join(&req.id).join("SKILL.md");
+        if let Some(b) = read_skill_md_within(&root_canon, &md).await {
+            body = Some(b);
+            break;
+        }
+    }
+    let Some(body) = body else {
+        return Err(CommandError::not_found("source skill not found"));
     };
-    let mut rd = match fs::read_dir(&dir).await {
-        Ok(rd) => rd,
-        Err(_) => return Ok(Vec::new()),
+
+    let dest_dir = config_paths::vibe_skills_dir().join(&req.id);
+    fs::create_dir_all(&dest_dir)
+        .await
+        .map_err(|e| CommandError::Io(e.to_string()))?;
+    atomic_write(&dest_dir.join("SKILL.md"), body.as_bytes())
+        .await
+        .map_err(|e| CommandError::internal(e.to_string()))?;
+
+    let (name, description) = parse_skill_meta(&req.id, &body);
+    Ok(ApiAgentSkillMeta {
+        id: req.id,
+        name,
+        description,
+    })
+}
+
+/// 専用フォルダから import 済み skill を削除する。
+#[tauri::command]
+pub async fn api_agent_skill_remove(id: String) -> CommandResult<()> {
+    if !is_valid_id_segment(&id) {
+        return Err(CommandError::validation("invalid skill id"));
+    }
+    let dir = config_paths::vibe_skills_dir().join(&id);
+    match fs::remove_dir_all(&dir).await {
+        Ok(()) | Err(_) => Ok(()), // 不在は成功扱い (冪等)
+    }
+}
+
+// ============================================================
+// 共有ヘルパ
+// ============================================================
+
+/// `dir/<id>/SKILL.md` を列挙して skill メタを返す。dir 不在時は空配列。symlink escape は除外。
+async fn list_skills_in(dir: &Path) -> Vec<ApiAgentSkillMeta> {
+    let Ok(dir_canon) = fs::canonicalize(dir).await else {
+        return Vec::new();
+    };
+    let Ok(mut rd) = fs::read_dir(dir).await else {
+        return Vec::new();
     };
     let mut out: Vec<ApiAgentSkillMeta> = Vec::new();
-    while let Some(entry) = rd
-        .next_entry()
-        .await
-        .map_err(|e| CommandError::Io(e.to_string()))?
-    {
+    while let Ok(Some(entry)) = rd.next_entry().await {
         let id = entry.file_name().to_string_lossy().to_string();
         if !is_valid_id_segment(&id) {
             continue;
         }
         let md = entry.path().join("SKILL.md");
-        // SKILL.md (や中間ディレクトリ) が skills root 外を指す symlink なら読まない。
         let Some(body) = read_skill_md_within(&dir_canon, &md).await else {
             continue;
         };
@@ -70,15 +191,11 @@ pub async fn api_agent_skill_list(
         });
     }
     out.sort_by(|a, b| a.id.cmp(&b.id));
-    Ok(out)
+    out
 }
 
-/// `api_agent_send` から呼ぶ内部ヘルパ。選択された `skill_ids` + 自動 `vibe-team` の
-/// `SKILL.md` 本文を読み込んで返す。無効 id / 不在ファイルはスキップ。`vibe-team` だけは
-/// ディスクに無ければバンドル本文へフォールバックする。
-pub(super) async fn load_skill_bodies(project_root: &str, skill_ids: &[String]) -> Vec<ApiAgentSkill> {
-    let root = project_root.trim();
-    // 重複排除しつつ順序を保つ。
+/// `dir/<id>/SKILL.md` から選択 skill + 自動 vibe-team の本文を読み込む。
+async fn load_skill_bodies_from(dir: &Path, skill_ids: &[String]) -> Vec<ApiAgentSkill> {
     let mut ids: Vec<String> = Vec::new();
     for id in skill_ids {
         if is_valid_id_segment(id) && !ids.iter().any(|x| x == id) {
@@ -89,25 +206,16 @@ pub(super) async fn load_skill_bodies(project_root: &str, skill_ids: &[String]) 
     if !ids.iter().any(|i| i == VIBE_TEAM_SKILL_ID) {
         ids.push(VIBE_TEAM_SKILL_ID.to_string());
     }
-
-    // symlink escape を防ぐため skills root を canonicalize して封じ込め基準にする。
-    let dir_canon = if root.is_empty() {
-        None
-    } else {
-        fs::canonicalize(skills_root(root)).await.ok()
-    };
+    let dir_canon = fs::canonicalize(dir).await.ok();
 
     let mut out: Vec<ApiAgentSkill> = Vec::new();
     for id in ids {
         let disk_body = match &dir_canon {
-            Some(dc) => {
-                read_skill_md_within(dc, &skills_root(root).join(&id).join("SKILL.md")).await
-            }
+            Some(dc) => read_skill_md_within(dc, &dir.join(&id).join("SKILL.md")).await,
             None => None,
         };
         let body = match disk_body {
             Some(b) => b,
-            // vibe-team は disk に無い / 読めない / symlink 拒否のときバンドル本文へフォールバック。
             None if id == VIBE_TEAM_SKILL_ID => {
                 crate::commands::vibe_team_skill::bundled_vibe_team_skill_text()
             }
@@ -119,10 +227,8 @@ pub(super) async fn load_skill_bodies(project_root: &str, skill_ids: &[String]) 
     out
 }
 
-/// `.claude/skills` (canonicalize 済み root) 配下に実体が収まる SKILL.md だけを読む。
-/// SKILL.md 自身や中間ディレクトリが root 外を指す symlink / traversal の場合は `None` を返し、
-/// **読み込まない**。canonicalize 後の実体パスを read するため、検査対象と読み込み対象が
-/// 一致し TOCTOU を避けられる (Issue #998 security review)。
+/// canonicalize 済み skills root 配下に実体が収まる SKILL.md だけを読む。root 外を指す
+/// symlink / traversal は `None` を返し読み込まない。
 async fn read_skill_md_within(skills_root_canon: &Path, md_path: &Path) -> Option<String> {
     let canon = fs::canonicalize(md_path).await.ok()?;
     if !canon.starts_with(skills_root_canon) {
@@ -137,8 +243,7 @@ async fn read_skill_md_within(skills_root_canon: &Path, md_path: &Path) -> Optio
 
 async fn read_capped(path: &Path) -> CommandResult<String> {
     use tokio::io::AsyncReadExt;
-    // サイズキャップを I/O 段階で効かせるため、ファイル全体ではなく先頭
-    // MAX_SKILL_FILE_BYTES だけを読む (巨大ファイルでの無駄な read / alloc を回避)。
+    // サイズキャップを I/O 段階で効かせるため先頭 MAX_SKILL_FILE_BYTES だけ読む。
     let file = fs::File::open(path)
         .await
         .map_err(|e| CommandError::Io(e.to_string()))?;
@@ -147,7 +252,6 @@ async fn read_capped(path: &Path) -> CommandResult<String> {
         .read_to_end(&mut buf)
         .await
         .map_err(|e| CommandError::Io(e.to_string()))?;
-    // 上限でのバイト境界切断は from_utf8_lossy が U+FFFD で吸収する。
     Ok(String::from_utf8_lossy(&buf).to_string())
 }
 
@@ -158,7 +262,6 @@ fn parse_skill_meta(id: &str, body: &str) -> (String, String) {
     let mut description: Option<String> = None;
 
     let trimmed = body.trim_start_matches('\u{feff}');
-    // HTML コメント行 (vibe-team の version マーカー等) は frontmatter 検出前にスキップ。
     let mut lines = trimmed.lines().peekable();
     while let Some(l) = lines.peek() {
         let t = l.trim();
@@ -169,7 +272,7 @@ fn parse_skill_meta(id: &str, body: &str) -> (String, String) {
         }
     }
     if lines.peek().map(|l| l.trim()) == Some("---") {
-        lines.next(); // opening ---
+        lines.next();
         for l in lines.by_ref() {
             let t = l.trim();
             if t == "---" {
@@ -193,7 +296,6 @@ fn parse_skill_meta(id: &str, body: &str) -> (String, String) {
             .unwrap_or("")
             .to_string()
     });
-    // description は selector の subtitle 用途なので適度に短縮。
     let description = truncate_chars(&description, 160);
     (name, description)
 }
@@ -219,124 +321,4 @@ fn truncate_chars(s: &str, max: usize) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_meta_reads_frontmatter() {
-        let body = "---\nname: My Skill\ndescription: \"Does a thing\"\n---\n# Heading\nbody text";
-        let (name, desc) = parse_skill_meta("my-skill", body);
-        assert_eq!(name, "My Skill");
-        assert_eq!(desc, "Does a thing");
-    }
-
-    #[test]
-    fn parse_meta_skips_leading_html_comment() {
-        let body = "<!-- vibe-team-skill-version: 1.6.3 -->\n---\nname: vibe-team\ndescription: team rules\n---\nbody";
-        let (name, desc) = parse_skill_meta("vibe-team", body);
-        assert_eq!(name, "vibe-team");
-        assert_eq!(desc, "team rules");
-    }
-
-    #[test]
-    fn parse_meta_falls_back_without_frontmatter() {
-        let body = "# Title\n\nFirst real line describes it.";
-        let (name, desc) = parse_skill_meta("plain", body);
-        assert_eq!(name, "plain");
-        assert_eq!(desc, "First real line describes it.");
-    }
-
-    #[tokio::test]
-    async fn load_skill_bodies_always_includes_vibe_team_via_bundle() {
-        // 存在しない root なのでディスク読み込みは全て失敗するが、vibe-team は
-        // バンドル本文でフォールバックされて必ず 1 件返る。
-        let skills = load_skill_bodies("/nonexistent-root-xyz", &["unknown".to_string()]).await;
-        assert!(skills.iter().any(|s| s.id == VIBE_TEAM_SKILL_ID));
-        assert!(!skills.iter().any(|s| s.id == "unknown"));
-        let vt = skills.iter().find(|s| s.id == VIBE_TEAM_SKILL_ID).unwrap();
-        assert!(vt.body.contains("vibe-team"));
-    }
-
-    #[tokio::test]
-    async fn load_skill_bodies_reads_disk_skill_and_rejects_traversal() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path().to_string_lossy().to_string();
-        let skill_dir = skills_root(&root).join("my-skill");
-        tokio::fs::create_dir_all(&skill_dir).await.unwrap();
-        tokio::fs::write(
-            skill_dir.join("SKILL.md"),
-            "---\nname: Mine\ndescription: d\n---\nhello body",
-        )
-        .await
-        .unwrap();
-
-        let skills = load_skill_bodies(
-            &root,
-            &["my-skill".to_string(), "../escape".to_string()],
-        )
-        .await;
-        let mine = skills.iter().find(|s| s.id == "my-skill").unwrap();
-        assert_eq!(mine.name, "Mine");
-        assert!(mine.body.contains("hello body"));
-        // traversal id は弾かれる
-        assert!(!skills.iter().any(|s| s.id.contains("..")));
-        // vibe-team は自動追加
-        assert!(skills.iter().any(|s| s.id == VIBE_TEAM_SKILL_ID));
-    }
-
-    /// security: SKILL.md が skills root 外を指す symlink の場合、本文を読み込まない。
-    /// 攻撃 repo を clone → API エージェント利用だけで任意ファイルが流出する経路を塞ぐ。
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn load_skill_bodies_rejects_symlink_escape() {
-        use std::os::unix::fs::symlink;
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path().to_string_lossy().to_string();
-        // プロジェクト内だが .claude/skills の外にある「秘密」ファイル
-        let secret = dir.path().join("secret.txt");
-        tokio::fs::write(&secret, "TOP SECRET KEY").await.unwrap();
-        // SKILL.md を秘密ファイルへの symlink にした悪意ある skill
-        let skill_dir = skills_root(&root).join("evil");
-        tokio::fs::create_dir_all(&skill_dir).await.unwrap();
-        symlink(&secret, skill_dir.join("SKILL.md")).unwrap();
-
-        let skills = load_skill_bodies(&root, &["evil".to_string()]).await;
-        // evil は拒否され、どの skill 本文にも秘密が混入しない
-        assert!(!skills.iter().any(|s| s.id == "evil"));
-        assert!(!skills.iter().any(|s| s.body.contains("TOP SECRET")));
-        // vibe-team の自動追加は維持される (バンドル本文)
-        assert!(skills.iter().any(|s| s.id == VIBE_TEAM_SKILL_ID));
-    }
-
-    /// security: skills root 内に収まる正当な symlink は許可される (dotfiles 運用等)。
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn load_skill_bodies_allows_symlink_within_root() {
-        use std::os::unix::fs::symlink;
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path().to_string_lossy().to_string();
-        let real_dir = skills_root(&root).join("real");
-        tokio::fs::create_dir_all(&real_dir).await.unwrap();
-        tokio::fs::write(real_dir.join("SKILL.md"), "inside body")
-            .await
-            .unwrap();
-        // skills root 内で real/SKILL.md を指す symlink ファイル
-        let alias_dir = skills_root(&root).join("alias");
-        tokio::fs::create_dir_all(&alias_dir).await.unwrap();
-        symlink(real_dir.join("SKILL.md"), alias_dir.join("SKILL.md")).unwrap();
-
-        let skills = load_skill_bodies(&root, &["alias".to_string()]).await;
-        let alias = skills.iter().find(|s| s.id == "alias").unwrap();
-        assert!(alias.body.contains("inside body"));
-    }
-
-    #[tokio::test]
-    async fn read_capped_limits_size() {
-        let dir = tempfile::tempdir().unwrap();
-        let p = dir.path().join("big.md");
-        let big = "x".repeat(MAX_SKILL_FILE_BYTES * 2);
-        tokio::fs::write(&p, &big).await.unwrap();
-        let out = read_capped(&p).await.unwrap();
-        assert!(out.len() <= MAX_SKILL_FILE_BYTES);
-    }
-}
+mod tests;

--- a/src-tauri/src/commands/api_agents/skills/tests.rs
+++ b/src-tauri/src/commands/api_agents/skills/tests.rs
@@ -1,0 +1,138 @@
+// api_agents/skills のユニットテスト (Issue #998 / #1017)。
+// 親 skills.rs の private fn / 型に `use super::*` でアクセスする。
+
+use super::*;
+
+#[test]
+fn parse_meta_reads_frontmatter() {
+    let body = "---\nname: My Skill\ndescription: \"Does a thing\"\n---\n# Heading\nbody text";
+    let (name, desc) = parse_skill_meta("my-skill", body);
+    assert_eq!(name, "My Skill");
+    assert_eq!(desc, "Does a thing");
+}
+
+#[test]
+fn parse_meta_skips_leading_html_comment() {
+    let body = "<!-- vibe-team-skill-version: 1.6.3 -->\n---\nname: vibe-team\ndescription: team rules\n---\nbody";
+    let (name, desc) = parse_skill_meta("vibe-team", body);
+    assert_eq!(name, "vibe-team");
+    assert_eq!(desc, "team rules");
+}
+
+#[test]
+fn parse_meta_falls_back_without_frontmatter() {
+    let body = "# Title\n\nFirst real line describes it.";
+    let (name, desc) = parse_skill_meta("plain", body);
+    assert_eq!(name, "plain");
+    assert_eq!(desc, "First real line describes it.");
+}
+
+/// 取り込み元 root: project 指定時は project+user の Claude/Codex 計 4 root をラベル付きで返す。
+#[test]
+fn source_roots_cover_claude_and_codex_user_and_project() {
+    let roots = source_roots("/tmp/proj");
+    let labels: Vec<(&str, &str)> = roots.iter().map(|(s, sc, _)| (*s, *sc)).collect();
+    assert!(labels.contains(&("claude", "project")));
+    assert!(labels.contains(&("codex", "project")));
+    assert!(labels.contains(&("claude", "user")));
+    assert!(labels.contains(&("codex", "user")));
+    // Codex は .agents/skills, Claude は .claude/skills
+    let codex_proj = roots.iter().find(|(s, sc, _)| *s == "codex" && *sc == "project");
+    assert!(codex_proj.unwrap().2.ends_with(".agents/skills"));
+    // project 未指定なら user スコープのみ
+    let user_only = source_roots("");
+    assert!(user_only.iter().all(|(_, sc, _)| *sc == "user"));
+}
+
+async fn write_skill(dir: &std::path::Path, id: &str, body: &str) {
+    let d = dir.join(id);
+    tokio::fs::create_dir_all(&d).await.unwrap();
+    tokio::fs::write(d.join("SKILL.md"), body).await.unwrap();
+}
+
+#[tokio::test]
+async fn list_skills_in_enumerates_and_parses() {
+    let dir = tempfile::tempdir().unwrap();
+    write_skill(dir.path(), "alpha", "---\nname: Alpha\ndescription: a\n---\nbody").await;
+    write_skill(dir.path(), "beta", "---\nname: Beta\ndescription: b\n---\nbody").await;
+    let list = list_skills_in(dir.path()).await;
+    let ids: Vec<&str> = list.iter().map(|s| s.id.as_str()).collect();
+    assert_eq!(ids, vec!["alpha", "beta"]);
+    assert_eq!(list[0].name, "Alpha");
+}
+
+#[tokio::test]
+async fn list_skills_in_returns_empty_for_missing_dir() {
+    assert!(list_skills_in(std::path::Path::new("/nonexistent-xyz-123")).await.is_empty());
+}
+
+#[tokio::test]
+async fn load_skill_bodies_always_includes_vibe_team_via_bundle() {
+    let dir = tempfile::tempdir().unwrap();
+    let skills = load_skill_bodies_from(dir.path(), &["unknown".to_string()]).await;
+    assert!(skills.iter().any(|s| s.id == VIBE_TEAM_SKILL_ID));
+    assert!(!skills.iter().any(|s| s.id == "unknown"));
+    let vt = skills.iter().find(|s| s.id == VIBE_TEAM_SKILL_ID).unwrap();
+    assert!(vt.body.contains("vibe-team"));
+}
+
+#[tokio::test]
+async fn load_skill_bodies_reads_disk_skill_and_rejects_traversal() {
+    let dir = tempfile::tempdir().unwrap();
+    write_skill(dir.path(), "my-skill", "---\nname: Mine\ndescription: d\n---\nhello body").await;
+    let skills =
+        load_skill_bodies_from(dir.path(), &["my-skill".to_string(), "../escape".to_string()]).await;
+    let mine = skills.iter().find(|s| s.id == "my-skill").unwrap();
+    assert_eq!(mine.name, "Mine");
+    assert!(mine.body.contains("hello body"));
+    assert!(!skills.iter().any(|s| s.id.contains("..")));
+    assert!(skills.iter().any(|s| s.id == VIBE_TEAM_SKILL_ID));
+}
+
+/// security: SKILL.md が skills root 外を指す symlink の場合、本文を読み込まない。
+#[cfg(unix)]
+#[tokio::test]
+async fn load_skill_bodies_rejects_symlink_escape() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::tempdir().unwrap();
+    let secret = dir.path().join("secret.txt");
+    tokio::fs::write(&secret, "TOP SECRET KEY").await.unwrap();
+    let skills_dir = dir.path().join("skills");
+    let evil = skills_dir.join("evil");
+    tokio::fs::create_dir_all(&evil).await.unwrap();
+    symlink(&secret, evil.join("SKILL.md")).unwrap();
+
+    let skills = load_skill_bodies_from(&skills_dir, &["evil".to_string()]).await;
+    assert!(!skills.iter().any(|s| s.id == "evil"));
+    assert!(!skills.iter().any(|s| s.body.contains("TOP SECRET")));
+    assert!(skills.iter().any(|s| s.id == VIBE_TEAM_SKILL_ID));
+}
+
+/// security: skills root 内に収まる正当な symlink は許可される。
+#[cfg(unix)]
+#[tokio::test]
+async fn load_skill_bodies_allows_symlink_within_root() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::tempdir().unwrap();
+    let skills_dir = dir.path().join("skills");
+    let real = skills_dir.join("real");
+    tokio::fs::create_dir_all(&real).await.unwrap();
+    tokio::fs::write(real.join("SKILL.md"), "inside body").await.unwrap();
+    let alias = skills_dir.join("alias");
+    tokio::fs::create_dir_all(&alias).await.unwrap();
+    symlink(real.join("SKILL.md"), alias.join("SKILL.md")).unwrap();
+
+    let skills = load_skill_bodies_from(&skills_dir, &["alias".to_string()]).await;
+    let a = skills.iter().find(|s| s.id == "alias").unwrap();
+    assert!(a.body.contains("inside body"));
+}
+
+#[tokio::test]
+async fn read_capped_limits_size() {
+    let dir = tempfile::tempdir().unwrap();
+    let p = dir.path().join("big.md");
+    let big = "x".repeat(MAX_SKILL_FILE_BYTES * 2);
+    tokio::fs::write(&p, &big).await.unwrap();
+    let out = read_capped(&p).await.unwrap();
+    assert!(out.len() <= MAX_SKILL_FILE_BYTES);
+}

--- a/src-tauri/src/commands/api_agents/types.rs
+++ b/src-tauri/src/commands/api_agents/types.rs
@@ -113,6 +113,30 @@ pub struct ApiAgentSkillMeta {
     pub description: String,
 }
 
+/// import 元 (Claude / Codex) の skill メタ。`api_agent_skill_sources_list` が返す (Issue #1017)。
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportableSkill {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    /// 'claude' | 'codex'
+    pub source: String,
+    /// 'user' | 'project'
+    pub scope: String,
+    /// 既に vibe-editor 専用フォルダへ import 済みか。
+    pub imported: bool,
+}
+
+/// skill import 要求 (Issue #1017)。`source` + `id` で取り込み元を特定する。
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportSkillRequest {
+    /// 'claude' | 'codex'
+    pub source: String,
+    pub id: String,
+}
+
 /// team 参加コンテキスト。renderer (apiAgent カード) が所属チーム情報を渡す (Issue #1004)。
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -281,6 +281,9 @@ pub fn run() {
             commands::api_agents::api_agent_send,
             commands::api_agents::api_agent_cancel,
             commands::api_agents::skills::api_agent_skill_list,
+            commands::api_agents::skills::api_agent_skill_sources_list,
+            commands::api_agents::skills::api_agent_skill_import,
+            commands::api_agents::skills::api_agent_skill_remove,
         ])
         .setup(|app| {
             info!(

--- a/src-tauri/src/util/config_paths.rs
+++ b/src-tauri/src/util/config_paths.rs
@@ -53,6 +53,21 @@ pub fn api_agent_sessions_dir() -> PathBuf {
     vibe_root().join("api-agent-sessions")
 }
 
+/// Issue #1017: API agent 専用 skill フォルダ `~/.vibe-editor/skills`。
+/// Claude (`~/.claude/skills`, `<project>/.claude/skills`) / Codex (`~/.agents/skills`,
+/// `<project>/.agents/skills`) から import (コピー) した SKILL.md をここに保存し、API agent は
+/// このフォルダを skill ソースとして読む。
+pub fn vibe_skills_dir() -> PathBuf {
+    vibe_root().join("skills")
+}
+
+/// ユーザー home。HOME 不在時は OS temp にフォールバックして必ず絶対パスを返す
+/// (`vibe_root` と同じ堅牢化, Issue #631)。import 元の `~/.claude/skills` / `~/.agents/skills`
+/// 解決に使う。
+pub fn home_dir() -> PathBuf {
+    dirs::home_dir().unwrap_or_else(std::env::temp_dir)
+}
+
 /// Issue #609 (Security): updater の minisign 署名検証失敗を「24h に 1 度だけ」ユーザーに
 /// 通知するための最終警告タイムスタンプ永続化先 `~/.vibe-editor/updater-warned.json` のパス。
 ///

--- a/src/renderer/src/components/settings/CustomAgentEditor.tsx
+++ b/src/renderer/src/components/settings/CustomAgentEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   API_AGENT_PROVIDER_PRESETS,
   type AgentConfig,
@@ -9,6 +9,7 @@ import {
   type CliAgentConfig
 } from '../../../../types/shared';
 import { useT } from '../../lib/i18n';
+import { SkillImportPanel } from './SkillImportPanel';
 import { useNativeConfirm } from '../../lib/use-native-confirm';
 import { parseShellArgsStrict } from '../../lib/parse-args';
 import type { UpdateSetting } from './types';
@@ -83,22 +84,18 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
     };
   }, [apiProviderId]);
 
-  // active project の .claude/skills/* を列挙 (API runtime のときだけ)。
-  useEffect(() => {
-    if (agent.runtime !== 'api') return;
-    let disposed = false;
+  // vibe-editor 専用フォルダの import 済み skill を列挙 (API runtime のときだけ)。
+  const reloadSkills = useCallback((): void => {
     void window.api.apiAgents
       .listSkills()
-      .then((list) => {
-        if (!disposed) setAvailableSkills(list);
-      })
-      .catch(() => {
-        if (!disposed) setAvailableSkills([]);
-      });
-    return () => {
-      disposed = true;
-    };
-  }, [agent.runtime]);
+      .then(setAvailableSkills)
+      .catch(() => setAvailableSkills([]));
+  }, []);
+
+  useEffect(() => {
+    if (agent.runtime !== 'api') return;
+    reloadSkills();
+  }, [agent.runtime, reloadSkills]);
 
   const toggleSkill = (id: string): void => {
     if (!apiAgent) return;
@@ -348,6 +345,7 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
               </div>
             )}
             <p className="modal__note">{t('settings.customAgents.skillsAutoTeam')}</p>
+            <SkillImportPanel onChanged={reloadSkills} />
           </div>
 
           <p className="modal__note">

--- a/src/renderer/src/components/settings/SkillImportPanel.tsx
+++ b/src/renderer/src/components/settings/SkillImportPanel.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { ApiAgentImportableSkill } from '../../../../types/shared';
+import { useT } from '../../lib/i18n';
+
+interface Props {
+  /** import / remove 後に親の skill selector を再読み込みさせる。 */
+  onChanged: () => void;
+}
+
+/**
+ * Claude / Codex の skill を vibe-editor 専用フォルダへ import (コピー) するパネル (Issue #1017)。
+ * `~/.claude/skills` `<project>/.claude/skills` `~/.agents/skills` `<project>/.agents/skills`
+ * を走査し、選択して import する。import 済みは削除もできる。
+ */
+export function SkillImportPanel({ onChanged }: Props): JSX.Element {
+  const t = useT();
+  const [sources, setSources] = useState<ApiAgentImportableSkill[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async (): Promise<void> => {
+    try {
+      setSources(await window.api.apiAgents.listSkillSources());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const run = async (
+    key: string,
+    op: () => Promise<unknown>
+  ): Promise<void> => {
+    setBusy(key);
+    setError('');
+    try {
+      await op();
+      await load();
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <details className="skill-import">
+      <summary>{t('settings.customAgents.skillImport.title')}</summary>
+      <p className="modal__note">{t('settings.customAgents.skillImport.note')}</p>
+      {error && <p className="modal__error">{error}</p>}
+      {sources.length === 0 ? (
+        <p className="modal__note">{t('settings.customAgents.skillImport.empty')}</p>
+      ) : (
+        <ul className="skill-import__list">
+          {sources.map((s) => {
+            const key = `${s.source}:${s.id}`;
+            return (
+              <li key={key} className="skill-import__item">
+                <div className="skill-import__meta">
+                  <span className="skill-import__name">{s.name}</span>
+                  <span className="skill-import__badge">
+                    {s.source} / {s.scope}
+                  </span>
+                  {s.description && (
+                    <span className="skill-import__desc" title={s.description}>
+                      {s.description}
+                    </span>
+                  )}
+                </div>
+                {s.imported ? (
+                  <button
+                    type="button"
+                    className="toolbar__btn"
+                    disabled={busy !== null}
+                    onClick={() => run(key, () => window.api.apiAgents.removeSkill(s.id))}
+                  >
+                    {busy === key ? '…' : t('settings.customAgents.skillImport.remove')}
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="toolbar__btn"
+                    disabled={busy !== null}
+                    onClick={() => run(key, () => window.api.apiAgents.importSkill(s.source, s.id))}
+                  >
+                    {busy === key ? '…' : t('settings.customAgents.skillImport.import')}
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </details>
+  );
+}

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -783,9 +783,9 @@ const ja: Dict = {
   'settings.customAgents.skillsAutoTeam': 'TeamHub 参加時は vibe-team skill が自動で追加されます。',
   'settings.customAgents.skillImport.title': 'Claude / Codex から skill を import',
   'settings.customAgents.skillImport.note':
-    '~/.claude/skills と .agents/skills (Codex) を走査し、選んだ skill を vibe-editor 専用フォルダにコピーします。',
+    '~/.claude/skills と ~/.agents/skills (Codex) を走査し、選んだ skill を vibe-editor 専用フォルダにコピーします。',
   'settings.customAgents.skillImport.empty':
-    'import 元 (~/.claude/skills・.agents/skills) に skill が見つかりません。',
+    'import 元 (~/.claude/skills・~/.agents/skills) に skill が見つかりません。',
   'settings.customAgents.skillImport.import': 'Import',
   'settings.customAgents.skillImport.remove': '削除',
 
@@ -1670,9 +1670,9 @@ const en: Dict = {
     'The vibe-team skill is added automatically when joining TeamHub.',
   'settings.customAgents.skillImport.title': 'Import skills from Claude / Codex',
   'settings.customAgents.skillImport.note':
-    'Scans ~/.claude/skills and .agents/skills (Codex), and copies the selected skill into the vibe-editor skills folder.',
+    'Scans ~/.claude/skills and ~/.agents/skills (Codex), and copies the selected skill into the vibe-editor skills folder.',
   'settings.customAgents.skillImport.empty':
-    'No skills found in the import sources (~/.claude/skills, .agents/skills).',
+    'No skills found in the import sources (~/.claude/skills, ~/.agents/skills).',
   'settings.customAgents.skillImport.import': 'Import',
   'settings.customAgents.skillImport.remove': 'Remove',
 

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -779,8 +779,15 @@ const ja: Dict = {
   'settings.customAgents.applyNote': '変更後、Canvas で該当エージェントのカードを作り直すと反映されます。',
   'settings.customAgents.skills': 'Skill (SKILL.md)',
   'settings.customAgents.skillsEmpty':
-    'このプロジェクトの .claude/skills に SKILL.md が見つかりません。',
+    'import 済みの skill がありません。下の「Claude / Codex から import」で追加してください。',
   'settings.customAgents.skillsAutoTeam': 'TeamHub 参加時は vibe-team skill が自動で追加されます。',
+  'settings.customAgents.skillImport.title': 'Claude / Codex から skill を import',
+  'settings.customAgents.skillImport.note':
+    '~/.claude/skills と .agents/skills (Codex) を走査し、選んだ skill を vibe-editor 専用フォルダにコピーします。',
+  'settings.customAgents.skillImport.empty':
+    'import 元 (~/.claude/skills・.agents/skills) に skill が見つかりません。',
+  'settings.customAgents.skillImport.import': 'Import',
+  'settings.customAgents.skillImport.remove': '削除',
 
   // ---------- MCP tab ----------
   'settings.mcp.autoTitle': '自動セットアップ',
@@ -1657,9 +1664,17 @@ const en: Dict = {
     'This provider/model degrades to read-only chat because tool calling is unavailable.',
   'settings.customAgents.applyNote': 'Recreate the agent card in Canvas to apply changes.',
   'settings.customAgents.skills': 'Skills (SKILL.md)',
-  'settings.customAgents.skillsEmpty': 'No SKILL.md found under this project’s .claude/skills.',
+  'settings.customAgents.skillsEmpty':
+    'No imported skills yet. Add some via “Import from Claude / Codex” below.',
   'settings.customAgents.skillsAutoTeam':
     'The vibe-team skill is added automatically when joining TeamHub.',
+  'settings.customAgents.skillImport.title': 'Import skills from Claude / Codex',
+  'settings.customAgents.skillImport.note':
+    'Scans ~/.claude/skills and .agents/skills (Codex), and copies the selected skill into the vibe-editor skills folder.',
+  'settings.customAgents.skillImport.empty':
+    'No skills found in the import sources (~/.claude/skills, .agents/skills).',
+  'settings.customAgents.skillImport.import': 'Import',
+  'settings.customAgents.skillImport.remove': 'Remove',
 
   // ---------- MCP tab ----------
   'settings.mcp.autoTitle': 'Auto setup',

--- a/src/renderer/src/lib/tauri-api/api-agents.ts
+++ b/src/renderer/src/lib/tauri-api/api-agents.ts
@@ -5,11 +5,13 @@ import { invokeCommand } from './command-error';
 import type {
   ApiAgentDoneEvent,
   ApiAgentErrorEvent,
+  ApiAgentImportableSkill,
   ApiAgentSendRequest,
   ApiAgentSendResult,
   ApiAgentSession,
   ApiAgentSessionCreateRequest,
   ApiAgentSkillMeta,
+  ApiAgentSkillSource,
   ApiAgentStreamEvent,
   ApiAgentToolEvent
 } from '../../../../types/shared';
@@ -32,6 +34,11 @@ export const apiAgents = {
   cancel: (sessionId: string, generationId: string): Promise<void> =>
     invokeCommand('api_agent_cancel', { sessionId, generationId }),
   listSkills: (): Promise<ApiAgentSkillMeta[]> => invokeCommand('api_agent_skill_list', {}),
+  listSkillSources: (): Promise<ApiAgentImportableSkill[]> =>
+    invokeCommand('api_agent_skill_sources_list', {}),
+  importSkill: (source: ApiAgentSkillSource, id: string): Promise<ApiAgentSkillMeta> =>
+    invokeCommand('api_agent_skill_import', { req: { source, id } }),
+  removeSkill: (id: string): Promise<void> => invokeCommand('api_agent_skill_remove', { id }),
   events: (sessionId: string) => ({
     onDeltaReady: (cb: (event: ApiAgentStreamEvent) => void): Promise<() => void> =>
       subscribeEventReady<ApiAgentStreamEvent>(`api-agent:delta:${sessionId}`, cb),

--- a/src/renderer/src/styles/components/modal.css
+++ b/src/renderer/src/styles/components/modal.css
@@ -422,6 +422,65 @@
   white-space: nowrap;
 }
 
+.skill-import {
+  margin-top: 8px;
+  font-size: 13px;
+}
+
+.skill-import > summary {
+  cursor: pointer;
+  color: var(--color-fg);
+  user-select: none;
+}
+
+.skill-import__list {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+  max-height: 240px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.skill-import__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+}
+
+.skill-import__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.skill-import__name {
+  font-weight: 500;
+  color: var(--color-fg);
+}
+
+.skill-import__badge {
+  font-size: 10px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.skill-import__desc {
+  font-size: 11px;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .segmented-control {
   display: inline-grid;
   grid-auto-flow: column;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -470,14 +470,32 @@ export interface ApiAgentSendRequest {
 }
 
 /**
- * skill selector 用のメタ情報。Rust `api_agent_skill_list` が active project の
- * `.claude/skills/<id>/SKILL.md` を列挙して返す。本文 (body) は送信時に Rust 側で解決し、
- * IPC では往復させない (Issue #998)。
+ * skill selector 用のメタ情報。Rust `api_agent_skill_list` が vibe-editor 専用フォルダ
+ * (`~/.vibe-editor/skills/<id>/SKILL.md`) を列挙して返す。本文 (body) は送信時に Rust 側で
+ * 解決し、IPC では往復させない (Issue #998 / #1017)。
  */
 export interface ApiAgentSkillMeta {
   id: string;
   name: string;
   description: string;
+}
+
+/** import 元の種別 (Issue #1017)。 */
+export type ApiAgentSkillSource = 'claude' | 'codex';
+
+/**
+ * Claude / Codex から import 可能な skill のメタ。`api_agent_skill_sources_list` が返す。
+ * `~/.claude/skills` `<project>/.claude/skills` `~/.agents/skills` `<project>/.agents/skills`
+ * を走査する。
+ */
+export interface ApiAgentImportableSkill {
+  id: string;
+  name: string;
+  description: string;
+  source: ApiAgentSkillSource;
+  scope: 'user' | 'project';
+  /** vibe-editor 専用フォルダへ import 済みか。 */
+  imported: boolean;
 }
 
 export interface ApiAgentSendResult {


### PR DESCRIPTION
## Summary
- API エージェントの skill を **vibe-editor 専用フォルダ** (`~/.vibe-editor/skills/`) に集約し、設定画面から **Claude / Codex の既存 skill を import (コピー)** して使えるようにする。
- 調査結果に基づき、取り込み元は **Claude** (`~/.claude/skills`, `<project>/.claude/skills`) と **Codex** (`~/.agents/skills`, `<project>/.agents/skills` ※OpenAI 公式仕様で `~/.codex/skills` ではない)。どちらも `SKILL.md` + frontmatter。

## 変更点
### Rust
- `config_paths`: `vibe_skills_dir()` (`~/.vibe-editor/skills`) と `home_dir()` を追加。
- `skills.rs`: API エージェントの skill ソースを専用フォルダへ変更 (`api_agent_skill_list` / `load_skill_bodies`)。新 IPC 3 件:
  - `api_agent_skill_sources_list` — 4 つの取り込み元を走査し `{ id, name, description, source, scope, imported }` を返す ((source,id) 重複排除, project 優先)。
  - `api_agent_skill_import` — 取り込み元の SKILL.md を専用フォルダへ atomic copy (snapshot)。
  - `api_agent_skill_remove` — import 済み skill を削除。
- **セキュリティ**: skill id 検証 (traversal 拒否)、各 skills root を canonicalize して SKILL.md 実体が root 配下に収まることを検証 (symlink escape 拒否)、256KB キャップ。
- `skills.rs` の test を `skills/tests.rs` へ分離 (500 行制限維持)。

### Renderer
- `SkillImportPanel` を新規追加し、`CustomAgentEditor` の skill セクションに統合 (取り込み元一覧 → import / 削除、import 後に selector を自動再読込)。
- shared.ts 型 (`ApiAgentImportableSkill` / `ApiAgentSkillSource`) / tauri-api wrapper / ja・en i18n / CSS を同期。

## file-size baseline
新 IPC 3 件に伴う単一 SoT の不可避増分のみ: `lib.rs` 516→519 (invoke_handler 登録) / `shared.ts` 1848→1866 (型) / `i18n.ts` 1815→1830 (文言)。

## Test plan
- [x] `cargo test --lib -- api_agents` (45 passed; source_roots ラベル / list_skills_in / 専用フォルダ読み込み / traversal・symlink escape 拒否 / サイズキャップ / vibe-team フォールバック)
- [x] `cargo check` 0 warnings / `npm run typecheck` 通過 / file-size ratchet OK
- [x] `cargo tauri dev` で新 IPC 3 件込みでビルド・起動成功 (invoke_handler 登録の sanity)

Closes #1017
