### PR TITLE
fix(security): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3330,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary
- **RUSTSEC-2026-0185** (2026-06-22 公開, severity 7.5 high): `quinn-proto` 0.11.14 の remote memory exhaustion (unbounded out-of-order stream reassembly)。
- 依存ツリー: `quinn-proto 0.11.14` → `quinn 0.11.9` → `reqwest 0.12.28` → `vibe-editor`。
- advisory DB 登録の結果、CI `verify` の `cargo audit` が **main を含む全 PR で fail** し、bot APPROVED + 他チェック green でも全 open PR が merge 不能になっていた。
- fixed 版 **0.11.15** へ patch bump。これにより `cargo audit` ゲートが解消され `verify` が green に戻る。
- 関連 issue: #1102

## 変更点
- `src-tauri/Cargo.lock`: `quinn-proto` 0.11.14 → 0.11.15 (1 エントリのみ、`cargo update -p quinn-proto --precise 0.11.15`)。`--dry-run` で cascade 無し・98 deps 不変を確認済み。

## なぜ ignore でなく版上げか
`src-tauri/.cargo/audit.toml` への ignore 追記は high-severity の実脆弱性を握り潰すことになるため不採用。fixed 版が存在するので版上げが正攻法。

## Test plan
- [x] `cargo check` 通過 (quinn-proto 0.11.15 でビルド)
- [x] `cargo update --dry-run` で cascade 無しを確認
- [ ] CI `verify` (`cargo audit`) が green になること ← この PR の主目的

Closes #1102