### PR TITLE
fix(settings): recover from invalid saved project root

### DIFF
--- a/src/renderer/src/lib/__tests__/settings-context.test.tsx
+++ b/src/renderer/src/lib/__tests__/settings-context.test.tsx
@@ -90,6 +90,37 @@ describe('settings-context', () => {
     expect(result.current.settings.editorFontSize).toBe(16);
   });
 
+  it('lastOpenedRoot が空なら claudeCwd を project root として同期しない', async () => {
+    const api = installApi({
+      claudeCwd: 'C:\\Users\\zooyo',
+      lastOpenedRoot: ''
+    });
+
+    const { result } = renderHook(() => useSettings(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(api.app.setProjectRoot).not.toHaveBeenCalled();
+  });
+
+  it('lastOpenedRoot だけを backend project root として同期する', async () => {
+    const api = installApi({
+      claudeCwd: 'C:\\Users\\zooyo',
+      lastOpenedRoot: 'C:\\Users\\zooyo\\Documents\\GitHub\\vibe-editor'
+    });
+
+    const { result } = renderHook(() => useSettings(), { wrapper: Wrapper });
+
+    await waitFor(() =>
+      expect(api.app.setProjectRoot).toHaveBeenCalledWith(
+        'C:\\Users\\zooyo\\Documents\\GitHub\\vibe-editor'
+      )
+    );
+    expect(result.current.loading).toBe(false);
+    expect(api.app.setProjectRoot).toHaveBeenCalledTimes(1);
+  });
+
   it('update() 後 200ms の debounce 経過で window.api.settings.save() が呼ばれる', async () => {
     const api = installApi();
     const { result } = renderHook(() => useSettings(), { wrapper: Wrapper });

--- a/src/renderer/src/lib/hooks/__tests__/use-project-loader.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-project-loader.test.tsx
@@ -1,0 +1,166 @@
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppSettings } from '../../../../../types/shared';
+
+const mocks = vi.hoisted(() => ({
+  settingsLoading: false,
+  settingsValues: {
+    claudeCwd: '',
+    lastOpenedRoot: '',
+    recentProjects: [] as string[],
+    hasCompletedOnboarding: true,
+    mcpAutoSetup: false,
+    workspaceFolders: [] as string[]
+  },
+  updateSettings: vi.fn(async () => undefined),
+  confirm: vi.fn(async () => true),
+  setStatus: vi.fn()
+}));
+
+vi.mock('../../settings-context', () => ({
+  useSettingsActions: () => ({ update: mocks.updateSettings }),
+  useSettingsLoading: () => mocks.settingsLoading,
+  useSettingsValue: (key: keyof AppSettings) =>
+    mocks.settingsValues[key as keyof typeof mocks.settingsValues]
+}));
+
+vi.mock('../../i18n', () => ({
+  useT: () => (key: string, params?: Record<string, string | number>) =>
+    params?.error ? `${key}: ${params.error}` : key
+}));
+
+vi.mock('../../use-native-confirm', () => ({
+  useNativeConfirm: () => mocks.confirm
+}));
+
+vi.mock('../../../stores/ui', () => ({
+  useUiStore: {
+    getState: () => ({ setStatus: mocks.setStatus })
+  }
+}));
+
+import {
+  useProjectLoader,
+  type UseProjectLoaderOptions
+} from '../use-project-loader';
+
+type TestWindow = Window &
+  typeof globalThis & {
+    api?: MockApi;
+  };
+
+interface MockApi {
+  app: {
+    setProjectRoot: ReturnType<typeof vi.fn>;
+    setupTeamMcp: ReturnType<typeof vi.fn>;
+    setWindowTitle: ReturnType<typeof vi.fn>;
+  };
+  dialog: {
+    openFolder: ReturnType<typeof vi.fn>;
+    openFile: ReturnType<typeof vi.fn>;
+    isFolderEmpty: ReturnType<typeof vi.fn>;
+  };
+  git: {
+    status: ReturnType<typeof vi.fn>;
+  };
+  sessions: {
+    list: ReturnType<typeof vi.fn>;
+  };
+}
+
+function installApi(): MockApi {
+  const api: MockApi = {
+    app: {
+      setProjectRoot: vi.fn(async () => undefined),
+      setupTeamMcp: vi.fn(async () => undefined),
+      setWindowTitle: vi.fn(async () => undefined)
+    },
+    dialog: {
+      openFolder: vi.fn(async () => ''),
+      openFile: vi.fn(async () => ''),
+      isFolderEmpty: vi.fn(async () => true)
+    },
+    git: {
+      status: vi.fn(async () => ({ ok: true, files: [] }))
+    },
+    sessions: {
+      list: vi.fn(async () => [])
+    }
+  };
+  (window as TestWindow).api = api;
+  return api;
+}
+
+function options(overrides: Partial<UseProjectLoaderOptions> = {}): UseProjectLoaderOptions {
+  return {
+    confirmDiscardEditorTabs: vi.fn(async () => true),
+    onProjectSwitched: vi.fn(),
+    onLoaded: vi.fn(),
+    showToast: vi.fn(),
+    discardEditorTabsForRoot: vi.fn(async () => true),
+    ...overrides
+  };
+}
+
+describe('useProjectLoader', () => {
+  let originalApi: MockApi | undefined;
+
+  beforeEach(() => {
+    originalApi = (window as TestWindow).api;
+    mocks.settingsLoading = false;
+    mocks.settingsValues.claudeCwd = '';
+    mocks.settingsValues.lastOpenedRoot = '';
+    mocks.settingsValues.recentProjects = [];
+    mocks.settingsValues.hasCompletedOnboarding = true;
+    mocks.settingsValues.mcpAutoSetup = false;
+    mocks.settingsValues.workspaceFolders = [];
+    mocks.updateSettings.mockClear();
+    mocks.confirm.mockClear();
+    mocks.setStatus.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (originalApi === undefined) {
+      delete (window as TestWindow).api;
+    } else {
+      (window as TestWindow).api = originalApi;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('保存済み root が拒否されたらフォルダ選択へフォールバックする', async () => {
+    const invalidRoot = 'C:\\Users\\zooyo';
+    const pickedRoot =
+      'C:\\Users\\zooyo\\Documents\\GitHub\\DX\\digital-management-consulting-app';
+    mocks.settingsValues.lastOpenedRoot = invalidRoot;
+    mocks.settingsValues.claudeCwd = invalidRoot;
+    const api = installApi();
+    api.app.setProjectRoot
+      .mockRejectedValueOnce(new Error('project_root rejected by safety check'))
+      .mockResolvedValueOnce(undefined);
+    api.dialog.openFolder.mockResolvedValueOnce(pickedRoot);
+    const onLoaded = vi.fn();
+    const onProjectSwitched = vi.fn();
+
+    const { result } = renderHook(() =>
+      useProjectLoader(options({ onLoaded, onProjectSwitched }))
+    );
+
+    await waitFor(() => expect(api.dialog.openFolder).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(api.git.status).toHaveBeenCalledWith(pickedRoot));
+
+    expect(api.app.setProjectRoot.mock.calls.map(([root]) => root)).toEqual([
+      invalidRoot,
+      pickedRoot
+    ]);
+    expect(mocks.updateSettings).toHaveBeenCalledWith({ lastOpenedRoot: '' });
+    expect(mocks.updateSettings).toHaveBeenCalledWith({ lastOpenedRoot: pickedRoot });
+    expect(result.current.projectRoot).toBe(pickedRoot);
+    expect(onLoaded).toHaveBeenCalledWith({
+      gitStatus: { ok: true, files: [] },
+      sessions: []
+    });
+    expect(onProjectSwitched).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/lib/hooks/use-project-loader.ts
+++ b/src/renderer/src/lib/hooks/use-project-loader.ts
@@ -160,8 +160,24 @@ export function useProjectLoader(
       try {
         // 既存ユーザーの移行: lastOpenedRoot が空で claudeCwd が設定されている場合は
         // かつての挙動 (claudeCwd = 最後に開いたルート) を尊重して再利用する。
-        const remembered = lastOpenedRoot || claudeCwd;
+        // ただし claudeCwd は CLI 既定 cwd でもあり、home 直下など project root として
+        // 不正な値を持ちうる。拒否された remembered root は起動ブロッカーにせず、
+        // 明示的なフォルダ選択へフォールバックする。
+        const remembered = (lastOpenedRoot || claudeCwd || '').trim();
         let root = remembered;
+        let rootIsActive = false;
+        if (root) {
+          try {
+            await window.api.app.setProjectRoot(root);
+            rootIsActive = true;
+          } catch (err) {
+            if (root === lastOpenedRoot) {
+              void updateSettings({ lastOpenedRoot: '' });
+            }
+            useUiStore.getState().setStatus(t('project.initError', { error: String(err) }));
+            root = '';
+          }
+        }
         if (!root) {
           const picked = await window.api.dialog.openFolder(t('appMenu.openFolderDialogTitle'));
           if (cancelled) return;
@@ -179,12 +195,14 @@ export function useProjectLoader(
         // active project_root を await で確定させてから git/sessions の fetch を発火する。
         // ゲート (#932 read 側拡張) は active root 未設定時に reject するため、これが無いと
         // 起動時の git パネルが transient reject で空振りする。
-        try {
-          await window.api.app.setProjectRoot(root);
-        } catch (err) {
-          useUiStore.getState().setStatus(t('project.initError', { error: String(err) }));
-          setGitLoading(false);
-          return;
+        if (!rootIsActive) {
+          try {
+            await window.api.app.setProjectRoot(root);
+          } catch (err) {
+            useUiStore.getState().setStatus(t('project.initError', { error: String(err) }));
+            setGitLoading(false);
+            return;
+          }
         }
         if (cancelled) return;
         setProjectRoot(root);

--- a/src/renderer/src/lib/settings-context.tsx
+++ b/src/renderer/src/lib/settings-context.tsx
@@ -185,7 +185,7 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
 
   const lastSyncedRootRef = useRef<string>('');
   useEffect(() => {
-    const effectiveRoot = (settingsState.lastOpenedRoot || settingsState.claudeCwd || '').trim();
+    const effectiveRoot = (settingsState.lastOpenedRoot || '').trim();
     if (effectiveRoot === lastSyncedRootRef.current) return;
     lastSyncedRootRef.current = effectiveRoot;
     void window.api.app.setProjectRoot(effectiveRoot).catch((err) => {
@@ -198,7 +198,7 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
         { tone: 'error' }
       );
     });
-  }, [settingsState.lastOpenedRoot, settingsState.claudeCwd]);
+  }, [settingsState.lastOpenedRoot]);
 
   const update = useCallback(
     async (patch: Partial<AppSettings>) => {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -214,3 +214,9 @@ codex exec --sandbox read-only --color never --ephemeral \
 - `data` は prompt 上で `data (untrusted)` と明示し、指示文ではなく資料として扱わせる。
 - 送信 API、JSON Schema、共有 TypeScript 型、worker / leader prompt、配布 Skill の文言は同じ境界で同期する。
 - Markdown fence で信頼できない本文を囲む場合は、本文中の backtick 連続数より長い fence を選ぶ。
+
+## Issue #1040 - Project root safety gate と claudeCwd の分離
+
+- `claudeCwd` は CLI 起動時の既定 cwd であり、アプリの active `projectRoot` と同一視しない。
+- 起動復元では `lastOpenedRoot` を優先し、保存済み root が safety gate に拒否されたら、エラーで停止せず明示的なフォルダ選択へ逃がす。
+- home 直下 / system 領域を許可する方向で直さない。Rust 側 safety gate は維持し、renderer 側の復旧フローで吸収する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1898,3 +1898,37 @@ Plan: `tasks/issue-568-plan.md`
 - `cargo test --lib`: 295/295 PASS
 - `npx vitest run`: 299/299 PASS (48 files)
 - `npm run typecheck`: 0 error
+
+## Issue #1040 - Invalid saved home root blocks startup after ProjectRoot safety gate (2026-06-15 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1040
+
+### 計画
+
+- [x] v1.6.5 の `ProjectRoot` safety gate と起動復元フローを確認する。
+- [x] ローカル設定で `lastOpenedRoot = C:\Users\zooyo` が起動エラーの直接原因であることを確認する。
+- [x] ローカル `~/.vibe-editor/settings.json` を安全な既存 workspace root に切り替え、当面の起動不能を解除する。
+- [x] `SettingsProvider` が `claudeCwd` を backend project root として同期しないようにする。
+- [x] 初回ロード時、保存済み root が安全チェックで拒否されたら、エラーで停止せずフォルダ選択へフォールバックする。
+- [x] renderer の回帰テスト、型チェック、ビルドを通す。
+
+### Next Steps
+
+- [x] `src/renderer/src/lib/settings-context.tsx` を最小修正する。
+- [x] `src/renderer/src/lib/hooks/use-project-loader.ts` の初回ロードを安全な fallback つきに整理する。
+- [x] 必要な hook / context テストを追加する。
+- [ ] PR を作成し、CodeRabbit / CI / reviewer bot の結果を確認する。
+
+### 進捗
+
+- [x] `settings-context` は `lastOpenedRoot` のみを active project root として同期し、`claudeCwd` を同期元から外した。
+- [x] `use-project-loader` は保存済み root の `setProjectRoot` 失敗時に `lastOpenedRoot` を空にし、フォルダ選択へフォールバックする。
+- [x] `settings-context.test.tsx` と `use-project-loader.test.tsx` に回帰テストを追加した。
+
+### 検証結果
+
+- [x] `npx vitest run src/renderer/src/lib/__tests__/settings-context.test.tsx src/renderer/src/lib/hooks/__tests__/use-project-loader.test.tsx`: PASS (2 files / 8 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run build:vite`: PASS
+- [x] `npm run test`: PASS (79 files / 478 tests、既存の React act / Tauri listen cleanup warning は継続)
+- [x] `git diff --check`: PASS


### PR DESCRIPTION
## Summary

- Stop syncing `claudeCwd` as the backend active project root; only `lastOpenedRoot` drives that sync.
- During startup restore, recover from an invalid remembered root by clearing `lastOpenedRoot` and falling back to explicit folder selection.
- Add regression coverage for the `claudeCwd` / project-root separation and rejected remembered-root fallback.

Closes #1040

## Test plan

- `npx vitest run src/renderer/src/lib/__tests__/settings-context.test.tsx src/renderer/src/lib/hooks/__tests__/use-project-loader.test.tsx`
- `npm run typecheck`
- `npm run build:vite`
- `npm run test`
- `git diff --check`