### PR TITLE
feat(canvas): custom agentをチーム作成UI + team_list_role_profiles(MCP雇用)に出す

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -39,6 +39,6 @@
   "src/renderer/src/lib/hooks/use-xterm-bind.ts": 889,
   "src/renderer/src/lib/i18n.ts": 1830,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
-  "src/renderer/src/stores/canvas.ts": 577,
+  "src/renderer/src/stores/canvas.ts": 584,
   "src/types/shared.ts": 1866
 }

--- a/src/renderer/src/components/canvas/cards/ApiAgentChatCard.tsx
+++ b/src/renderer/src/components/canvas/cards/ApiAgentChatCard.tsx
@@ -30,9 +30,12 @@ function ApiAgentChatCardImpl({
   const generationRef = useRef<string | null>(null);
   const bodyRef = useRef<HTMLDivElement | null>(null);
 
+  // team recruit 生成カードは agentId に Hub の instance id が入るため、設定解決は
+  // agentConfigId を優先する (通常カードは agentConfigId 未設定で従来どおり agentId, Issue #1021)。
+  const configAgentId = payload?.agentConfigId ?? payload?.agentId;
   const agent = useMemo(
-    () => (settings.customAgents ?? []).find((a) => a.id === payload?.agentId),
-    [payload?.agentId, settings.customAgents]
+    () => (settings.customAgents ?? []).find((a) => a.id === configAgentId),
+    [configAgentId, settings.customAgents]
   );
   const apiAgent = isApiAgentConfig(agent) ? agent : null;
   const provider = API_AGENT_PROVIDER_PRESETS.find((p) => p.id === apiAgent?.providerId);

--- a/src/renderer/src/lib/__tests__/custom-agent-role.test.ts
+++ b/src/renderer/src/lib/__tests__/custom-agent-role.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  customAgentToProfile,
+  customAgentIdFromRole,
+  CUSTOM_AGENT_ROLE_PREFIX
+} from '../role-profiles-context';
+import type { AgentConfig } from '../../../../types/shared';
+
+describe('custom agent → role profile synthesis (Issue #1021)', () => {
+  it('synthesizes an API agent into a role profile', () => {
+    const agent = {
+      id: 'gpt5',
+      name: 'GPT-5',
+      runtime: 'api',
+      providerId: 'openai',
+      model: 'gpt-5'
+    } as AgentConfig;
+    const p = customAgentToProfile(agent);
+    expect(p.id).toBe('custom:gpt5');
+    expect(p.source).toBe('user');
+    expect(p.i18n.en.label).toBe('GPT-5');
+    expect(p.i18n.en.description).toContain('openai');
+    expect(p.i18n.en.description).toContain('gpt-5');
+    // custom agent は recruit/dismiss 権限を持たない
+    expect(p.permissions.canRecruit).toBe(false);
+    expect(p.permissions.canDismiss).toBe(false);
+  });
+
+  it('synthesizes a CLI agent and shows its command', () => {
+    const agent = {
+      id: 'aider',
+      name: 'Aider',
+      runtime: 'cli',
+      command: 'aider',
+      args: '',
+      cwd: ''
+    } as AgentConfig;
+    const p = customAgentToProfile(agent);
+    expect(p.id).toBe('custom:aider');
+    expect(p.i18n.en.label).toBe('Aider');
+    expect(p.i18n.en.description).toContain('aider');
+  });
+
+  it('falls back to id when name is empty', () => {
+    const agent = {
+      id: 'x1',
+      name: '',
+      runtime: 'cli',
+      command: 'foo',
+      args: '',
+      cwd: ''
+    } as AgentConfig;
+    expect(customAgentToProfile(agent).i18n.en.label).toBe('x1');
+  });
+
+  it('round-trips the agent id from the role id', () => {
+    expect(CUSTOM_AGENT_ROLE_PREFIX).toBe('custom:');
+    expect(customAgentIdFromRole('custom:gpt5')).toBe('gpt5');
+    expect(customAgentIdFromRole('custom:aider')).toBe('aider');
+    // 非 custom role は null
+    expect(customAgentIdFromRole('leader')).toBeNull();
+    expect(customAgentIdFromRole('hr')).toBeNull();
+  });
+});

--- a/src/renderer/src/lib/__tests__/use-recruit-listener-hidden.test.tsx
+++ b/src/renderer/src/lib/__tests__/use-recruit-listener-hidden.test.tsx
@@ -73,7 +73,19 @@ vi.mock('../../stores/canvas', () => ({
 }));
 
 vi.mock('../role-profiles-context', () => ({
-  useRoleProfiles: () => ({ registerDynamicRole: vi.fn() })
+  useRoleProfiles: () => ({ registerDynamicRole: vi.fn() }),
+  // Issue #1021: listener が custom agent role を判定するのに使う。
+  customAgentIdFromRole: (roleProfileId: string): string | null =>
+    roleProfileId.startsWith('custom:') ? roleProfileId.slice('custom:'.length) : null
+}));
+
+// Issue #1021: listener は settings.customAgents を ref で参照する (custom agent recruit 用)。
+vi.mock('../settings-context', () => ({
+  useSettings: () => ({ settings: { customAgents: [] } })
+}));
+
+vi.mock('../parse-args', () => ({
+  parseShellArgsStrict: (s: string) => ({ args: s ? s.split(/\s+/) : [] })
 }));
 
 // 最小 i18n: 表示用にキー + パラメータ値を結合して返し、テストで count を文字列照合できるようにする。

--- a/src/renderer/src/lib/__tests__/use-recruit-listener-team-name.test.tsx
+++ b/src/renderer/src/lib/__tests__/use-recruit-listener-team-name.test.tsx
@@ -28,7 +28,18 @@ vi.mock('../tauri-api', () => ({
 }));
 
 vi.mock('../role-profiles-context', () => ({
-  useRoleProfiles: () => ({ registerDynamicRole: vi.fn() })
+  useRoleProfiles: () => ({ registerDynamicRole: vi.fn() }),
+  customAgentIdFromRole: (roleProfileId: string): string | null =>
+    roleProfileId.startsWith('custom:') ? roleProfileId.slice('custom:'.length) : null
+}));
+
+// Issue #1021: listener は settings.customAgents / parse-args を参照する。
+vi.mock('../settings-context', () => ({
+  useSettings: () => ({ settings: { customAgents: [] } })
+}));
+
+vi.mock('../parse-args', () => ({
+  parseShellArgsStrict: (s: string) => ({ args: s ? s.split(/\s+/) : [] })
 }));
 
 vi.mock('../toast-context', () => ({

--- a/src/renderer/src/lib/role-profiles-context.tsx
+++ b/src/renderer/src/lib/role-profiles-context.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import type {
+  AgentConfig,
   DynamicRoleEntry,
   Language,
   RoleCreatedPayload,
@@ -30,6 +31,14 @@ import {
   composeWorkerProfile,
   toolsPlaceholder
 } from './role-profiles-builtin';
+import { useSettings } from './settings-context';
+// Issue #1021: custom agent (CLI/API) → role profile の合成は pure helper に分離。
+import { customAgentToProfile } from './role-profiles-custom-agents';
+export {
+  customAgentToProfile,
+  customAgentIdFromRole,
+  CUSTOM_AGENT_ROLE_PREFIX
+} from './role-profiles-custom-agents';
 
 /**
  * Issue #513: 旧 local 定義 `DynamicRoleEntry` を shared.ts に集約。
@@ -71,7 +80,8 @@ const EMPTY_FILE: RoleProfilesFile = { schemaVersion: 1, overrides: {}, custom: 
 
 function compose(
   file: RoleProfilesFile,
-  dynamic: Record<string, DynamicRoleEntry>
+  dynamic: Record<string, DynamicRoleEntry>,
+  customAgents: AgentConfig[]
 ): {
   byId: Record<string, RoleProfile>;
   ordered: RoleProfile[];
@@ -119,7 +129,17 @@ function compose(
       instructionsJa: entry.instructionsJa
     });
   }
-  // 順序: leader 先頭 → builtin の元順 → user 追加分 → 動的ロール
+  // 5. custom agent (設定の CLI/API agent) を role profile として合成 (Issue #1021)。
+  //    既存 id と衝突する場合は既存を優先 (custom:<id> prefix で実質衝突しない)。
+  const customAgentIds: string[] = [];
+  for (const agent of customAgents) {
+    const profile = customAgentToProfile(agent);
+    if (byId[profile.id]) continue;
+    byId[profile.id] = profile;
+    customAgentIds.push(profile.id);
+  }
+
+  // 順序: leader 先頭 → builtin の元順 → user 追加分 → 動的ロール → custom agent
   const ordered: RoleProfile[] = [];
   const leader = byId['leader'];
   if (leader) ordered.push(leader);
@@ -134,6 +154,9 @@ function compose(
       const p = byId[id];
       if (p) ordered.push(p);
     }
+  }
+  for (const id of customAgentIds) {
+    ordered.push(byId[id]);
   }
   return { byId, ordered };
 }
@@ -245,7 +268,12 @@ export function RoleProfilesProvider({ children }: { children: ReactNode }): JSX
     };
   }, []);
 
-  const { byId, ordered } = useMemo(() => compose(file, dynamic), [file, dynamic]);
+  // Issue #1021: 設定の custom agent (CLI/API) を role profile に合成する。
+  const { settings } = useSettings();
+  const { byId, ordered } = useMemo(
+    () => compose(file, dynamic, settings.customAgents ?? []),
+    [file, dynamic, settings.customAgents]
+  );
 
   // Tauri TeamHub に role profile summary を同期 (team_list_role_profiles / permissions 検証用)。
   // 動的ロールは Hub 側で別管理 (team_id スコープ) なので、ここでは builtin / custom だけを送る。

--- a/src/renderer/src/lib/role-profiles-custom-agents.ts
+++ b/src/renderer/src/lib/role-profiles-custom-agents.ts
@@ -1,0 +1,53 @@
+// role-profiles-custom-agents — 設定の custom agent (CLI/API) を team の role profile に
+// 合成する pure helper (Issue #1021)。
+//
+// これにより custom agent がチーム作成 UI と team_list_role_profiles (MCP 雇用) の両方に出る。
+// recruit 時は `useRecruitListener` が id prefix で分岐し、runtime に応じたカードを spawn する。
+// React に依存しないため単体テスト・listener から直接 import できる。
+
+import type { AgentConfig, RoleProfile } from '../../../types/shared';
+
+/** custom agent role profile の id prefix。recruit 時にこの prefix で分岐する。 */
+export const CUSTOM_AGENT_ROLE_PREFIX = 'custom:';
+
+/** custom agent role profile の id から元の agent id を取り出す。custom でなければ null。 */
+export function customAgentIdFromRole(roleProfileId: string): string | null {
+  return roleProfileId.startsWith(CUSTOM_AGENT_ROLE_PREFIX)
+    ? roleProfileId.slice(CUSTOM_AGENT_ROLE_PREFIX.length)
+    : null;
+}
+
+/** 設定の custom agent (CLI/API) を team の role profile へ合成する。 */
+export function customAgentToProfile(agent: AgentConfig): RoleProfile {
+  const label = agent.name?.trim() || agent.id;
+  const description =
+    agent.runtime === 'api'
+      ? `API agent — ${agent.providerId} / ${agent.model}`
+      : `CLI agent — ${agent.command || '(no command)'}`;
+  return {
+    schemaVersion: 1,
+    id: `${CUSTOM_AGENT_ROLE_PREFIX}${agent.id}`,
+    source: 'user',
+    i18n: {
+      en: { label, description },
+      ja: { label, description }
+    },
+    visual: {
+      color: agent.color ?? '#d97757',
+      glyph: label.slice(0, 1).toUpperCase() || '?'
+    },
+    // CLI/API agent は worker prompt template を使わない (CLI は command 起動 / API は
+    // systemPrompt を card 側で扱う)。
+    prompt: { template: '' },
+    permissions: {
+      canRecruit: false,
+      canDismiss: false,
+      canAssignTasks: false,
+      canCreateRoleProfile: false
+    },
+    // defaultEngine は claude/codex のみの型。custom は recruit 時に id prefix で分岐するため
+    // ここはプレースホルダ (実 spawn は engine ではなく runtime で決まる)。
+    defaultEngine: 'claude',
+    singleton: false
+  };
+}

--- a/src/renderer/src/lib/use-recruit-listener.ts
+++ b/src/renderer/src/lib/use-recruit-listener.ts
@@ -248,7 +248,10 @@ export function useRecruitListener(): void {
             title: titleHint,
             position: pos,
             payload: {
-              agentId: customAgent.id,
+              // agentId は Hub の runtime instance id に揃える (dismiss/cancel のカード検索キー)。
+              // 設定 (provider/model) の解決は agentConfigId 経由 (Issue #1021)。
+              agentId: p.newAgentId,
+              agentConfigId: customAgent.id,
               teamId: p.teamId,
               teamName: requesterTeamName,
               // teamRole が teamId と揃うと team_read / team_send / team_info が有効になる (#1005)。

--- a/src/renderer/src/lib/use-recruit-listener.ts
+++ b/src/renderer/src/lib/use-recruit-listener.ts
@@ -26,7 +26,9 @@ import {
 } from '../stores/canvas';
 import type { Node } from '@xyflow/react';
 import type { CardData } from '../stores/canvas';
-import { useRoleProfiles } from './role-profiles-context';
+import { useRoleProfiles, customAgentIdFromRole } from './role-profiles-context';
+import { useSettings } from './settings-context';
+import { parseShellArgsStrict } from './parse-args';
 import { ackRecruit } from './recruit-ack';
 import { findRecruitPosition } from './canvas-recruit-position';
 import type {
@@ -97,6 +99,10 @@ function waitPolicyInstructions(policy: WaitPolicy | undefined): string {
 export function useRecruitListener(): void {
   // 動的ロールを RoleProfilesContext に投入するためのフック関数
   const { registerDynamicRole } = useRoleProfiles();
+  // Issue #1021: recruit が custom agent role の場合に runtime を解決するため最新 settings を ref で保持。
+  const { settings } = useSettings();
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
   const { showToast } = useToast();
   const t = useT();
 
@@ -228,28 +234,72 @@ export function useRecruitListener(): void {
         );
         const pos = findRecruitPosition(requester, teamNodes);
         const titleHint = p.agentLabelHint?.trim() || p.roleProfileId;
-        const newNodeId = store.addCard({
-          type: 'agent',
-          title: titleHint,
-          position: pos,
-          payload: {
-            agent: p.engine,
-            roleProfileId: p.roleProfileId,
-            // 旧コード互換: role 旧フィールドにも書く (一時的)
-            role: p.roleProfileId,
-            teamId: p.teamId,
-            teamName: requesterTeamName,
-            agentId: p.newAgentId,
-            organization: requesterOrganization,
-            // Issue #117: AgentNodeCard が拾って Claude(--append-system-prompt) /
-            // Codex(model_instructions_file) 両方の経路に注入する正本フィールド。
-            // Issue #930: 旧 p.customInstructions は Rust 側に存在しないファントム
-            // フィールドで常に undefined だったため、waitPolicy 由来の指示のみを使う
-            // (実行時挙動は従来と同一)。
-            customInstructions: waitPolicyInstructions(p.waitPolicy),
-            waitPolicy: p.waitPolicy ?? 'strict'
-          }
-        });
+        // Issue #1021: custom agent role の recruit は runtime に応じて正しいカードを spawn する。
+        // (claude/codex を誤起動しない)。CLI → agent カードを custom command で、
+        // API → apiAgent カードを team context 付きで pull 参加させる。
+        const customAgentId = customAgentIdFromRole(p.roleProfileId);
+        const customAgent = customAgentId
+          ? (settingsRef.current.customAgents ?? []).find((a) => a.id === customAgentId)
+          : undefined;
+        let newNodeId: string;
+        if (customAgent?.runtime === 'api') {
+          newNodeId = store.addCard({
+            type: 'apiAgent',
+            title: titleHint,
+            position: pos,
+            payload: {
+              agentId: customAgent.id,
+              teamId: p.teamId,
+              teamName: requesterTeamName,
+              // teamRole が teamId と揃うと team_read / team_send / team_info が有効になる (#1005)。
+              teamRole: p.roleProfileId
+            }
+          });
+        } else if (customAgent?.runtime === 'cli') {
+          newNodeId = store.addCard({
+            type: 'agent',
+            title: titleHint,
+            position: pos,
+            payload: {
+              // command override で custom CLI を起動する (CardFrame は payload.command を優先)。
+              agent: p.engine,
+              command: customAgent.command || undefined,
+              args: customAgent.args ? parseShellArgsStrict(customAgent.args).args : undefined,
+              cwd: customAgent.cwd || undefined,
+              roleProfileId: p.roleProfileId,
+              role: p.roleProfileId,
+              teamId: p.teamId,
+              teamName: requesterTeamName,
+              agentId: p.newAgentId,
+              organization: requesterOrganization,
+              customInstructions: waitPolicyInstructions(p.waitPolicy),
+              waitPolicy: p.waitPolicy ?? 'strict'
+            }
+          });
+        } else {
+          newNodeId = store.addCard({
+            type: 'agent',
+            title: titleHint,
+            position: pos,
+            payload: {
+              agent: p.engine,
+              roleProfileId: p.roleProfileId,
+              // 旧コード互換: role 旧フィールドにも書く (一時的)
+              role: p.roleProfileId,
+              teamId: p.teamId,
+              teamName: requesterTeamName,
+              agentId: p.newAgentId,
+              organization: requesterOrganization,
+              // Issue #117: AgentNodeCard が拾って Claude(--append-system-prompt) /
+              // Codex(model_instructions_file) 両方の経路に注入する正本フィールド。
+              // Issue #930: 旧 p.customInstructions は Rust 側に存在しないファントム
+              // フィールドで常に undefined だったため、waitPolicy 由来の指示のみを使う
+              // (実行時挙動は従来と同一)。
+              customInstructions: waitPolicyInstructions(p.waitPolicy),
+              waitPolicy: p.waitPolicy ?? 'strict'
+            }
+          });
+        }
         // Issue #253 / #372: 新メンバー配置後、Canvas 側で「新しい worker」を中心に
         // viewport を寄せる。HR が worker を増やすケースでも Leader ではなく
         // 追加されたばかりの worker が viewport の中央に来る。

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -83,7 +83,14 @@ export type AgentCardPayload = AgentPayload & CardPayloadBase;
 
 /** apiAgent カード: API 駆動 Chat session への参照だけを payload に持つ。 */
 export interface ApiAgentCardPayload extends CardPayloadBase {
+  /**
+   * canvas / TeamHub 上のインスタンス ID (dismiss/cancel のカード検索キー)。通常カードは
+   * 設定の agent config id と同じだが、team recruit で生成されたカードは Hub の runtime
+   * instance id (newAgentId) が入る。その場合の設定解決は `agentConfigId` を使う (Issue #1021)。
+   */
   agentId: string;
+  /** 設定の custom agent config id。`agentId` が instance id のときの provider/model 解決用。 */
+  agentConfigId?: string;
   sessionId?: string;
   providerId?: string;
   model?: string;


### PR DESCRIPTION
## Summary
- 設定で作成した custom agent (CLI / API) を team の **role profile** に合成し、**チーム作成 UI** と **vibe-team MCP の `team_list_role_profiles`（雇用）**の両方に選択肢として出す (Issue #1021)。

## アーキテクチャ
合成は renderer 主導：`compose()` → `ordered` → 既存の `setRoleProfileSummary` で Hub に push → `team_list_role_profiles` がそれを返す。`team_recruit` (Rust) は id を summary と照合して `team:recruit-request` を emit するだけで、実 spawn は renderer (`useRecruitListener`)。よって**中核は不変**で、renderer 側の合成 + recruit 分岐だけで成立する。

## 変更点
- `role-profiles-custom-agents.ts` (新規, pure): `customAgentToProfile` / `customAgentIdFromRole` / `CUSTOM_AGENT_ROLE_PREFIX`。role id は `custom:<agentId>`。
- `role-profiles-context.tsx`: `compose()` に `settings.customAgents` を渡して合成。`ordered` 末尾に追加され、summary 同期経由で `team_list_role_profiles` に自動掲載。
- `use-recruit-listener.ts`: recruit が `custom:<id>` role のとき runtime で分岐し claude/codex を誤起動しない。
  - **CLI** → `agent` カードを custom の command/args/cwd で起動 (`CardFrame` の `payload.command` 優先)。
  - **API** → `apiAgent` カードを team context (teamId/teamRole) 付きで生成し pull 参加 (#1005)。

## 注意 (スコープ外の制約)
- CLI custom agent がチームと**協調**するには vibe-team MCP を話せる必要がある (一般 CLI ツールは handshake しない)。
- API agent は pull 型参加で **auto-turn は無い** (safe 版 E の制約)。
- 本 PR は「選択肢に出して、recruit 時に runtime に応じた正しいカードを spawn する」ところまで。完全な自動協調は別途。

## Test plan
- [x] `npm run typecheck` 通過
- [x] `vitest` 合成 helper の単体テスト (custom-agent-role.test.ts, 4 件) + recruit listener テスト 2 件 (settings/parse-args mock 補完) = 9 passed
- [x] file-size ratchet OK (helper を別ファイルに分離し role-profiles-context を 500 行未満に維持)
- [x] Rust / 型 / baseline 変更なし
- ※ 既存の `agent-resolver.test.ts` の 1 件失敗は本変更前から main で失敗しており本 PR と無関係 (agent-resolver は変更ファイルを import しない)。

Closes #1021
