### PR TITLE
fix(deps): dompurify を 3.4.10 に更新して npm audit の脆弱性を解消

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "@xyflow/react": "^12.10.2",
-        "dompurify": "^3.4.0",
+        "dompurify": "^3.4.10",
         "lucide-react": "^1.11.0",
         "marked": "^18.0.2",
         "monaco-editor": "^0.55.1",
@@ -3559,9 +3559,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.10.2",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.10",
     "lucide-react": "^1.11.0",
     "marked": "^18.0.2",
     "monaco-editor": "^0.55.1",


### PR DESCRIPTION
## Summary

CI `verify` の `npm audit --omit=dev --audit-level=moderate` が、lockfile の `dompurify@3.2.7` により moderate 脆弱性 (複数 GHSA, `dompurify <=3.4.8`) を検出し、**全オープンPR共通で fail** していた。dompurify を patched 版 **3.4.10** に更新して解消する。

Closes #1064

## 変更

- `package.json`: `dompurify` `^3.4.0` → `^3.4.10`
- `package-lock.json`: dompurify 解決版 → `3.4.10`（直接依存 + `overrides.dompurify=$dompurify` 経由で monaco-editor の間接依存も追従）
- monaco-editor は据え置き（破壊的変更なし）

## Test plan

- [x] `npm audit --omit=dev --audit-level=moderate` → **found 0 vulnerabilities** (exit 0)
- [x] 変更は dompurify 関連のみ（diff 確認済み）