### PR TITLE
fix(team_hub): #1061 leader handoff の長い引数を削減

### DIFF
--- a/src-tauri/src/team_hub/protocol/schema.rs
+++ b/src-tauri/src/team_hub/protocol/schema.rs
@@ -2,8 +2,8 @@
 //!
 //! Issue #373 Phase 2 で `protocol.rs` から切り出し。
 //!
-//! 各 tool 名 / description / inputSchema は逐字保持 (renderer / Claude Code / Codex
-//! 側の MCP クライアントが文字列マッチに依存する可能性があるため、改変禁止)。
+//! 各 tool 名 / description / inputSchema は互換性を意識して変更する (renderer /
+//! Claude Code / Codex 側の MCP クライアントが参照するため)。
 
 use serde_json::{json, Value};
 
@@ -331,10 +331,6 @@ pub(super) fn tool_defs() -> Value {
                         "type": "string",
                         "description": "Optional canvas card title override for the new leader."
                     },
-                    "handoff_id": {
-                        "type": "string",
-                        "description": "Optional handoff id to record replacement leader creation against."
-                    },
                     "engine_policy": {
                         "type": "object",
                         "description": "Optional team-level engine policy. When set, all subsequent team_recruit calls validate `engine` against this policy.",
@@ -450,4 +446,31 @@ pub(super) fn tool_defs() -> Value {
             }
         }
     ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tool_defs;
+
+    #[test]
+    fn team_create_leader_schema_does_not_advertise_handoff_id() {
+        let tools = tool_defs();
+        let create_leader = tools
+            .as_array()
+            .and_then(|items| {
+                items.iter().find(|tool| {
+                    tool.get("name").and_then(|v| v.as_str()) == Some("team_create_leader")
+                })
+            })
+            .expect("team_create_leader schema exists");
+        let properties = create_leader
+            .pointer("/inputSchema/properties")
+            .and_then(|v| v.as_object())
+            .expect("team_create_leader properties");
+
+        assert!(
+            !properties.contains_key("handoff_id"),
+            "team_create_leader should not ask models to echo long handoff ids"
+        );
+    }
 }

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardHandoff.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardHandoff.tsx
@@ -73,7 +73,7 @@ function buildLeaderHandoffPrompt(markdownPath: string, handoffId: string): stri
     '1. 上記 handoff markdown を Read tool で読み、現在の作業状況・未完了タスク・次アクションを確認する。',
     '2. 必要なら handoff の Notes / Next Actions を補強する追加メモを書き足す。',
     '3. MCP tool `team_create_leader` を呼び、新しい Leader を採用する:',
-    `     team_create_leader({ handoff_id: "${handoffId}" })`,
+    '     team_create_leader({})',
     '   返り値の `agentId` を控えること。',
     '4. 新 Leader が起動したら、`team_send` で agentId 宛にこの handoff のパスと「お前が新 Leader だ」という旨を伝える:',
     `     team_send({ to: "<上で得た agentId>", handoff_id: "${handoffId}", message: "あなたが新 Leader です。handoff を読んで team_ack_handoff({ handoff_id: '${handoffId}' }) を呼び、ACK を返してください: ${markdownPath}" })`,


### PR DESCRIPTION
## Summary
- `team_create_leader` の MCP schema から `handoff_id` を外し、モデルに長い handoff ID を echo させにくくしました。
- Canvas の引き継ぎ手順も `team_create_leader({})` に変更しました。
- 既存互換として Rust 実装側は従来どおり `handoff_id` / `handoffId` を受け付けます。

Closes #1061

## Test plan
- [x] `npm run typecheck`
- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml team_create_leader_schema_does_not_advertise_handoff_id`
- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml`
- [ ] `npm run lint:file-size` は現在の main 由来の既存 baseline ずれ 20 件で失敗（今回変更した 2 ファイルは違反リスト外）