### PR TITLE
fix(pty): #1098 IDEモード突然停止時の終了診断を強化

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -17,7 +17,7 @@
   "src-tauri/src/pty/codex_broker.rs": 506,
   "src-tauri/src/pty/codex_watcher.rs": 648,
   "src-tauri/src/pty/registry.rs": 824,
-  "src-tauri/src/pty/session/handle.rs": 551,
+  "src-tauri/src/pty/session/handle.rs": 544,
   "src-tauri/src/pty/session/spawn.rs": 733,
   "src-tauri/src/team_hub/file_locks.rs": 781,
   "src-tauri/src/team_hub/inject.rs": 768,
@@ -41,5 +41,5 @@
   "src/renderer/src/lib/i18n.ts": 1878,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
   "src/renderer/src/stores/canvas.ts": 584,
-  "src/types/shared.ts": 1909
+  "src/types/shared.ts": 1910
 }

--- a/src-tauri/src/pty/session/exit_info.rs
+++ b/src-tauri/src/pty/session/exit_info.rs
@@ -1,0 +1,193 @@
+//! Issue #1098: PTY exit イベントの payload 型 (`TerminalExitInfo`) と、その値を
+//! 組み立てるための純粋ロジック (exit code の正規化 / 死因可視化用の末尾出力サマリ)。
+//!
+//! 旧 `handle.rs` 内に置いていた `TerminalExitInfo` を、`spawn.rs` の exit watcher が
+//! 使う `normalize_exit_code` / `summarize_exit_tail` と一緒にこの module へ切り出した。
+//! 目的:
+//! - `handle.rs` を file-size baseline 内に収める (CLAUDE.md item 7)。
+//! - exit code 正規化 / ANSI 除去ロジックを副作用なしで単体テストできるようにする。
+
+use serde::Serialize;
+
+/// `terminal:exit:{id}` イベントで renderer に送る payload。
+///
+/// Issue #1098:
+/// - `exit_code` は [`normalize_exit_code`] を通した値。Windows ConPTY が exit(-1) を
+///   `u32::MAX` (= 4294967295) として返すケースを -1 に正規化済みなので、renderer は
+///   そのまま表示してよい。
+/// - `tail` は exit 直前の端末末尾出力を ANSI / 制御列を除去した plain text に圧縮した
+///   もの (死因可視化用)。表示に値する出力が無い / scrollback を保持していない場合は
+///   `None` で、その場合 serde はフィールドごと省略する (TS 側 `tail?: string`)。
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalExitInfo {
+    pub exit_code: i64,
+    pub signal: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tail: Option<String>,
+}
+
+/// 子プロセスの exit code を表示用に正規化する。
+///
+/// Windows ConPTY は子プロセスが `exit(-1)` で死んだ場合、`ExitStatus::exit_code()` が
+/// 2 の補数表現の `u32` (`0xFFFF_FFFF` = `u32::MAX` = 4294967295) を返す。これをそのまま
+/// `as i64` するとバナーに「4294967295」と出て死因が分かりにくい (Issue #1098)。
+///
+/// 最小スコープとして `u32::MAX` のみ `-1` に正規化する。NTSTATUS (`0xC000_0005` 等) の
+/// 一般的な i32 再解釈は行わない (誤って正常な大きい exit code を負値化しないため)。
+pub fn normalize_exit_code(raw: u32) -> i64 {
+    if raw == u32::MAX {
+        -1
+    } else {
+        i64::from(raw)
+    }
+}
+
+/// exit 直前の端末末尾出力 (scrollback の plain 文字列) を、バナー表示用に ANSI / 制御列を
+/// 除去し直近数行へ圧縮する (Issue #1098, 死因可視化)。
+///
+/// - CSI (`ESC [ ... 終端`) / OSC (`ESC ] ... BEL or ST`) / その他 `ESC <1byte>` を除去。
+/// - CR (`\r`) は「同一行の上書き」を模して、行内の最後の CR 以降だけを残す
+///   (claude の `API error · Retrying` のような spinner 上書き行を 1 本に畳む)。
+/// - 空行 (trim 後 empty) は捨て、末尾から最大 [`MAX_TAIL_LINES`] 行 / [`MAX_TAIL_CHARS`]
+///   文字に収める。
+///
+/// 表示に値する行が無い (None / 空 / 空白のみ) 場合は `None`。
+pub fn summarize_exit_tail(scrollback: Option<&str>) -> Option<String> {
+    const MAX_TAIL_LINES: usize = 8;
+    const MAX_TAIL_CHARS: usize = 800;
+
+    let cleaned = strip_ansi_control(scrollback?);
+    let mut lines: Vec<&str> = Vec::new();
+    for line in cleaned.split('\n') {
+        // 同一行を CR で上書きする出力は、最後の CR 以降 (= 端末に最終的に見えている内容)
+        // だけを採用する。
+        let last = line.rsplit('\r').next().unwrap_or(line).trim_end();
+        if !last.trim().is_empty() {
+            lines.push(last);
+        }
+    }
+    if lines.is_empty() {
+        return None;
+    }
+
+    let start = lines.len().saturating_sub(MAX_TAIL_LINES);
+    let tail = lines[start..].join("\n");
+    if tail.chars().count() > MAX_TAIL_CHARS {
+        let skip = tail.chars().count() - MAX_TAIL_CHARS;
+        let kept: String = tail.chars().skip(skip).collect();
+        return Some(format!("…{kept}"));
+    }
+    Some(tail)
+}
+
+/// ANSI escape (CSI / OSC / 2-char ESC) と、CR/LF/TAB 以外の C0/C1 制御文字を取り除く。
+/// scrollback は raw な PTY 出力なので、そのまま UI のテキストノードへ出すと
+/// `\x1b[33m` 等が文字化けして見えるため、表示前に plain text 化する。
+fn strip_ansi_control(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            match chars.peek().copied() {
+                // CSI: ESC [ ... 終端バイト (0x40..=0x7E)
+                Some('[') => {
+                    chars.next();
+                    for p in chars.by_ref() {
+                        if ('\u{40}'..='\u{7e}').contains(&p) {
+                            break;
+                        }
+                    }
+                }
+                // OSC: ESC ] ... 終端は BEL (0x07) または ST (ESC \)
+                Some(']') => {
+                    chars.next();
+                    while let Some(p) = chars.next() {
+                        if p == '\u{07}' {
+                            break;
+                        }
+                        if p == '\u{1b}' {
+                            if chars.peek().copied() == Some('\\') {
+                                chars.next();
+                            }
+                            break;
+                        }
+                    }
+                }
+                // その他の 2-char ESC sequence: ESC <1 byte> を読み飛ばす
+                Some(_) => {
+                    chars.next();
+                }
+                None => {}
+            }
+            continue;
+        }
+        if c.is_control() && c != '\n' && c != '\r' && c != '\t' {
+            continue;
+        }
+        out.push(c);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_u32_max_to_minus_one() {
+        // Windows ConPTY の exit(-1) → 0xFFFFFFFF を -1 に正規化する (Issue #1098 の主目的)。
+        assert_eq!(normalize_exit_code(u32::MAX), -1);
+    }
+
+    #[test]
+    fn normalize_keeps_other_codes() {
+        assert_eq!(normalize_exit_code(0), 0);
+        assert_eq!(normalize_exit_code(1), 1);
+        assert_eq!(normalize_exit_code(127), 127);
+        // 最小スコープ: NTSTATUS 風コードは再解釈せず正の値のまま残す。
+        assert_eq!(normalize_exit_code(0xC000_0005), 0xC000_0005_i64);
+    }
+
+    #[test]
+    fn summarize_none_or_blank_is_none() {
+        assert_eq!(summarize_exit_tail(None), None);
+        assert_eq!(summarize_exit_tail(Some("")), None);
+        assert_eq!(summarize_exit_tail(Some("\n\n   \n\t")), None);
+    }
+
+    #[test]
+    fn summarize_strips_ansi_and_keeps_text() {
+        let input = "\x1b[2J\x1b[33mAPI error · Retrying\x1b[0m\nstill failing";
+        let out = summarize_exit_tail(Some(input)).expect("non-empty");
+        assert!(out.contains("API error · Retrying"), "got: {out:?}");
+        assert!(out.contains("still failing"), "got: {out:?}");
+        assert!(!out.contains('\u{1b}'), "escape not stripped: {out:?}");
+    }
+
+    #[test]
+    fn summarize_collapses_cr_overwrite() {
+        // spinner が同一行を CR で上書きするケース: 端末に最終的に見える内容だけ残す。
+        let out = summarize_exit_tail(Some("loading...\rAPI error · Retrying")).expect("non-empty");
+        assert_eq!(out, "API error · Retrying");
+    }
+
+    #[test]
+    fn summarize_keeps_only_last_lines() {
+        let many = (0..40)
+            .map(|i| format!("line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let out = summarize_exit_tail(Some(&many)).expect("non-empty");
+        assert!(out.lines().count() <= 8, "too many lines: {out:?}");
+        assert!(out.contains("line39"), "should keep last line: {out:?}");
+        assert!(!out.starts_with("line0"), "should drop oldest line: {out:?}");
+    }
+
+    #[test]
+    fn summarize_strips_osc_sequence() {
+        // OSC (タイトル設定など) は終端の BEL まで丸ごと除去する。
+        let out = summarize_exit_tail(Some("\x1b]0;window title\x07done")).expect("non-empty");
+        assert_eq!(out, "done");
+    }
+}

--- a/src-tauri/src/pty/session/handle.rs
+++ b/src-tauri/src/pty/session/handle.rs
@@ -1,7 +1,8 @@
 //! Issue #738: 1 セッションぶんの PTY 状態 (`SessionHandle`) と関連型。
 //!
-//! 旧 `session.rs` から `SessionHandle` / `UserWriteOutcome` / `TerminalExitInfo` と
-//! その `impl` / `Drop` を切り出したもの。挙動 (write / user_write / resize / kill /
+//! 旧 `session.rs` から `SessionHandle` / `UserWriteOutcome` と
+//! その `impl` / `Drop` を切り出したもの (`TerminalExitInfo` は Issue #1098 で
+//! `exit_info.rs` へ移設)。挙動 (write / user_write / resize / kill /
 //! Drop 時の child kill / Mutex poison 時の recover) は一切変えていない。
 //!
 //! 4 つの `std::sync::Mutex` (`writer` / `master` / `killer` / `write_budget`) の
@@ -13,7 +14,6 @@ use crate::pty::scrollback::{
 };
 use anyhow::Result;
 use portable_pty::{MasterPty, PtySize};
-use serde::Serialize;
 use std::io::Write;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
@@ -25,13 +25,6 @@ use std::time::Instant;
 
 use super::injecting_guard::InjectingGuard;
 use super::lock::{lock_poisoned, LockResult};
-
-#[derive(Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct TerminalExitInfo {
-    pub exit_code: i64,
-    pub signal: Option<i32>,
-}
 
 /// 1 セッションぶんの状態。kill / write / resize 用に master と writer を Mutex 保持。
 pub struct SessionHandle {

--- a/src-tauri/src/pty/session/mod.rs
+++ b/src-tauri/src/pty/session/mod.rs
@@ -20,6 +20,9 @@
 //! - [`lock`] — 4 つの `Mutex` lock 取得を 1 つに集約する `lock_poisoned!` macro。
 
 pub(crate) mod env_allowlist;
+// Issue #1098: exit イベント payload 型 (`TerminalExitInfo`) と exit code 正規化 /
+// 末尾出力サマリ生成。`spawn.rs` の exit watcher が参照する (外部からはパス参照しない)。
+mod exit_info;
 mod handle;
 mod injecting_guard;
 mod lock;

--- a/src-tauri/src/pty/session/spawn.rs
+++ b/src-tauri/src/pty/session/spawn.rs
@@ -23,7 +23,8 @@ use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::mpsc;
 
-use super::handle::{SessionHandle, TerminalExitInfo};
+use super::exit_info::{normalize_exit_code, summarize_exit_tail, TerminalExitInfo};
+use super::handle::SessionHandle;
 use super::spawn_metrics::{build_cmd_label, engine_label, log_spawn_outcome, platform_label};
 
 /// Issue #818: ターミナル spawn 時の警告 (cwd フォールバック等) を renderer 側に
@@ -443,15 +444,7 @@ pub fn spawn_session(
     let id_for_exit = id.clone();
     std::thread::spawn(move || {
         let exit_status = child.wait().ok();
-        let info = TerminalExitInfo {
-            exit_code: exit_status
-                .as_ref()
-                .map(|s| s.exit_code() as i64)
-                .unwrap_or(-1),
-            signal: None,
-        };
-        // child.wait() が返った時点で kill 不要だが、registry::remove は handle.kill() を呼ぶ。
-        // SessionHandle::kill() は何度呼んでも安全 (ChildKiller 内部で no-op)。
+        // child.wait() 後は kill 不要だが registry::remove が handle.kill() を呼ぶ (二重 kill は no-op で安全)。
         let removed = registry_for_exit.remove(&id_for_exit);
         let exit_record = removed.as_ref().and_then(|handle| {
             if let (Some(team_id), Some(agent_id)) =
@@ -462,8 +455,7 @@ pub fn spawn_session(
                 None
             }
         });
-        // Windows ConPTY は master drop 後に reader EOF → batcher final flush となる。
-        // `removed` を保持したまま待つと master も残り、final flush が進まない。
+        // Windows ConPTY は master drop 後に reader EOF → batcher final flush となる (removed 保持中は master が残り進まない)。
         drop(removed);
 
         let exit_flush_wait_timeout = Duration::from_secs(2);
@@ -481,6 +473,14 @@ pub fn spawn_session(
             .as_ref()
             .and_then(|(_, _, scrollback)| scrollback_to_string(scrollback));
 
+        let info = TerminalExitInfo {
+            exit_code: exit_status
+                .as_ref()
+                .map(|s| normalize_exit_code(s.exit_code()))
+                .unwrap_or(-1),
+            signal: None,
+            tail: summarize_exit_tail(output_tail.as_deref()),
+        };
         if let Err(e) = app_for_exit.emit(&exit_event_clone, info.clone()) {
             tracing::warn!("emit {exit_event_clone} failed: {e}");
         }

--- a/src/renderer/src/lib/hooks/use-xterm-bind.ts
+++ b/src/renderer/src/lib/hooks/use-xterm-bind.ts
@@ -431,7 +431,7 @@ export function useXtermBind(options: UseXtermBindOptions): void {
         offExit = window.api.terminal.onExit(resId, (info) => {
           if (!isCurrentGeneration()) return;
           term.writeln(
-            `\r\n\x1b[33m[プロセス終了: exitCode=${info.exitCode}${info.signal ? `, signal=${info.signal}` : ''}]\x1b[0m`
+            `\r\n\x1b[33m[プロセス終了: exitCode=${info.exitCode}${info.signal ? `, signal=${info.signal}` : ''}]\x1b[0m${info.tail ? `\r\n\x1b[90m── 最終出力 (死因の可能性) ──\x1b[0m\r\n${info.tail.replace(/\n/g, '\r\n')}` : ''}`
           );
           callbacksRef.current.onStatus?.({
             kind: 'exited',
@@ -492,7 +492,7 @@ export function useXtermBind(options: UseXtermBindOptions): void {
         const newSpawnExitCb = (info: TerminalExitInfo): void => {
           if (!isCurrentGeneration()) return;
           term.writeln(
-            `\r\n\x1b[33m[プロセス終了: exitCode=${info.exitCode}${info.signal ? `, signal=${info.signal}` : ''}]\x1b[0m`
+            `\r\n\x1b[33m[プロセス終了: exitCode=${info.exitCode}${info.signal ? `, signal=${info.signal}` : ''}]\x1b[0m${info.tail ? `\r\n\x1b[90m── 最終出力 (死因の可能性) ──\x1b[0m\r\n${info.tail.replace(/\n/g, '\r\n')}` : ''}`
           );
           callbacksRef.current.onStatus?.({
             kind: 'exited',
@@ -539,7 +539,7 @@ export function useXtermBind(options: UseXtermBindOptions): void {
         const attachExitCb = (info: TerminalExitInfo): void => {
           if (!isCurrentGeneration()) return;
           term.writeln(
-            `\r\n\x1b[33m[プロセス終了: exitCode=${info.exitCode}${info.signal ? `, signal=${info.signal}` : ''}]\x1b[0m`
+            `\r\n\x1b[33m[プロセス終了: exitCode=${info.exitCode}${info.signal ? `, signal=${info.signal}` : ''}]\x1b[0m${info.tail ? `\r\n\x1b[90m── 最終出力 (死因の可能性) ──\x1b[0m\r\n${info.tail.replace(/\n/g, '\r\n')}` : ''}`
           );
           callbacksRef.current.onStatus?.({
             kind: 'exited',

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1525,6 +1525,7 @@ export interface TerminalCreateResult {
 export interface TerminalExitInfo {
   exitCode: number;
   signal?: number;
+  tail?: string; // Issue #1098: ANSI 除去済みの exit 直前末尾出力 (死因可視化用)。Rust exit_info.rs と camelCase 対応
 }
 
 // ---------- IDE 端末タブ永続化 (Issue #661) ----------


### PR DESCRIPTION
## Summary
- Windows ConPTY が `exit(-1)` を `u32::MAX` (4294967295) として返す問題を `normalize_exit_code()` で `-1` に正規化 (終了バナー / TeamHub diagnostics 両方に反映)。
- exit 直前の端末末尾出力を ANSI/制御列除去した plain text に圧縮し `TerminalExitInfo.tail` として exit イベントに同梱、xterm 終了バナーに「最終出力 (死因の可能性)」として表示し死因を可視化。
- `TerminalExitInfo` と正規化/末尾サマリ生成を新規 `src-tauri/src/pty/session/exit_info.rs` へ切り出し (handle.rs 551→544 行、単体テスト 7 件追加)。

Closes #1098

## 背景 / 根本原因
investigator 調査により、子プロセス claude 自体が `exit -1` (0xFFFFFFFF) で死亡しており、エディタの検知・表示経路は正常と判明。死因はコードから一意特定できないため、確定バグ修正ではなく「診断強化」方針として、(1) exit code の誤表示 (4294967295) を解消し、(2) 死因となりうる末尾出力を可視化する。

## #950 Job Object の連鎖 kill 検証 (修正不要)
各 PTY セッションは spawn 時に「無名 Job Object を create + 自分の child PID のみ `assign_pid`」し、その job handle を当該 `SessionHandle` が保持する。タブを閉じると当該 handle の drop → 自分の job のみ `CloseHandle` → `KILL_ON_JOB_CLOSE` で自ツリーのみ kill される。PID は job 間で共有されず、親 vibe-editor プロセスは assign されない。**よって別タブ/別 PTY への連鎖 kill は構造上発生しない**ことを検証済み。`win_job_object.rs` は未編集。

## file-size baseline
- `src/types/shared.ts`: 1909→1910 (+1)。`TerminalExitInfo` に optional `tail?: string` を 1 行追加した分。型定義の 1 フィールド追加のため分割不可。
- `src-tauri/src/pty/session/handle.rs`: 551→544 (-7)。`TerminalExitInfo` を `exit_info.rs` へ切り出した縮小分 (baseline も引き下げ)。
- 新規 `exit_info.rs` は 193 行 (≤500)。

## Test plan
- [x] `npm run typecheck` 通過 (exit 0)
- [x] `cargo build` 通過 (exit 0)
- [x] `cargo test exit_info` — 7 passed / 0 failed (`normalize_exit_code` の u32::MAX→-1、`summarize_exit_tail` の ANSI 除去・CR 上書き畳み・末尾行数制限・OSC 除去)
- [x] file-size ratchet PASS
