### PR TITLE
feat(skill): #1119 CLI エージェントへの Skill アタッチとプロジェクト materialize

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -41,5 +41,5 @@
   "src/renderer/src/lib/i18n.ts": 1913,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
   "src/renderer/src/stores/canvas.ts": 588,
-  "src/types/shared.ts": 1958
+  "src/types/shared.ts": 1959
 }

--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -12,7 +12,7 @@
   "src-tauri/src/commands/terminal/command_validation.rs": 916,
   "src-tauri/src/commands/terminal_tabs.rs": 817,
   "src-tauri/src/commands/voice.rs": 550,
-  "src-tauri/src/lib.rs": 520,
+  "src-tauri/src/lib.rs": 521,
   "src-tauri/src/pty/claude_watcher.rs": 609,
   "src-tauri/src/pty/codex_broker.rs": 506,
   "src-tauri/src/pty/codex_watcher.rs": 648,
@@ -38,8 +38,8 @@
   "src/renderer/src/layouts/CanvasLayout.tsx": 1010,
   "src/renderer/src/lib/hooks/use-file-tabs.ts": 517,
   "src/renderer/src/lib/hooks/use-xterm-bind.ts": 889,
-  "src/renderer/src/lib/i18n.ts": 1898,
+  "src/renderer/src/lib/i18n.ts": 1913,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
   "src/renderer/src/stores/canvas.ts": 588,
-  "src/types/shared.ts": 1944
+  "src/types/shared.ts": 1958
 }

--- a/src-tauri/src/commands/api_agents/skills.rs
+++ b/src-tauri/src/commands/api_agents/skills.rs
@@ -21,7 +21,9 @@ use std::path::{Path, PathBuf};
 use tauri::State;
 use tokio::fs;
 
-use super::types::{ApiAgentSkill, ApiAgentSkillMeta, ImportSkillRequest, ImportableSkill};
+use super::types::{
+    ApiAgentSkill, ApiAgentSkillMeta, ImportSkillRequest, ImportableSkill, SkillApplyResult,
+};
 
 /// 1 つの SKILL.md から読み込む最大バイト数。
 const MAX_SKILL_FILE_BYTES: usize = 256 * 1024;
@@ -179,6 +181,74 @@ pub async fn api_agent_skill_remove(id: String) -> CommandResult<()> {
     match fs::remove_dir_all(&dir).await {
         Ok(()) | Err(_) => Ok(()), // 不在は成功扱い (冪等)
     }
+}
+
+/// dest の現在内容 (None=不在) と新 body から materialize 後のステータスを決める純関数。
+/// 内容一致なら unchanged (idempotent)、不在なら created、差分ありは updated。
+fn apply_status(existing: Option<&str>, body: &str) -> &'static str {
+    match existing {
+        None => "created",
+        Some(cur) if cur == body => "unchanged",
+        Some(_) => "updated",
+    }
+}
+
+/// Issue #1119: 選択 skill を現在のプロジェクトの `.claude/skills/<id>/SKILL.md` へ materialize する。
+/// claude/codex は起動時に `.claude/skills` を自動探索するため、これで CLI エージェントでも
+/// skill が効く。idempotent (内容一致は unchanged で書かない)。読み込みは `read_skill_md_within`
+/// で traversal / symlink escape をガードし、書き込みは atomic_write。
+#[tauri::command]
+pub async fn api_agent_skill_apply_to_project(
+    state: State<'_, AppState>,
+    skill_ids: Vec<String>,
+) -> CommandResult<Vec<SkillApplyResult>> {
+    let project_root = current_project_root(&state.project_root).unwrap_or_default();
+    let pr = project_root.trim();
+    if pr.is_empty() {
+        return Err(CommandError::validation("no project open"));
+    }
+    let src_dir = config_paths::vibe_skills_dir();
+    let src_canon = fs::canonicalize(&src_dir).await.ok();
+    let claude_skills = Path::new(pr).join(".claude").join("skills");
+
+    let mut out: Vec<SkillApplyResult> = Vec::new();
+    for id in skill_ids {
+        if !is_valid_id_segment(&id) {
+            out.push(SkillApplyResult {
+                id,
+                status: "invalid".into(),
+            });
+            continue;
+        }
+        let body = match &src_canon {
+            Some(dc) => read_skill_md_within(dc, &src_dir.join(&id).join("SKILL.md")).await,
+            None => None,
+        };
+        let Some(body) = body else {
+            out.push(SkillApplyResult {
+                id,
+                status: "missing".into(),
+            });
+            continue;
+        };
+        let dest_dir = claude_skills.join(&id);
+        let dest_md = dest_dir.join("SKILL.md");
+        let existing = fs::read_to_string(&dest_md).await.ok();
+        let status = apply_status(existing.as_deref(), &body);
+        if status != "unchanged" {
+            fs::create_dir_all(&dest_dir)
+                .await
+                .map_err(|e| CommandError::Io(e.to_string()))?;
+            atomic_write(&dest_md, body.as_bytes())
+                .await
+                .map_err(|e| CommandError::internal(e.to_string()))?;
+        }
+        out.push(SkillApplyResult {
+            id,
+            status: status.into(),
+        });
+    }
+    Ok(out)
 }
 
 // ============================================================

--- a/src-tauri/src/commands/api_agents/skills.rs
+++ b/src-tauri/src/commands/api_agents/skills.rs
@@ -23,6 +23,7 @@ use tokio::fs;
 
 use super::types::{
     ApiAgentSkill, ApiAgentSkillMeta, ImportSkillRequest, ImportableSkill, SkillApplyResult,
+    SkillApplyStatus,
 };
 
 /// 1 つの SKILL.md から読み込む最大バイト数。
@@ -184,19 +185,23 @@ pub async fn api_agent_skill_remove(id: String) -> CommandResult<()> {
 }
 
 /// dest の現在内容 (None=不在) と新 body から materialize 後のステータスを決める純関数。
-/// 内容一致なら unchanged (idempotent)、不在なら created、差分ありは updated。
-fn apply_status(existing: Option<&str>, body: &str) -> &'static str {
+/// 内容一致なら Unchanged (idempotent)、不在なら Created、差分ありは Updated。
+fn apply_status(existing: Option<&str>, body: &str) -> SkillApplyStatus {
     match existing {
-        None => "created",
-        Some(cur) if cur == body => "unchanged",
-        Some(_) => "updated",
+        None => SkillApplyStatus::Created,
+        Some(cur) if cur == body => SkillApplyStatus::Unchanged,
+        Some(_) => SkillApplyStatus::Updated,
     }
 }
 
 /// Issue #1119: 選択 skill を現在のプロジェクトの `.claude/skills/<id>/SKILL.md` へ materialize する。
 /// claude/codex は起動時に `.claude/skills` を自動探索するため、これで CLI エージェントでも
-/// skill が効く。idempotent (内容一致は unchanged で書かない)。読み込みは `read_skill_md_within`
-/// で traversal / symlink escape をガードし、書き込みは atomic_write。
+/// skill が効く。idempotent (内容一致は Unchanged で書かない)。
+///
+/// セキュリティ (PR #1120 review): 読み込み側 `read_skill_md_within` と対称に、**書き込み先**も
+/// project root を canonicalize して「materialize 先が project 配下に収まる」ことを検証する。
+/// `.claude` / `.claude/skills` / `.claude/skills/<id>` に symlink が仕込まれて project 外を
+/// 指す場合は Unsafe で拒否し、SKILL.md 本文を外部へ書き出さない。
 #[tauri::command]
 pub async fn api_agent_skill_apply_to_project(
     state: State<'_, AppState>,
@@ -207,16 +212,20 @@ pub async fn api_agent_skill_apply_to_project(
     if pr.is_empty() {
         return Err(CommandError::validation("no project open"));
     }
+    // 書き込み先 escape を防ぐため project root を canonicalize しておく。
+    let proj_canon = fs::canonicalize(pr)
+        .await
+        .map_err(|_| CommandError::validation("project root not found"))?;
     let src_dir = config_paths::vibe_skills_dir();
     let src_canon = fs::canonicalize(&src_dir).await.ok();
-    let claude_skills = Path::new(pr).join(".claude").join("skills");
+    let claude_skills = proj_canon.join(".claude").join("skills");
 
     let mut out: Vec<SkillApplyResult> = Vec::new();
     for id in skill_ids {
         if !is_valid_id_segment(&id) {
             out.push(SkillApplyResult {
                 id,
-                status: "invalid".into(),
+                status: SkillApplyStatus::Invalid,
             });
             continue;
         }
@@ -227,26 +236,39 @@ pub async fn api_agent_skill_apply_to_project(
         let Some(body) = body else {
             out.push(SkillApplyResult {
                 id,
-                status: "missing".into(),
+                status: SkillApplyStatus::Missing,
             });
             continue;
         };
         let dest_dir = claude_skills.join(&id);
-        let dest_md = dest_dir.join("SKILL.md");
+        fs::create_dir_all(&dest_dir)
+            .await
+            .map_err(|e| CommandError::Io(e.to_string()))?;
+        // create 後に canonicalize し、symlink を辿って project root 外へ出ていないか検証する。
+        // escape していれば本文を書かずに Unsafe で記録 (読み込み側と対称な防御)。
+        let dest_canon = match fs::canonicalize(&dest_dir).await {
+            Ok(c) if c.starts_with(&proj_canon) => c,
+            _ => {
+                tracing::warn!(
+                    "[api-agent] rejected skill materialize escaping project root: {}",
+                    dest_dir.display()
+                );
+                out.push(SkillApplyResult {
+                    id,
+                    status: SkillApplyStatus::Unsafe,
+                });
+                continue;
+            }
+        };
+        let dest_md = dest_canon.join("SKILL.md");
         let existing = fs::read_to_string(&dest_md).await.ok();
         let status = apply_status(existing.as_deref(), &body);
-        if status != "unchanged" {
-            fs::create_dir_all(&dest_dir)
-                .await
-                .map_err(|e| CommandError::Io(e.to_string()))?;
+        if status != SkillApplyStatus::Unchanged {
             atomic_write(&dest_md, body.as_bytes())
                 .await
                 .map_err(|e| CommandError::internal(e.to_string()))?;
         }
-        out.push(SkillApplyResult {
-            id,
-            status: status.into(),
-        });
+        out.push(SkillApplyResult { id, status });
     }
     Ok(out)
 }

--- a/src-tauri/src/commands/api_agents/skills/tests.rs
+++ b/src-tauri/src/commands/api_agents/skills/tests.rs
@@ -4,6 +4,14 @@
 use super::*;
 
 #[test]
+fn apply_status_is_idempotent_and_detects_changes() {
+    // 不在 → created、内容一致 → unchanged (再適用は no-op)、差分 → updated。
+    assert_eq!(apply_status(None, "x"), "created");
+    assert_eq!(apply_status(Some("x"), "x"), "unchanged");
+    assert_eq!(apply_status(Some("old"), "new"), "updated");
+}
+
+#[test]
 fn parse_meta_reads_frontmatter() {
     let body = "---\nname: My Skill\ndescription: \"Does a thing\"\n---\n# Heading\nbody text";
     let (name, desc) = parse_skill_meta("my-skill", body);

--- a/src-tauri/src/commands/api_agents/skills/tests.rs
+++ b/src-tauri/src/commands/api_agents/skills/tests.rs
@@ -2,13 +2,14 @@
 // 親 skills.rs の private fn / 型に `use super::*` でアクセスする。
 
 use super::*;
+use crate::commands::api_agents::types::SkillApplyStatus;
 
 #[test]
 fn apply_status_is_idempotent_and_detects_changes() {
-    // 不在 → created、内容一致 → unchanged (再適用は no-op)、差分 → updated。
-    assert_eq!(apply_status(None, "x"), "created");
-    assert_eq!(apply_status(Some("x"), "x"), "unchanged");
-    assert_eq!(apply_status(Some("old"), "new"), "updated");
+    // 不在 → Created、内容一致 → Unchanged (再適用は no-op)、差分 → Updated。
+    assert_eq!(apply_status(None, "x"), SkillApplyStatus::Created);
+    assert_eq!(apply_status(Some("x"), "x"), SkillApplyStatus::Unchanged);
+    assert_eq!(apply_status(Some("old"), "new"), SkillApplyStatus::Updated);
 }
 
 #[test]

--- a/src-tauri/src/commands/api_agents/types.rs
+++ b/src-tauri/src/commands/api_agents/types.rs
@@ -137,13 +137,26 @@ pub struct ImportSkillRequest {
     pub id: String,
 }
 
+/// Issue #1119 / PR #1120 review: skill materialize のステータス。TS 側 literal union と
+/// 1:1 対応する型付き enum (kebab-case で 'created' 等にシリアライズ) にして型契約を揃える。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SkillApplyStatus {
+    Created,
+    Updated,
+    Unchanged,
+    Missing,
+    Invalid,
+    /// 書き込み先が symlink でプロジェクト外へ escape したため拒否。
+    Unsafe,
+}
+
 /// Issue #1119: skill を project の `.claude/skills` へ materialize した結果。
-/// status は 'created' | 'updated' | 'unchanged' | 'missing' | 'invalid'。
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SkillApplyResult {
     pub id: String,
-    pub status: String,
+    pub status: SkillApplyStatus,
 }
 
 /// team 参加コンテキスト。renderer (apiAgent カード) が所属チーム情報を渡す (Issue #1004)。

--- a/src-tauri/src/commands/api_agents/types.rs
+++ b/src-tauri/src/commands/api_agents/types.rs
@@ -137,6 +137,15 @@ pub struct ImportSkillRequest {
     pub id: String,
 }
 
+/// Issue #1119: skill を project の `.claude/skills` へ materialize した結果。
+/// status は 'created' | 'updated' | 'unchanged' | 'missing' | 'invalid'。
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillApplyResult {
+    pub id: String,
+    pub status: String,
+}
+
 /// team 参加コンテキスト。renderer (apiAgent カード) が所属チーム情報を渡す (Issue #1004)。
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -284,6 +284,7 @@ pub fn run() {
             commands::api_agents::skills::api_agent_skill_sources_list,
             commands::api_agents::skills::api_agent_skill_import,
             commands::api_agents::skills::api_agent_skill_remove,
+            commands::api_agents::skills::api_agent_skill_apply_to_project,
             commands::api_agents::models::api_agent_list_models,
         ])
         .setup(|app| {

--- a/src/renderer/src/components/settings/CliAgentSkillsField.tsx
+++ b/src/renderer/src/components/settings/CliAgentSkillsField.tsx
@@ -1,0 +1,96 @@
+/**
+ * CliAgentSkillsField — CLI custom agent の Skill 選択 + プロジェクト materialize (Issue #1119)。
+ *
+ * CustomAgentEditor から CLI skill セクションを切り出した子コンポーネント (god-file 回避)。
+ * import 済み skill を検索フィルタ付きで列挙し、`defaultSkillIds` をトグルする。「適用」で
+ * 選択 skill を現在のプロジェクトの `.claude/skills` へ materialize し、claude/codex の
+ * 自動探索で skill が効くようにする。
+ */
+import { useState } from 'react';
+import type { ApiAgentSkillMeta, CliAgentConfig } from '../../../../types/shared';
+import { useT } from '../../lib/i18n';
+import { useToast } from '../../lib/toast-context';
+import { SkillImportPanel } from './SkillImportPanel';
+
+interface Props {
+  agent: CliAgentConfig;
+  availableSkills: ApiAgentSkillMeta[];
+  /** defaultSkillIds をトグルする (永続化は親の patch 経由)。 */
+  onToggle: (id: string) => void;
+  reloadSkills: () => void;
+}
+
+export function CliAgentSkillsField({
+  agent,
+  availableSkills,
+  onToggle,
+  reloadSkills
+}: Props): JSX.Element {
+  const t = useT();
+  const { showToast } = useToast();
+  const [filter, setFilter] = useState('');
+
+  const matches = (s: ApiAgentSkillMeta): boolean => {
+    const needle = filter.trim().toLowerCase();
+    if (!needle) return true;
+    return `${s.name} ${s.id} ${s.description}`.toLowerCase().includes(needle);
+  };
+
+  const apply = async (): Promise<void> => {
+    const ids = agent.defaultSkillIds ?? [];
+    if (ids.length === 0) {
+      showToast(t('settings.customAgents.applySkillsEmpty'), { tone: 'info' });
+      return;
+    }
+    try {
+      const res = await window.api.apiAgents.applySkillsToProject(ids);
+      const applied = res.filter((r) => r.status === 'created' || r.status === 'updated').length;
+      showToast(
+        t('settings.customAgents.applySkillsDone', { count: applied, total: res.length }),
+        { tone: 'success' }
+      );
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : String(e);
+      showToast(t('settings.customAgents.applySkillsError', { detail }), {
+        tone: 'error',
+        duration: 8000
+      });
+    }
+  };
+
+  return (
+    <div className="modal__label modal__label--full">
+      <span>{t('settings.customAgents.skills')}</span>
+      {availableSkills.length === 0 ? (
+        <p className="modal__note">{t('settings.customAgents.skillsEmpty')}</p>
+      ) : (
+        <>
+          <input
+            type="search"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder={t('settings.customAgents.skillSearch')}
+            spellCheck={false}
+          />
+          <div className="custom-agent__skills">
+            {availableSkills.filter(matches).map((skill) => (
+              <label key={skill.id} className="custom-agent__skill" title={skill.description}>
+                <input
+                  type="checkbox"
+                  checked={(agent.defaultSkillIds ?? []).includes(skill.id)}
+                  onChange={() => onToggle(skill.id)}
+                />
+                <span className="custom-agent__skill-name">{skill.name}</span>
+              </label>
+            ))}
+          </div>
+          <button type="button" className="toolbar__btn" onClick={apply}>
+            {t('settings.customAgents.applySkills')}
+          </button>
+        </>
+      )}
+      <p className="modal__note">{t('settings.customAgents.cliSkillsNote')}</p>
+      <SkillImportPanel onChanged={reloadSkills} />
+    </div>
+  );
+}

--- a/src/renderer/src/components/settings/CustomAgentEditor.tsx
+++ b/src/renderer/src/components/settings/CustomAgentEditor.tsx
@@ -12,6 +12,7 @@ import {
 import { useT } from '../../lib/i18n';
 import { useToast } from '../../lib/toast-context';
 import { SkillImportPanel } from './SkillImportPanel';
+import { CliAgentSkillsField } from './CliAgentSkillsField';
 import { useNativeConfirm } from '../../lib/use-native-confirm';
 import { parseShellArgsStrict } from '../../lib/parse-args';
 import type { UpdateSetting } from './types';
@@ -117,10 +118,10 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
       .catch(() => setAvailableSkills([]));
   }, []);
 
+  // Issue #1119: CLI でも skill を選べるよう runtime に関わらず一覧をロードする。
   useEffect(() => {
-    if (agent.runtime !== 'api') return;
     reloadSkills();
-  }, [agent.runtime, reloadSkills]);
+  }, [reloadSkills]);
 
   const toggleSkill = (id: string): void => {
     if (!apiAgent) return;
@@ -129,6 +130,16 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
       ? current.filter((s) => s !== id)
       : [...current, id];
     patchApiAgent({ skillIds: next });
+  };
+
+  // Issue #1119: CLI agent の defaultSkillIds をトグルする (UI は CliAgentSkillsField へ分離)。
+  const toggleCliSkill = (id: string): void => {
+    if (!cliAgent) return;
+    const current = cliAgent.defaultSkillIds ?? [];
+    const next = current.includes(id)
+      ? current.filter((s) => s !== id)
+      : [...current, id];
+    patchAgent({ defaultSkillIds: next });
   };
 
   const switchRuntime = (runtime: 'cli' | 'api'): void => {
@@ -288,6 +299,13 @@ export function CustomAgentEditor({ agent, draft, update }: Props): JSX.Element 
               <option value="codex">{t('settings.customAgents.engineCodex')}</option>
             </select>
           </label>
+
+          <CliAgentSkillsField
+            agent={cliAgent}
+            availableSkills={availableSkills}
+            onToggle={toggleCliSkill}
+            reloadSkills={reloadSkills}
+          />
         </>
       )}
 

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -815,6 +815,14 @@ const ja: Dict = {
   'settings.customAgents.skillsEmpty':
     'import 済みの skill がありません。下の「Claude / Codex から import」で追加してください。',
   'settings.customAgents.skillsAutoTeam': 'TeamHub 参加時は vibe-team skill が自動で追加されます。',
+  'settings.customAgents.skillSearch': 'skill を検索',
+  'settings.customAgents.applySkills': 'プロジェクトに適用',
+  'settings.customAgents.applySkillsEmpty': '適用する skill が選択されていません。',
+  'settings.customAgents.applySkillsDone':
+    '{count}/{total} 件の skill を .claude/skills に適用しました。',
+  'settings.customAgents.applySkillsError': 'skill の適用に失敗しました: {detail}',
+  'settings.customAgents.cliSkillsNote':
+    'CLI エージェントは .claude/skills を自動探索します。チェックして「適用」でプロジェクトに配置してください。',
   'settings.customAgents.skillImport.title': 'Claude / Codex から skill を import',
   'settings.customAgents.skillImport.note':
     '~/.claude/skills と ~/.agents/skills (Codex) を走査し、選んだ skill を vibe-editor 専用フォルダにコピーします。',
@@ -1736,6 +1744,13 @@ const en: Dict = {
     'No imported skills yet. Add some via “Import from Claude / Codex” below.',
   'settings.customAgents.skillsAutoTeam':
     'The vibe-team skill is added automatically when joining TeamHub.',
+  'settings.customAgents.skillSearch': 'Search skills',
+  'settings.customAgents.applySkills': 'Apply to project',
+  'settings.customAgents.applySkillsEmpty': 'No skills selected to apply.',
+  'settings.customAgents.applySkillsDone': 'Applied {count}/{total} skills to .claude/skills.',
+  'settings.customAgents.applySkillsError': 'Failed to apply skills: {detail}',
+  'settings.customAgents.cliSkillsNote':
+    'CLI agents auto-discover .claude/skills. Check skills and Apply to place them in the project.',
   'settings.customAgents.skillImport.title': 'Import skills from Claude / Codex',
   'settings.customAgents.skillImport.note':
     'Scans ~/.claude/skills and ~/.agents/skills (Codex), and copies the selected skill into the vibe-editor skills folder.',

--- a/src/renderer/src/lib/tauri-api/api-agents.ts
+++ b/src/renderer/src/lib/tauri-api/api-agents.ts
@@ -13,7 +13,8 @@ import type {
   ApiAgentSkillMeta,
   ApiAgentSkillSource,
   ApiAgentStreamEvent,
-  ApiAgentToolEvent
+  ApiAgentToolEvent,
+  SkillApplyResult
 } from '../../../../types/shared';
 
 export const apiAgents = {
@@ -41,6 +42,9 @@ export const apiAgents = {
   importSkill: (source: ApiAgentSkillSource, id: string): Promise<ApiAgentSkillMeta> =>
     invokeCommand('api_agent_skill_import', { req: { source, id } }),
   removeSkill: (id: string): Promise<void> => invokeCommand('api_agent_skill_remove', { id }),
+  /** Issue #1119: 選択 skill を現在のプロジェクトの .claude/skills へ materialize する。 */
+  applySkillsToProject: (skillIds: string[]): Promise<SkillApplyResult[]> =>
+    invokeCommand('api_agent_skill_apply_to_project', { skillIds }),
   events: (sessionId: string) => ({
     onDeltaReady: (cb: (event: ApiAgentStreamEvent) => void): Promise<() => void> =>
       subscribeEventReady<ApiAgentStreamEvent>(`api-agent:delta:${sessionId}`, cb),

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -573,6 +573,20 @@ export interface ApiAgentImportableSkill {
   imported: boolean;
 }
 
+/**
+ * Issue #1119: skill を現在のプロジェクトの `.claude/skills/<id>/SKILL.md` へ materialize した
+ * 結果。claude/codex はこのフォルダを自動探索するため、CLI エージェントでも skill が効く。
+ *  - 'created'   : 新規配置
+ *  - 'updated'   : 既存と差分があり上書き
+ *  - 'unchanged' : 既存と同一 (no-op, idempotent)
+ *  - 'missing'   : import 済みフォルダに該当 skill が無い
+ *  - 'invalid'   : 不正な skill id
+ */
+export interface SkillApplyResult {
+  id: string;
+  status: 'created' | 'updated' | 'unchanged' | 'missing' | 'invalid';
+}
+
 export interface ApiAgentSendResult {
   ok: boolean;
   generationId: string;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -581,10 +581,11 @@ export interface ApiAgentImportableSkill {
  *  - 'unchanged' : 既存と同一 (no-op, idempotent)
  *  - 'missing'   : import 済みフォルダに該当 skill が無い
  *  - 'invalid'   : 不正な skill id
+ *  - 'unsafe'    : 書き込み先が symlink でプロジェクト外へ escape したため拒否
  */
 export interface SkillApplyResult {
   id: string;
-  status: 'created' | 'updated' | 'unchanged' | 'missing' | 'invalid';
+  status: 'created' | 'updated' | 'unchanged' | 'missing' | 'invalid' | 'unsafe';
 }
 
 export interface ApiAgentSendResult {


### PR DESCRIPTION
## Summary
- Canvas マルチエージェント拡張の **Phase 4** (`tasks/canvas-multi-agent-skill-plan.md` §3.3)。Skill が API agent の system_prompt 注入にしか効かなかった状態を解消し、**CLI エージェント (claude/codex) でも Skill を使える**ようにした。
- **Rust**: `api_agent_skill_apply_to_project(skillIds)` を追加。`~/.vibe-editor/skills/<id>/SKILL.md` を現在のプロジェクトの `.claude/skills/<id>/SKILL.md` へ materialize する。claude/codex は `.claude/skills` を自動探索するため、配置するだけで CLI でも skill が効く。**idempotent** (内容一致は `unchanged` で書かない)、`read_skill_md_within` で traversal/symlink escape ガード、`atomic_write` で原子書き込み、`is_valid_id_segment` で id 検証。`apply_status` 純関数を unit test。
- **IPC 5点**: command + `invoke_handler` 登録 + `tauri-api/api-agents.ts` wrapper + shared/Rust 型 (`SkillApplyResult`)。
- **UI**: `CustomAgentEditor` で **CLI runtime でも skill を選択可能**に (`defaultSkillIds`)。skill 一覧に**検索フィルタ**、「**プロジェクトに適用**」ボタンで materialize を実行しトースト報告。肥大化回避のため CLI skill UI は新規 `CliAgentSkillsField.tsx` に分離 (CustomAgentEditor を 500 行以下に維持)。
- **i18n** ja/en を追加。

## Test plan
- [x] `npm run typecheck` 通過
- [x] `cargo test apply_status_is_idempotent_and_detects_changes` 通過 (Rust コンパイル含む)
- [x] `npx vitest run` 全 492 tests 通過
- [x] `npm run lint:file-size` OK / eslint 0 findings

## file-size baseline
i18n.ts / shared.ts / lib.rs は baseline 同値の god-file。i18n キー・`SkillApplyResult` 型・`invoke_handler` 1 行はこれらに属する追加で分割不可のため baseline を最小 delta (+15 / +14 / +1) で更新。CustomAgentEditor は 500 行超を避けるため `CliAgentSkillsField` へ分離した。

## 補足
auto-on-launch の materialize (起動時自動適用) は Phase 5 で best-effort 追加予定。本 PR は明示「適用」ボタン + claude の自動探索で確実に効く経路を提供する。

Closes #1119