### PR TITLE
fix(terminal): codex 初手プロンプトの末尾 \r 失敗を retry して Enter を確実に確定する

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -8,7 +8,7 @@
   "src-tauri/src/commands/settings.rs": 869,
   "src-tauri/src/commands/team_history.rs": 1239,
   "src-tauri/src/commands/team_state.rs": 593,
-  "src-tauri/src/commands/terminal.rs": 1017,
+  "src-tauri/src/commands/terminal.rs": 1195,
   "src-tauri/src/commands/terminal/command_validation.rs": 916,
   "src-tauri/src/commands/terminal_tabs.rs": 817,
   "src-tauri/src/commands/voice.rs": 550,

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -211,6 +211,55 @@ fn filter_codex_resume_id_in_place(is_codex: bool, args: Vec<String>) -> Vec<Str
     }
 }
 
+/// Issue #1077: codex 初手プロンプトの確定 `\r` 送出 retry の最終結果。
+///
+/// session 消滅由来の打ち切りと「全試行が write 失敗で尽きた」を区別し、ログの文言と
+/// レベルを出し分けるために使う (code review M1)。
+#[derive(Debug, PartialEq, Eq)]
+enum FinalCrOutcome {
+    /// `\r` write が確定した (成功)。
+    Confirmed,
+    /// retry 途中で session が消えた (codex は既に exit 済みの可能性) → 確定待ちではない。
+    SessionGone,
+    /// 全試行が write 失敗で尽きた → codex が確定待ちのまま固まる恐れ。
+    Exhausted,
+}
+
+/// Issue #1077: 確定 `\r` を最大 `max_attempts` 回試行する汎用 retry ループ。
+///
+/// `spawn_blocking` / 実 PTY 依存を `write_cr` / `session_alive` の closure 境界の外に出す
+/// ことで、試行回数・retry 打ち切り条件・session 消滅検知をユニットテスト可能にする。
+///
+/// - `write_cr(attempt)`: 1 回分の `\r` write を行う。`true` で確定成功。失敗時の warn ログは
+///   呼び出し側 closure 内で出す。
+/// - `session_alive()`: retry sleep に入る前に session がまだ生きているか確認する。生きて
+///   いなければ SessionGone で即打ち切る。
+async fn write_final_cr_with_retry<WFut, W, A>(
+    max_attempts: u32,
+    retry_delay: Duration,
+    mut write_cr: W,
+    mut session_alive: A,
+) -> FinalCrOutcome
+where
+    W: FnMut(u32) -> WFut,
+    WFut: std::future::Future<Output = bool>,
+    A: FnMut() -> bool,
+{
+    for attempt in 1..=max_attempts {
+        if write_cr(attempt).await {
+            return FinalCrOutcome::Confirmed;
+        }
+        if attempt < max_attempts {
+            // session がもう無ければ再送しても無駄。codex は確定前に exit 済みと判断して打ち切る。
+            if !session_alive() {
+                return FinalCrOutcome::SessionGone;
+            }
+            tokio::time::sleep(retry_delay).await;
+        }
+    }
+    FinalCrOutcome::Exhausted
+}
+
 /// Codex の system prompt を、PTY (TUI) に直接「最初の入力」として注入する fallback 経路。
 ///
 /// 動作:
@@ -294,40 +343,49 @@ async fn inject_codex_prompt_to_pty(
     // Issue #1077: 旧実装は `\r` 失敗を warn のみで握り潰しており、本文 paste は届いたのに
     // Enter 未確定で codex が起動指示を実行しないまま待機する事故 (「起動したのに何も
     // 始まらない」) を招いていた。ConPTY back-pressure 等の一過性失敗に備え、確定 `\r` を
-    // 最大 CODEX_FINAL_CR_MAX_ATTEMPTS 回まで再試行する。retry 間は短い sleep を挟み、
-    // session が既に消えていれば retry を打ち切る。
-    let mut final_cr_ok = false;
-    for attempt in 1..=CODEX_FINAL_CR_MAX_ATTEMPTS {
-        let s = session.clone();
-        match tokio::task::spawn_blocking(move || s.write(b"\r")).await {
-            Ok(Ok(())) => {
-                final_cr_ok = true;
-                break;
+    // write_final_cr_with_retry で最大 CODEX_FINAL_CR_MAX_ATTEMPTS 回まで再試行する。
+    let outcome = write_final_cr_with_retry(
+        CODEX_FINAL_CR_MAX_ATTEMPTS,
+        Duration::from_millis(CODEX_FINAL_CR_RETRY_DELAY_MS),
+        |attempt| {
+            let s = session.clone();
+            let term_id = term_id.clone();
+            async move {
+                match tokio::task::spawn_blocking(move || s.write(b"\r")).await {
+                    Ok(Ok(())) => true,
+                    Ok(Err(e)) => {
+                        tracing::warn!(
+                            "[terminal] codex prompt write(\\r) attempt {attempt}/{CODEX_FINAL_CR_MAX_ATTEMPTS} failed for {term_id}: {e}"
+                        );
+                        false
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "[terminal] codex prompt spawn_blocking(\\r) attempt {attempt}/{CODEX_FINAL_CR_MAX_ATTEMPTS} failed for {term_id}: {e}"
+                        );
+                        false
+                    }
+                }
             }
-            Ok(Err(e)) => {
-                tracing::warn!(
-                    "[terminal] codex prompt write(\\r) attempt {attempt}/{CODEX_FINAL_CR_MAX_ATTEMPTS} failed for {term_id}: {e}"
-                );
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "[terminal] codex prompt spawn_blocking(\\r) attempt {attempt}/{CODEX_FINAL_CR_MAX_ATTEMPTS} failed for {term_id}: {e}"
-                );
-            }
+        },
+        || registry.get(&term_id).is_some(),
+    )
+    .await;
+    match outcome {
+        FinalCrOutcome::Confirmed => {}
+        FinalCrOutcome::SessionGone => {
+            // session が消えている = codex は確定前に既に exit 済み。確定待ちではないので
+            // warn 止まり (「unconfirmed で固まっている」誤解を生む error を出さない)。
+            tracing::warn!(
+                "[terminal] codex prompt final \\r aborted for {term_id} — session already gone (codex likely exited before confirm)"
+            );
         }
-        if attempt < CODEX_FINAL_CR_MAX_ATTEMPTS {
-            // session がもう無ければ再送しても無駄なので打ち切る。
-            if registry.get(&term_id).is_none() {
-                break;
-            }
-            sleep(Duration::from_millis(CODEX_FINAL_CR_RETRY_DELAY_MS)).await;
+        FinalCrOutcome::Exhausted => {
+            // 全試行が write 失敗で尽きた。codex は確定待ちのまま固まる可能性が高い。
+            tracing::error!(
+                "[terminal] codex prompt final \\r never confirmed for {term_id} after {CODEX_FINAL_CR_MAX_ATTEMPTS} attempts — codex may be waiting unconfirmed"
+            );
         }
-    }
-    if !final_cr_ok {
-        // 全試行が尽きた場合は error ログを残す。codex は確定待ちのまま固まる可能性が高い。
-        tracing::error!(
-            "[terminal] codex prompt final \\r never confirmed for {term_id} after {CODEX_FINAL_CR_MAX_ATTEMPTS} attempts — codex may be waiting unconfirmed"
-        );
     }
     tracing::info!(
         "[terminal] codex prompt injected into pty {term_id} ({} bytes)",
@@ -1052,5 +1110,85 @@ mod codex_resume_filter_tests {
         let input = s(&["-c", "k=v", "resume", "abc;rm -rf /"]);
         let out = filter_codex_resume_id_in_place(true, input.clone());
         assert_eq!(out, input);
+    }
+}
+
+#[cfg(test)]
+mod final_cr_retry_tests {
+    use super::{write_final_cr_with_retry, FinalCrOutcome};
+    use std::cell::Cell;
+    use std::time::Duration;
+
+    // retry delay は 0 にして、テストが実時間 sleep しないようにする。
+    const NO_DELAY: Duration = Duration::from_millis(0);
+
+    #[tokio::test]
+    async fn confirmed_on_first_attempt() {
+        let calls = Cell::new(0u32);
+        let outcome = write_final_cr_with_retry(
+            3,
+            NO_DELAY,
+            |_attempt| {
+                calls.set(calls.get() + 1);
+                async { true }
+            },
+            || true,
+        )
+        .await;
+        assert_eq!(outcome, FinalCrOutcome::Confirmed);
+        assert_eq!(calls.get(), 1, "成功すれば 1 回で打ち切るはず");
+    }
+
+    #[tokio::test]
+    async fn confirmed_after_transient_failures() {
+        // Issue #1077 の本命: 最初の 2 回失敗 → 3 回目で確定。
+        let calls = Cell::new(0u32);
+        let outcome = write_final_cr_with_retry(
+            3,
+            NO_DELAY,
+            |attempt| {
+                calls.set(calls.get() + 1);
+                async move { attempt == 3 }
+            },
+            || true,
+        )
+        .await;
+        assert_eq!(outcome, FinalCrOutcome::Confirmed);
+        assert_eq!(calls.get(), 3, "3 回目で成功するまで retry するはず");
+    }
+
+    #[tokio::test]
+    async fn exhausted_when_all_attempts_fail() {
+        let calls = Cell::new(0u32);
+        let outcome = write_final_cr_with_retry(
+            3,
+            NO_DELAY,
+            |_attempt| {
+                calls.set(calls.get() + 1);
+                async { false }
+            },
+            || true, // session は生存し続ける
+        )
+        .await;
+        assert_eq!(outcome, FinalCrOutcome::Exhausted);
+        assert_eq!(calls.get(), 3, "max_attempts ぶん試行して尽きるはず");
+    }
+
+    #[tokio::test]
+    async fn aborts_when_session_gone() {
+        // session 消滅時は retry せず即 SessionGone (Exhausted の error 文言を出さない / M1)。
+        let calls = Cell::new(0u32);
+        let outcome = write_final_cr_with_retry(
+            3,
+            NO_DELAY,
+            |_attempt| {
+                calls.set(calls.get() + 1);
+                async { false }
+            },
+            || false, // 1 回目失敗後の生存確認で「消滅」を返す
+        )
+        .await;
+        assert_eq!(outcome, FinalCrOutcome::SessionGone);
+        assert_eq!(calls.get(), 1, "session 消滅を検知したら追加 retry しないはず");
     }
 }

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -36,6 +36,20 @@ const CODEX_INITIAL_PROMPT_DELAY_MS: u64 = 1800;
 /// terminal 側のチャンク注入用にローカル定数として持つ (旧実装は `15` の直書きだった)。
 const CODEX_PROMPT_CHUNK_DELAY_MS: u64 = 15;
 
+/// Issue #1077: codex 初手プロンプト注入の末尾確定 `\r` を送る試行回数 (初回 + retry)。
+///
+/// 本文 (bracketed paste) は届いたのに最終 `\r` だけ失敗すると、codex TUI は入力欄に
+/// 貼られた表示のまま confirm されず「起動したのに何も始まらない」状態になる。ConPTY
+/// back-pressure 等で `\r` が一過性に失敗するケースに備え、確定 write を最大この回数まで
+/// 再試行する (team_hub の inject は #378 で最終 `\r` 失敗を `FinalCrFailed` として伝播
+/// 済みだが、本経路は fire-and-forget task のため retry で復旧を図る)。
+const CODEX_FINAL_CR_MAX_ATTEMPTS: u32 = 3;
+
+/// Issue #1077: 末尾確定 `\r` の retry 間に挟むスリープ (ミリ秒)。
+///
+/// back-pressure が解ける猶予を与えてから再送するための短い待ち。
+const CODEX_FINAL_CR_RETRY_DELAY_MS: u64 = 30;
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TerminalCreateOptions {
@@ -277,17 +291,43 @@ async fn inject_codex_prompt_to_pty(
     }
     sleep(Duration::from_millis(CODEX_PROMPT_CHUNK_DELAY_MS)).await;
     // Issue #620: 末尾の確定 `\r` も spawn_blocking 経由で送る。
-    let s = session.clone();
-    match tokio::task::spawn_blocking(move || s.write(b"\r")).await {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => {
-            tracing::warn!("[terminal] codex prompt write(\\r) failed for {term_id}: {e}");
+    // Issue #1077: 旧実装は `\r` 失敗を warn のみで握り潰しており、本文 paste は届いたのに
+    // Enter 未確定で codex が起動指示を実行しないまま待機する事故 (「起動したのに何も
+    // 始まらない」) を招いていた。ConPTY back-pressure 等の一過性失敗に備え、確定 `\r` を
+    // 最大 CODEX_FINAL_CR_MAX_ATTEMPTS 回まで再試行する。retry 間は短い sleep を挟み、
+    // session が既に消えていれば retry を打ち切る。
+    let mut final_cr_ok = false;
+    for attempt in 1..=CODEX_FINAL_CR_MAX_ATTEMPTS {
+        let s = session.clone();
+        match tokio::task::spawn_blocking(move || s.write(b"\r")).await {
+            Ok(Ok(())) => {
+                final_cr_ok = true;
+                break;
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    "[terminal] codex prompt write(\\r) attempt {attempt}/{CODEX_FINAL_CR_MAX_ATTEMPTS} failed for {term_id}: {e}"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[terminal] codex prompt spawn_blocking(\\r) attempt {attempt}/{CODEX_FINAL_CR_MAX_ATTEMPTS} failed for {term_id}: {e}"
+                );
+            }
         }
-        Err(e) => {
-            tracing::warn!(
-                "[terminal] codex prompt spawn_blocking(\\r) failed for {term_id}: {e}"
-            );
+        if attempt < CODEX_FINAL_CR_MAX_ATTEMPTS {
+            // session がもう無ければ再送しても無駄なので打ち切る。
+            if registry.get(&term_id).is_none() {
+                break;
+            }
+            sleep(Duration::from_millis(CODEX_FINAL_CR_RETRY_DELAY_MS)).await;
         }
+    }
+    if !final_cr_ok {
+        // 全試行が尽きた場合は error ログを残す。codex は確定待ちのまま固まる可能性が高い。
+        tracing::error!(
+            "[terminal] codex prompt final \\r never confirmed for {term_id} after {CODEX_FINAL_CR_MAX_ATTEMPTS} attempts — codex may be waiting unconfirmed"
+        );
     }
     tracing::info!(
         "[terminal] codex prompt injected into pty {term_id} ({} bytes)",


### PR DESCRIPTION
## Summary
- codex 起動直後の初手プロンプト PTY 注入で、bracketed paste 本体は届いたのに最終確定 `\r` の write だけ失敗すると、codex TUI が入力欄に貼られた表示のまま confirm されず「起動したのに何も始まらない」状態になっていた。
- 旧 `inject_codex_prompt_to_pty` は末尾 `\r` 失敗を `tracing::warn!` のみで握り潰していた (team_hub の inject は #378 で `FinalCrFailed` として厳密化済みだったが、本経路だけ未対応)。
- ConPTY back-pressure 等の一過性失敗に備え、確定 `\r` を最大 3 回まで再試行する。retry 間に短い sleep を挟み、session が既に消えていれば打ち切る。
- 関連 issue: #1077

## 変更点
- `src-tauri/src/commands/terminal.rs`
  - `CODEX_FINAL_CR_MAX_ATTEMPTS` (=3) / `CODEX_FINAL_CR_RETRY_DELAY_MS` (=30) 定数を追加。
  - retry ロジックを `write_final_cr_with_retry` 汎用ヘルパに抽出し、`spawn_blocking` / 実 PTY 依存を closure 境界の外に出してユニットテスト可能にした。
  - 打ち切り理由を `FinalCrOutcome` (Confirmed / SessionGone / Exhausted) で区別。session 消滅由来の打ち切りは `warn`、全試行失敗のみ `error` にしてログ文言の誤解を解消 (auto-review M1)。
- `build/file-size-baseline.json`
  - terminal.rs の baseline を 1017 → 1195 に引き上げ (auto-review B1)。**理由**: 末尾 `\r` の retry 化 + retry helper 抽出 + 回帰テスト追加による +178 行の小規模 bug fix であり、terminal.rs の god-file 分割は本 PR のスコープ外 (CLAUDE.md #7)。

## Test plan
- [x] `cargo test --lib final_cr_retry` 4 件通過 (初回成功 / 一過性失敗→3回目で確定 / 全失敗→Exhausted / session 消滅→SessionGone)
- [x] `cargo check` (非テストビルド) 通過
- [x] `npm run typecheck` 通過 (Rust のみ変更で TS は origin/main と同一)
- [x] `node build/check-file-size-ratchet.mjs` 通過

Closes #1077