### PR TITLE
feat(canvas): #1125 codex/CLI に prompt-file skill 注入を実装し死蔵 append-flag を撤去

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -12,7 +12,7 @@
   "src-tauri/src/commands/terminal/command_validation.rs": 916,
   "src-tauri/src/commands/terminal_tabs.rs": 817,
   "src-tauri/src/commands/voice.rs": 550,
-  "src-tauri/src/lib.rs": 521,
+  "src-tauri/src/lib.rs": 522,
   "src-tauri/src/pty/claude_watcher.rs": 609,
   "src-tauri/src/pty/codex_broker.rs": 506,
   "src-tauri/src/pty/codex_watcher.rs": 648,
@@ -41,5 +41,5 @@
   "src/renderer/src/lib/i18n.ts": 1935,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
   "src/renderer/src/stores/canvas.ts": 588,
-  "src/types/shared.ts": 1959
+  "src/types/shared.ts": 1974
 }

--- a/src-tauri/src/commands/api_agents/skills.rs
+++ b/src-tauri/src/commands/api_agents/skills.rs
@@ -22,8 +22,8 @@ use tauri::State;
 use tokio::fs;
 
 use super::types::{
-    ApiAgentSkill, ApiAgentSkillMeta, ImportSkillRequest, ImportableSkill, SkillApplyResult,
-    SkillApplyStatus,
+    ApiAgentSkill, ApiAgentSkillBody, ApiAgentSkillMeta, ImportSkillRequest, ImportableSkill,
+    SkillApplyResult, SkillApplyStatus,
 };
 
 /// 1 つの SKILL.md から読み込む最大バイト数。
@@ -47,6 +47,25 @@ pub async fn api_agent_skill_list() -> CommandResult<Vec<ApiAgentSkillMeta>> {
 /// ファイルが無ければバンドル本文へフォールバックする。
 pub(super) async fn load_skill_bodies(skill_ids: &[String]) -> Vec<ApiAgentSkill> {
     load_skill_bodies_from(&config_paths::vibe_skills_dir(), skill_ids).await
+}
+
+/// 選択された skill の本文を renderer へ返す (Issue #1125)。CLI エージェントの prompt-file 注入
+/// (codex の `model_instructions_file` 等) で、renderer が本文を system prompt へ前置するために
+/// 使う。`load_skill_bodies` と異なり vibe-team は強制同梱しない (standalone への混入回避)。
+#[tauri::command]
+pub async fn api_agent_skill_load_bodies(
+    skill_ids: Vec<String>,
+) -> CommandResult<Vec<ApiAgentSkillBody>> {
+    let bodies =
+        load_selected_skill_bodies_from(&config_paths::vibe_skills_dir(), &skill_ids).await;
+    Ok(bodies
+        .into_iter()
+        .map(|s| ApiAgentSkillBody {
+            id: s.id,
+            name: s.name,
+            body: s.body,
+        })
+        .collect())
 }
 
 // ============================================================
@@ -307,15 +326,34 @@ async fn list_skills_in(dir: &Path) -> Vec<ApiAgentSkillMeta> {
 }
 
 /// `dir/<id>/SKILL.md` から選択 skill + 自動 vibe-team の本文を読み込む。
+/// API エージェントの system prompt 構築用 (`load_skill_bodies` 経由)。
 async fn load_skill_bodies_from(dir: &Path, skill_ids: &[String]) -> Vec<ApiAgentSkill> {
+    load_skill_bodies_inner(dir, skill_ids, true).await
+}
+
+/// `dir/<id>/SKILL.md` から **選択された skill だけ** の本文を読み込む (vibe-team は同梱しない)。
+/// CLI エージェントの prompt-file 注入で使う。standalone (非チーム) エージェントに TeamHub
+/// プロトコル (vibe-team) が混入しないよう、自動追加を行わない点が `load_skill_bodies_from`
+/// との違い (Issue #1125)。
+async fn load_selected_skill_bodies_from(dir: &Path, skill_ids: &[String]) -> Vec<ApiAgentSkill> {
+    load_skill_bodies_inner(dir, skill_ids, false).await
+}
+
+/// skill 本文ローダの実体。`include_vibe_team` で vibe-team の自動追加を切り替える。
+/// id 検証 / 重複排除 / symlink-safe 読み込み / vibe-team のバンドル fallback は共通。
+async fn load_skill_bodies_inner(
+    dir: &Path,
+    skill_ids: &[String],
+    include_vibe_team: bool,
+) -> Vec<ApiAgentSkill> {
     let mut ids: Vec<String> = Vec::new();
     for id in skill_ids {
         if is_valid_id_segment(id) && !ids.iter().any(|x| x == id) {
             ids.push(id.clone());
         }
     }
-    // 計画 v2: TeamHub 参加時は vibe-team を自動追加。
-    if !ids.iter().any(|i| i == VIBE_TEAM_SKILL_ID) {
+    // 計画 v2: TeamHub 参加時は vibe-team を自動追加 (API エージェント経路のみ)。
+    if include_vibe_team && !ids.iter().any(|i| i == VIBE_TEAM_SKILL_ID) {
         ids.push(VIBE_TEAM_SKILL_ID.to_string());
     }
     let dir_canon = fs::canonicalize(dir).await.ok();

--- a/src-tauri/src/commands/api_agents/skills/tests.rs
+++ b/src-tauri/src/commands/api_agents/skills/tests.rs
@@ -119,6 +119,29 @@ async fn load_skill_bodies_always_includes_vibe_team_via_bundle() {
 }
 
 #[tokio::test]
+async fn load_selected_skill_bodies_excludes_vibe_team() {
+    // prompt-file 注入用ローダは vibe-team を強制同梱しない (standalone への混入回避, Issue #1125)。
+    let dir = tempfile::tempdir().unwrap();
+    write_skill(dir.path(), "my-skill", "---\nname: Mine\ndescription: d\n---\nhello body").await;
+    let skills =
+        load_selected_skill_bodies_from(dir.path(), &["my-skill".to_string()]).await;
+    assert!(skills.iter().any(|s| s.id == "my-skill"));
+    assert!(
+        !skills.iter().any(|s| s.id == VIBE_TEAM_SKILL_ID),
+        "selected loader must not auto-inject vibe-team"
+    );
+}
+
+#[tokio::test]
+async fn load_selected_skill_bodies_includes_vibe_team_only_when_requested() {
+    // 明示的に vibe-team を選んだ場合はバンドル本文へフォールバックして返す。
+    let dir = tempfile::tempdir().unwrap();
+    let skills =
+        load_selected_skill_bodies_from(dir.path(), &[VIBE_TEAM_SKILL_ID.to_string()]).await;
+    assert!(skills.iter().any(|s| s.id == VIBE_TEAM_SKILL_ID));
+}
+
+#[tokio::test]
 async fn load_skill_bodies_reads_disk_skill_and_rejects_traversal() {
     let dir = tempfile::tempdir().unwrap();
     write_skill(dir.path(), "my-skill", "---\nname: Mine\ndescription: d\n---\nhello body").await;

--- a/src-tauri/src/commands/api_agents/types.rs
+++ b/src-tauri/src/commands/api_agents/types.rs
@@ -113,6 +113,18 @@ pub struct ApiAgentSkillMeta {
     pub description: String,
 }
 
+/// skill 本文込みの IPC 表現。`api_agent_skill_load_bodies` が renderer へ返す (Issue #1125)。
+/// CLI エージェントの prompt-file 注入 (codex の `model_instructions_file` 等) で、renderer が
+/// 本文を system prompt に前置するために使う。内部表現の `ApiAgentSkill` とは別に持ち、
+/// vibe-team の強制同梱はせず「選択された skill だけ」を返す。
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiAgentSkillBody {
+    pub id: String,
+    pub name: String,
+    pub body: String,
+}
+
 /// import 元 (Claude / Codex) の skill メタ。`api_agent_skill_sources_list` が返す (Issue #1017)。
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -229,7 +229,7 @@ pub struct AgentConfig {
     /// 定義レベルの既定 skill 群 (Phase4)。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_skill_ids: Option<Vec<String>>,
-    /// skill 注入方式 ('claude-dir' | 'append-flag' | 'prompt-file' | 'none', Phase4)。
+    /// skill 注入方式 ('claude-dir' | 'prompt-file' | 'none', Phase4 / Issue #1125)。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skill_injection: Option<String>,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -285,6 +285,7 @@ pub fn run() {
             commands::api_agents::skills::api_agent_skill_import,
             commands::api_agents::skills::api_agent_skill_remove,
             commands::api_agents::skills::api_agent_skill_apply_to_project,
+            commands::api_agents::skills::api_agent_skill_load_bodies,
             commands::api_agents::models::api_agent_list_models,
         ])
         .setup(|app| {

--- a/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
+++ b/src/renderer/src/components/canvas/cards/AgentNodeCard/CardFrame.tsx
@@ -59,6 +59,7 @@ import { parseShellArgs } from '../../../../lib/parse-args';
 import { resolveAgentConfig } from '../../../../lib/agent-resolver';
 import { resolveAgentDescriptor } from '../../../../lib/agent-registry';
 import type { AgentEngine } from '../../../../../../types/shared';
+import { useSkillInjection } from '../../../../lib/use-skill-injection';
 import { useToast } from '../../../../lib/toast-context';
 import {
   deriveCardSummary,
@@ -126,18 +127,10 @@ function AgentNodeCardImpl({
     return () => clearActivity(id);
   }, [id, clearActivity]);
 
-  // Issue #1121 (Phase5): skillInjection==='claude-dir' の CLI エージェントは mount 時に
-  // 既定 skill (defaultSkillIds) をプロジェクトの .claude/skills へ best-effort で materialize
-  // する。claude/codex は起動時に .claude/skills を自動探索するため、手動「適用」なしに skill が
-  // 効く。書き込みは idempotent (内容一致なら no-op)、失敗は warn のみで起動は継続する。
-  useEffect(() => {
-    if (agentDescriptor.skillInjection !== 'claude-dir') return;
-    const ids = agentDescriptor.defaultSkillIds;
-    if (!ids || ids.length === 0) return;
-    void window.api.apiAgents
-      .applySkillsToProject(ids)
-      .catch((e) => console.warn('[agent-card] skill materialize failed:', e));
-  }, [agentDescriptor.skillInjection, agentDescriptor.defaultSkillIds]);
+  // Issue #1121 / #1125: skill 注入 (claude-dir = .claude/skills へ materialize /
+  // prompt-file = 本文を preamble 化) は `useSkillInjection` hook に集約。prompt-file 経路の
+  // preamble を受け取り、下で team ロール prompt と結合して instructions にする。
+  const skillPreamble = useSkillInjection(agentDescriptor);
 
   // Issue #23 + カスタムエージェント対応:
   // agent-resolver 経由で built-in (claude/codex) + customAgents のコマンド/引数/cwd を解決する。
@@ -279,8 +272,16 @@ function AgentNodeCardImpl({
     settings.codexArgs
   ]);
 
-  const claudeInstructions = isClaude ? sysPrompt : undefined;
-  const codexInstructions = isCodex ? sysPrompt : undefined;
+  // Issue #1125: skill 本文 (prompt-file 注入) と team ロール prompt を結合して instructions とする。
+  // claude は通常 claude-dir のため skillPreamble は空 (materialize 経路) で、二重注入は起きない。
+  const instructions = useMemo(() => {
+    const parts = [skillPreamble, sysPrompt]
+      .map((s) => (s ?? '').trim())
+      .filter((s) => s.length > 0);
+    return parts.length > 0 ? parts.join('\n\n') : undefined;
+  }, [skillPreamble, sysPrompt]);
+  const claudeInstructions = isClaude ? instructions : undefined;
+  const codexInstructions = isCodex ? instructions : undefined;
 
   // ---------- Issue #509: 未読 inbox 数の event-driven 集計 ----------
   //

--- a/src/renderer/src/lib/__tests__/agent-registry.test.ts
+++ b/src/renderer/src/lib/__tests__/agent-registry.test.ts
@@ -58,7 +58,7 @@ describe('agent-registry', () => {
     expect(claude.kind).toBe('builtin');
     expect(claude.skillInjection).toBe('claude-dir');
     expect(codex.engine).toBe('codex');
-    expect(codex.skillInjection).toBe('none');
+    expect(codex.skillInjection).toBe('prompt-file');
   });
 
   it('engineForAgentConfig respects cli engine, defaults to claude, treats api as claude', () => {
@@ -77,8 +77,8 @@ describe('agent-registry', () => {
     expect(d.accentColor).toBe('#abcdef');
     expect(d.tags).toEqual(['exp']);
     expect(d.command).toBe('mycli');
-    // engine codex かつ skillInjection 未指定 → engine 既定 'none'
-    expect(d.skillInjection).toBe('none');
+    // engine codex かつ skillInjection 未指定 → engine 既定 'prompt-file' (Issue #1125)
+    expect(d.skillInjection).toBe('prompt-file');
   });
 
   it('customAgentDescriptor fills defaults for a plain cli agent', () => {
@@ -102,7 +102,7 @@ describe('agent-registry', () => {
 
   it('defaultSkillInjectionForEngine maps engine to injection default', () => {
     expect(defaultSkillInjectionForEngine('claude')).toBe('claude-dir');
-    expect(defaultSkillInjectionForEngine('codex')).toBe('none');
+    expect(defaultSkillInjectionForEngine('codex')).toBe('prompt-file');
   });
 
   it('resolveAgentDescriptor resolves by agentConfigId then engine fallback', () => {

--- a/src/renderer/src/lib/__tests__/use-skill-injection.test.ts
+++ b/src/renderer/src/lib/__tests__/use-skill-injection.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { buildSkillPreamble } from '../use-skill-injection';
+import type { ApiAgentSkillBody } from '../../../../types/shared';
+
+describe('buildSkillPreamble', () => {
+  it('returns empty string for no skills', () => {
+    expect(buildSkillPreamble([])).toBe('');
+  });
+
+  it('formats each skill with a "## Skill: name (id)" header and trimmed body', () => {
+    const skills: ApiAgentSkillBody[] = [
+      { id: 'alpha', name: 'Alpha', body: '  hello body  \n' },
+      { id: 'beta', name: 'Beta', body: 'second' }
+    ];
+    expect(buildSkillPreamble(skills)).toBe(
+      '## Skill: Alpha (alpha)\nhello body\n\n## Skill: Beta (beta)\nsecond'
+    );
+  });
+});

--- a/src/renderer/src/lib/agent-registry.ts
+++ b/src/renderer/src/lib/agent-registry.ts
@@ -74,9 +74,13 @@ const BUILTIN_AGENT_META: BuiltinAgentMeta[] = [
   { id: 'codex', engine: 'codex', displayName: 'Codex', icon: 'Terminal' }
 ];
 
-/** engine ごとの skill 注入の既定 (Phase4)。claude は .claude/skills 自動探索が効くので materialize。 */
+/**
+ * engine ごとの skill 注入の既定 (Phase4 / Issue #1125)。
+ *  - claude: `.claude/skills` 自動探索が効くので materialize ('claude-dir')。
+ *  - codex : 自動探索しないため、skill 本文を `model_instructions_file` に前置注入 ('prompt-file')。
+ */
 export function defaultSkillInjectionForEngine(engine: AgentEngine): AgentSkillInjection {
-  return engine === 'claude' ? 'claude-dir' : 'none';
+  return engine === 'claude' ? 'claude-dir' : 'prompt-file';
 }
 
 /** runtime ごとのアイコン既定 (custom がアイコン未指定のとき)。 */

--- a/src/renderer/src/lib/tauri-api/api-agents.ts
+++ b/src/renderer/src/lib/tauri-api/api-agents.ts
@@ -10,6 +10,7 @@ import type {
   ApiAgentSendResult,
   ApiAgentSession,
   ApiAgentSessionCreateRequest,
+  ApiAgentSkillBody,
   ApiAgentSkillMeta,
   ApiAgentSkillSource,
   ApiAgentStreamEvent,
@@ -45,6 +46,9 @@ export const apiAgents = {
   /** Issue #1119: 選択 skill を現在のプロジェクトの .claude/skills へ materialize する。 */
   applySkillsToProject: (skillIds: string[]): Promise<SkillApplyResult[]> =>
     invokeCommand('api_agent_skill_apply_to_project', { skillIds }),
+  /** Issue #1125: 選択 skill の本文を読み込む (prompt-file 注入用、vibe-team は同梱しない)。 */
+  loadSkillBodies: (skillIds: string[]): Promise<ApiAgentSkillBody[]> =>
+    invokeCommand('api_agent_skill_load_bodies', { skillIds }),
   events: (sessionId: string) => ({
     onDeltaReady: (cb: (event: ApiAgentStreamEvent) => void): Promise<() => void> =>
       subscribeEventReady<ApiAgentStreamEvent>(`api-agent:delta:${sessionId}`, cb),

--- a/src/renderer/src/lib/use-skill-injection.ts
+++ b/src/renderer/src/lib/use-skill-injection.ts
@@ -1,0 +1,75 @@
+/**
+ * use-skill-injection — CLI エージェントの skill 注入を司る hook (Issue #1125)。
+ *
+ * AgentNodeCard / CardFrame から skill 注入ロジックを切り出したもの (god-file 回避)。
+ * `skillInjection` の capability に応じて 2 経路を扱う:
+ *   - 'claude-dir'  : mount 時に既定 skill をプロジェクトの .claude/skills へ best-effort で
+ *                     materialize する。claude/codex は起動時に .claude/skills を自動探索する
+ *                     ため、手動「適用」なしに skill が効く。書き込みは idempotent。
+ *   - 'prompt-file' : 選択 skill の本文を読み込み、戻り値の preamble として返す。呼び出し側は
+ *                     これを system prompt に前置し、temp ファイル経由 (codex の
+ *                     model_instructions_file / claude の append-system-prompt-file) で渡す。
+ *                     codex は .claude/skills を自動探索しないため、この経路でのみ skill が効く。
+ *   - 'none'        : 何もしない (preamble は空文字)。
+ *
+ * いずれも mount 時 best-effort で、失敗は warn に留めて起動を妨げない。ユーザー起動の
+ * 「プロジェクトに適用」(設定エディタ) は別途トーストで結果を返すため、ここでは通知しない
+ * (全カード mount でのトースト連発を避ける)。
+ */
+import { useEffect, useMemo, useState } from 'react';
+import type { AgentSkillInjection, ApiAgentSkillBody } from '../../../types/shared';
+
+/** prompt-file 注入用に skill 本文を system prompt セクションへ整形する。
+ *  Rust 側 `build_skills_context` と同じ `## Skill: name (id)` 見出し形式に揃え、LLM が
+ *  読む内容なので UI 言語に依存しない固定見出しを使う。 */
+export function buildSkillPreamble(skills: ApiAgentSkillBody[]): string {
+  if (skills.length === 0) return '';
+  return skills.map((s) => `## Skill: ${s.name} (${s.id})\n${s.body.trim()}`).join('\n\n');
+}
+
+interface SkillInjectionInput {
+  skillInjection: AgentSkillInjection;
+  defaultSkillIds: string[];
+}
+
+/**
+ * descriptor の skill 注入を実行し、prompt-file 経路の preamble (空なら '') を返す。
+ * claude-dir 経路は副作用 (materialize) のみで preamble は空。
+ */
+export function useSkillInjection(input: SkillInjectionInput): string {
+  const { skillInjection, defaultSkillIds } = input;
+
+  // claude-dir: mount 時に .claude/skills へ materialize (best-effort, idempotent)。
+  useEffect(() => {
+    if (skillInjection !== 'claude-dir') return;
+    if (!defaultSkillIds || defaultSkillIds.length === 0) return;
+    void window.api.apiAgents
+      .applySkillsToProject(defaultSkillIds)
+      .catch((e) => console.warn('[agent-card] skill materialize failed:', e));
+  }, [skillInjection, defaultSkillIds]);
+
+  // prompt-file: 選択 skill の本文を読み込み preamble 化する。
+  const [skillBodies, setSkillBodies] = useState<ApiAgentSkillBody[]>([]);
+  useEffect(() => {
+    if (skillInjection !== 'prompt-file' || !defaultSkillIds || defaultSkillIds.length === 0) {
+      setSkillBodies([]);
+      return;
+    }
+    let cancelled = false;
+    void window.api.apiAgents
+      .loadSkillBodies(defaultSkillIds)
+      .then((skills) => {
+        if (!cancelled) setSkillBodies(skills);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setSkillBodies([]);
+        console.warn('[agent-card] skill body load failed:', e);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [skillInjection, defaultSkillIds]);
+
+  return useMemo(() => buildSkillPreamble(skillBodies), [skillBodies]);
+}

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -65,13 +65,17 @@ export type AgentRuntime = 'cli' | 'api';
 export type AgentEngine = 'claude' | 'codex';
 
 /**
- * CLI agent に skill (.claude/skills/<id>/SKILL.md) をどう効かせるか (Issue #1113 Phase4)。
+ * CLI agent に skill (.claude/skills/<id>/SKILL.md) をどう効かせるか (Issue #1113 Phase4 / #1125)。
  *  - 'claude-dir'  : 起動前にプロジェクトの .claude/skills へ materialize し CLI の自動探索に任せる
- *  - 'append-flag' : 起動引数 (--append-system-prompt 相当) に skill 本文を連結注入
- *  - 'prompt-file' : 一時ファイル化して system-prompt-file 系フラグへ渡す
- *  - 'none'        : skill 注入を行わない (default)
+ *                    (claude エンジン既定)
+ *  - 'prompt-file' : skill 本文を system prompt に前置し、一時ファイル経由で起動フラグへ渡す
+ *                    (codex の `--config model_instructions_file=` / claude の
+ *                    `--append-system-prompt-file`)。codex エンジン既定。
+ *  - 'none'        : skill 注入を行わない (注入手段が不明な custom CLI 等)
+ *
+ * Issue #1125: 到達不能だった 'append-flag' を撤去し、全モードが配線済み・有意になるよう整理した。
  */
-export type AgentSkillInjection = 'claude-dir' | 'append-flag' | 'prompt-file' | 'none';
+export type AgentSkillInjection = 'claude-dir' | 'prompt-file' | 'none';
 
 export interface AgentConfigBase {
   id: string;
@@ -553,6 +557,17 @@ export interface ApiAgentSkillMeta {
   id: string;
   name: string;
   description: string;
+}
+
+/**
+ * skill 本文込みの表現。`api_agent_skill_load_bodies` が選択 skill の本文を返す (Issue #1125)。
+ * CLI エージェントの prompt-file 注入で、renderer が本文を system prompt へ前置するために使う。
+ * `load_skill_bodies` (API 経路) と異なり vibe-team は強制同梱しない。
+ */
+export interface ApiAgentSkillBody {
+  id: string;
+  name: string;
+  body: string;
 }
 
 /** import 元の種別 (Issue #1017)。 */


### PR DESCRIPTION
## Summary
Skill 注入 capability のうち **配線されていたのは `claude-dir` のみ** で、`prompt-file` / `append-flag` は型に存在するが到達不能 (死蔵) だった。結果 **codex エンジンのエージェントは skill が一切効かない** 状態。本 PR で `prompt-file` を end-to-end で配線し、死蔵 `append-flag` を撤去して、全モードが配線済み・有意になるよう整理する。

Closes #1125

## 何を変えたか
- **`api_agent_skill_load_bodies` コマンド新設** — 選択 skill の本文 (`ApiAgentSkillBody { id, name, body }`) を renderer へ返す。API 経路の `load_skill_bodies` と異なり **vibe-team を強制同梱しない** ため、standalone (非チーム) エージェントに TeamHub プロトコルが混入しない。
- **`defaultSkillInjectionForEngine(codex)` → `'prompt-file'`** — codex は `.claude/skills` を自動探索しないため、skill 本文を system prompt へ前置し、既存の一時ファイル経路 (`--config model_instructions_file=` / `--append-system-prompt-file`) で渡す。Rust 側の注入機構は新設不要。
- **`useSkillInjection` hook に切り出し** — CardFrame から skill 注入ロジック (claude-dir materialize + prompt-file 本文ロード + preamble 整形) を分離 (god-file 回避)。preamble を team ロール prompt と結合して instructions へ前置。claude は通常 claude-dir のため preamble は空で二重注入しない。
- **`append-flag` を撤去** — `AgentSkillInjection` を 3 モード (`'claude-dir' | 'prompt-file' | 'none'`) に整理。

## 設計メモ
- `prompt-file` の instruction filing は command-gate (`is_codex_command` / claude command) のため、実体が codex/claude CLI のときに効く。注入手段が不明な custom CLI は `none` が正 (従来どおり)。本 PR は **codex で skill が効く** 状態を新規に成立させるもので、既存挙動の後退はない。
- 背景の mount 時自動注入は best-effort で失敗は `console.warn` に留める (全カード mount でのトースト連発回避)。ユーザー起動の「プロジェクトに適用」は従来どおりトーストで結果を返す。
- 分割不可の additive 変更 (`shared.ts` = 型定義 SSOT、`lib.rs` = コマンド登録) のみ file-size baseline を +15 / +1 引き上げ。

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run` (494 passed — 新規 2 件含む)
- [x] `cargo test`(`load_selected_skill_bodies_*` 2 件 green) / `cargo check --all-targets`
- [x] `npm run lint:file-size` OK / eslint 0 errors
- [ ] `npm run dev` で codex カスタムエージェントに skill を選択 → 起動時に system prompt へ届くことを実機確認