### PR TITLE
chore(release): bump version to 1.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-editor",
-  "version": "1.6.4",
+  "version": "1.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-editor",
-      "version": "1.6.4",
+      "version": "1.6.6",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/geist-mono": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5525,7 +5525,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.6.5"
+version = "1.6.6"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",

--- a/tasks/release-v1.6.6.md
+++ b/tasks/release-v1.6.6.md
@@ -1,0 +1,41 @@
+# Release v1.6.6
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1047
+
+## 計画
+
+- `v1.6.5` の startup blocker 対策を含む hotfix release として `v1.6.6` を作成する。
+- `main` は PR #1041 / #1043 / #1046 merge commit まで同期済み。
+- version files を `1.6.6` に更新する。
+- release PR を作成し、CI と reviewer bot の承認を待つ。
+- PR merge 後に local `main` を同期する。
+- `v1.6.6` annotated tag を merge commit に作成して push する。
+- `release.yml` の build を監視する。
+- draft release の assets と `latest.json` を確認し、publish する。
+
+## Next Steps
+
+- [x] `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` を `1.6.6` に更新する。
+- [x] `src-tauri/Cargo.lock` を `1.6.6` に同期する。
+- [x] `npm run typecheck`、`npm run build:vite`、`cargo check`、`git diff --check` を実行する。
+- [ ] release PR を作成し、CI / reviewer bot を確認する。
+- [ ] PR merge 後に `v1.6.6` tag を push する。
+- [ ] release workflow を監視し、draft release の assets と `latest.json` を確認する。
+- [ ] draft release を publish する。
+
+## 進捗
+
+- [x] `chore/release-v1.6.6` ブランチを作成。
+- [x] `package.json` / `package-lock.json` を `1.6.6` に更新。
+- [x] `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` / `src-tauri/tauri.conf.json` を `1.6.6` に更新。
+- [x] ローカル品質ゲートを通過。
+
+## 検証結果
+
+- [x] `npm run typecheck`: PASS
+- [x] `npm run build:vite`: PASS
+- [x] `cargo check --offline --manifest-path src-tauri/Cargo.toml --all-targets`: PASS（`Cargo.lock` 同期）
+- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`: PASS
+- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
+- [x] `npm run test`: PASS on rerun (79 files / 478 tests)
+- [x] `git diff --check`: PASS

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1962,6 +1962,44 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1042
 - [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`: PASS
 - [x] `git diff --check`: PASS
 
+## Release v1.6.6 startup hotfix (2026-06-15 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1047
+Plan: `tasks/release-v1.6.6.md`
+
+### 計画
+
+- [x] 最新 release が `v1.6.5` のままであることを確認する。
+- [x] `main` が #1041 / #1043 / #1046 を含むことを確認する。
+- [x] Release workflow が `v*` tag push で draft release を作ることを確認する。
+- [x] npm / Rust / Tauri の version を `1.6.6` に更新する。
+- [ ] release PR を作成し、CI / reviewer bot を確認する。
+- [ ] PR merge 後に `v1.6.6` tag を push する。
+- [ ] release workflow を監視し、draft release の assets と `latest.json` を確認する。
+- [ ] draft release を publish する。
+
+### Next Steps
+
+- [x] version files を更新する。
+- [x] `npm run typecheck`、`npm run build:vite`、`cargo check`、`git diff --check` を実行する。
+- [ ] PR を作成する。
+
+### 進捗
+
+- [x] `chore/release-v1.6.6` ブランチを作成した。
+- [x] npm / Rust / Tauri の version を `1.6.6` に同期した。
+- [x] ローカル品質ゲートを通した。
+
+### 検証結果
+
+- [x] `npm run typecheck`: PASS
+- [x] `npm run build:vite`: PASS
+- [x] `cargo check --offline --manifest-path src-tauri/Cargo.toml --all-targets`: PASS
+- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`: PASS
+- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
+- [x] `npm run test`: PASS on rerun (79 files / 478 tests)
+- [x] `git diff --check`: PASS
+
 ## Issue #1045 - Agentic tool specs test expects outdated tool list (2026-06-15 / Codex)
 
 Issue: https://github.com/yusei531642/vibe-editor/issues/1045


### PR DESCRIPTION
## Summary

- Bump npm, Rust, and Tauri versions to `1.6.6`.
- Prepare the hotfix release for the v1.6.5 startup blocker fixed by #1041.
- Include the current `main` fixes from #1041, #1043, and #1046 in the v1.6.6 release line.

Closes #1047

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build:vite`
- [x] `cargo check --offline --manifest-path src-tauri/Cargo.toml --all-targets`
- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`
- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- [x] `npm run test` (PASS on rerun; first run completed 79 files / 478 tests, then hit an existing teardown unhandled error)
- [x] `git diff --check`