### PR TITLE
docs(release): record v1.6.6 closeout

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -232,3 +232,9 @@ codex exec --sandbox read-only --color never --ephemeral \
 - API agent の tool surface を増やしたら、provider 統合テストの期待値も同じ PR 内で更新する。
 - 「team 有りで追加される tool」を見るテストでも、base tool list を明示して drift を早く検出する。
 - コメントに `read_file / list_dir` のような古い限定表現を残すと、後続修正で仕様を読み違えやすい。
+
+## Release v1.6.6 - Startup blocker hotfix
+
+- startup blocker の hotfix release では、修正PRのCIだけでなく、release PR、tag push、release workflow、公開後の latest release 表示まで一連で確認する。
+- `package-lock.json` の root version が古いまま残ることがあるため、release bump では `package.json` だけでなく lockfile の root/package version も必ず確認する。
+- Draft release を publish する前に、assets と `latest.json` の `version`、platform URL、署名エントリを確認する。

--- a/tasks/release-v1.6.6.md
+++ b/tasks/release-v1.6.6.md
@@ -18,10 +18,10 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1047
 - [x] `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` を `1.6.6` に更新する。
 - [x] `src-tauri/Cargo.lock` を `1.6.6` に同期する。
 - [x] `npm run typecheck`、`npm run build:vite`、`cargo check`、`git diff --check` を実行する。
-- [ ] release PR を作成し、CI / reviewer bot を確認する。
-- [ ] PR merge 後に `v1.6.6` tag を push する。
-- [ ] release workflow を監視し、draft release の assets と `latest.json` を確認する。
-- [ ] draft release を publish する。
+- [x] release PR を作成し、CI / reviewer bot を確認する。
+- [x] PR merge 後に `v1.6.6` tag を push する。
+- [x] release workflow を監視し、draft release の assets と `latest.json` を確認する。
+- [x] draft release を publish する。
 
 ## 進捗
 
@@ -29,6 +29,12 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1047
 - [x] `package.json` / `package-lock.json` を `1.6.6` に更新。
 - [x] `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` / `src-tauri/tauri.conf.json` を `1.6.6` に更新。
 - [x] ローカル品質ゲートを通過。
+- [x] PR #1048 を作成し、reviewer bot 承認と CI 全PASSを確認。
+- [x] PR #1048 が自動マージされ、Issue #1047 が close されたことを確認。
+- [x] `v1.6.6` annotated tag を merge commit `80f5361` に作成して push。
+- [x] Release workflow run `27518218007` が Linux / Windows / macOS すべて成功。
+- [x] Draft release の assets 13個と `latest.json` の `version: 1.6.6` を確認。
+- [x] GitHub Release `v1.6.6` を publish。
 
 ## 検証結果
 
@@ -39,3 +45,6 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1047
 - [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
 - [x] `npm run test`: PASS on rerun (79 files / 478 tests)
 - [x] `git diff --check`: PASS
+- [x] PR #1048 CI: `verify` / `cargo-cfg (windows-latest)` / `cargo-cfg (macos-latest)` / `secrets-scan`: PASS
+- [x] Release workflow `27518218007`: Linux / Windows / macOS build jobs: PASS
+- [x] Published release: https://github.com/yusei531642/vibe-editor/releases/tag/v1.6.6

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1973,22 +1973,28 @@ Plan: `tasks/release-v1.6.6.md`
 - [x] `main` が #1041 / #1043 / #1046 を含むことを確認する。
 - [x] Release workflow が `v*` tag push で draft release を作ることを確認する。
 - [x] npm / Rust / Tauri の version を `1.6.6` に更新する。
-- [ ] release PR を作成し、CI / reviewer bot を確認する。
-- [ ] PR merge 後に `v1.6.6` tag を push する。
-- [ ] release workflow を監視し、draft release の assets と `latest.json` を確認する。
-- [ ] draft release を publish する。
+- [x] release PR を作成し、CI / reviewer bot を確認する。
+- [x] PR merge 後に `v1.6.6` tag を push する。
+- [x] release workflow を監視し、draft release の assets と `latest.json` を確認する。
+- [x] draft release を publish する。
 
 ### Next Steps
 
 - [x] version files を更新する。
 - [x] `npm run typecheck`、`npm run build:vite`、`cargo check`、`git diff --check` を実行する。
-- [ ] PR を作成する。
+- [x] PR を作成する。
+- [x] GitHub Release `v1.6.6` を publish する。
 
 ### 進捗
 
 - [x] `chore/release-v1.6.6` ブランチを作成した。
 - [x] npm / Rust / Tauri の version を `1.6.6` に同期した。
 - [x] ローカル品質ゲートを通した。
+- [x] PR #1048 を作成し、reviewer bot 承認と CI 全PASSを確認した。
+- [x] PR #1048 が自動マージされ、Issue #1047 が close されたことを確認した。
+- [x] `v1.6.6` tag を merge commit `80f5361` に作成して push した。
+- [x] Release workflow run `27518218007` が成功した。
+- [x] Draft release の assets 13個と `latest.json` の `version: 1.6.6` を確認し、publish した。
 
 ### 検証結果
 
@@ -1999,6 +2005,9 @@ Plan: `tasks/release-v1.6.6.md`
 - [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
 - [x] `npm run test`: PASS on rerun (79 files / 478 tests)
 - [x] `git diff --check`: PASS
+- [x] PR #1048 CI: `verify` / `cargo-cfg (windows-latest)` / `cargo-cfg (macos-latest)` / `secrets-scan`: PASS
+- [x] Release workflow `27518218007`: Linux / Windows / macOS build jobs: PASS
+- [x] Published release: https://github.com/yusei531642/vibe-editor/releases/tag/v1.6.6
 
 ## Issue #1045 - Agentic tool specs test expects outdated tool list (2026-06-15 / Codex)
 


### PR DESCRIPTION
## Summary

- Mark the v1.6.6 hotfix release checklist as complete.
- Record PR #1048, release workflow run `27518218007`, published assets, and the final release URL.
- Add release-process lessons for future hotfixes.

## Test plan

- [x] `git diff --check`

Docs-only closeout for the already-published v1.6.6 release.