### PR TITLE
fix(ci): restore API agent Rust checks

### DIFF
--- a/src-tauri/src/commands/api_agents/skills.rs
+++ b/src-tauri/src/commands/api_agents/skills.rs
@@ -116,7 +116,7 @@ fn dedup_by_scope_id(
             scope: scope.to_string(),
         });
     }
-    out.sort_by(|a, b| (a.scope.clone(), a.id.clone()).cmp(&(b.scope.clone(), b.id.clone())));
+    out.sort_by_key(|a| (a.scope.clone(), a.id.clone()));
     out
 }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -220,3 +220,9 @@ codex exec --sandbox read-only --color never --ephemeral \
 - `claudeCwd` は CLI 起動時の既定 cwd であり、アプリの active `projectRoot` と同一視しない。
 - 起動復元では `lastOpenedRoot` を優先し、保存済み root が safety gate に拒否されたら、エラーで停止せず明示的なフォルダ選択へ逃がす。
 - home 直下 / system 領域を許可する方向で直さない。Rust 側 safety gate は維持し、renderer 側の復旧フローで吸収する。
+
+## Issue #1042 - Rust Clippy unnecessary_sort_by
+
+- CI が `cargo clippy ... -D warnings` で落ちた場合は、ローカルでも同じコマンドで再現してから直す。
+- `(scope, id)` のような key tuple でソートするだけなら、`sort_by` の比較式より `sort_by_key` を使う。
+- Windows の toolchain に Clippy が無い場合は、検証前に `rustup component add clippy` を実行する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1932,3 +1932,32 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1040
 - [x] `npm run build:vite`: PASS
 - [x] `npm run test`: PASS (79 files / 478 tests、既存の React act / Tauri listen cleanup warning は継続)
 - [x] `git diff --check`: PASS
+
+## Issue #1042 - Rust Clippy unnecessary_sort_by in API agent skills (2026-06-15 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1042
+
+### 計画
+
+- [x] PR #1041 merge 後の `cargo-cfg` 失敗ログを確認する。
+- [x] `src-tauri/src/commands/api_agents/skills.rs` の `sort_by` が Clippy `unnecessary_sort_by` に該当することを確認する。
+- [x] `sort_by_key` へ置き換え、動作を変えずに CI エラーを解消する。
+- [x] Rust 検証と差分確認を実行する。
+- [ ] PR を作成し、CI / reviewer bot の結果を確認する。
+
+### Next Steps
+
+- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
+- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`
+- [x] `git diff --check`
+
+### 進捗
+
+- [x] `dedup_by_scope_id` の `(scope, id)` ソートを `sort_by_key` に変更した。
+- [x] CI と同じ `-D warnings` 条件で Clippy を通した。
+
+### 検証結果
+
+- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
+- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`: PASS
+- [x] `git diff --check`: PASS


### PR DESCRIPTION
## Summary

- Replace the API agent skill source sort comparator with `sort_by_key` to satisfy Clippy's `unnecessary_sort_by` lint.
- Update the agentic provider tool-spec test to match the current auto-mode tool surface (`read`, `write`, `bash`, `search`, plus team tools when in a team).
- Record the CI failures and verification notes in `tasks/todo.md` / `tasks/lessons.md`.

Closes #1042
Closes #1045

## Test plan

- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml --lib commands::api_agents::providers::agentic::tests::tool_specs_adds_team_tools_only_when_in_a_team`
- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml --lib`
- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`
- [x] `git diff --check`