### PR TITLE
feat(canvas): #1115 エージェントカードに種別アイコンを追加しヘッダーを高密度化

### DIFF
--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/AgentTypeIcon.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/AgentTypeIcon.tsx
@@ -1,0 +1,36 @@
+/**
+ * AgentTypeIcon — agent-registry の `ResolvedAgentDescriptor.icon` (lucide アイコン名) を
+ * 実際の lucide コンポーネントへ解決して描画する (Issue #1115 Phase2)。
+ *
+ * 種別 (claude / codex / custom) をヘッダーで一目で識別するためのアイコン。
+ * claude-design 準拠: 16px / strokeWidth 1.75。色は親 (`.canvas-agent-card__type-icon`) の
+ * `color` を継承する (custom は accent、builtin はロール accent)。
+ * 未知のアイコン名は Terminal にフォールバックする。
+ */
+import {
+  Bot,
+  Boxes,
+  Cloud,
+  Cpu,
+  Rocket,
+  Sparkles,
+  Terminal,
+  Wrench,
+  type LucideIcon
+} from 'lucide-react';
+
+const TYPE_ICONS: Record<string, LucideIcon> = {
+  Sparkles,
+  Terminal,
+  Bot,
+  Boxes,
+  Cloud,
+  Cpu,
+  Rocket,
+  Wrench
+};
+
+export function AgentTypeIcon({ name }: { name: string }): JSX.Element {
+  const Icon = TYPE_ICONS[name] ?? Terminal;
+  return <Icon size={16} strokeWidth={1.75} aria-hidden="true" />;
+}

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -57,6 +57,7 @@ import {
 import { resolveAgentVisual } from '../../../../lib/agent-visual';
 import { parseShellArgs } from '../../../../lib/parse-args';
 import { resolveAgentConfig } from '../../../../lib/agent-resolver';
+import { resolveAgentDescriptor } from '../../../../lib/agent-registry';
 import type { AgentEngine } from '../../../../../../types/shared';
 import { useToast } from '../../../../lib/toast-context';
 import {
@@ -95,6 +96,12 @@ function AgentNodeCardImpl({
   const profile = visual.profile;
   const accent = visual.agentAccent;
   const organizationAccent = visual.organizationAccent;
+  // Issue #1115: エージェント種別 (claude/codex/custom) の正規化記述子。ヘッダーのアイコン/
+  // 表示名/accent はこれを使い、custom が Claude に偽装されず一目で区別できるようにする。
+  const agentDescriptor = useMemo(
+    () => resolveAgentDescriptor({ agentConfigId: payload.agentConfigId, engine: payload.agent }, settings),
+    [payload.agentConfigId, payload.agent, settings]
+  );
   const title = data?.title ?? visual.label;
   const [status, setStatus] = useState<TerminalRuntimeStatus | null>(null);
   const [activity, setActivityState] = useState<AgentStatus>('idle');
@@ -379,7 +386,9 @@ function AgentNodeCardImpl({
           cardId={id}
           title={title}
           roleLabel={visual.label}
-          glyph={profile.visual.glyph}
+          typeIcon={agentDescriptor.icon}
+          typeName={agentDescriptor.displayName}
+          typeAccent={agentDescriptor.accentColor}
           organizationName={payload.organization?.name}
           activity={activity}
           status={terminalStatus}

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardPresentation.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardPresentation.tsx
@@ -1,37 +1,37 @@
 /**
  * AgentNodeCard / CardPresentation
  *
- * Issue #735: 旧 `CardFrame.tsx` (~900 行 god card) から「カードヘッダーの視覚表現」
- * (avatar / title / organization / role badge / status pill / close ボタン) を
- * 切り出した子コンポーネント。
+ * Issue #735: 旧 `CardFrame.tsx` god card から「カードヘッダーの視覚表現」を切り出した子。
+ * Issue #1115 (Phase2): role glyph アバターを **エージェント種別アイコン** (agent-registry の
+ * 記述子由来, lucide) に置き換え、ロールは muted な inline ラベルに降格。状態は色+形のドット+語
+ * で表す。種別 (claude/codex/custom) が一目で区別できる Option A (1 行・アイコン先頭) レイアウト。
  *
- * 純粋な表示コンポーネント: 値は親 (CardFrame) が解決して props で渡す。
- * handoff ボタンは責務分離のため `handoff` slot (ReactNode) で受け取り、本体は
- * その配置だけを担う (handoff ロジックは CardHandoff.tsx)。
- * 挙動・DOM・クラス名は元 `.canvas-agent-card__header` と完全一致。
+ * 純粋な表示コンポーネント: 値は親 (CardFrame) が解決して props で渡す。handoff は slot で受ける。
  */
 import type { ReactNode } from 'react';
 import type { AgentStatus } from './types';
+import { AgentTypeIcon } from './AgentTypeIcon';
 
 /** i18n の `t` 関数シグネチャ。 */
 type TFn = (key: string, params?: Record<string, string | number>) => string;
 
 /**
- * pty 起動時の status 文字列 ("実行中: claude --append-system-prompt ...long text...") を
- * 最初のフラグ/引数まで切り詰める。チームプロンプトなど巨大な文字列がヘッダに溢れるのを防ぐ。
+ * ヘッダー右の状態バッジ (idle=灰 / thinking=マスタード / typing=accent パルス)。
+ * 色だけでなくドットの形・パルスでも状態を識別できる (claude-design: form over color)。
+ * pty 起動 status 文字列は tooltip に退避する。
  */
-export function shortStatus(s: string): string {
-  // "実行中: claude --append-system-prompt あなたは..." → "実行中: claude"
-  const m = s.match(/^(\S+:\s*)?([^\s]+)/);
-  if (m) return `${m[1] ?? ''}${m[2]}`;
-  return s.length > 32 ? s.slice(0, 32) + '…' : s;
-}
-
-/** ヘッダー右の小さなステータスドット (idle=灰, thinking=黄, typing=accent パルス) */
-function StatusBadge({ state, label }: { state: AgentStatus; label: string }): JSX.Element {
+function StatusBadge({
+  state,
+  label,
+  title
+}: {
+  state: AgentStatus;
+  label: string;
+  title?: string;
+}): JSX.Element {
   return (
     <span
-      title={label}
+      title={title || label}
       aria-label={label}
       className={`canvas-agent-status canvas-agent-status--${state}`}
     >
@@ -48,13 +48,17 @@ interface CardPresentationProps {
   title: string;
   /** ロール表示ラベル (リーダー / プログラマー 等)。 */
   roleLabel: string;
-  /** ロール由来の avatar glyph。 */
-  glyph: string;
+  /** Issue #1115: エージェント種別アイコン (lucide 名, agent-registry 記述子由来)。 */
+  typeIcon: string;
+  /** 種別の表示名 (アイコンの tooltip 用)。 */
+  typeName: string;
+  /** 種別の accent カラー (custom のみ。未指定はロール accent を継承)。 */
+  typeAccent?: string;
   /** 所属組織名 (複数組織運用時のみ。無ければ非表示)。 */
   organizationName: string | undefined;
   /** 現在のアクティビティ状態 (idle / thinking / typing)。 */
   activity: AgentStatus;
-  /** pty 起動 status 文字列 (空なら status pill 非表示)。 */
+  /** pty 起動 status 文字列 (状態バッジの tooltip に表示)。 */
   status: string;
   /** handoff ボタン slot (Leader 以外では呼び出し側が null を渡す)。 */
   handoff: ReactNode;
@@ -63,11 +67,13 @@ interface CardPresentationProps {
   t: TFn;
 }
 
-/** Issue #735: 旧 CardFrame の `.canvas-agent-card__header`。 */
+/** Issue #735 / #1115: `.canvas-agent-card__header` (Option A: アイコン先頭・1 行・高密度)。 */
 export function CardPresentation({
   title,
   roleLabel,
-  glyph,
+  typeIcon,
+  typeName,
+  typeAccent,
   organizationName,
   activity,
   status,
@@ -78,22 +84,24 @@ export function CardPresentation({
   return (
     <header className="canvas-agent-card__header">
       <span className="canvas-agent-card__title-row">
-        <span aria-hidden="true" className="canvas-agent-card__avatar">
-          {glyph}
+        <span
+          className="canvas-agent-card__type-icon"
+          style={typeAccent ? { color: typeAccent } : undefined}
+          title={typeName}
+          aria-label={typeName}
+        >
+          <AgentTypeIcon name={typeIcon} />
         </span>
         <span className="canvas-agent-card__title">{title}</span>
         {organizationName && (
           <span className="canvas-agent-card__organization">{organizationName}</span>
         )}
-        <span className="canvas-agent-card__role">{roleLabel}</span>
+        <span className="canvas-agent-card__role canvas-agent-card__role--inline">
+          ·{roleLabel}
+        </span>
       </span>
       <span className="canvas-agent-card__actions">
-        <StatusBadge state={activity} label={t(`agentStatus.${activity}`)} />
-        {status && (
-          <span className="canvas-agent-card__status" title={status}>
-            {shortStatus(status)}
-          </span>
-        )}
+        <StatusBadge state={activity} label={t(`agentStatus.${activity}`)} title={status} />
         {handoff}
         <button
           type="button"

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -38,6 +38,7 @@ import './styles/components/menu.css';
 import './styles/components/toast.css';
 import './styles/components/claude-not-found.css';
 import './styles/components/canvas.css';
+import './styles/components/canvas-agent-card.css';
 import './styles/components/team-dashboard.css';
 import './styles/components/claude-patterns.css';
 import './styles/components/shell.css';

--- a/src/renderer/src/styles/components/canvas-agent-card.css
+++ b/src/renderer/src/styles/components/canvas-agent-card.css
@@ -1,0 +1,38 @@
+/**
+ * canvas-agent-card.css — Issue #1115 (Phase2) エージェントカード GUI 刷新の追加スタイル。
+ *
+ * 既存の `.canvas-agent-card` 系ベーススタイルは canvas.css (file-size baseline 済) に残し、
+ * Phase2 で増える新要素 (種別アイコン / ロール inline 化) のみここで定義して canvas.css の
+ * 肥大化を避ける。claude-design 準拠: hairline border / shadow なし / terra cotta は小面積 /
+ * warm gray。main.tsx では canvas.css の直後・glass.css より前に import する。
+ */
+
+/* エージェント種別アイコン (claude / codex / custom)。色は親から継承し、
+   custom は CardPresentation 側の inline style で accent を上書きする。 */
+.canvas-agent-card__type-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  color: var(--agent-accent, var(--accent));
+}
+
+.canvas-agent-card__type-icon svg {
+  display: block;
+}
+
+/* ロールは avatar glyph を廃し、種別アイコンに主役を譲って muted な inline ラベルへ降格。
+   既存 `.canvas-agent-card__role` (uppercase / letter-spacing) を上書きする。 */
+.canvas-agent-card__role--inline {
+  color: var(--fg-muted, var(--fg-subtle));
+  font-size: 11px;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary
- Canvas マルチエージェント拡張の **Phase 2** (実装計画 `tasks/canvas-multi-agent-skill-plan.md` §3.2)。
- Phase 1 (#1113) の `agent-registry.ts` を **カード描画に接続**。ヘッダーの role glyph アバターを **エージェント種別アイコン** (claude=Sparkles / codex=Terminal / custom=定義アイコン, lucide) に置き換え、custom agent が Claude/Codex と視覚的に区別できるようにした。
- レイアウトは **Option A (1 行・アイコン先頭・高密度, Linear/Raycast 風)**。ロールは muted な inline ラベルに降格、pty status 文字列は状態バッジの tooltip へ退避。
- 状態バッジは **色 + 形** (ドット形/パルス + ラベル) で idle/thinking/typing を識別 (claude-design: form over color)。
- 新規 `AgentTypeIcon.tsx` (lucide 名→コンポーネント解決) + 新規 `styles/components/canvas-agent-card.css` (種別アイコン / ロール inline のみ) で `canvas.css` の肥大化を回避。
- claude-design 準拠: hairline border / shadow なし / terra cotta 小面積 / 角丸据え置き。Glass テーマは既に `.canvas-agent-card` に backdrop-filter 適用済みのため変更不要。

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npx vitest run` 全 492 tests 通過 (AgentNodeCard render / CSS contract tests 含む)
- [x] `npm run lint:file-size` OK / eslint 0 errors (既存 warning 1 件のみ)
- [ ] `npm run dev` での実機ビジュアル確認 (レビュー前にユーザー確認)

Closes #1115