### PR TITLE
feat(api-agents): ローカル AI プロバイダ (Ollama / LM Studio) を追加

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -40,5 +40,5 @@
   "src/renderer/src/lib/i18n.ts": 1862,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
   "src/renderer/src/stores/canvas.ts": 584,
-  "src/types/shared.ts": 1866
+  "src/types/shared.ts": 1893
 }

--- a/src-tauri/src/commands/api_agents.rs
+++ b/src-tauri/src/commands/api_agents.rs
@@ -225,7 +225,7 @@ pub async fn api_agent_send(
         );
     }
 
-    let key = read_key(&req.agent.provider_id).await?;
+    let key = { let k = read_key(&req.agent.provider_id).await; if provider.requires_key { k? } else { k.unwrap_or_default() } };
     // project_root は team の read_file / list_dir tool が参照する (Issue #1004)。
     let project_root = current_project_root(&state.project_root).unwrap_or_default();
     // Issue #998/#1017: 選択 skill + 自動 vibe-team の本文を vibe-editor 専用フォルダから読む。

--- a/src-tauri/src/commands/api_agents/providers.rs
+++ b/src-tauri/src/commands/api_agents/providers.rs
@@ -35,44 +35,48 @@ pub(super) struct ProviderPreset {
     pub adapter: &'static str,
     pub base_url: String,
     pub supports_tools: bool,
+    /// false のとき API キー不要 (ローカル / OpenAI 互換ローカル)。
+    pub requires_key: bool,
 }
 
 pub(super) fn provider_preset(
     provider_id: &str,
     custom_base_url: Option<&str>,
 ) -> CommandResult<ProviderPreset> {
-    let preset = match provider_id {
-        "openai" => ("openai-compatible", "https://api.openai.com/v1", true),
-        "openrouter" => ("openai-compatible", "https://openrouter.ai/api/v1", true),
-        "nvidia-nim" => (
-            "openai-compatible",
-            "https://integrate.api.nvidia.com/v1",
-            false,
-        ),
-        "groq" => ("openai-compatible", "https://api.groq.com/openai/v1", false),
-        "mistral" => ("openai-compatible", "https://api.mistral.ai/v1", true),
-        "together" => ("openai-compatible", "https://api.together.xyz/v1", false),
-        "cerebras" => ("openai-compatible", "https://api.cerebras.ai/v1", false),
-        "anthropic" => ("anthropic", "https://api.anthropic.com/v1", true),
-        "gemini" => (
-            "gemini",
-            "https://generativelanguage.googleapis.com/v1beta",
-            true,
-        ),
-        "custom-openai-compatible" => (
-            "openai-compatible",
-            custom_base_url.unwrap_or("").trim(),
-            false,
-        ),
+    // (adapter, default_base_url, supports_tools, requires_key)
+    let (adapter, default_base, supports_tools, requires_key) = match provider_id {
+        "openai" => ("openai-compatible", "https://api.openai.com/v1", true, true),
+        "openrouter" => ("openai-compatible", "https://openrouter.ai/api/v1", true, true),
+        "nvidia-nim" => ("openai-compatible", "https://integrate.api.nvidia.com/v1", false, true),
+        "groq" => ("openai-compatible", "https://api.groq.com/openai/v1", false, true),
+        "mistral" => ("openai-compatible", "https://api.mistral.ai/v1", true, true),
+        "together" => ("openai-compatible", "https://api.together.xyz/v1", false, true),
+        "cerebras" => ("openai-compatible", "https://api.cerebras.ai/v1", false, true),
+        "anthropic" => ("anthropic", "https://api.anthropic.com/v1", true, true),
+        "gemini" => ("gemini", "https://generativelanguage.googleapis.com/v1beta", true, true),
+        // ローカル / OpenAI 互換: API キー不要、base URL は custom_base_url で上書き可。
+        "ollama" => ("openai-compatible", "http://localhost:11434/v1", true, false),
+        "lmstudio" => ("openai-compatible", "http://localhost:1234/v1", true, false),
+        "custom-openai-compatible" => ("openai-compatible", "", false, false),
         _ => return Err(CommandError::validation("unknown providerId")),
     };
-    if preset.1.is_empty() {
+    // local / custom は custom_base_url で上書き可。それ以外は固定 base。
+    let custom = custom_base_url.unwrap_or("").trim();
+    let base_url = if !custom.is_empty()
+        && matches!(provider_id, "ollama" | "lmstudio" | "custom-openai-compatible")
+    {
+        custom
+    } else {
+        default_base
+    };
+    if base_url.is_empty() {
         return Err(CommandError::validation("custom base URL is required"));
     }
     Ok(ProviderPreset {
-        adapter: preset.0,
-        base_url: preset.1.trim_end_matches('/').to_string(),
-        supports_tools: preset.2,
+        adapter,
+        base_url: base_url.trim_end_matches('/').to_string(),
+        supports_tools,
+        requires_key,
     })
 }
 
@@ -428,6 +432,23 @@ mod tests {
     fn custom_provider_requires_base_url() {
         assert!(provider_preset("custom-openai-compatible", None).is_err());
         assert!(provider_preset("custom-openai-compatible", Some("   ")).is_err());
+        // custom はキー任意 (ローカル想定)。
+        assert!(!provider_preset("custom-openai-compatible", Some("http://x/v1")).unwrap().requires_key);
+    }
+
+    #[test]
+    fn local_providers_default_base_and_no_key() {
+        let ollama = provider_preset("ollama", None).unwrap();
+        assert_eq!(ollama.base_url, "http://localhost:11434/v1");
+        assert!(!ollama.requires_key && ollama.supports_tools);
+        let lm = provider_preset("lmstudio", None).unwrap();
+        assert_eq!(lm.base_url, "http://localhost:1234/v1");
+        assert!(!lm.requires_key);
+        // custom_base_url で上書き可 (リモート host)。
+        let ov = provider_preset("ollama", Some("http://192.168.1.2:11434/v1/")).unwrap();
+        assert_eq!(ov.base_url, "http://192.168.1.2:11434/v1");
+        // cloud は requires_key=true。
+        assert!(provider_preset("openai", None).unwrap().requires_key);
     }
 
     #[test]

--- a/src-tauri/src/commands/api_agents/providers.rs
+++ b/src-tauri/src/commands/api_agents/providers.rs
@@ -60,7 +60,7 @@ pub(super) fn provider_preset(
         "custom-openai-compatible" => ("openai-compatible", "", false, false),
         _ => return Err(CommandError::validation("unknown providerId")),
     };
-    // local / custom は custom_base_url で上書き可。それ以外は固定 base。
+    // ローカル系 (ollama / lmstudio / custom) は custom_base_url で上書き可。他は固定 base URL。
     let custom = custom_base_url.unwrap_or("").trim();
     let base_url = if !custom.is_empty()
         && matches!(provider_id, "ollama" | "lmstudio" | "custom-openai-compatible")

--- a/src-tauri/src/commands/api_agents/providers/agentic/tests.rs
+++ b/src-tauri/src/commands/api_agents/providers/agentic/tests.rs
@@ -103,7 +103,11 @@ use super::*;
             team: None,
         };
         let solo: Vec<&str> = tool_specs(&rt_solo).iter().map(|s| s.name).collect();
-        assert_eq!(solo, vec!["read_file", "list_dir"]);
+        // team 無しでも read/write/exec/search tool は公開される (team tool だけが付かない)。
+        for expected in ["read_file", "list_dir", "write_file", "edit_file", "bash", "grep", "glob"] {
+            assert!(solo.contains(&expected), "missing {expected}");
+        }
+        assert!(!solo.contains(&"team_read"));
 
         // team 有り: team_read / team_send / team_info が追加される
         let mut noop2 = |_: &str, _: &str, _: Option<&str>| {};

--- a/src/renderer/src/components/settings/CustomAgentEditor.tsx
+++ b/src/renderer/src/components/settings/CustomAgentEditor.tsx
@@ -248,7 +248,7 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
                   providerId,
                   model: nextProvider?.defaultModel ?? apiAgent.model,
                   customBaseUrl:
-                    providerId === 'custom-openai-compatible'
+                    providerId === 'custom-openai-compatible' || nextProvider?.local
                       ? apiAgent.customBaseUrl
                       : undefined
                 });
@@ -262,14 +262,14 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
             </select>
           </label>
 
-          {apiAgent.providerId === 'custom-openai-compatible' && (
+          {(apiAgent.providerId === 'custom-openai-compatible' || provider.local) && (
             <label className="modal__label modal__label--full">
               <span>{t('settings.customAgents.baseUrl')}</span>
               <input
                 type="text"
                 value={apiAgent.customBaseUrl ?? ''}
                 onChange={(e) => patchApiAgent({ customBaseUrl: e.target.value })}
-                placeholder="https://example.com/v1"
+                placeholder={provider.baseUrl ?? 'https://example.com/v1'}
                 spellCheck={false}
               />
             </label>

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -48,6 +48,8 @@ export type ApiAgentProviderId =
   | 'cerebras'
   | 'anthropic'
   | 'gemini'
+  | 'ollama'
+  | 'lmstudio'
   | 'custom-openai-compatible';
 
 export type AgentRuntime = 'cli' | 'api';
@@ -100,6 +102,10 @@ export interface ApiAgentProviderPreset {
   baseUrl?: string;
   defaultModel: string;
   supportsTools: boolean;
+  /** ローカル実行 (Ollama / LM Studio 等)。base URL 入力を表示し API キーを任意にする。 */
+  local?: boolean;
+  /** API キー必須か (既定 true)。ローカル / custom は false。 */
+  requiresKey?: boolean;
 }
 
 export const API_AGENT_PROVIDER_PRESETS: ApiAgentProviderPreset[] = [
@@ -176,11 +182,32 @@ export const API_AGENT_PROVIDER_PRESETS: ApiAgentProviderPreset[] = [
     supportsTools: true
   },
   {
+    id: 'ollama',
+    label: 'Ollama (local)',
+    adapter: 'openai-compatible',
+    baseUrl: 'http://localhost:11434/v1',
+    defaultModel: 'llama3.1',
+    supportsTools: true,
+    local: true,
+    requiresKey: false
+  },
+  {
+    id: 'lmstudio',
+    label: 'LM Studio (local)',
+    adapter: 'openai-compatible',
+    baseUrl: 'http://localhost:1234/v1',
+    defaultModel: '',
+    supportsTools: true,
+    local: true,
+    requiresKey: false
+  },
+  {
     id: 'custom-openai-compatible',
     label: 'Custom OpenAI-compatible',
     adapter: 'openai-compatible',
     defaultModel: '',
-    supportsTools: false
+    supportsTools: false,
+    requiresKey: false
   }
 ];
 


### PR DESCRIPTION
## Summary
ゴール「localAI (ollama/lmstudio) も使えるように」対応。API agent でローカル LLM を使えるようにする。どちらも OpenAI 互換エンドポイントなので既存アダプタを流用。

- **provider 追加**: `ollama` (既定 `http://localhost:11434/v1`) / `lmstudio` (既定 `http://localhost:1234/v1`)。`supports_tools=true`。
- **API キー不要**: `ProviderPreset.requires_key` を追加。ローカル (ollama/lmstudio) と custom は鍵任意 (`api_agent_send` は requires_key の provider のみ keyring 必須。Authorization は両ローカルとも無視)。
- **base URL 上書き**: `customBaseUrl` で ollama/lmstudio/custom を上書き可 (リモート host / 別 port)。
- **model はフリーテキスト**で任意のローカルモデル ID を入力可。`ollama` 既定 `llama3.1`。
- UI: local provider のとき base URL 入力欄を表示 (既定値を placeholder)。
- 5 点同期: shared.ts (union/preset) / providers.rs / api_agents.rs / CustomAgentEditor。
- 関連 issue: #1044

### 付随
- 既存 stale test `tool_specs_adds_team_tools_only_when_in_a_team` を現行 tool セットに追従 (#1033 で write tool 追加後、`cargo test` 未走のため main で壊れていたのを修正)。
- file-size baseline: `shared.ts` を realign (provider preset 追加分。god-file 分割は #1032)。

## Test plan
- [x] `cargo test api_agents` → 90 tests pass (local provider preset / stale test 修正含む)
- [x] `npm run typecheck` / `cargo check` 緑
- [x] `node build/check-file-size-ratchet.mjs` 緑
- [ ] `npm run dev` 実機: Ollama 起動中に provider=Ollama / model=llama3.1 の API agent を作成 → 鍵なしで送受信できる。LM Studio も同様。

## 後続 (別 PR)
インストール済みモデルの自動取得 (`/v1/models`) でモデル dropdown 化。