### PR TITLE
fix(pty): PTY 安定化 Tier1 の 3 件 (#1075 #1076 #1077)

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -36,6 +36,12 @@ const CODEX_INITIAL_PROMPT_DELAY_MS: u64 = 1800;
 /// terminal 側のチャンク注入用にローカル定数として持つ (旧実装は `15` の直書きだった)。
 const CODEX_PROMPT_CHUNK_DELAY_MS: u64 = 15;
 
+/// Issue #1077: 末尾の確定 `\r` (Enter) だけ失敗すると、paste 本体は届いたのに Codex が初手指示を
+/// 実行しないまま入力欄表示で止まる (team_hub の inject は #378 で `FinalCrFailed` として厳密化済み
+/// だが codex 初手注入経路は未対応だった)。transient な ConPTY back-pressure を吸収するため、最終
+/// `\r` 送出が失敗したときに再送する最大回数。
+const CODEX_FINAL_CR_MAX_RETRY: u32 = 2;
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TerminalCreateOptions {
@@ -275,19 +281,40 @@ async fn inject_codex_prompt_to_pty(
             }
         }
     }
-    sleep(Duration::from_millis(CODEX_PROMPT_CHUNK_DELAY_MS)).await;
     // Issue #620: 末尾の確定 `\r` も spawn_blocking 経由で送る。
-    let s = session.clone();
-    match tokio::task::spawn_blocking(move || s.write(b"\r")).await {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => {
-            tracing::warn!("[terminal] codex prompt write(\\r) failed for {term_id}: {e}");
+    // Issue #1077: 最終 `\r` (Enter) の失敗を握り潰すと「起動したのに何も始まらない」状態になる。
+    // transient な ConPTY back-pressure を考慮し、失敗時は backoff を挟んで最大
+    // CODEX_FINAL_CR_MAX_RETRY 回まで再送する。write 成功時のみ break するので、再送が走るのは
+    // 実際に失敗したときだけ (= 二重 Enter は起きない)。
+    let mut cr_sent = false;
+    for attempt in 0..=CODEX_FINAL_CR_MAX_RETRY {
+        sleep(Duration::from_millis(CODEX_PROMPT_CHUNK_DELAY_MS)).await;
+        if registry.get(&term_id).is_none() {
+            return;
         }
-        Err(e) => {
-            tracing::warn!(
-                "[terminal] codex prompt spawn_blocking(\\r) failed for {term_id}: {e}"
-            );
+        let s = session.clone();
+        match tokio::task::spawn_blocking(move || s.write(b"\r")).await {
+            Ok(Ok(())) => {
+                cr_sent = true;
+                break;
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    "[terminal] codex prompt write(\\r) failed for {term_id} (attempt {attempt}/{CODEX_FINAL_CR_MAX_RETRY}): {e}"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[terminal] codex prompt spawn_blocking(\\r) failed for {term_id} (attempt {attempt}/{CODEX_FINAL_CR_MAX_RETRY}): {e}"
+                );
+            }
         }
+    }
+    if !cr_sent {
+        tracing::error!(
+            "[terminal] codex prompt final \\r (Enter) could not be delivered to pty {term_id} after {CODEX_FINAL_CR_MAX_RETRY} retries — prompt may be left unconfirmed in the input box"
+        );
+        return;
     }
     tracing::info!(
         "[terminal] codex prompt injected into pty {term_id} ({} bytes)",
@@ -747,6 +774,22 @@ pub async fn terminal_write(
     Ok(())
 }
 
+/// Issue #1076: PTY resize の下限。spawn 経路 (`openpty`) と同じ floor を resize にも適用する。
+const MIN_PTY_COLS: u32 = 20;
+const MIN_PTY_ROWS: u32 = 5;
+
+/// Issue #1076: resize の cols/rows を `[下限, u16::MAX]` にクランプする。
+///
+/// spawn 経路は `openpty` で cols>=20 / rows>=5 の下限を持つが、`terminal_resize` は上限のみ
+/// クランプしていた。renderer の grid 計算は 20×5 未満を送らないものの、信頼境界外 (renderer の
+/// 任意呼び出し / 将来の別 caller) からの 0×0 resize が ConPTY/portable-pty に渡ると再描画破綻を
+/// 招くため、同じ下限を defense-in-depth でクランプする。
+fn clamp_resize_dims(cols: u32, rows: u32) -> (u16, u16) {
+    let cols = cols.clamp(MIN_PTY_COLS, u32::from(u16::MAX)) as u16;
+    let rows = rows.clamp(MIN_PTY_ROWS, u32::from(u16::MAX)) as u16;
+    (cols, rows)
+}
+
 #[tauri::command]
 pub async fn terminal_resize(
     state: State<'_, AppState>,
@@ -755,8 +798,7 @@ pub async fn terminal_resize(
     rows: u32,
 ) -> crate::commands::error::CommandResult<()> {
     if let Some(s) = state.pty_registry.get(&id) {
-        let cols = cols.min(u32::from(u16::MAX)) as u16;
-        let rows = rows.min(u32::from(u16::MAX)) as u16;
+        let (cols, rows) = clamp_resize_dims(cols, rows);
         // resize 失敗は無害なので握りつぶす (旧実装と同じ)
         match tokio::task::spawn_blocking(move || s.resize(cols, rows)).await {
             Ok(Ok(())) | Ok(Err(_)) => {}
@@ -787,6 +829,41 @@ pub async fn terminal_save_pasted_image(
     mime_type: String,
 ) -> SavePastedImageResult {
     paste_image::save(base64, mime_type).await
+}
+
+#[cfg(test)]
+mod resize_clamp_tests {
+    use super::{clamp_resize_dims, MIN_PTY_COLS, MIN_PTY_ROWS};
+
+    #[test]
+    fn zero_is_clamped_to_spawn_floor() {
+        // Issue #1076: 信頼境界外からの 0×0 resize は ConPTY に届かず下限へ丸められる。
+        assert_eq!(
+            clamp_resize_dims(0, 0),
+            (MIN_PTY_COLS as u16, MIN_PTY_ROWS as u16)
+        );
+    }
+
+    #[test]
+    fn below_floor_is_raised_to_floor() {
+        assert_eq!(
+            clamp_resize_dims(10, 2),
+            (MIN_PTY_COLS as u16, MIN_PTY_ROWS as u16)
+        );
+        // 下限ちょうどは保持される。
+        assert_eq!(clamp_resize_dims(20, 5), (20, 5));
+    }
+
+    #[test]
+    fn normal_values_pass_through() {
+        assert_eq!(clamp_resize_dims(120, 40), (120, 40));
+    }
+
+    #[test]
+    fn above_u16_ceiling_is_clamped() {
+        assert_eq!(clamp_resize_dims(u32::MAX, u32::MAX), (u16::MAX, u16::MAX));
+        assert_eq!(clamp_resize_dims(100_000, 70_000), (u16::MAX, u16::MAX));
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/pty/registry.rs
+++ b/src-tauri/src/pty/registry.rs
@@ -236,7 +236,11 @@ impl SessionRegistry {
                             "[registry] replacing session {prev_sid} with {id} — killing old PTY"
                         );
                         let _ = old.kill();
-                        old.cleanup_codex_broker_if_stale();
+                        // Issue #1075: broker 掃除は子プロセス起動 (tasklist/kill/git) + 最大 250ms
+                        // sleep を伴う。`inner` lock を保持したまま同期実行すると全 PTY 操作を
+                        // 直列ブロックするため、`remove()` / `kill_team()` と同じ detached 版を使う
+                        // (直前に kill 済みなので "after kill" 掃除として意味的にも正しい)。
+                        old.cleanup_codex_broker_after_kill();
                     }
                 }
             }
@@ -367,8 +371,8 @@ impl SessionRegistry {
     ///  なったため削除した。)
     ///
     /// Issue #834: 終了経路では broker の stale state 掃除を**スキップ**する (掃除は best-effort で
-    /// 次回起動時の spawn 前 cleanup `cleanup_codex_broker_if_stale` で回収できる)。ここでは
-    /// process-tree kill だけを確実に行う。
+    /// 次回起動時の spawn 前 cleanup (`terminal_create` 内の `codex_broker::cleanup_stale_for_cwd`)
+    /// で回収できる)。ここでは process-tree kill だけを確実に行う。
     pub fn kill_all_blocking(&self, timeout: Duration) {
         let sessions: Vec<Arc<SessionHandle>> = {
             let mut g = recover(self.inner.lock());

--- a/src-tauri/src/pty/session/handle.rs
+++ b/src-tauri/src/pty/session/handle.rs
@@ -209,12 +209,6 @@ impl SessionHandle {
         self.watcher_cancel.clone()
     }
 
-    pub fn cleanup_codex_broker_if_stale(&self) {
-        if self.is_codex {
-            crate::pty::codex_broker::cleanup_stale_for_cwd(&self.cwd);
-        }
-    }
-
     /// Issue #834: codex PTY を kill した後の broker stale state 掃除。
     ///
     /// `cleanup_stale_for_cwd` は `git rev-parse` / `tasklist` (Windows) / `kill` (Unix) の


### PR DESCRIPTION
## Summary
PTY 安定化監査(read-only)で検出した Tier 1 の 3 件をまとめて修正。いずれも低リスク・正常系不変。

- **#1075 (perf/freeze)**: `insert_locked` が `inner` グローバルロック保持中に同期 broker 掃除(`tasklist`/`kill`/`git` + 最大 250ms sleep)を実行し、全 PTY 操作を直列ブロックしていた。`remove()`/`kill_team()` と同じ detached 版 `cleanup_codex_broker_after_kill()` に統一(#834 の取りこぼし経路)。dead 化した `cleanup_codex_broker_if_stale` を削除。
- **#1076 (bug)**: `terminal_resize` が上限のみクランプで 0×0 が ConPTY に到達しえた。spawn と同じ下限(20×5)を `clamp_resize_dims` に切り出して適用 + 回帰テスト 4 件。
- **#1077 (bug)**: codex 初手注入の最終 `\r`(Enter)失敗を握り潰し「起動したのに何も始まらない」状態になりえた。transient back-pressure 向けに最大 2 回再送 + 失敗時 error ログ格上げ。

## Test plan
- [x] `cargo check` / `cargo clippy --lib` 警告なし
- [x] `cargo test pty::` 118 passed、`resize_clamp` 4 passed
- [x] `npm run typecheck` 通過
- [ ] (該当時)Windows 実機で codex タブ再 spawn 時のフリーズ解消を確認

Closes #1075
Closes #1076
Closes #1077