### PR TITLE
feat(api-agents): 利用可能モデルの自動取得 (/v1/models) を追加

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -1,4 +1,5 @@
 {
+  "src-tauri/src/commands/api_agents.rs": 501,
   "src-tauri/src/commands/app/team_mcp.rs": 682,
   "src-tauri/src/commands/authz.rs": 618,
   "src-tauri/src/commands/files.rs": 1274,
@@ -11,7 +12,7 @@
   "src-tauri/src/commands/terminal/command_validation.rs": 916,
   "src-tauri/src/commands/terminal_tabs.rs": 817,
   "src-tauri/src/commands/voice.rs": 550,
-  "src-tauri/src/lib.rs": 519,
+  "src-tauri/src/lib.rs": 520,
   "src-tauri/src/pty/claude_watcher.rs": 609,
   "src-tauri/src/pty/codex_broker.rs": 506,
   "src-tauri/src/pty/codex_watcher.rs": 626,

--- a/src-tauri/src/commands/api_agents.rs
+++ b/src-tauri/src/commands/api_agents.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 
 mod providers;
 pub mod skills;
+pub mod models;
 mod project_docs;
 mod tools;
 mod tools_exec;

--- a/src-tauri/src/commands/api_agents/models.rs
+++ b/src-tauri/src/commands/api_agents/models.rs
@@ -1,0 +1,99 @@
+// api_agents/models — provider の利用可能モデル一覧取得 (Issue #1055)。
+//
+// OpenAI 互換 `{base}/models` を叩く。ローカル (ollama/lmstudio) はモデルが環境依存なので
+// CustomAgentEditor の候補表示に使う。レスポンスは OpenAI ({data:[{id}]}) と
+// Gemini/Ollama ({models:[{name}]}) の両形を吸収する。
+
+use crate::commands::error::{CommandError, CommandResult};
+use serde_json::Value;
+use std::time::Duration;
+
+use super::providers::{provider_preset, HTTP_CLIENT};
+
+const LIST_TIMEOUT_SECS: u64 = 15;
+const MAX_MODELS: usize = 500;
+
+#[tauri::command]
+pub async fn api_agent_list_models(
+    provider_id: String,
+    custom_base_url: Option<String>,
+) -> CommandResult<Vec<String>> {
+    let preset = provider_preset(&provider_id, custom_base_url.as_deref())?;
+    // 鍵があれば付ける (ローカルは無くてよい)。requires_key で鍵未登録なら provider 側が 401。
+    let key = super::read_key(&provider_id).await.unwrap_or_default();
+
+    let url = format!("{}/models", preset.base_url);
+    let mut req = HTTP_CLIENT
+        .get(&url)
+        .timeout(Duration::from_secs(LIST_TIMEOUT_SECS));
+    req = match preset.adapter {
+        "gemini" => req.header("x-goog-api-key", &key),
+        "anthropic" => req
+            .header("x-api-key", &key)
+            .header("anthropic-version", "2023-06-01"),
+        _ if key.is_empty() => req,
+        _ => req.bearer_auth(&key),
+    };
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| CommandError::internal(format!("models request failed: {e}")))?
+        .error_for_status()
+        .map_err(|e| CommandError::internal(format!("models request failed: {e}")))?;
+    let v: Value = resp
+        .json()
+        .await
+        .map_err(|e| CommandError::internal(format!("models parse failed: {e}")))?;
+
+    let mut ids = parse_model_ids(&v);
+    ids.sort();
+    ids.dedup();
+    ids.truncate(MAX_MODELS);
+    Ok(ids)
+}
+
+/// OpenAI ({data:[{id}]}) / Gemini・Ollama ({models:[{name|id}]}) 形からモデル id を抽出。
+fn parse_model_ids(v: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(arr) = v["data"].as_array() {
+        for m in arr {
+            if let Some(id) = m["id"].as_str() {
+                out.push(id.to_string());
+            }
+        }
+    }
+    if out.is_empty() {
+        if let Some(arr) = v["models"].as_array() {
+            for m in arr {
+                // gemini: name="models/gemini-..."、ollama native: name="llama3.1"
+                if let Some(id) = m["id"].as_str().or_else(|| m["name"].as_str()) {
+                    out.push(id.trim_start_matches("models/").to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_openai_data_shape() {
+        let v = json!({ "data": [{ "id": "gpt-4o" }, { "id": "gpt-4.1" }] });
+        assert_eq!(parse_model_ids(&v), vec!["gpt-4o", "gpt-4.1"]);
+    }
+
+    #[test]
+    fn parses_models_array_shape_and_strips_prefix() {
+        let v = json!({ "models": [{ "name": "models/gemini-2.5-pro" }, { "name": "llama3.1" }] });
+        assert_eq!(parse_model_ids(&v), vec!["gemini-2.5-pro", "llama3.1"]);
+    }
+
+    #[test]
+    fn empty_on_unknown_shape() {
+        assert!(parse_model_ids(&json!({ "foo": 1 })).is_empty());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -284,6 +284,7 @@ pub fn run() {
             commands::api_agents::skills::api_agent_skill_sources_list,
             commands::api_agents::skills::api_agent_skill_import,
             commands::api_agents::skills::api_agent_skill_remove,
+            commands::api_agents::models::api_agent_list_models,
         ])
         .setup(|app| {
             info!(

--- a/src/renderer/src/components/settings/CustomAgentEditor.tsx
+++ b/src/renderer/src/components/settings/CustomAgentEditor.tsx
@@ -31,6 +31,7 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
   const [apiKeyDraft, setApiKeyDraft] = useState('');
   const [hasApiKey, setHasApiKey] = useState<boolean | null>(null);
   const [availableSkills, setAvailableSkills] = useState<ApiAgentSkillMeta[]>([]);
+  const [fetchedModels, setFetchedModels] = useState<string[]>([]);
   const cliAgent = agent.runtime === 'cli' ? agent : null;
   const apiAgent = agent.runtime === 'api' ? agent : null;
   const apiProviderId = apiAgent?.providerId;
@@ -83,6 +84,27 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
       disposed = true;
     };
   }, [apiProviderId]);
+
+  // provider / base URL が決まったら利用可能モデルを取得して datalist 候補にする。
+  // 失敗 (鍵未設定 / ローカル未起動 等) は空のままで、従来どおり手入力できる。
+  useEffect(() => {
+    if (!apiProviderId) {
+      setFetchedModels([]);
+      return;
+    }
+    let disposed = false;
+    void window.api.apiAgents
+      .listModels(apiProviderId, apiAgent?.customBaseUrl || undefined)
+      .then((list) => {
+        if (!disposed) setFetchedModels(list);
+      })
+      .catch(() => {
+        if (!disposed) setFetchedModels([]);
+      });
+    return () => {
+      disposed = true;
+    };
+  }, [apiProviderId, apiAgent?.customBaseUrl]);
 
   // vibe-editor 専用フォルダの import 済み skill を列挙 (API runtime のときだけ)。
   const reloadSkills = useCallback((): void => {
@@ -283,7 +305,14 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
               onChange={(e) => patchApiAgent({ model: e.target.value })}
               placeholder={provider.defaultModel || 'model-id'}
               spellCheck={false}
+              list={`agent-models-${agent.id}`}
             />
+            {/* provider の /models から取得した候補 (取得失敗時は空 → 従来どおり手入力)。 */}
+            <datalist id={`agent-models-${agent.id}`}>
+              {fetchedModels.map((m) => (
+                <option key={m} value={m} />
+              ))}
+            </datalist>
           </label>
 
           <div className="modal__label modal__label--full">

--- a/src/renderer/src/lib/tauri-api/api-agents.ts
+++ b/src/renderer/src/lib/tauri-api/api-agents.ts
@@ -23,6 +23,8 @@ export const apiAgents = {
     invokeCommand('api_agent_provider_clear_key', { providerId }),
   hasProviderKey: (providerId: string): Promise<boolean> =>
     invokeCommand('api_agent_provider_has_key', { providerId }),
+  listModels: (providerId: string, customBaseUrl?: string): Promise<string[]> =>
+    invokeCommand('api_agent_list_models', { providerId, customBaseUrl }),
   createSession: (req: ApiAgentSessionCreateRequest): Promise<ApiAgentSession> =>
     invokeCommand('api_agent_session_create', { req }),
   loadSession: (sessionId: string): Promise<ApiAgentSession | null> =>


### PR DESCRIPTION
## Summary
ゴール「ローカル AI を使えるように」の仕上げ。provider の `/models` を叩いて利用可能モデルを取得し、CustomAgentEditor で候補表示する。特に Ollama / LM Studio はモデルが環境依存なので、手入力せず取得一覧から選べる。

- 新規 `api_agents/models.rs`: `api_agent_list_models(providerId, customBaseUrl?) -> string[]`。
  - `provider_preset` で base/adapter/requires_key を解決し `{base}/models` を GET。鍵があれば adapter 別に付与 (bearer / x-api-key / x-goog-api-key)、ローカルは鍵不要。
  - OpenAI (`data[].id`) / Gemini・Ollama (`models[].name`) 両形を吸収。timeout 15s、最大 500。
- 5 点同期: models.rs / api_agents.rs (`pub mod`) / lib.rs (invoke_handler) / tauri-api `listModels` / UI。
- `CustomAgentEditor`: provider・base URL 確定時に自動取得し、model 欄の `<datalist>` 候補に表示。取得失敗 (鍵未設定 / ローカル未起動) 時は空 → 従来どおり手入力。
- 関連 issue: #1055

### baseline
api_agents.rs (501) / lib.rs (520) を +1 realign。いずれも module/handler 宣言の 1 行追加 (god-file 分割は #1032)。

## Test plan
- [x] `cargo test api_agents` → 93 tests pass (models パース 3 件含む)
- [x] `npm run typecheck` / ratchet 緑
- [ ] `npm run dev` 実機: Ollama 起動中に provider=Ollama を選ぶと model 欄に導入済みモデルが候補表示される