### PR TITLE
refactor(canvas): #1113 エージェント識別を AgentDescriptor に正規化 (engine/identity 分離)

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -5,7 +5,7 @@
   "src-tauri/src/commands/files.rs": 1274,
   "src-tauri/src/commands/git.rs": 529,
   "src-tauri/src/commands/handoffs.rs": 513,
-  "src-tauri/src/commands/settings.rs": 888,
+  "src-tauri/src/commands/settings.rs": 900,
   "src-tauri/src/commands/team_history.rs": 1239,
   "src-tauri/src/commands/team_state.rs": 593,
   "src-tauri/src/commands/terminal.rs": 1278,

--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -5,7 +5,7 @@
   "src-tauri/src/commands/files.rs": 1274,
   "src-tauri/src/commands/git.rs": 529,
   "src-tauri/src/commands/handoffs.rs": 513,
-  "src-tauri/src/commands/settings.rs": 869,
+  "src-tauri/src/commands/settings.rs": 888,
   "src-tauri/src/commands/team_history.rs": 1239,
   "src-tauri/src/commands/team_state.rs": 593,
   "src-tauri/src/commands/terminal.rs": 1278,
@@ -35,11 +35,11 @@
   "src/renderer/src/components/AppShell.tsx": 977,
   "src/renderer/src/components/FileTreePanel.tsx": 767,
   "src/renderer/src/components/canvas/Canvas.tsx": 593,
-  "src/renderer/src/layouts/CanvasLayout.tsx": 946,
+  "src/renderer/src/layouts/CanvasLayout.tsx": 951,
   "src/renderer/src/lib/hooks/use-file-tabs.ts": 517,
   "src/renderer/src/lib/hooks/use-xterm-bind.ts": 889,
   "src/renderer/src/lib/i18n.ts": 1884,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
-  "src/renderer/src/stores/canvas.ts": 584,
-  "src/types/shared.ts": 1910
+  "src/renderer/src/stores/canvas.ts": 588,
+  "src/types/shared.ts": 1944
 }

--- a/src-tauri/src/commands/schema_version.rs
+++ b/src-tauri/src/commands/schema_version.rs
@@ -20,7 +20,10 @@ use crate::commands::error::{CommandError, CommandResult};
 /// `~/.vibe-editor/settings.json` の現行 schema version。
 /// renderer 側 `src/types/shared.ts` の `APP_SETTINGS_SCHEMA_VERSION` と同期。
 /// Issue #75 / #449 / #618 で bump されてきた。
-pub const SETTINGS_SCHEMA_VERSION: u32 = 12;
+/// Issue #1113 で custom agent descriptor フィールド (engine/env/icon/tags/defaultSkillIds/
+/// skillInjection) を追加し v13。additive-optional だが #641 save-guard が旧 build による
+/// 新フィールド silent drop を防ぐよう版数を上げる。
+pub const SETTINGS_SCHEMA_VERSION: u32 = 13;
 
 /// `~/.vibe-editor/team-state/*.json` (TeamHub orchestration state) の現行 schema version。
 /// Issue #470 で導入。

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -213,6 +213,25 @@ pub struct AgentConfig {
     pub skill_ids: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_mode: Option<String>,
+    // ---- Issue #1113: custom agent descriptor フィールド (すべて additive-optional) ----
+    /// CLI custom が動作する engine ('claude' | 'codex')。未指定なら renderer 側で 'claude' 既定。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engine: Option<String>,
+    /// 起動時に注入する環境変数。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<HashMap<String, String>>,
+    /// カード表示アイコン (lucide アイコン名)。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    /// 分類・フィルタ用タグ。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    /// 定義レベルの既定 skill 群 (Phase4)。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_skill_ids: Option<Vec<String>>,
+    /// skill 注入方式 ('claude-dir' | 'append-flag' | 'prompt-file' | 'none', Phase4)。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skill_injection: Option<String>,
 }
 
 fn default_agent_runtime() -> String {

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -784,6 +784,12 @@ mod tests {
                 system_prompt: None,
                 skill_ids: None,
                 tool_mode: None,
+                engine: None,
+                env: None,
+                icon: None,
+                tags: None,
+                default_skill_ids: None,
+                skill_injection: None,
             }]),
             ..Settings::default()
         };
@@ -811,6 +817,12 @@ mod tests {
                 system_prompt: None,
                 skill_ids: None,
                 tool_mode: None,
+                engine: None,
+                env: None,
+                icon: None,
+                tags: None,
+                default_skill_ids: None,
+                skill_injection: None,
             }]),
             ..Settings::default()
         };

--- a/src-tauri/src/commands/tests/settings.rs
+++ b/src-tauri/src/commands/tests/settings.rs
@@ -139,6 +139,12 @@ async fn agent_config_full_entry_round_trips() {
             system_prompt: None,
             skill_ids: None,
             tool_mode: None,
+            engine: None,
+            env: None,
+            icon: None,
+            tags: None,
+            default_skill_ids: None,
+            skill_injection: None,
         }]),
         ..Settings::default()
     };

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -57,6 +57,7 @@ import {
 import { resolveAgentVisual } from '../../../../lib/agent-visual';
 import { parseShellArgs } from '../../../../lib/parse-args';
 import { resolveAgentConfig } from '../../../../lib/agent-resolver';
+import type { AgentEngine } from '../../../../../../types/shared';
 import { useToast } from '../../../../lib/toast-context';
 import {
   deriveCardSummary,
@@ -142,13 +143,13 @@ function AgentNodeCardImpl({
   const teamMembers = useMemo(() => {
     if (!payload.teamId) return null;
     if (teamMembersSig === '')
-      return [] as { agentId: string; roleProfileId: string; agent: 'claude' | 'codex' }[];
+      return [] as { agentId: string; roleProfileId: string; agent: AgentEngine }[];
     return teamMembersSig.split(';').map((s) => {
       const [agentId, roleProfileId, agent] = s.split(':');
       return {
         agentId,
         roleProfileId,
-        agent: agent as 'claude' | 'codex'
+        agent: agent as AgentEngine
       };
     });
   }, [teamMembersSig, payload.teamId]);

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/types.ts
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/types.ts
@@ -5,6 +5,7 @@
  * index.tsx に分割した際、両側が読む型をここに集約する。挙動は不変、構造のみ。
  */
 import type {
+  AgentEngine,
   HandoffReference,
   InjectFailureReason,
   TeamOrganizationMeta,
@@ -12,7 +13,10 @@ import type {
 } from '../../../../../../types/shared';
 
 export interface AgentPayload {
-  agent?: 'claude' | 'codex';
+  /** 挙動系統 (engine)。識別子ではない。custom CLI も claude/codex いずれかの engine 上で動く。 */
+  agent?: AgentEngine;
+  /** Issue #1113: custom agent の settings.customAgents id。名前/アイコン/色/skill 解決に使う。 */
+  agentConfigId?: string;
   /** 新スキーマ: ロール識別子。未設定時は legacy `role` をフォールバックとして読む。 */
   roleProfileId?: string;
   /** @deprecated 旧フィールド。canvas store v2 マイグレーションで roleProfileId に移行済み */

--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -31,6 +31,7 @@ import type {
   TeamOrganizationMeta,
   TeamPreset
 } from '../../../types/shared';
+import { engineForAgentConfig } from '../lib/agent-registry';
 import { Canvas, type CanvasActions } from '../components/canvas/Canvas';
 import { CanvasSidebar } from '../components/canvas/CanvasSidebar';
 import {
@@ -333,10 +334,12 @@ export function CanvasLayout(): JSX.Element {
       ]);
     } else {
       // CLI custom agent: 組み込み leader と同様に MCP team tool を配線する。
+      // Issue #1113: engine は custom 定義の engine (default 'claude') を尊重する (registry に集約)。
+      const engine = engineForAgentConfig(agent);
       if (settings.mcpAutoSetup !== false) {
         try {
           await window.api.app.setupTeamMcp(cwd, teamId, teamName, [
-            { agentId, role: 'leader', agent: 'claude' }
+            { agentId, role: 'leader', agent: engine }
           ]);
         } catch (err) {
           console.warn('[custom-agent-preset] setupTeamMcp failed:', err);
@@ -352,7 +355,9 @@ export function CanvasLayout(): JSX.Element {
           position,
           payload: {
             // CardFrame は payload.command を優先して custom CLI を起動する。
-            agent: 'claude',
+            agent: engine,
+            // Issue #1113: custom agent の identity をカードへ伝える (名前/アイコン/色/skill 解決用)。
+            agentConfigId: agent.id,
             command: agent.command || undefined,
             args: agent.args ? customArgs.args : undefined,
             cwd: agent.cwd || cwd,

--- a/src/renderer/src/lib/__tests__/agent-registry.test.ts
+++ b/src/renderer/src/lib/__tests__/agent-registry.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  builtinAgentDescriptors,
+  customAgentDescriptor,
+  defaultSkillInjectionForEngine,
+  engineForAgentConfig,
+  listAgentDescriptors,
+  resolveAgentDescriptor
+} from '../agent-registry';
+import { DEFAULT_SETTINGS } from '../../../../types/shared';
+import type {
+  ApiAgentConfig,
+  AppSettings,
+  CliAgentConfig
+} from '../../../../types/shared';
+
+const cliCodex: CliAgentConfig = {
+  id: 'my-cli',
+  name: 'My CLI',
+  runtime: 'cli',
+  command: 'mycli',
+  args: '--foo',
+  engine: 'codex',
+  color: '#abcdef',
+  icon: 'Rocket',
+  tags: ['exp']
+};
+
+const cliPlain: CliAgentConfig = {
+  id: 'plain',
+  name: 'Plain',
+  runtime: 'cli',
+  command: 'plain',
+  args: ''
+};
+
+const apiAgent: ApiAgentConfig = {
+  id: 'gpt',
+  name: 'GPT',
+  runtime: 'api',
+  providerId: 'openai',
+  model: 'gpt-4',
+  skillIds: ['s1']
+};
+
+const settings: AppSettings = {
+  ...DEFAULT_SETTINGS,
+  customAgents: [cliCodex, cliPlain, apiAgent]
+};
+
+describe('agent-registry', () => {
+  it('builtin descriptors expose claude/codex with correct engine and skill injection', () => {
+    const builtins = builtinAgentDescriptors(settings);
+    expect(builtins.map((d) => d.id)).toEqual(['claude', 'codex']);
+    const claude = builtins.find((d) => d.id === 'claude')!;
+    const codex = builtins.find((d) => d.id === 'codex')!;
+    expect(claude.engine).toBe('claude');
+    expect(claude.kind).toBe('builtin');
+    expect(claude.skillInjection).toBe('claude-dir');
+    expect(codex.engine).toBe('codex');
+    expect(codex.skillInjection).toBe('none');
+  });
+
+  it('engineForAgentConfig respects cli engine, defaults to claude, treats api as claude', () => {
+    expect(engineForAgentConfig(cliCodex)).toBe('codex');
+    expect(engineForAgentConfig(cliPlain)).toBe('claude');
+    expect(engineForAgentConfig(apiAgent)).toBe('claude');
+  });
+
+  it('customAgentDescriptor normalizes a cli agent with explicit engine/icon/color', () => {
+    const d = customAgentDescriptor(cliCodex);
+    expect(d.kind).toBe('custom');
+    expect(d.runtime).toBe('cli');
+    expect(d.engine).toBe('codex');
+    expect(d.displayName).toBe('My CLI');
+    expect(d.icon).toBe('Rocket');
+    expect(d.accentColor).toBe('#abcdef');
+    expect(d.tags).toEqual(['exp']);
+    expect(d.command).toBe('mycli');
+    // engine codex かつ skillInjection 未指定 → engine 既定 'none'
+    expect(d.skillInjection).toBe('none');
+  });
+
+  it('customAgentDescriptor fills defaults for a plain cli agent', () => {
+    const d = customAgentDescriptor(cliPlain);
+    expect(d.engine).toBe('claude');
+    expect(d.icon).toBe('Terminal');
+    expect(d.skillInjection).toBe('claude-dir');
+    expect(d.defaultSkillIds).toEqual([]);
+  });
+
+  it('customAgentDescriptor normalizes an api agent', () => {
+    const d = customAgentDescriptor(apiAgent);
+    expect(d.runtime).toBe('api');
+    expect(d.engine).toBe('claude');
+    expect(d.icon).toBe('Bot');
+    expect(d.providerId).toBe('openai');
+    expect(d.model).toBe('gpt-4');
+    expect(d.defaultSkillIds).toEqual(['s1']);
+    expect(d.skillInjection).toBe('none');
+  });
+
+  it('defaultSkillInjectionForEngine maps engine to injection default', () => {
+    expect(defaultSkillInjectionForEngine('claude')).toBe('claude-dir');
+    expect(defaultSkillInjectionForEngine('codex')).toBe('none');
+  });
+
+  it('resolveAgentDescriptor resolves by agentConfigId then engine fallback', () => {
+    expect(resolveAgentDescriptor({ agentConfigId: 'my-cli' }, settings).id).toBe('my-cli');
+    expect(resolveAgentDescriptor({ engine: 'codex' }, settings).id).toBe('codex');
+    // 未指定は claude built-in に解決
+    expect(resolveAgentDescriptor({}, settings).id).toBe('claude');
+    // 未知の agentConfigId は engine fallback
+    expect(resolveAgentDescriptor({ agentConfigId: 'nope', engine: 'codex' }, settings).id).toBe(
+      'codex'
+    );
+  });
+
+  it('listAgentDescriptors concatenates builtins and customs', () => {
+    const all = listAgentDescriptors(settings);
+    expect(all.map((d) => d.id)).toEqual(['claude', 'codex', 'my-cli', 'plain', 'gpt']);
+  });
+});

--- a/src/renderer/src/lib/agent-registry.ts
+++ b/src/renderer/src/lib/agent-registry.ts
@@ -1,0 +1,170 @@
+/**
+ * agent-registry.ts — エージェント定義の正規化レジストリ (Issue #1113 Phase1)。
+ *
+ * built-in (claude / codex) と settings.customAgents を **同一の `ResolvedAgentDescriptor`**
+ * に解決する単一の窓口。Canvas カードの表示 (名前 / アイコン / accent) と起動パラメータ、
+ * engine 判定、skill 注入方式の既定をここに集約し、`'claude' | 'codex'` リテラルの散在や
+ * 「custom が claude に偽装される」状態を解消する。
+ *
+ * 所有権 (DoD #939): エージェント記述子の解決ロジックはこの module に閉じる。起動の
+ * command/args/cwd は `agent-resolver.ts` の `resolveAgentConfig` を単一ソースとして委譲し、
+ * 二重定義を作らない。表示メタ (displayName/icon/accentColor/tags) と engine / skill 既定の
+ * 合成だけをこの module が担う。
+ *
+ * 役割分担: この module は **エージェント種別 (claude/codex/custom)** の identity を扱う。
+ * カードの **ロール (leader/programmer 等)** ベースの glyph/accent は `agent-visual.ts`
+ * (`resolveAgentVisual`) が所有しており軸が直交する。両者を混同しないこと。
+ */
+import type {
+  AgentConfig,
+  AgentEngine,
+  AgentRuntime,
+  AgentSkillInjection,
+  ApiAgentProviderId,
+  AppSettings
+} from '../../../types/shared';
+import { resolveAgentConfig } from './agent-resolver';
+
+/** UI / 起動 / skill 判定が参照する、正規化済みのエージェント記述子。 */
+export interface ResolvedAgentDescriptor {
+  /** 識別子。'claude' | 'codex' | customAgents の id。 */
+  id: string;
+  /** built-in (同梱) か custom (settings.customAgents) か。 */
+  kind: 'builtin' | 'custom';
+  /** 'cli' (PTY) か 'api' (Chat)。 */
+  runtime: AgentRuntime;
+  /** 挙動系統。args/resume/inject の組み立てと team tool 配線がこれで分岐する。 */
+  engine: AgentEngine;
+  /** カードヘッダー等に出す表示名。 */
+  displayName: string;
+  /** 表示アイコン (lucide アイコン名)。必ず既定込みで埋める。 */
+  icon: string;
+  /** accent カラー (CSS color)。省略時は呼び出し側で `--accent` を使う。 */
+  accentColor?: string;
+  /** 分類・フィルタ用タグ。 */
+  tags: string[];
+  /** CLI 起動コマンド (runtime === 'cli' のみ意味を持つ)。 */
+  command?: string;
+  /** CLI 起動引数 (展開前テキスト)。 */
+  args?: string;
+  /** 作業ディレクトリ。 */
+  cwd?: string;
+  /** 起動時に注入する環境変数 (Issue #1113)。 */
+  env?: Record<string, string>;
+  /** 定義レベルの既定 skill 群 (Phase4)。 */
+  defaultSkillIds: string[];
+  /** skill の注入方式 (Phase4)。 */
+  skillInjection: AgentSkillInjection;
+  /** API provider id (runtime === 'api' のみ)。 */
+  providerId?: ApiAgentProviderId;
+  /** API モデル (runtime === 'api' のみ)。 */
+  model?: string;
+}
+
+/** built-in エージェントの表示メタ。command/args は settings から解決するのでここには持たない。 */
+interface BuiltinAgentMeta {
+  id: string;
+  engine: AgentEngine;
+  displayName: string;
+  icon: string;
+}
+
+const BUILTIN_AGENT_META: BuiltinAgentMeta[] = [
+  { id: 'claude', engine: 'claude', displayName: 'Claude Code', icon: 'Sparkles' },
+  { id: 'codex', engine: 'codex', displayName: 'Codex', icon: 'Terminal' }
+];
+
+/** engine ごとの skill 注入の既定 (Phase4)。claude は .claude/skills 自動探索が効くので materialize。 */
+export function defaultSkillInjectionForEngine(engine: AgentEngine): AgentSkillInjection {
+  return engine === 'claude' ? 'claude-dir' : 'none';
+}
+
+/** runtime ごとのアイコン既定 (custom がアイコン未指定のとき)。 */
+function defaultIconForRuntime(runtime: AgentRuntime): string {
+  return runtime === 'api' ? 'Bot' : 'Terminal';
+}
+
+/** custom agent 設定 (cli/api) の engine を返す。cli は宣言値 (既定 'claude')、api は 'claude' 互換。 */
+export function engineForAgentConfig(agent: AgentConfig): AgentEngine {
+  if (agent.runtime === 'cli') return agent.engine ?? 'claude';
+  // API agent は team tool 配線上 claude 互換として扱う (engine policy の互換維持)。
+  return 'claude';
+}
+
+/** built-in (claude/codex) の記述子を settings から合成する。 */
+export function builtinAgentDescriptors(settings: AppSettings): ResolvedAgentDescriptor[] {
+  return BUILTIN_AGENT_META.map((meta) => {
+    const resolved = resolveAgentConfig(meta.id, settings);
+    return {
+      id: meta.id,
+      kind: 'builtin' as const,
+      runtime: 'cli' as const,
+      engine: meta.engine,
+      displayName: meta.displayName,
+      icon: meta.icon,
+      tags: ['builtin'],
+      command: resolved.command,
+      args: resolved.args,
+      cwd: resolved.cwd,
+      defaultSkillIds: [],
+      skillInjection: defaultSkillInjectionForEngine(meta.engine)
+    };
+  });
+}
+
+/** custom agent 設定を正規化記述子へ変換する。 */
+export function customAgentDescriptor(agent: AgentConfig): ResolvedAgentDescriptor {
+  const engine = engineForAgentConfig(agent);
+  const base = {
+    id: agent.id,
+    kind: 'custom' as const,
+    runtime: agent.runtime,
+    engine,
+    displayName: agent.name || agent.id,
+    icon: agent.icon || defaultIconForRuntime(agent.runtime),
+    accentColor: agent.color,
+    tags: agent.tags ?? []
+  };
+  if (agent.runtime === 'cli') {
+    return {
+      ...base,
+      command: agent.command,
+      args: agent.args,
+      cwd: agent.cwd,
+      env: agent.env,
+      defaultSkillIds: agent.defaultSkillIds ?? [],
+      skillInjection: agent.skillInjection ?? defaultSkillInjectionForEngine(engine)
+    };
+  }
+  return {
+    ...base,
+    providerId: agent.providerId,
+    model: agent.model,
+    defaultSkillIds: agent.skillIds ?? [],
+    skillInjection: 'none'
+  };
+}
+
+/** built-in + custom をまとめた記述子一覧 (追加エージェントピッカー / 管理 UI 用, Phase3)。 */
+export function listAgentDescriptors(settings: AppSettings): ResolvedAgentDescriptor[] {
+  const customs = (settings.customAgents ?? []).map(customAgentDescriptor);
+  return [...builtinAgentDescriptors(settings), ...customs];
+}
+
+/**
+ * カード payload の identity から記述子を解決する。
+ *  - agentConfigId が custom にマッチ → その custom 記述子。
+ *  - それ以外 → engine (既定 'claude') の built-in 記述子。
+ */
+export function resolveAgentDescriptor(
+  ref: { agentConfigId?: string; engine?: AgentEngine },
+  settings: AppSettings
+): ResolvedAgentDescriptor {
+  if (ref.agentConfigId) {
+    const custom = (settings.customAgents ?? []).find((a) => a.id === ref.agentConfigId);
+    if (custom) return customAgentDescriptor(custom);
+  }
+  const engine: AgentEngine = ref.engine ?? 'claude';
+  const builtins = builtinAgentDescriptors(settings);
+  return builtins.find((d) => d.engine === engine) ?? builtins[0];
+}

--- a/src/renderer/src/lib/canvas-team-spawn.ts
+++ b/src/renderer/src/lib/canvas-team-spawn.ts
@@ -23,6 +23,7 @@
 
 import type { Node } from '@xyflow/react';
 import type {
+  AgentEngine,
   HandoffReference,
   TeamOrganizationMeta
 } from '../../../types/shared';
@@ -33,7 +34,8 @@ import type { AgentPayload } from '../components/canvas/cards/AgentNodeCard/type
 export interface SpawnTeamMember {
   /** roleProfileId / role 兼用 (新スキーマ + 旧コード互換)。 */
   role: string;
-  agent: 'claude' | 'codex';
+  /** 挙動系統 (engine)。custom CLI も claude/codex いずれかの engine 上で動く。 */
+  agent: AgentEngine;
   position: { x: number; y: number };
   /** カードヘッダーに表示する label。caller 側で ROLE_META 等から解決して渡す。 */
   title: string;
@@ -64,7 +66,7 @@ export type SetupTeamMcpFn = (
   cwd: string,
   teamId: string,
   teamName: string,
-  members: { agentId: string; role: string; agent: 'claude' | 'codex' }[]
+  members: { agentId: string; role: string; agent: AgentEngine }[]
 ) => Promise<unknown>;
 
 export interface SpawnTeamsInput {

--- a/src/renderer/src/stores/canvas.ts
+++ b/src/renderer/src/stores/canvas.ts
@@ -22,6 +22,7 @@ import {
   normalizeCanvasState
 } from '../lib/canvas-migrations';
 import type { AgentPayload } from '../components/canvas/cards/AgentNodeCard/types';
+import type { AgentEngine } from '../../../types/shared';
 import {
   findReconcileTarget,
   makeCardNode,
@@ -102,7 +103,10 @@ export interface ApiAgentCardPayload extends CardPayloadBase {
 
 /** terminal カード: 単発の Claude/Codex/シェル端末を起動するための payload。 */
 export interface TerminalCardPayload extends CardPayloadBase {
-  agent?: 'claude' | 'codex';
+  /** 挙動系統 (engine)。識別子ではない。custom CLI も claude/codex いずれかの engine 上で動く。 */
+  agent?: AgentEngine;
+  /** Issue #1113: custom agent の settings.customAgents id。名前/アイコン/色/skill 解決に使う。 */
+  agentConfigId?: string;
   role?: string;
   agentId?: string;
   command?: string;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -31,8 +31,11 @@ export interface DialogFileFilter {
  * Issue #618 で `terminalForceUtf8` (default true) を追加し v11。Windows + cmd.exe / PowerShell
  * で起動時に `chcp 65001` を inject して CP932 シェルでの U+FFFD 化を防ぐ。
  * Issue #994 で API 駆動エージェントを追加し、customAgents を `runtime: cli|api` に拡張して v12。
+ * Issue #1113 で custom agent に descriptor フィールド (engine/env/icon/tags/defaultSkillIds/
+ * skillInjection) を追加し v13。すべて additive-optional なので migration block は不要だが、
+ * 旧 build (#641 save-guard) が新フィールドを silent drop しないよう版数を上げる。
  */
-export const APP_SETTINGS_SCHEMA_VERSION = 12;
+export const APP_SETTINGS_SCHEMA_VERSION = 13;
 
 /**
  * API agent provider preset。`openai-compatible` 系は base URL と request shape を共有し、
@@ -54,11 +57,31 @@ export type ApiAgentProviderId =
 
 export type AgentRuntime = 'cli' | 'api';
 
+/**
+ * エージェントの挙動系統 (engine)。識別子 (TerminalAgent) とは別概念で、
+ * args/resume/inject の組み立てや team tool 配線がこの値で分岐する。
+ * custom CLI agent は claude / codex のどちらかの engine 上で動く。
+ */
+export type AgentEngine = 'claude' | 'codex';
+
+/**
+ * CLI agent に skill (.claude/skills/<id>/SKILL.md) をどう効かせるか (Issue #1113 Phase4)。
+ *  - 'claude-dir'  : 起動前にプロジェクトの .claude/skills へ materialize し CLI の自動探索に任せる
+ *  - 'append-flag' : 起動引数 (--append-system-prompt 相当) に skill 本文を連結注入
+ *  - 'prompt-file' : 一時ファイル化して system-prompt-file 系フラグへ渡す
+ *  - 'none'        : skill 注入を行わない (default)
+ */
+export type AgentSkillInjection = 'claude-dir' | 'append-flag' | 'prompt-file' | 'none';
+
 export interface AgentConfigBase {
   id: string;
   name: string;
   /** Canvas カードの accent カラー (省略時は --accent) */
   color?: string;
+  /** Issue #1113: カード表示用アイコン (lucide アイコン名)。省略時は engine/runtime 既定。 */
+  icon?: string;
+  /** Issue #1113: 分類・フィルタ用タグ。 */
+  tags?: string[];
 }
 
 /**
@@ -70,6 +93,17 @@ export interface CliAgentConfig extends AgentConfigBase {
   command: string;
   args: string;
   cwd?: string;
+  /**
+   * Issue #1113: この custom CLI が動作する engine (default 'claude')。
+   * args/resume/inject の組み立てと team tool 配線がこの値で claude 互換 / codex 互換に分岐する。
+   */
+  engine?: AgentEngine;
+  /** Issue #1113: 起動時に注入する環境変数。 */
+  env?: Record<string, string>;
+  /** Issue #1113: 定義レベルの既定 skill 群 (ノードインスタンスで上書き可能, Phase4)。 */
+  defaultSkillIds?: string[];
+  /** Issue #1113: skill の注入方式 (Phase4)。省略時は engine から既定を決める。 */
+  skillInjection?: AgentSkillInjection;
 }
 
 /**

--- a/tasks/canvas-multi-agent-skill-plan.md
+++ b/tasks/canvas-multi-agent-skill-plan.md
@@ -1,0 +1,285 @@
+# Canvas マルチエージェント拡張 & Skill 機能 実装計画
+
+> 対象: Canvas モードで Claude Code / Codex に加え **任意の追加エージェント** を一級ノードとして登録・配置できるようにし、**カードの GUI を刷新**、**Skill 機能を作り込む**。
+> 調査: 5本の Explore subagent による並列コードベース調査 + grok-4.3 (`x-ai/grok-4.3`) の設計知見。
+> 作成日: 2026-06-26 / ステータス: ドラフト（実装着手前のレビュー用）
+
+---
+
+## 0. ゴール（ユーザー要望の分解）
+
+1. **追加エージェントの拡張性**: Claude / Codex 以外の任意 CLI / API エージェント（例: Gemini CLI, Aider, opencode, 自作 CLI, 各種 API モデル）を、Claude/Codex と同格でキャンバスに追加・配置できる。
+2. **見やすいカード GUI**: 「微妙」な現状カードを、状態・役割・種別が一目で分かる高密度ミニマル（Linear / Raycast 風）デザインに刷新。
+3. **Skill 機能の作り込み**: SKILL.md をエージェントに紐付け・注入する仕組みを、CLI エージェントにも効かせ、検索 / タグ / 検証 / version 管理 / 有効無効トグルまで揃える。
+
+---
+
+## 1. 現状アーキテクチャ（調査サマリ）
+
+### 1.1 すでにある基盤（=ゼロからではない）
+
+- `settings.customAgents: AgentConfig[]` は **CLI / API 両 runtime を既にサポート**。
+  - `AgentConfig = CliAgentConfig | ApiAgentConfig`（discriminated union）— `src/types/shared.ts:57-96`
+  - `CliAgentConfig`: `{ id, name, color?, runtime:'cli', command, args, cwd? }`
+  - `ApiAgentConfig`: `{ …, runtime:'api', providerId, model, skillIds?, systemPrompt?, toolMode?, … }`
+- CLI custom agent の起動は解決済み: `resolveAgentConfig()` が `customAgents.find()` で命令を引く — `src/renderer/src/lib/agent-resolver.ts:22-58`
+- Rust 側 allowlist は settings から動的に許可: `SAFE_BASENAMES`(`claude,codex,bash,…`) ∪ `configured_terminal_commands()` — `src-tauri/src/commands/terminal/command_validation.rs:149-204,183-194`
+- PTY spawn 本体: `src-tauri/src/commands/terminal.rs:396-501`（allowlist→危険フラグ filter→`spawn_session`）
+- 設定永続化 SSOT: `~/.vibe-editor/settings.json`（schemaVersion=12）— `src-tauri/src/commands/settings.rs:46-129,224-262`
+- カスタムエージェントの設定 UI: `CustomAgentEditor.tsx`（runtime 切替 / command / args / color / API は skill チェックボックス）
+- Custom agent を Canvas で「Leader として起動」する経路は実装済み（Issue #1025）— `src/renderer/src/layouts/CanvasLayout.tsx:308-370`
+
+### 1.2 Canvas ノードモデル
+
+- `CardType = 'terminal' | 'agent' | 'apiAgent' | 'editor' | 'diff' | 'fileTree' | 'changes'` — `src/renderer/src/stores/canvas.ts:42-49`
+  - `agent` カード = Claude/Codex の TUI ターミナル（`AgentPayload.agent: 'claude' | 'codex'` **ハードコード** — `components/canvas/cards/AgentNodeCard/types.ts:15`）
+  - `apiAgent` カード = API 駆動チャット（`agentConfigId` で `settings.customAgents` を解決）
+- 追加フロー: 右クリックメニュー（`Canvas.tsx:309-352`）→ `CanvasLayout` の `addAgent()/addApiAgent()`（`CanvasLayout.tsx:488-523`）→ store `addCard()`（`canvas.ts:401-449`）→ 同 `agentId` は upsert（`canvas-card-identity.ts:56-65`）
+
+### 1.3 Skill 機能
+
+- IPC: `app_install_vibe_team_skill`（`.claude/skills/vibe-team/SKILL.md` を書く / version-aware ダウングレードガード, 50d4546 / #1108）— `src-tauri/src/commands/vibe_team_skill.rs:215-269`
+- API agent への注入: `load_skill_bodies()`（`api_agents/skills.rs:218-248`）→ `build_skills_context()` で `system_prompt` に連結（`api_agents.rs:476+`, 上限 `MAX_SKILL_BYTES=48KB`）
+- UI: `SkillImportPanel.tsx`（Claude/Codex から import/remove/list）、`CustomAgentEditor.tsx:111-157`（API agent のみ skill チェックボックス → `skillIds[]`）
+- 配置: import 済み = `~/.vibe-editor/skills/<id>/SKILL.md`、プロジェクト = `.claude/skills/<id>/SKILL.md`
+- 型: `ApiAgentSkillMeta` / `ApiAgentImportableSkill` / `ApiAgentSkillSource` — `shared.ts`
+
+### 1.4 永続化 / SSOT
+
+| 種類 | SSOT | 場所 |
+|---|---|---|
+| Custom agents (CLI/API) | `Settings.customAgents` | `settings.json` |
+| Builtin (claude/codex) | `settings.{claude,codex}Command/Args` | `settings.json`（customAgents には**入っていない**） |
+| Role profiles | `role-profiles.json` + HubState | overrides/custom/dynamic |
+| Canvas ノード instance | canvas store (localStorage) | `data.payload.agentId` 等 |
+| TeamHub 実行状態 | `team-state/<team>.json(.messages.json)` | in-memory + disk |
+
+---
+
+## 2. 問題点（=作り込みが必要な箇所）
+
+| # | 問題 | 根拠（file:line） |
+|---|---|---|
+| P1 | `'claude' \| 'codex'` リテラル union が多数のファイルに散在し、カスタム CLI が一級 `agent` ノードになれない | `canvas.ts:105`, `AgentNodeCard/types.ts:15`, `canvas-team-spawn.ts:36`, `CanvasLayout.tsx:244,280,401`, `Canvas.tsx:575` |
+| P2 | 型コメントと実装の乖離（`TerminalAgent = string` だが実装は claude/codex 固定） | `shared.ts:784` |
+| P3 | カスタム追加 UI が貧弱（leader-only 固定 / API は最初の1個のみ / 「Add API agent here」が i18n 無しハードコード） | `CanvasLayout.tsx:502-523`, `Canvas.tsx:328` |
+| P4 | builtin プリセットが leader-claude / leader-codex の2種のみ | `workspace-presets.ts:48-63` |
+| P5 | カードのビジュアル弱点（status バッジが弱い・役割視認性低・glass未対応・ヘッダー詰め込み・semantic color 未使用・折りたたみ無し） | `styles/components/canvas.css:818-1106` |
+| P6 | **Skill は API agent にしか効かない**（`skillIds` は `ApiAgentConfig` のみ、CLI agent は紐付け不可） | `shared.ts:87`, `CustomAgentEditor.tsx:120` |
+| P7 | Skill 管理機能が薄い（検索 / タグ / frontmatter 検証 / version 一般化 / rollback 無し、48KB cap, キャッシュ無し） | `api_agents/skills.rs`, `vibe_team_skill.rs` |
+| P8 | カスタムエージェントに `env` / `icon` / `tags` を持たせるフィールドが無い | `shared.ts:57-96` |
+| P9 | `engine_policy` は claude/codex のみ判定、custom はスキップ（mixed 扱い） | （Rust engine policy, 調査で確認） |
+
+---
+
+## 3. 設計方針
+
+### 3.1 正規化されたエージェント記述子（AgentDescriptor）
+
+**狙い**: builtin(claude/codex) と custom を**同一の正規型**に解決し、UI / 起動 / Skill 注入はすべてこの型を見る。リテラル union（P1/P2）を撲滅する。
+
+```ts
+// 永続化されない “解決済み” 記述子（renderer 内部表現）。
+// builtin は settings.{claude,codex}* + 内蔵レジストリから合成し、custom は settings.customAgents から合成する。
+export interface ResolvedAgentDescriptor {
+  id: string;                       // 'claude' | 'codex' | custom id
+  kind: 'builtin' | 'custom';
+  runtime: 'cli' | 'api';
+  displayName: string;
+  // CLI
+  command?: string;
+  args?: string;                    // テンプレート展開前
+  cwd?: string;
+  env?: Record<string, string>;     // 新規（P8）
+  // 表示
+  icon?: string;                    // lucide アイコン名 or glyph
+  accentColor?: string;
+  tags?: string[];                  // 新規（P8）
+  // Skill
+  defaultSkillIds?: string[];       // 新規: 定義レベルの既定 skill（cli/api 共通, P6）
+  skillInjection?: 'claude-dir' | 'append-flag' | 'prompt-file' | 'none'; // CLI への効かせ方
+  // API 固有はサブ型で保持
+}
+```
+
+**永続化型の拡張（最小差分）**:
+- `AgentConfigBase` に `icon?`, `tags?`, `defaultSkillIds?` を追加。
+- `CliAgentConfig` に `env?`, `skillIds?`（or `defaultSkillIds` を base へ）, `skillInjection?` を追加。
+- builtin は customAgents に入れず、**内蔵レジストリ module** が `settings.{claude,codex}*` から `ResolvedAgentDescriptor` を合成（DoD #7: 状態と不変条件の所有権を単一 module に閉じる）。
+
+**module 所有権（god-file 回避, CLAUDE.md DoD #7）**:
+- 新規 `src/renderer/src/lib/agent-registry.ts`（≤500行）が「builtin + custom → `ResolvedAgentDescriptor[]`」解決の単一ソース。
+- 既存の分散ヘルパ（`m.agent === 'codex' ? …`）はこの module の `resolveDescriptor(agentId)` / `isCodex(descriptor)` 等に集約。
+
+### 3.2 カード GUI 刷新
+
+**新カードの情報設計**（grok-4.3 案 + 現状 component 分割を踏襲）:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ [icon] DisplayName            ·CLI·   ● running  [⋯][×]│  ← Header: 種別アイコン+accent / name / runtimeバッジ / 状態ドット+label / actions
+├─────────────────────────────────────────────────────┤
+│  task: 〇〇を実装中…                                   │  ← Summary（折りたたみ可）: task / elapsed / health
+│  ⏱ 3m   ❤ alive                                       │
+├─────────────────────────────────────────────────────┤
+│  [ xterm / chat 本体 ]                                │  ← Body
+├─────────────────────────────────────────────────────┤
+│  🧩 pullrequest  🧩 vibeeditor  +2          [Skills▾] │  ← Footer: skill チップ（最大3 + overflow）/ skill 管理入口
+└─────────────────────────────────────────────────────┘
+```
+
+- **状態表現**: `idle`(灰) / `running`(accent パルス) / `waiting`(warning黄) / `error`(danger赤+アイコン)。semantic token（`--accent-success/-warning/-danger`）を使用。
+- **役割/種別**: lucide アイコン + accentColor で区別（avatar の1文字 glyph から脱却）。
+- **折りたたみ**: ヘッダーダブルクリックで Summary を collapse（`max-height` トランジション、`display:none` を廃止）。
+- **Glass 対応**: `.canvas-agent-card` に `glass-surface` 付与、`tokens.css` のホワイトリストに追加。
+- **CSS 配置**: 新規 `styles/components/canvas-agent-card.css`（≤500行）。既存 `canvas.css`(1893行, baseline 済) は触る範囲を最小化。
+- スタイリングは **Tailwind 不使用**、`var(--*)` トークン + 機能別 CSS（grok 提案の `text-[13px]`/`ring-2` は CSS 変数へ翻訳）。
+- 詳細トーンは `claude-design` skill を参照。
+
+### 3.3 Skill 機能の作り込み
+
+**(a) CLI エージェントへの skill 注入（最重要・要決定）** — 3 案:
+
+| 案 | 方式 | 長所 | 短所 |
+|---|---|---|---|
+| A. claude-dir materialize | 起動前に `.claude/skills/<id>/SKILL.md`（Codex は `.agents/skills`）へ書き出し、CLI 標準の自動探索に任せる | claude/codex でネイティブに効く / arg 長制限なし | ユーザーのプロジェクトにファイルを書く / cleanup と衝突管理 / version ガード必須（#1108 パターン流用） |
+| B. append-flag 注入 | 起動時に `--append-system-prompt "<連結 skill 本文>"` を付与 | ファイルを書かない | Windows のコマンドライン長制限(~32KB) / フラグ非対応 CLI は不可 / 48KB cap |
+| C. prompt-file 注入 | temp ファイルに書き `--system-prompt-file` 等で渡す | 長さ制限緩和 | CLI 依存のフラグ / temp 管理 |
+
+→ **決定（2026-06-26, capability 駆動）**: 記述子の `skillInjection` で切替。builtin claude は A（materialize, version-aware ガード #1108 を再利用）を既定、append-flag 対応 CLI は B、API は現行の system_prompt 注入を継続、未対応 custom CLI は `none`（将来 B/C をオプトイン）。
+
+**(b) 紐付け粒度**: 定義レベル（`descriptor.defaultSkillIds`）と **ノードインスタンスレベル**（`node.data.payload.skillIds` で上書き）の2層。
+
+**(c) 管理 UI**: skill 一覧に検索 / タグフィルタ / installed インジケータ / 有効無効トグル。カード Footer の `Skills▾` から当該ノードの skill を切替。
+
+**(d) 合成/順序/衝突**: 配列順に連結、同名セクションは後勝ち、`version` で hash 検証。`MAX_SKILL_BYTES` は据え置き＋超過時は明示警告（silent truncation 禁止）。
+
+**(e) frontmatter 検証 / version 一般化**: 全 skill に version frontmatter を標準化、必須セクション検査、破損時 quarantine（既存 safe_load パターン）。
+
+---
+
+## 4. Phase 別実装計画
+
+> 各 Phase は **独立した Issue + PR** に分割（CLAUDE.md: 問題発見→Issue→branch→PR→reviewer bot merge）。新規ファイルは ≤500行（CI ratchet）。
+
+### Phase 0 — Issue 起票 & ガードレール
+- **成果物**: GitHub Issue 群（§10 の分割案）。各 Issue に `enhancement`/`refactor` + 領域ラベル（`canvas`/`ui`/`javascript`/`rust`/`persistence` 等）。
+- 本計画 md をリポジトリに置き、各 Issue から参照。
+
+### Phase 1 — エージェント識別の正規化（基盤 / リテラル union 撲滅）
+- **成果物**:
+  - `agent-registry.ts`（builtin+custom → `ResolvedAgentDescriptor`）。
+  - `shared.ts` の `TerminalAgent`/`AgentPayload.agent` を `agentId: string` 化、`AgentConfigBase` に `icon?/tags?/defaultSkillIds?`、`CliAgentConfig` に `env?/skillIds?/skillInjection?` 追加。
+  - Rust `settings.rs` の `AgentConfig` struct を同期（camelCase）、defaults 追加。
+  - 散在リテラル（P1）を registry 経由に置換。
+- **触る**: `shared.ts:57-96,784`、`stores/canvas.ts:105`、`AgentNodeCard/types.ts:15`、`canvas-team-spawn.ts:36`、`CanvasLayout.tsx:244,280,401`、`Canvas.tsx:575`、`agent-resolver.ts:22-58`、`settings.rs:185-216`、`tauri-api.ts`。
+- **DoD**: `agentId` が string で通り、claude/codex/custom が同一経路で起動。型の5点同期（§5）OK。`npm run typecheck` + `cargo check` green。挙動は現状維持（リグレッション無し）。
+- **マイグレーション**: schemaVersion 12→13。旧データは無変換で読めること（`icon` 等は optional）。
+
+### Phase 2 — カード GUI 刷新
+- **成果物**: 新 `canvas-agent-card.css`、状態バッジ（icon+semantic color）、役割 lucide アイコン化、glass-surface 対応、折りたたみ、Footer の skill チップ。
+- **触る**: `AgentNodeCard/CardPresentation.tsx`、`CardSummary.tsx`、`CardFrame.tsx`、`styles/components/canvas-agent-card.css`(新)、`tokens.css`(glass ホワイトリスト)、type に icon mapping。
+- **DoD**: idle/running/waiting/error が一目で判別、種別アイコン表示、全テーマ（dark/light/midnight/glass）で視認性 OK。`npm run dev` 実機確認。
+- **不変条件**: Tailwind 不使用 / テーマ切替は `[data-theme]` のみで成立。
+
+### Phase 3 — 追加エージェント UX（追加導線の作り込み）
+- **成果物**:
+  - 右クリック「Add agent…」→ **任意の custom agent を選べるピッカー**（leader-only / first-only を解消、P3）。
+  - メニューラベルの i18n 化（`Canvas.tsx:328`）。
+  - builtin プリセット拡張（pair / custom 構成, P4）。
+  - `CustomAgentEditor` に icon / tags / env（CLI）入力欄追加。
+- **触る**: `Canvas.tsx:309-352`、`CanvasLayout.tsx:488-557`、`workspace-presets.ts:48-63`、`CustomAgentEditor.tsx`、i18n。
+- **DoD**: 任意の登録済みエージェントをキャンバスに追加でき、複数 API agent も選択可能。
+
+### Phase 4 — Skill システムの作り込み
+- **成果物**:
+  - CLI エージェントへの skill 注入（§3.3(a) capability 駆動、推奨案を実装）。
+  - ノードインスタンス単位の skill トグル（Footer `Skills▾`）。
+  - skill 管理 UI 強化（検索 / タグ / installed / version 表示）。
+  - frontmatter 検証 + version frontmatter 標準化 + 破損 quarantine。
+- **触る**: `api_agents/skills.rs`、`vibe_team_skill.rs`(materialize+ガード)、新規 `commands/skills.rs`（共通ロード）、`SkillImportPanel.tsx`、`CustomAgentEditor.tsx`、`shared.ts`(skill 型)、CardFrame の args 組み立て(`CardFrame.tsx:215-249`)。
+- **DoD**: claude CLI に skill を効かせられる（materialize 経路で実証）、複数 skill 合成、version ガードがダウングレードを防ぐ、検索/タグが動く。security（traversal/symlink/サイズ上限）維持。
+- **不変条件**: skill 注入は Rust 側で実行、renderer は OS リソース直接非アクセス。version-aware 上書きガード（#1108）を CLI materialize に適用。
+
+### Phase 5 — 仕上げ / 高度化
+- tags/capability フィルタ、レイアウト保存、テスト拡充、ドキュメント（README / docs）更新。engine_policy の custom 対応検討（P9）。
+
+---
+
+## 5. 型の5点同期チェックリスト（毎 PR）
+
+新規/変更フィールドごとに以下を**必ず**揃える（vibeeditor skill の不変式）:
+
+1. `src/types/shared.ts`（TS 型, camelCase）
+2. `src-tauri/src/commands/settings.rs` の Rust struct（`#[serde(rename_all="camelCase")]`）
+3. Rust `Default`（defaults）
+4. `src/renderer/src/lib/settings-context.tsx`（load/migrate）
+5. 設定モーダル UI（`CustomAgentEditor.tsx` 等）
+
+加えて IPC を増やす場合は `tauri-api.ts` wrapper + `invoke_handler!` 登録 + `commands/mod.rs` 宣言（rust-ipc-reviewer の5点）。
+
+---
+
+## 6. マイグレーション / 後方互換
+
+- `schemaVersion` 12→13。新フィールドはすべて optional にし、旧 `settings.json` を無変換で読める状態を保つ。
+- builtin を customAgents に昇格させない（既存ユーザーの settings 構造を壊さない）。registry 側で合成する。
+- canvas store（localStorage）の `payload.agent` 旧値は registry の `resolveDescriptor` でフォールバック解決。
+- Skill: 既存 `~/.vibe-editor/skills` と `.claude/skills` の配置はそのまま、version frontmatter は段階導入（無印は従来挙動）。
+
+---
+
+## 7. 落とし穴 / リスク（grok-4.3 + コードベース）
+
+- **PTY ライフサイクル**: 親終了後 zombie / IDE 突然停止（#1098 既知）。spawn は client-generated id + `subscribeEventReady` で pre-subscribe（Issue #285/#291）。
+- **起動コマンド注入の安全性**: `argsTemplate` のプレースホルダ展開は **ホワイトリスト**（`{skillPrompt}` 等の既知トークンのみ置換）。任意文字列の shell 展開を許さない。`reject_danger_flags` を skill 注入フラグが誤って弾かれないか検証。
+- **allowlist**: custom command は `configured_terminal_commands()` で settings 由来のみ許可（既存の安全策を維持）。
+- **Windows コマンドライン長**: append-flag 方式は長さ制限に注意 → materialize / prompt-file を優先。
+- **engine_policy**: custom agent はポリシー対象外（P9）。Phase 5 で扱う。
+- **god-file / file-size ratchet**: 新規 module/CSS は ≤500行。`canvas.css` への追記は最小化、新 CSS ファイルへ。
+- **Claude 署名禁止**（CLAUDE.md #6）: commit / PR に Claude 署名・生成元クレジットを入れない。
+
+---
+
+## 8. grok-4.3 知見の反映ポイント
+
+- `AgentDescriptor` 正規型 + リテラル union を `agentId: string` へ置換し schemaVersion で migrate（§3.1, Phase1）。
+- カード = Header(icon+accent+name+runtime badge+状態) / Body / Footer(skill チップ +N)（§3.2）。
+- Skill は `argsTemplate {skillPrompt}` プレースホルダ注入を基本、定義レベル `defaultSkillIds` + インスタンス上書き、後勝ち合成 + version 検証（§3.3）。
+- 落とし穴: PTY graceful shutdown / argsTemplate ホワイトリスト / allowlist / 後方互換 / **materialize より引数注入を優先**（§7）。
+  - ※ ただし claude/codex は `.claude/skills` 自動探索がネイティブなため、本計画では builtin に限り materialize 案 A も候補に残す（§9 で決定）。
+
+---
+
+## 9. 決定事項 / 未決事項
+
+**決定（2026-06-26）**:
+1. **CLI への skill 注入方式**: **capability 駆動**（記述子 `skillInjection`）。builtin claude は materialize(A)、対応 CLI は append-flag(B)、未対応は none。
+2. **スコープ/優先度**: **Phase 1→2→3→4 を順に一気通貫**。各 Phase は独立 Issue+PR。
+
+**未決（実装中に確定）**:
+3. **builtin の扱い**: claude/codex を将来 customAgents へ統合表示するか、registry 合成のままにするか（暫定: registry 合成のまま）。
+4. **追加エージェントの初期同梱**: Gemini CLI / Aider / opencode 等のビルトインプリセットを同梱するか（command 名のみ、ユーザー環境にインストール前提）。
+
+---
+
+## 10. Issue 分割案（Phase 対応）
+
+| Issue 候補 | type | 領域ラベル |
+|---|---|---|
+| エージェント識別の正規化（AgentDescriptor / リテラル union 撲滅） | `refactor` | `javascript` `rust` `canvas` `persistence` |
+| Canvas エージェントカード GUI 刷新 | `enhancement` | `canvas` `ui` |
+| 追加エージェント追加導線の作り込み（ピッカー / i18n / プリセット） | `enhancement` | `canvas` `ui` `i18n` |
+| Skill 機能の作り込み（CLI 注入 / 管理 UI / 検証 / version） | `enhancement` | `rust` `javascript` `persistence` |
+| 仕上げ（tags フィルタ / レイアウト保存 / engine_policy / docs） | `enhancement` | `canvas` `documentation` |
+
+---
+
+## 11. 参照ファイル早見表
+
+- 型: `src/types/shared.ts:57-96,214-339,784,794-882`
+- Canvas: `stores/canvas.ts:42-49,105`, `components/canvas/Canvas.tsx:309-352,575`, `layouts/CanvasLayout.tsx:308-557`, `lib/workspace-presets.ts:48-63`, `lib/canvas-team-spawn.ts:36`
+- カード: `components/canvas/cards/AgentNodeCard/{CardFrame,CardPresentation,CardSummary,types}.tsx`, `styles/components/canvas.css:818-1106`, `styles/tokens.css`
+- 起動: `lib/agent-resolver.ts:22-58`, `src-tauri/src/commands/terminal.rs:396-501`, `terminal/command_validation.rs:149-204`
+- Skill: `src-tauri/src/commands/vibe_team_skill.rs:215-269`, `api_agents/skills.rs:218-248`, `api_agents.rs:476+`, `components/settings/{SkillImportPanel,CustomAgentEditor}.tsx`
+- 永続化: `src-tauri/src/commands/settings.rs:46-129,185-262`, `lib/settings-context.tsx:70-139`, `commands/role_profiles.rs:18-42`


### PR DESCRIPTION
## Summary
- Issue #1113 — Canvas マルチエージェント拡張の **Phase 1 (基盤)**。
- `'claude' | 'codex'` リテラルを `AgentEngine` 型に集約し、「**engine** (挙動系統)」と「**agent identity** (claude/codex/custom)」を概念分離。
- 新規 `agent-registry.ts` を SSOT に、builtin (claude/codex) と `settings.customAgents` を同一の `ResolvedAgentDescriptor` へ正規化。role ベース視覚を持つ `agent-visual.ts` とは軸が直交 (種別 identity vs ロール)。
- custom CLI agent に `engine` / `env` / `icon` / `tags` / `defaultSkillIds` / `skillInjection` の descriptor フィールドを追加 (`shared.ts` ⇄ Rust `settings.rs` を camelCase 同期)。
- `applyCustomAgentLeaderPreset` を engine 尊重 + `agentConfigId` 伝搬に更新 — custom が claude に偽装されず identity を保持し、codex 互換 custom も engine を宣言できる。
- `schemaVersion` 12→13 (全フィールド additive-optional。#641 save-guard が旧 build による新フィールド silent drop を防ぐため bump。migration block 不要)。
- 全 Phase のロードマップ: `tasks/canvas-multi-agent-skill-plan.md`。

## 後方互換 / マイグレーション
- 新フィールドはすべて optional。旧 `settings.json` を無変換で読める。
- builtin は customAgents に昇格させず registry 側で合成 (既存 settings 構造を維持)。
- canvas store の旧 `payload.agent` は引き続き engine として解釈。

## file-size baseline について
`shared.ts` / `settings.rs` / `canvas.ts` / `CanvasLayout.tsx` は baseline と同値の god-file。本 PR の追加は「shared 型は shared.ts / `AgentConfig` struct は settings.rs / `TerminalCardPayload` は canvas.ts」という不変式上これらにしか置けない**型・フィールド定義**で、分割すると別の不変式を破るため、baseline を最小 delta (+34 / +19 / +4 / +5) で更新した。god-file 分割自体は本ロードマップの後続 Phase で別途扱う。

## Test plan
- [x] `npm run typecheck` 通過
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 通過
- [x] `npx vitest run` — 全 492 tests 通過 (新規 `agent-registry.test.ts` 8 件含む)
- [x] `npm run lint:file-size` OK / `eslint` 0 errors (既存 warning 1 件のみ)

Closes #1113