### PR TITLE
feat(api-agents): project skillは作業フォルダの.claude優先で重複排除

### DIFF
--- a/src-tauri/src/commands/api_agents/skills.rs
+++ b/src-tauri/src/commands/api_agents/skills.rs
@@ -50,17 +50,24 @@ pub(super) async fn load_skill_bodies(skill_ids: &[String]) -> Vec<ApiAgentSkill
 // import 元 (Claude / Codex) の列挙と import / remove
 // ============================================================
 
-/// import 候補の skills root を (source, scope, path) で返す。project root が空ならユーザー
-/// スコープのみ。project を user より先に並べて「project 優先」の重複排除を可能にする。
+/// import 候補の skills root を (source, scope, path) で返す (Issue #1019)。
+/// 各 scope 内で `.claude` を先頭に並べ、`(scope, id)` の first-wins 重複排除で `.claude` を
+/// 優先させる。Codex は `.codex/skills` (ユーザー指定) と公式の `.agents/skills` の両方を走査。
+/// project root が空ならユーザースコープのみ。
 fn source_roots(project_root: &str) -> Vec<(&'static str, &'static str, PathBuf)> {
     let home = config_paths::home_dir();
     let pr = project_root.trim();
     let mut roots: Vec<(&'static str, &'static str, PathBuf)> = Vec::new();
+    // project = ファイルツリーで今開いている作業フォルダ。.claude 優先 → .codex → .agents。
     if !pr.is_empty() {
-        roots.push(("claude", "project", Path::new(pr).join(".claude").join("skills")));
-        roots.push(("codex", "project", Path::new(pr).join(".agents").join("skills")));
+        let p = Path::new(pr);
+        roots.push(("claude", "project", p.join(".claude").join("skills")));
+        roots.push(("codex", "project", p.join(".codex").join("skills")));
+        roots.push(("codex", "project", p.join(".agents").join("skills")));
     }
+    // user (home) も同じ優先順。
     roots.push(("claude", "user", home.join(".claude").join("skills")));
+    roots.push(("codex", "user", home.join(".codex").join("skills")));
     roots.push(("codex", "user", home.join(".agents").join("skills")));
     roots
 }
@@ -78,26 +85,39 @@ pub async fn api_agent_skill_sources_list(
             .map(|s| s.id)
             .collect();
 
-    let mut out: Vec<ImportableSkill> = Vec::new();
-    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    // priority 順 (claude → codex, project → user) に flat 収集してから (scope, id) で dedup。
+    let mut raw: Vec<(&'static str, &'static str, ApiAgentSkillMeta)> = Vec::new();
     for (source, scope, root) in source_roots(&project_root) {
         for meta in list_skills_in(&root).await {
-            let key = (source.to_string(), meta.id.clone());
-            if !seen.insert(key) {
-                continue; // 同 (source, id) は project を優先済み
-            }
-            out.push(ImportableSkill {
-                imported: imported.contains(&meta.id),
-                id: meta.id,
-                name: meta.name,
-                description: meta.description,
-                source: source.to_string(),
-                scope: scope.to_string(),
-            });
+            raw.push((source, scope, meta));
         }
     }
-    out.sort_by(|a, b| (a.source.clone(), a.id.clone()).cmp(&(b.source.clone(), b.id.clone())));
-    Ok(out)
+    Ok(dedup_by_scope_id(raw, &imported))
+}
+
+/// `(scope, id)` の first-wins 重複排除。`source_roots` が各 scope 内で `.claude` を先頭に
+/// 並べるため、同名 skill では `.claude` が勝つ (Issue #1019)。
+fn dedup_by_scope_id(
+    raw: Vec<(&str, &str, ApiAgentSkillMeta)>,
+    imported: &std::collections::HashSet<String>,
+) -> Vec<ImportableSkill> {
+    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    let mut out: Vec<ImportableSkill> = Vec::new();
+    for (source, scope, meta) in raw {
+        if !seen.insert((scope.to_string(), meta.id.clone())) {
+            continue; // 同 scope の同 id は先勝ち (= .claude 優先)
+        }
+        out.push(ImportableSkill {
+            imported: imported.contains(&meta.id),
+            id: meta.id,
+            name: meta.name,
+            description: meta.description,
+            source: source.to_string(),
+            scope: scope.to_string(),
+        });
+    }
+    out.sort_by(|a, b| (a.scope.clone(), a.id.clone()).cmp(&(b.scope.clone(), b.id.clone())));
+    out
 }
 
 /// 指定 skill を取り込み元から専用フォルダへコピー (snapshot) する。

--- a/src-tauri/src/commands/api_agents/skills/tests.rs
+++ b/src-tauri/src/commands/api_agents/skills/tests.rs
@@ -27,21 +27,54 @@ fn parse_meta_falls_back_without_frontmatter() {
     assert_eq!(desc, "First real line describes it.");
 }
 
-/// 取り込み元 root: project 指定時は project+user の Claude/Codex 計 4 root をラベル付きで返す。
+/// 取り込み元 root: 各 scope で `.claude` を codex より先に並べ (= .claude 優先)、project codex は
+/// `.codex/skills` と公式 `.agents/skills` の両方を含む (Issue #1019)。
 #[test]
-fn source_roots_cover_claude_and_codex_user_and_project() {
+fn source_roots_prioritize_claude_and_include_codex_and_agents() {
     let roots = source_roots("/tmp/proj");
-    let labels: Vec<(&str, &str)> = roots.iter().map(|(s, sc, _)| (*s, *sc)).collect();
-    assert!(labels.contains(&("claude", "project")));
-    assert!(labels.contains(&("codex", "project")));
-    assert!(labels.contains(&("claude", "user")));
-    assert!(labels.contains(&("codex", "user")));
-    // Codex は .agents/skills, Claude は .claude/skills
-    let codex_proj = roots.iter().find(|(s, sc, _)| *s == "codex" && *sc == "project");
-    assert!(codex_proj.unwrap().2.ends_with(".agents/skills"));
+    let claude_idx = roots
+        .iter()
+        .position(|(s, sc, _)| *s == "claude" && *sc == "project")
+        .unwrap();
+    let codex_idx = roots
+        .iter()
+        .position(|(s, sc, _)| *s == "codex" && *sc == "project")
+        .unwrap();
+    assert!(claude_idx < codex_idx, ".claude must be scanned before codex");
+    let project_codex: Vec<&std::path::PathBuf> = roots
+        .iter()
+        .filter(|(s, sc, _)| *s == "codex" && *sc == "project")
+        .map(|(_, _, p)| p)
+        .collect();
+    assert!(project_codex.iter().any(|p| p.ends_with(".codex/skills")));
+    assert!(project_codex.iter().any(|p| p.ends_with(".agents/skills")));
     // project 未指定なら user スコープのみ
-    let user_only = source_roots("");
-    assert!(user_only.iter().all(|(_, sc, _)| *sc == "user"));
+    assert!(source_roots("").iter().all(|(_, sc, _)| *sc == "user"));
+}
+
+/// `(scope, id)` dedup: 同 scope の同名 skill は `.claude` を優先し、別 scope は残す。
+#[test]
+fn dedup_prefers_claude_within_scope() {
+    let meta = |id: &str| ApiAgentSkillMeta {
+        id: id.to_string(),
+        name: id.to_string(),
+        description: String::new(),
+    };
+    let raw = vec![
+        ("claude", "project", meta("shared")),
+        ("codex", "project", meta("shared")), // 同 (project, shared) → 捨てる
+        ("codex", "project", meta("codex-only")),
+        ("claude", "user", meta("shared")), // 別 scope なので残る
+    ];
+    let out = dedup_by_scope_id(raw, &std::collections::HashSet::new());
+    let shared_proj: Vec<&ImportableSkill> = out
+        .iter()
+        .filter(|s| s.id == "shared" && s.scope == "project")
+        .collect();
+    assert_eq!(shared_proj.len(), 1);
+    assert_eq!(shared_proj[0].source, "claude");
+    assert!(out.iter().any(|s| s.id == "codex-only" && s.source == "codex"));
+    assert!(out.iter().any(|s| s.id == "shared" && s.scope == "user"));
 }
 
 async fn write_skill(dir: &std::path::Path, id: &str, body: &str) {


### PR DESCRIPTION
## Summary
- project スコープの skill 取り込み元を「ファイルツリーで今開いている作業フォルダ」(= active project root) の **`.claude` 優先**にし、同名 skill の二重表示を解消 (Issue #1019)。
- 本 repo は `.claude/skills` と Codex の `.agents/skills` がミラー (同名 14 skill) のため、import パネルに各 skill が claude/codex で二重表示されていた。

## 変更点
- `source_roots`: 各 scope で `.claude` → `.codex` → `.agents` の優先順に並べる。project の Codex は**ユーザー指定の `<project>/.codex/skills`** と公式仕様の `<project>/.agents/skills` の両方を走査 (取りこぼし防止)。user スコープ (`~/`) も同様。
- 重複排除を `(source, id)` から **`(scope, id)`** へ変更。各 scope 内で claude を先に走査するため first-wins で `.claude` が勝つ。別 scope (project/user) は残す。
- dedup を pure 関数 `dedup_by_scope_id` に切り出し。

## 挙動
- project の `.claude/skills` と `.codex`(/`.agents`)`/skills` に同名 skill → **`.claude` のみ表示**。
- `.codex`/`.agents` にしか無い skill → codex として表示・import 可能。

## Test plan
- [x] `cargo test --lib -- api_agents::skills` (12 passed; source_roots の priority 順 + `.codex`/`.agents` 両走査、`(scope, id)` dedup で claude 優先・別 scope 保持)
- [x] `cargo check` 0 warnings / file-size ratchet OK
- [x] renderer / 型変更なし

Closes #1019
