### PR TITLE
feat(api-agents): web_fetch tool を追加 (SSRF ガード付き)

### DIFF
--- a/src-tauri/src/commands/api_agents.rs
+++ b/src-tauri/src/commands/api_agents.rs
@@ -17,6 +17,7 @@ mod project_docs;
 mod tools;
 mod tools_exec;
 mod tools_search;
+mod tools_web;
 mod tools_write;
 pub mod types;
 
@@ -143,8 +144,7 @@ pub async fn api_agent_session_delete(session_id: String) -> CommandResult<()> {
 
 #[tauri::command]
 pub async fn api_agent_cancel(_session_id: String, _generation_id: String) -> CommandResult<()> {
-    // v1 requests are short-lived reqwest calls. Cancellation is represented in the UI by
-    // ignoring stale generationId events; this command is intentionally idempotent.
+    // v1: short-lived reqwest calls; cancel is represented by ignoring stale generationId events.
     Ok(())
 }
 

--- a/src-tauri/src/commands/api_agents/providers/agentic.rs
+++ b/src-tauri/src/commands/api_agents/providers/agentic.rs
@@ -14,6 +14,7 @@ use serde_json::{json, Value};
 use super::super::tools;
 use super::super::tools_exec;
 use super::super::tools_search;
+use super::super::tools_web;
 use super::super::tools_write;
 use super::super::types::{ApiAgentConfig, ApiAgentMessage, ApiAgentUsage};
 use super::{usage_from_value, ProviderPreset, TeamToolCtx, ToolRuntime, HTTP_CLIENT};
@@ -39,6 +40,8 @@ fn tool_specs(rt: &ToolRuntime<'_>) -> Vec<tools::ToolSpec> {
     specs.extend(tools_exec::builtin_exec_tools());
     // Issue #1036: grep / glob 検索 tool も auto のとき公開する。
     specs.extend(tools_search::builtin_search_tools());
+    // Issue #1053: web_fetch (SSRF ガード付き) も auto のとき公開する。
+    specs.extend(tools_web::builtin_web_tools());
     if rt.team.is_some() {
         specs.extend(tools::builtin_team_tools());
     }
@@ -391,6 +394,9 @@ async fn run_tool_with_flag(rt: &mut ToolRuntime<'_>, call: &ToolCall) -> (Strin
     } else if tools_exec::is_exec_tool(&call.name) {
         // bash は子プロセス + timeout のため async で実行する (Issue #1034)。
         tools_exec::execute_exec_tool(rt.project_root, &call.name, &call.args).await
+    } else if tools_web::is_web_tool(&call.name) {
+        // web_fetch は HTTP のため async で実行する (Issue #1053)。
+        tools_web::execute_web_tool(&call.name, &call.args).await
     } else {
         // read_file / list_dir / write_file / edit_file は同期ブロッキング fs を含むため
         // spawn_blocking へ退避する。write 系 (Issue #1031) は tools_write へ dispatch する。

--- a/src-tauri/src/commands/api_agents/providers/agentic/tests.rs
+++ b/src-tauri/src/commands/api_agents/providers/agentic/tests.rs
@@ -111,6 +111,7 @@ use super::*;
             "bash",
             "grep",
             "glob",
+            "web_fetch",
         ];
         assert_eq!(solo, base_tools);
 
@@ -138,6 +139,7 @@ use super::*;
                 "bash",
                 "grep",
                 "glob",
+                "web_fetch",
                 "team_read",
                 "team_send",
                 "team_info",

--- a/src-tauri/src/commands/api_agents/tools_web.rs
+++ b/src-tauri/src/commands/api_agents/tools_web.rs
@@ -16,6 +16,18 @@ use super::tools::{ToolOutcome, ToolSpec};
 const MAX_FETCH_BYTES: usize = 128 * 1024;
 /// HTTP リクエストのタイムアウト。
 const FETCH_TIMEOUT_SECS: u64 = 20;
+/// 自前で辿るリダイレクトの最大ホップ数。
+const MAX_REDIRECTS: usize = 5;
+
+/// redirect を自動追従しない専用クライアント。リダイレクト先も毎回 SSRF 検証するため、
+/// reqwest の自動 follow (redirect 経由の内部アクセス) を無効化する。
+static NO_REDIRECT_CLIENT: once_cell::sync::Lazy<reqwest::Client> =
+    once_cell::sync::Lazy::new(|| {
+        reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new())
+    });
 
 fn ok(content: impl Into<String>) -> ToolOutcome {
     ToolOutcome { content: content.into(), is_error: false }
@@ -82,30 +94,10 @@ async fn web_fetch(args: &Value) -> ToolOutcome {
     let Some(url_str) = args.get("url").and_then(Value::as_str) else {
         return err("web_fetch requires a string 'url' argument");
     };
-    let url = match reqwest::Url::parse(url_str.trim()) {
+    let mut url = match reqwest::Url::parse(url_str.trim()) {
         Ok(u) => u,
         Err(e) => return err(format!("invalid url: {e}")),
     };
-    if !matches!(url.scheme(), "http" | "https") {
-        return err("only http/https URLs are allowed");
-    }
-    let Some(host) = url.host_str().map(str::to_string) else {
-        return err("url has no host");
-    };
-    let port = url.port_or_known_default().unwrap_or(443);
-
-    // SSRF: host を resolve し、内部 IP に解決されるなら拒否。
-    let addrs = match tokio::net::lookup_host((host.as_str(), port)).await {
-        Ok(a) => a.collect::<Vec<_>>(),
-        Err(e) => return err(format!("could not resolve host: {e}")),
-    };
-    if addrs.is_empty() {
-        return err("could not resolve host");
-    }
-    if addrs.iter().any(|a| is_blocked_ip(a.ip())) {
-        return err("blocked: host resolves to a private/loopback/internal address");
-    }
-
     let max = args
         .get("max_bytes")
         .and_then(Value::as_u64)
@@ -113,40 +105,83 @@ async fn web_fetch(args: &Value) -> ToolOutcome {
         .unwrap_or(MAX_FETCH_BYTES)
         .max(1);
 
-    let mut resp = match super::providers::HTTP_CLIENT
-        .get(url)
-        .header("user-agent", "vibe-editor-agent")
-        .timeout(Duration::from_secs(FETCH_TIMEOUT_SECS))
-        .send()
-        .await
-    {
-        Ok(r) => r,
-        Err(e) => return err(format!("request failed: {e}")),
-    };
-    let status = resp.status();
-
-    // 逐次 chunk で読み、上限で打ち切る (巨大レスポンスのメモリ保護)。
-    let mut buf: Vec<u8> = Vec::new();
-    let mut truncated = false;
-    loop {
-        match resp.chunk().await {
-            Ok(Some(chunk)) => {
-                buf.extend_from_slice(&chunk);
-                if buf.len() >= max {
-                    buf.truncate(max);
-                    truncated = true;
-                    break;
-                }
-            }
-            Ok(None) => break,
-            Err(e) => return err(format!("read failed: {e}")),
+    // redirect を自前で辿り、各ホップで SSRF 検証する (redirect 経由の内部アクセスを塞ぐ)。
+    for _hop in 0..=MAX_REDIRECTS {
+        if let Err(e) = validate_url_host(&url).await {
+            return err(e);
         }
+        let mut resp = match NO_REDIRECT_CLIENT
+            .get(url.clone())
+            .header("user-agent", "vibe-editor-agent")
+            .timeout(Duration::from_secs(FETCH_TIMEOUT_SECS))
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return err(format!("request failed: {e}")),
+        };
+        let status = resp.status();
+        if status.is_redirection() {
+            let Some(loc) = resp
+                .headers()
+                .get(reqwest::header::LOCATION)
+                .and_then(|v| v.to_str().ok())
+            else {
+                return err(format!("HTTP {status}: redirect without a Location header"));
+            };
+            url = match url.join(loc) {
+                Ok(u) => u,
+                Err(e) => return err(format!("invalid redirect target: {e}")),
+            };
+            continue;
+        }
+        // 非リダイレクト: 本文を逐次 chunk で読み上限で打ち切る (メモリ保護)。
+        let mut buf: Vec<u8> = Vec::new();
+        let mut truncated = false;
+        loop {
+            match resp.chunk().await {
+                Ok(Some(chunk)) => {
+                    buf.extend_from_slice(&chunk);
+                    if buf.len() >= max {
+                        buf.truncate(max);
+                        truncated = true;
+                        break;
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => return err(format!("read failed: {e}")),
+            }
+        }
+        let mut text = format!("HTTP {status}\n\n{}", String::from_utf8_lossy(&buf));
+        if truncated {
+            text.push_str("\n…(truncated; exceeds size limit)");
+        }
+        return ok(text);
     }
-    let mut text = format!("HTTP {status}\n\n{}", String::from_utf8_lossy(&buf));
-    if truncated {
-        text.push_str("\n…(truncated; exceeds size limit)");
+    err("too many redirects")
+}
+
+/// scheme + host を検証する。host が内部 (loopback/private/...) に解決されるなら拒否。
+/// redirect の各ホップで呼び、redirect 経由の SSRF を防ぐ。
+async fn validate_url_host(url: &reqwest::Url) -> Result<(), String> {
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err("only http/https URLs are allowed".to_string());
     }
-    ok(text)
+    let Some(host) = url.host_str() else {
+        return Err("url has no host".to_string());
+    };
+    let port = url.port_or_known_default().unwrap_or(443);
+    let addrs = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|e| format!("could not resolve host: {e}"))?
+        .collect::<Vec<_>>();
+    if addrs.is_empty() {
+        return Err("could not resolve host".to_string());
+    }
+    if addrs.iter().any(|a| is_blocked_ip(a.ip())) {
+        return Err("blocked: host resolves to a private/loopback/internal address".to_string());
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/api_agents/tools_web.rs
+++ b/src-tauri/src/commands/api_agents/tools_web.rs
@@ -1,0 +1,204 @@
+// api_agents/tools_web — web_fetch tool (Issue #1053, Codex web 相当)。
+//
+// 公開 URL の内容を取得して返す。autonomous エージェントがドキュメント/ページを参照できる。
+// security: SSRF を防ぐため host を resolve し loopback/private/link-local 等に解決される host は
+// 拒否する (ローカル AI が localhost で動くため特に重要)。本文は逐次 chunk で読み上限で truncate。
+//
+// 露出は auto 経路のみ。async (HTTP) なので bash と同じ async dispatch で実行する。
+
+use serde_json::{json, Value};
+use std::net::IpAddr;
+use std::time::Duration;
+
+use super::tools::{ToolOutcome, ToolSpec};
+
+/// web_fetch が返す本文の最大バイト数 (既定 / 上限)。
+const MAX_FETCH_BYTES: usize = 128 * 1024;
+/// HTTP リクエストのタイムアウト。
+const FETCH_TIMEOUT_SECS: u64 = 20;
+
+fn ok(content: impl Into<String>) -> ToolOutcome {
+    ToolOutcome { content: content.into(), is_error: false }
+}
+fn err(content: impl Into<String>) -> ToolOutcome {
+    ToolOutcome { content: content.into(), is_error: true }
+}
+
+/// web 系 tool 名か (async dispatch)。
+pub(super) fn is_web_tool(name: &str) -> bool {
+    name == "web_fetch"
+}
+
+/// auto 経路で公開する web tool 定義。
+pub(super) fn builtin_web_tools() -> Vec<ToolSpec> {
+    vec![ToolSpec {
+        name: "web_fetch",
+        description: "Fetch the contents of a public http(s) URL (read-only). \
+            Returns the HTTP status and body text, truncated to 128KB. \
+            Private/loopback/internal hosts are blocked for security.",
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "url": { "type": "string", "description": "Absolute http(s) URL to fetch." },
+                "max_bytes": { "type": "integer", "description": "Max body bytes to return (default/cap 131072)." }
+            },
+            "required": ["url"]
+        }),
+    }]
+}
+
+/// web 系 tool を実行する (async)。
+pub(super) async fn execute_web_tool(name: &str, args: &Value) -> ToolOutcome {
+    match name {
+        "web_fetch" => web_fetch(args).await,
+        other => err(format!("unknown web tool: {other}")),
+    }
+}
+
+/// SSRF ガード: 内部 / 予約レンジに解決される IP を拒否する。
+fn is_blocked_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_documentation()
+                // 100.64.0.0/10 (CGNAT)
+                || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xc0) == 0x40)
+        }
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || (v6.segments()[0] & 0xfe00) == 0xfc00 // unique local fc00::/7
+                || (v6.segments()[0] & 0xffc0) == 0xfe80 // link local fe80::/10
+                || v6.to_ipv4_mapped().map(IpAddr::V4).map(is_blocked_ip).unwrap_or(false)
+        }
+    }
+}
+
+async fn web_fetch(args: &Value) -> ToolOutcome {
+    let Some(url_str) = args.get("url").and_then(Value::as_str) else {
+        return err("web_fetch requires a string 'url' argument");
+    };
+    let url = match reqwest::Url::parse(url_str.trim()) {
+        Ok(u) => u,
+        Err(e) => return err(format!("invalid url: {e}")),
+    };
+    if !matches!(url.scheme(), "http" | "https") {
+        return err("only http/https URLs are allowed");
+    }
+    let Some(host) = url.host_str().map(str::to_string) else {
+        return err("url has no host");
+    };
+    let port = url.port_or_known_default().unwrap_or(443);
+
+    // SSRF: host を resolve し、内部 IP に解決されるなら拒否。
+    let addrs = match tokio::net::lookup_host((host.as_str(), port)).await {
+        Ok(a) => a.collect::<Vec<_>>(),
+        Err(e) => return err(format!("could not resolve host: {e}")),
+    };
+    if addrs.is_empty() {
+        return err("could not resolve host");
+    }
+    if addrs.iter().any(|a| is_blocked_ip(a.ip())) {
+        return err("blocked: host resolves to a private/loopback/internal address");
+    }
+
+    let max = args
+        .get("max_bytes")
+        .and_then(Value::as_u64)
+        .map(|n| (n as usize).min(MAX_FETCH_BYTES))
+        .unwrap_or(MAX_FETCH_BYTES)
+        .max(1);
+
+    let mut resp = match super::providers::HTTP_CLIENT
+        .get(url)
+        .header("user-agent", "vibe-editor-agent")
+        .timeout(Duration::from_secs(FETCH_TIMEOUT_SECS))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return err(format!("request failed: {e}")),
+    };
+    let status = resp.status();
+
+    // 逐次 chunk で読み、上限で打ち切る (巨大レスポンスのメモリ保護)。
+    let mut buf: Vec<u8> = Vec::new();
+    let mut truncated = false;
+    loop {
+        match resp.chunk().await {
+            Ok(Some(chunk)) => {
+                buf.extend_from_slice(&chunk);
+                if buf.len() >= max {
+                    buf.truncate(max);
+                    truncated = true;
+                    break;
+                }
+            }
+            Ok(None) => break,
+            Err(e) => return err(format!("read failed: {e}")),
+        }
+    }
+    let mut text = format!("HTTP {status}\n\n{}", String::from_utf8_lossy(&buf));
+    if truncated {
+        text.push_str("\n…(truncated; exceeds size limit)");
+    }
+    ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn is_web_tool_recognizes_name() {
+        assert!(is_web_tool("web_fetch"));
+        assert!(!is_web_tool("read_file"));
+        let names: Vec<&str> = builtin_web_tools().iter().map(|s| s.name).collect();
+        assert_eq!(names, vec!["web_fetch"]);
+    }
+
+    #[test]
+    fn blocks_internal_ips() {
+        assert!(is_blocked_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+        assert!(is_blocked_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5))));
+        assert!(is_blocked_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
+        assert!(is_blocked_ip(IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1))));
+        assert!(is_blocked_ip(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)))); // CGNAT
+        assert!(is_blocked_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        // 公開 IP は許可
+        assert!(!is_blocked_ip(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+        assert!(!is_blocked_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+    }
+
+    #[tokio::test]
+    async fn rejects_non_http_scheme() {
+        let out = execute_web_tool("web_fetch", &json!({ "url": "ftp://example.com/x" })).await;
+        assert!(out.is_error);
+        assert!(out.content.contains("http/https"));
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_url() {
+        let out = execute_web_tool("web_fetch", &json!({ "url": "not a url" })).await;
+        assert!(out.is_error);
+        assert!(out.content.contains("invalid url"));
+    }
+
+    #[tokio::test]
+    async fn blocks_loopback_literal_host() {
+        let out = execute_web_tool("web_fetch", &json!({ "url": "http://127.0.0.1:1/" })).await;
+        assert!(out.is_error);
+        assert!(out.content.contains("blocked"));
+    }
+
+    #[tokio::test]
+    async fn requires_url_arg() {
+        let out = execute_web_tool("web_fetch", &json!({})).await;
+        assert!(out.is_error);
+    }
+}

--- a/src/renderer/src/components/canvas/cards/ApiAgentChatCard.tsx
+++ b/src/renderer/src/components/canvas/cards/ApiAgentChatCard.tsx
@@ -91,7 +91,7 @@ function ApiAgentChatCardImpl({
       `Workspace: ${tildify(workspace) || '—'}`,
       `Mode: ${toolMode === 'auto' ? 'autonomous' : 'read-only'}`,
       toolsEnabled
-        ? 'Tools: read_file, list_dir, write_file, edit_file, bash, grep, glob'
+        ? 'Tools: read_file, list_dir, write_file, edit_file, bash, grep, glob, web_fetch'
         : 'Tools: (read-only chat)'
     ];
     if (payload?.teamId) lines.push('Team tools: team_read, team_send, team_info');


### PR DESCRIPTION
## Summary
ゴール「Codex のように」対応。API agent に **web_fetch** tool を追加 (Codex の web 機能相当)。autonomous エージェントが公開 URL を参照できる。

- 新規 `api_agents/tools_web.rs`:
  - `web_fetch { url, max_bytes? }` — http/https のみ。HTTP status + 本文を返す。
  - **SSRF ガード**: host を resolve し、loopback / private / link-local / unspecified / CGNAT / unique-local(v6) に解決される host を拒否 (ローカル AI が localhost で動くため特に重要)。
  - timeout 20s、逐次 chunk 読みで 128KB(既定/上限) truncate (メモリ保護)。
- 露出は auto 経路のみ。`agentic.rs` の tool_specs + async dispatch (bash と同経路)。
- banner Tools 行 + `tool_specs` テストを web_fetch 込みに更新。
- 関連 issue: #1053

### 既知の限界
DNS-rebinding TOCTOU (resolve 後に reqwest が再 resolve する隙) は残る。必要なら解決 IP を pin する connect に強化予定。

## Test plan
- [x] `cargo test api_agents` → 95 tests pass (SSRF IP 判定 / scheme / loopback literal / 不正 URL)
- [x] `npm run typecheck` / `node build/check-file-size-ratchet.mjs` 緑 (新規 tools_web.rs 204 行)