### PR TITLE
test(agent-resolver): custom agent fixture に runtime:'cli' を補完

### DIFF
--- a/src/renderer/src/lib/__tests__/agent-resolver.test.ts
+++ b/src/renderer/src/lib/__tests__/agent-resolver.test.ts
@@ -12,6 +12,7 @@ describe('resolveAgentConfig', () => {
         {
           id: 'claude',
           name: 'Shadow Claude',
+          runtime: 'cli',
           command: 'shadow-claude',
           args: '--shadow'
         }
@@ -34,6 +35,7 @@ describe('resolveAgentConfig', () => {
         {
           id: 'codex',
           name: 'Shadow Codex',
+          runtime: 'cli',
           command: 'shadow-codex',
           args: '--shadow'
         }
@@ -55,6 +57,7 @@ describe('resolveAgentConfig', () => {
         {
           id: 'aider',
           name: 'Aider',
+          runtime: 'cli',
           command: 'aider',
           args: '--yes',
           color: '#00ffaa'


### PR DESCRIPTION
## Summary
- `agent-resolver.test.ts` の custom agent fixture 3 箇所に `runtime: 'cli'` を補完。
- #1021 の `AgentConfig` discriminated union 移行で `resolveAgentConfig` は `runtime === 'cli'` を要求するようになったが、fixture が旧形 (runtime 欠落) のままで、custom agent 解決テストが claude default に落ちて失敗していた (main で再現)。
- production は Rust の serde `default = "default_agent_runtime"` (`settings.rs:184/212`) と v12 migration で `runtime` が必ず入るため production コードは正しく、テスト fixture を post-migration の形に揃えるだけの修正。
- 関連 issue: #1027

## Test plan
- [x] `vitest run agent-resolver.test.ts` → 3 tests pass
- [x] `npm run typecheck` 通過