### PR TITLE
feat(team): codex の team_send 配送方式 (PTY/backend) を設定で切替可能にする

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -5,7 +5,7 @@
   "src-tauri/src/commands/files.rs": 1274,
   "src-tauri/src/commands/git.rs": 529,
   "src-tauri/src/commands/handoffs.rs": 513,
-  "src-tauri/src/commands/settings.rs": 841,
+  "src-tauri/src/commands/settings.rs": 869,
   "src-tauri/src/commands/team_history.rs": 1239,
   "src-tauri/src/commands/team_state.rs": 593,
   "src-tauri/src/commands/terminal.rs": 1017,
@@ -21,7 +21,7 @@
   "src-tauri/src/pty/session/spawn.rs": 733,
   "src-tauri/src/team_hub/file_locks.rs": 781,
   "src-tauri/src/team_hub/inject.rs": 768,
-  "src-tauri/src/team_hub/mod.rs": 960,
+  "src-tauri/src/team_hub/mod.rs": 962,
   "src-tauri/src/team_hub/protocol/role_template.rs": 632,
   "src-tauri/src/team_hub/protocol/tools/assign_task.rs": 832,
   "src-tauri/src/team_hub/protocol/tools/recruit.rs": 941,
@@ -38,8 +38,8 @@
   "src/renderer/src/layouts/CanvasLayout.tsx": 943,
   "src/renderer/src/lib/hooks/use-file-tabs.ts": 517,
   "src/renderer/src/lib/hooks/use-xterm-bind.ts": 889,
-  "src/renderer/src/lib/i18n.ts": 1864,
+  "src/renderer/src/lib/i18n.ts": 1878,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
   "src/renderer/src/stores/canvas.ts": 584,
-  "src/types/shared.ts": 1893
+  "src/types/shared.ts": 1909
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -94,6 +94,12 @@ pub struct Settings {
     pub codex_command: String,
     #[serde(default)]
     pub codex_args: String,
+    /// Issue #1068: codex への `team_send` 配送方式 (`"backend"` / `"pty"`)。
+    /// `"backend"` (既定) は app-server JSON-RPC を優先し、ダメなら PTY 注入へ fallback。
+    /// `"pty"` は常に PTY 注入。未知値 / None は `"backend"` 扱い。renderer の
+    /// `CodexTeamSendDelivery` literal union と camelCase で対応。
+    #[serde(default = "default_codex_team_send_delivery")]
+    pub codex_team_send_delivery: String,
 
     #[serde(default)]
     pub notepad: String,
@@ -240,6 +246,7 @@ impl Default for Settings {
             sidebar_width: default_sidebar_width(),
             codex_command: default_codex_command(),
             codex_args: String::new(),
+            codex_team_send_delivery: default_codex_team_send_delivery(),
             notepad: String::new(),
             has_completed_onboarding: Some(false),
             custom_agents: Some(Vec::new()),
@@ -318,6 +325,11 @@ fn default_codex_command() -> String {
     "codex".to_string()
 }
 
+/// Issue #1068: codex `team_send` 配送方式の既定。app-server 優先 (現挙動維持)。
+fn default_codex_team_send_delivery() -> String {
+    "backend".to_string()
+}
+
 fn default_claude_code_panel_width() -> f64 {
     460.0
 }
@@ -362,23 +374,35 @@ async fn read_optional_file_with_retry(
 pub async fn settings_load() -> CommandResult<Settings> {
     tracing::info!("[IPC] settings_load called");
     let path = crate::util::config_paths::settings_path();
-    let Some(bytes) =
-        read_optional_file_with_retry(&path, "settings_load", SETTINGS_READ_RETRY_DELAYS).await?
-    else {
+    let settings = match read_optional_file_with_retry(
+        &path,
+        "settings_load",
+        SETTINGS_READ_RETRY_DELAYS,
+    )
+    .await?
+    {
         // Issue #29: 初回起動で settings.json がまだ無いときだけ default を返す。
         // Issue #905: PermissionDenied / sharing violation 等の読み取り不能は default 扱いに
         // しない。renderer 側へ Err を返し、default ベースの auto-save で原本を上書きしない。
-        return Ok(Settings::default());
+        None => Settings::default(),
+        Some(bytes) => {
+            backup_pre_v12_settings_snapshot(&path, &bytes).await;
+            match serde_json::from_slice::<Settings>(&bytes) {
+                Ok(v) => v,
+                // Issue #170 / #493 / #644 / #996: parse 失敗時の原本退避 + v11 スナップショット復旧は
+                // `settings_recovery` に集約 (settings.rs の肥大化を避ける)。
+                Err(e) => {
+                    crate::commands::settings_recovery::recover_after_parse_failure(
+                        &path, &bytes, e,
+                    )
+                    .await
+                }
+            }
+        }
     };
-    backup_pre_v12_settings_snapshot(&path, &bytes).await;
-    match serde_json::from_slice::<Settings>(&bytes) {
-        Ok(v) => Ok(v),
-        // Issue #170 / #493 / #644 / #996: parse 失敗時の原本退避 + v11 スナップショット復旧は
-        // `settings_recovery` に集約 (settings.rs の肥大化を避ける)。
-        Err(e) => Ok(
-            crate::commands::settings_recovery::recover_after_parse_failure(&path, &bytes, e).await,
-        ),
-    }
+    // Issue #1068: team_hub は永続 Settings を直接読まないため、起動時 load でミラーを同期する。
+    crate::team_hub::codex_delivery::set_from_settings(Some(&settings.codex_team_send_delivery));
+    Ok(settings)
 }
 
 async fn backup_pre_v12_settings_snapshot(path: &Path, bytes: &[u8]) {
@@ -500,6 +524,8 @@ pub async fn settings_save(app: tauri::AppHandle, settings: Settings) -> Command
     atomic_write(&path, &json)
         .await
         .map_err(|e| CommandError::Internal(e.to_string()))?;
+    // Issue #1068: 設定変更を team_hub の配送方式ミラーへ即時反映する (settings.json が SSOT)。
+    crate::team_hub::codex_delivery::set_from_settings(Some(&settings.codex_team_send_delivery));
     // Issue #724: mascot custom 画像 (PR #716) をユーザーが設定画面で選び直したとき、
     // assetProtocol.scope は空なので、再起動を待たず同一セッション内でその 1 ファイルを
     // `asset://` で表示できるよう asset scope へ許可する。失敗しても save 自体は成功扱い。
@@ -546,6 +572,8 @@ mod tests {
         assert_eq!(v["terminalFontSize"], json!(13.0));
         assert_eq!(v["claudeCommand"], json!("claude"));
         assert_eq!(v["codexCommand"], json!("codex"));
+        // Issue #1068: codex team_send 配送方式の既定は app-server 優先 (現挙動維持)。
+        assert_eq!(v["codexTeamSendDelivery"], json!("backend"));
         assert_eq!(v["claudeCodePanelWidth"], json!(460.0));
         assert_eq!(v["sidebarWidth"], json!(272.0));
         assert_eq!(v["mcpAutoSetup"], json!(true));

--- a/src-tauri/src/team_hub/codex_delivery.rs
+++ b/src-tauri/src/team_hub/codex_delivery.rs
@@ -1,0 +1,93 @@
+//! Issue #1068: codex への `team_send` 配送方式 (PTY 注入 / backend app-server) のユーザー設定を
+//! team_hub から参照するためのプロセス内ミラー。
+//!
+//! team_hub はランタイム設定を環境変数から読む設計 (`delivery_mode.rs` 参照) で、永続 Settings を
+//! 直接読まない。そこで `commands::settings` の `settings_load` / `settings_save` がこのアトミックな
+//! ミラーを更新し、`deliver.rs` がここを見て分岐する。settings.json を Single Source of Truth とし、
+//! 本ミラーはその読み取り専用キャッシュにすぎない。
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// codex `team_send` の配送方式。
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CodexDelivery {
+    /// app-server (JSON-RPC) が使えれば app-server、ダメなら PTY 注入へ fallback (既定)。
+    Backend,
+    /// 常に従来の PTY bracketed-paste 注入を使う。
+    Pty,
+}
+
+impl CodexDelivery {
+    fn as_u8(self) -> u8 {
+        match self {
+            Self::Backend => 0,
+            Self::Pty => 1,
+        }
+    }
+
+    fn from_u8(v: u8) -> Self {
+        match v {
+            1 => Self::Pty,
+            _ => Self::Backend,
+        }
+    }
+}
+
+/// settings.json 由来の文字列を配送方式に解釈する。
+/// `"pty"` のみ PTY 強制。未知値 / 空 / `None` は既定の `Backend` (= 現挙動維持)。
+pub fn parse(value: Option<&str>) -> CodexDelivery {
+    match value.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
+        Some("pty") => CodexDelivery::Pty,
+        _ => CodexDelivery::Backend,
+    }
+}
+
+/// 既定は `Backend` (= app-server 優先、現挙動維持)。
+static PREF: AtomicU8 = AtomicU8::new(0);
+
+/// settings の `codexTeamSendDelivery` をミラーへ反映する。
+pub fn set_from_settings(value: Option<&str>) {
+    PREF.store(parse(value).as_u8(), Ordering::Relaxed);
+}
+
+/// 現在の配送方式。
+pub fn current() -> CodexDelivery {
+    CodexDelivery::from_u8(PREF.load(Ordering::Relaxed))
+}
+
+/// PTY 注入を強制する設定か。`deliver.rs` の分岐で使う。
+pub fn prefers_pty() -> bool {
+    current() == CodexDelivery::Pty
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_maps_known_and_unknown_values() {
+        assert_eq!(parse(Some("pty")), CodexDelivery::Pty);
+        assert_eq!(parse(Some("PTY")), CodexDelivery::Pty);
+        assert_eq!(parse(Some("  pty  ")), CodexDelivery::Pty);
+        assert_eq!(parse(Some("backend")), CodexDelivery::Backend);
+        // 未知値 / 空 / None はすべて既定の Backend にフォールバックする。
+        assert_eq!(parse(Some("app-server")), CodexDelivery::Backend);
+        assert_eq!(parse(Some("")), CodexDelivery::Backend);
+        assert_eq!(parse(None), CodexDelivery::Backend);
+    }
+
+    #[test]
+    fn set_from_settings_roundtrips_through_mirror() {
+        set_from_settings(Some("pty"));
+        assert!(prefers_pty());
+        assert_eq!(current(), CodexDelivery::Pty);
+
+        set_from_settings(Some("backend"));
+        assert!(!prefers_pty());
+        assert_eq!(current(), CodexDelivery::Backend);
+
+        // 未知 / None は Backend へ戻る。
+        set_from_settings(None);
+        assert!(!prefers_pty());
+    }
+}

--- a/src-tauri/src/team_hub/deliver.rs
+++ b/src-tauri/src/team_hub/deliver.rs
@@ -4,6 +4,9 @@
 //! codex セッションで `app_server_socket` と `thread_id` の両方が分かっている場合のみ、
 //! codex 公式 app-server JSON-RPC (`turn/start`) で配送する。app-server 配送が失敗したら
 //! PTY 注入にフォールバックするため、可用性は従来以上を保つ。
+//!
+//! Issue #1068: ユーザーが設定 (`codexTeamSendDelivery`) で `pty` を選んだ場合は、app-server 経路を
+//! 一切使わず常に PTY 注入する (`codex_delivery::prefers_pty`)。既定の `backend` は上記の挙動。
 
 use std::sync::Arc;
 
@@ -17,13 +20,18 @@ pub async fn deliver_message(
     from_role: &str,
     text: &str,
 ) -> Result<(), InjectError> {
-    if let Some(session) = registry.get_by_agent(agent_id) {
-        if session.is_codex {
-            if let Some((socket, thread_id)) = crate::pty::codex_app_server::target_for_session(&session) {
-                if try_app_server(agent_id, &socket, &thread_id, text).await {
-                    return Ok(());
+    // Issue #1068: 設定で PTY を強制している場合は app-server 経路を完全にスキップする。
+    if !crate::team_hub::codex_delivery::prefers_pty() {
+        if let Some(session) = registry.get_by_agent(agent_id) {
+            if session.is_codex {
+                if let Some((socket, thread_id)) =
+                    crate::pty::codex_app_server::target_for_session(&session)
+                {
+                    if try_app_server(agent_id, &socket, &thread_id, text).await {
+                        return Ok(());
+                    }
+                    // app-server 未対応 / 失敗時は下の PTY 注入へフォールバック。
                 }
-                // app-server 未対応 / 失敗時は下の PTY 注入へフォールバック。
             }
         }
     }

--- a/src-tauri/src/team_hub/mod.rs
+++ b/src-tauri/src/team_hub/mod.rs
@@ -13,6 +13,8 @@
 #[cfg(unix)]
 pub mod app_server;
 pub mod bridge;
+// Issue #1068: codex team_send 配送方式 (PTY 注入 / backend app-server) のユーザー設定ミラー。
+pub mod codex_delivery;
 // Issue #1062: team_send の配送経路ルータ (codex=app-server / それ以外=PTY inject)。
 pub mod deliver;
 pub mod delivery_mode;

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowLeft, Check, Plus, Search, X } from 'lucide-react';
-import type { AgentConfig, AppSettings } from '../../../types/shared';
+import type { AgentConfig, AppSettings, CodexTeamSendDelivery } from '../../../types/shared';
 import { resetPreferencesToDefaults } from '../../../types/shared';
 import { useT } from '../lib/i18n';
 import { useToast } from '../lib/toast-context';
@@ -268,16 +268,34 @@ export function SettingsModal({
         );
       case 'codex':
         return (
-          <CommandOptionsSection
-            title={t('settings.launch.title')}
-            commandKey="codexCommand"
-            commandPlaceholder="codex"
-            argsKey="codexArgs"
-            argsLabel={t('settings.launch.argsLabelSimple')}
-            argsPlaceholder="--model o3"
-            draft={draft}
-            update={update}
-          />
+          <>
+            <CommandOptionsSection
+              title={t('settings.launch.title')}
+              commandKey="codexCommand"
+              commandPlaceholder="codex"
+              argsKey="codexArgs"
+              argsLabel={t('settings.launch.argsLabelSimple')}
+              argsPlaceholder="--model o3"
+              draft={draft}
+              update={update}
+            />
+            <section className="modal__section">
+              <h3>{t('settings.codexDelivery.title')}</h3>
+              <label className="modal__label modal__label--full">
+                <span>{t('settings.codexDelivery.label')}</span>
+                <select
+                  value={draft.codexTeamSendDelivery ?? 'backend'}
+                  onChange={(e) =>
+                    update('codexTeamSendDelivery', e.target.value as CodexTeamSendDelivery)
+                  }
+                >
+                  <option value="backend">{t('settings.codexDelivery.optBackend')}</option>
+                  <option value="pty">{t('settings.codexDelivery.optPty')}</option>
+                </select>
+              </label>
+              <p className="modal__note">{t('settings.codexDelivery.hint')}</p>
+            </section>
+          </>
         );
       case 'roles':
         return <RoleProfilesSection />;

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -492,6 +492,13 @@ const ja: Dict = {
   'settings.section.codex.label': 'Codex',
   'settings.section.codex.title': 'Codex',
   'settings.section.codex.desc': '起動コマンドと引数',
+  // Issue #1068: codex team_send の配送方式トグル
+  'settings.codexDelivery.title': 'team_send の配送方式',
+  'settings.codexDelivery.label': '配送方式',
+  'settings.codexDelivery.optBackend': 'バックエンド (app-server) — 使えなければ PTY に自動 fallback',
+  'settings.codexDelivery.optPty': 'PTY 注入 — 常にターミナルへ貼り付け',
+  'settings.codexDelivery.hint':
+    'codex への team_send を、codex 公式 app-server (JSON-RPC) 経由で送るか、従来どおりターミナルへ PTY 注入するか。バックエンドは履歴に残り入力競合も避けられますが、app-server が使えない場合は自動で PTY に fallback します。Windows は app-server 未対応のため常に PTY です。',
   'settings.section.roles.label': 'ロール定義',
   'settings.section.roles.title': 'ロール定義',
   'settings.section.roles.desc': 'チームメンバーの役割テンプレ',
@@ -1390,6 +1397,13 @@ const en: Dict = {
   'settings.section.codex.label': 'Codex',
   'settings.section.codex.title': 'Codex',
   'settings.section.codex.desc': 'Launch command and args',
+  // Issue #1068: codex team_send delivery method toggle
+  'settings.codexDelivery.title': 'team_send delivery',
+  'settings.codexDelivery.label': 'Delivery method',
+  'settings.codexDelivery.optBackend': 'Backend (app-server) — falls back to PTY if unavailable',
+  'settings.codexDelivery.optPty': 'PTY injection — always paste into the terminal',
+  'settings.codexDelivery.hint':
+    'How team_send reaches codex: via the official codex app-server (JSON-RPC) or the legacy PTY paste into the terminal. Backend keeps history and avoids input races, but automatically falls back to PTY when the app-server is unavailable. Windows always uses PTY (app-server is not supported).',
   'settings.section.roles.label': 'Role profiles',
   'settings.section.roles.title': 'Role profiles',
   'settings.section.roles.desc': 'Team member role templates',

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -292,6 +292,13 @@ export interface AppSettings {
    */
   mcpAutoSetup?: boolean;
   /**
+   * Issue #1068: codex への `team_send` をどの経路で配送するか。
+   * `backend` (既定) は app-server JSON-RPC を優先し、ダメなら PTY 注入へ fallback。
+   * `pty` は常に従来の PTY 注入を使う。undefined は `backend` 扱い。
+   * Windows は app-server 未対応のため、この値に関わらず常に PTY 注入になる。
+   */
+  codexTeamSendDelivery?: CodexTeamSendDelivery;
+  /**
    * Issue #161: webview zoom factor (0.5〜3.0)。Ctrl+=/-/0 や Shift+wheel で変動。
    * 旧実装は永続化していなかったため、再起動後に内部 current=1.0 と実際の zoom が
    * 食い違って Ctrl+= で逆に縮む現象が起きていた。
@@ -333,6 +340,13 @@ export interface AppSettings {
 
 /** Issue #825: 音声指揮モードで「送信時の確認」を 2 段に分けるためのモード。 */
 export type VoiceConfirmationMode = 'always' | 'bypass';
+
+/**
+ * Issue #1068: codex への `team_send` 配送方式。
+ * - `backend`: codex 公式 app-server JSON-RPC で配送し、使えない/失敗時は PTY 注入へ fallback (既定)。
+ * - `pty`: 常に従来の PTY bracketed-paste 注入を使い、app-server 経路を使わない。
+ */
+export type CodexTeamSendDelivery = 'backend' | 'pty';
 
 /**
  * Issue #825: 音声指揮モード (Beta) のユーザー設定。
@@ -635,6 +649,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   hasCompletedOnboarding: false,
   customAgents: [],
   mcpAutoSetup: true,
+  codexTeamSendDelivery: 'backend',
   fileTreeExpanded: {},
   fileTreeCollapsedRoots: [],
   // Issue #618: Windows + cmd.exe / PowerShell で UTF-8 を強制する (CP932 化対策)。
@@ -671,6 +686,7 @@ export const RESETTABLE_SETTING_KEYS = [
   'codexCommand',
   'codexArgs',
   'mcpAutoSetup',
+  'codexTeamSendDelivery',
   'terminalForceUtf8'
 ] as const satisfies readonly (keyof AppSettings)[];
 


### PR DESCRIPTION
## Summary
- Issue #1062 / PR #1063 で導入した codex への `team_send` の app-server 配送は **capability ベースでユーザーが選べるゲートが無かった**。設定で「PTY 注入」か「backend (app-server)」かを切り替えられるようにする。
- 新設定 `codexTeamSendDelivery: 'backend' | 'pty'` を追加 (設定画面 → Codex セクションの select)。
  - `backend` (既定): app-server が使えれば app-server JSON-RPC、ダメ/失敗時は PTY へ fallback (= 現挙動)
  - `pty`: 常に従来の PTY bracketed-paste 注入を使い、app-server 経路を完全にスキップ
- Closes #1068

## 設計
- team_hub はランタイム設定を **環境変数からしか読まない** (`delivery_mode.rs` が先例) ため、永続 Settings を直接参照できない。
- そこで新モジュール `team_hub/codex_delivery.rs` にプロセス内ミラー (`AtomicU8`) を置き、`settings_load` / `settings_save` がこれを更新。`deliver_message` は `codex_delivery::prefers_pty()` を見て分岐する。
- settings.json を Single Source of Truth とし、ミラーは読み取り専用キャッシュ。既定は `backend` なので load 前でも現挙動を維持。

## 後方互換 / プラットフォーム
- 既定 `backend`。旧 settings.json はフィールド無し → serde default で `backend` が入る (schema version bump 不要)。
- Windows は app-server (unix socket) 未対応のため、この設定に関わらず常に PTY 注入 (挙動不変)。

## file-size baseline について
設定 1 個の追加で、中央レジストリである `shared.ts` (型) / `settings.rs` (Settings struct) / `i18n.ts` (ja+en) / `team_hub/mod.rs` (module 宣言) は不可避に数行増える。これらは責務分割で回避できない集約点のため、`build/file-size-baseline.json` を **該当 4 ファイルのみ** `--update-baseline` で更新した (他ファイルへの波及なし)。

## Test plan
- [x] `npm run typecheck` 通過
- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets` 通過
- [x] `cargo test` — `team_hub::codex_delivery` 2件 / `default_settings_serializes_to_expected_camelcase_shape` 1件 pass
- [x] `npm run lint:safe-load` / ESLint (変更ファイル) / `node build/check-file-size-ratchet.mjs` OK
- [x] vitest: SettingsModal / settings-migrate / settings-context 31件 pass
- [x] i18n ja/en パリティ確認
- [ ] 実機: 設定で `pty` を選ぶ → codex への team_send が PTY 注入になること / `backend` で app-server 経路に戻ること