### PR TITLE
test(api-agents): update agentic tool spec expectations

### DIFF
--- a/src-tauri/src/commands/api_agents/providers/agentic.rs
+++ b/src-tauri/src/commands/api_agents/providers/agentic.rs
@@ -2,7 +2,7 @@
 //
 // tools_enabled (supports_tools && toolMode != readOnly) のとき呼ばれる。tool 解決ターンは
 // SSE の差分蓄積を避けるため非ストリーミング (完全 JSON から tool_calls をパース) で回し、
-// read_file / list_dir を実行して結果を会話へ戻す。最終回答は on_delta で emit する。
+// read/write/shell/search ツールを実行して結果を会話へ戻す。最終回答は on_delta で emit する。
 //
 // 各 provider のツール表現:
 //   - OpenAI:    request.tools[].function / response.message.tool_calls[] / role:"tool"
@@ -29,7 +29,7 @@ struct ToolCall {
 const BUDGET_MSG: &str = "Tool turn budget exceeded before a final answer.";
 
 /// このターンでモデルに公開するツール spec。team 参加時は team_read / team_send / team_info を
-/// read_file / list_dir に追加する。
+/// 標準ツールに追加する。
 fn tool_specs(rt: &ToolRuntime<'_>) -> Vec<tools::ToolSpec> {
     let mut specs = tools::builtin_read_tools();
     // Issue #1031: agentic 経路は auto (= !readOnly && supports_tools) のときだけ到達するため、

--- a/src-tauri/src/commands/api_agents/providers/agentic/tests.rs
+++ b/src-tauri/src/commands/api_agents/providers/agentic/tests.rs
@@ -95,7 +95,7 @@ use super::*;
         use std::sync::Arc;
 
         let mut noop = |_: &str, _: &str, _: Option<&str>| {};
-        // team 無し: read_file / list_dir のみ
+        // team 無し: auto mode の標準ツールのみ
         let rt_solo = ToolRuntime {
             project_root: "",
             max_turns: 1,
@@ -103,7 +103,16 @@ use super::*;
             team: None,
         };
         let solo: Vec<&str> = tool_specs(&rt_solo).iter().map(|s| s.name).collect();
-        assert_eq!(solo, vec!["read_file", "list_dir"]);
+        let base_tools = vec![
+            "read_file",
+            "list_dir",
+            "write_file",
+            "edit_file",
+            "bash",
+            "grep",
+            "glob",
+        ];
+        assert_eq!(solo, base_tools);
 
         // team 有り: team_read / team_send / team_info が追加される
         let mut noop2 = |_: &str, _: &str, _: Option<&str>| {};
@@ -119,8 +128,19 @@ use super::*;
             }),
         };
         let team: Vec<&str> = tool_specs(&rt_team).iter().map(|s| s.name).collect();
-        assert!(team.contains(&"read_file"));
-        assert!(team.contains(&"team_read"));
-        assert!(team.contains(&"team_send"));
-        assert!(team.contains(&"team_info"));
+        assert_eq!(
+            team,
+            vec![
+                "read_file",
+                "list_dir",
+                "write_file",
+                "edit_file",
+                "bash",
+                "grep",
+                "glob",
+                "team_read",
+                "team_send",
+                "team_info",
+            ]
+        );
     }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -226,3 +226,9 @@ codex exec --sandbox read-only --color never --ephemeral \
 - CI が `cargo clippy ... -D warnings` で落ちた場合は、ローカルでも同じコマンドで再現してから直す。
 - `(scope, id)` のような key tuple でソートするだけなら、`sort_by` の比較式より `sort_by_key` を使う。
 - Windows の toolchain に Clippy が無い場合は、検証前に `rustup component add clippy` を実行する。
+
+## Issue #1045 - Agentic tool specs test drift
+
+- API agent の tool surface を増やしたら、provider 統合テストの期待値も同じ PR 内で更新する。
+- 「team 有りで追加される tool」を見るテストでも、base tool list を明示して drift を早く検出する。
+- コメントに `read_file / list_dir` のような古い限定表現を残すと、後続修正で仕様を読み違えやすい。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1961,3 +1961,32 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1042
 - [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
 - [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`: PASS
 - [x] `git diff --check`: PASS
+
+## Issue #1045 - Agentic tool specs test expects outdated tool list (2026-06-15 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1045
+
+### 計画
+
+- [x] PR #1043 の `verify` 失敗ログを確認する。
+- [x] `tool_specs_adds_team_tools_only_when_in_a_team` が古い tool list を期待していることを確認する。
+- [x] agentic auto mode の現仕様（read / write / bash / search + team tools）へテスト期待値を更新する。
+- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml --lib commands::api_agents::providers::agentic::tests::tool_specs_adds_team_tools_only_when_in_a_team` を実行する。
+- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml --lib` を実行する。
+
+### Next Steps
+
+- [ ] Issue #1045 専用 PR を作成し、CI / reviewer bot を確認する。
+
+### 進捗
+
+- [x] `tool_specs` のコメントを現仕様に合わせた。
+- [x] solo 時の base tools と team 時の追加 tools を明示的に検証するようテストを更新した。
+
+### 検証結果
+
+- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml --lib commands::api_agents::providers::agentic::tests::tool_specs_adds_team_tools_only_when_in_a_team`: PASS
+- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml --lib`: PASS (793 passed / 0 failed / 2 ignored)
+- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
+- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`: PASS
+- [x] `git diff --check`: PASS


### PR DESCRIPTION
## Summary

- Update the agentic provider tool-spec test to match the current auto-mode tool surface: read, write, bash, search, and team tools when joined to a team.
- Refresh nearby comments so they no longer describe the old read-only tool list.
- Record the `verify` failure and the follow-up verification in `tasks/todo.md` / `tasks/lessons.md`.

Closes #1045

## Test plan

- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml --lib commands::api_agents::providers::agentic::tests::tool_specs_adds_team_tools_only_when_in_a_team`
- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml --lib`
- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`
- [x] `git diff --check HEAD~1..HEAD`