### PR TITLE
fix(deps): dompurify を 3.4.11 に更新して npm audit の新 advisory を解消

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "@xyflow/react": "^12.10.2",
-        "dompurify": "^3.4.10",
+        "dompurify": "^3.4.11",
         "lucide-react": "^1.11.0",
         "marked": "^18.0.2",
         "monaco-editor": "^0.55.1",
@@ -3559,9 +3559,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.10.2",
-    "dompurify": "^3.4.10",
+    "dompurify": "^3.4.11",
     "lucide-react": "^1.11.0",
     "marked": "^18.0.2",
     "monaco-editor": "^0.55.1",


### PR DESCRIPTION
## Summary
- 新 advisory **GHSA-cmwh-pvxp-8882** が `dompurify <=3.4.10` を脆弱対象に含み、CI の `verify`(`npm audit --omit=dev --audit-level=moderate`)が moderate で失敗するようになった。
- #1065 の `3.4.10` では不十分なため `^3.4.11`(修正版 / 現 latest)へ更新し、`package-lock.json` を override 経由で全箇所 3.4.11 に固定。
- 関連: Closes #1066

## 背景
main が現在 red で、オープン PR が軒並み `verify` 失敗 (UNSTABLE) で merge 不能になっていた根本原因。本 PR を入れた後に各 PR を rebase することで解消する。

## Test plan
- [x] `npm audit --omit=dev --audit-level=moderate` → found 0 vulnerabilities
- [x] `npm run typecheck` 通過
- [x] lock の `node_modules/dompurify` が 3.4.11 に解決されることを確認