### PR TITLE
feat(settings): #1127 追加ウィザードに skill 選択ステップを追加

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -38,7 +38,7 @@
   "src/renderer/src/layouts/CanvasLayout.tsx": 1010,
   "src/renderer/src/lib/hooks/use-file-tabs.ts": 517,
   "src/renderer/src/lib/hooks/use-xterm-bind.ts": 889,
-  "src/renderer/src/lib/i18n.ts": 1935,
+  "src/renderer/src/lib/i18n.ts": 1943,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
   "src/renderer/src/stores/canvas.ts": 588,
   "src/types/shared.ts": 1959

--- a/src/renderer/src/components/settings/AgentWizard.tsx
+++ b/src/renderer/src/components/settings/AgentWizard.tsx
@@ -10,12 +10,13 @@
  * 完成した AgentConfig は `onCreate` で親 (SettingsModal) に渡し、customAgents へ append する。
  * 表示は自己完結した `agent-wizard.css` を使い、入力欄は共通の `modal__*` クラスを流用する。
  */
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   API_AGENT_PROVIDER_PRESETS,
   type AgentConfig,
   type AgentEngine,
-  type ApiAgentProviderId
+  type ApiAgentProviderId,
+  type ApiAgentSkillMeta
 } from '../../../../types/shared';
 import { useT } from '../../lib/i18n';
 import { useToast } from '../../lib/toast-context';
@@ -27,8 +28,8 @@ interface Props {
 }
 
 type Runtime = 'api' | 'cli';
-type StepId = 'type' | 'configure' | 'appearance' | 'review';
-const STEPS: StepId[] = ['type', 'configure', 'appearance', 'review'];
+type StepId = 'type' | 'configure' | 'appearance' | 'skills' | 'review';
+const STEPS: StepId[] = ['type', 'configure', 'appearance', 'skills', 'review'];
 
 const ICON_SUGGESTIONS = ['Sparkles', 'Terminal', 'Bot', 'Boxes', 'Cloud', 'Cpu', 'Rocket', 'Wrench'];
 
@@ -56,6 +57,27 @@ export function AgentWizard({ onCreate, onCancel }: Props): JSX.Element {
   const [icon, setIcon] = useState('');
   const [color, setColor] = useState('');
   const [tagsRaw, setTagsRaw] = useState('');
+  // skills (Issue #1127): import 済み skill を列挙して複数選択する。
+  const [availableSkills, setAvailableSkills] = useState<ApiAgentSkillMeta[]>([]);
+  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    void window.api.apiAgents
+      .listSkills()
+      .then((s) => {
+        if (!cancelled) setAvailableSkills(s);
+      })
+      .catch(() => {
+        if (!cancelled) setAvailableSkills([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  const toggleSkill = (id: string): void =>
+    setSelectedSkillIds((cur) =>
+      cur.includes(id) ? cur.filter((x) => x !== id) : [...cur, id]
+    );
 
   const step = STEPS[stepIdx];
   const provider = useMemo(
@@ -95,16 +117,28 @@ export function AgentWizard({ onCreate, onCancel }: Props): JSX.Element {
       icon: icon.trim() || undefined,
       tags: tags.length ? tags : undefined
     };
+    const skillIds = selectedSkillIds.length ? selectedSkillIds : undefined;
     if (runtime === 'api') {
       return {
         ...base,
         runtime: 'api',
         providerId,
         model: model.trim(),
-        toolMode: provider.supportsTools ? 'auto' : 'readOnly'
+        toolMode: provider.supportsTools ? 'auto' : 'readOnly',
+        // API agent は skillIds を system prompt に注入する。
+        skillIds
       };
     }
-    return { ...base, runtime: 'cli', command: command.trim(), args: args.trim(), cwd: '', engine };
+    // CLI agent は defaultSkillIds を起動時に注入 (engine 既定の skillInjection 経由)。
+    return {
+      ...base,
+      runtime: 'cli',
+      command: command.trim(),
+      args: args.trim(),
+      cwd: '',
+      engine,
+      defaultSkillIds: skillIds
+    };
   };
 
   const handleCreate = async (): Promise<void> => {
@@ -281,6 +315,29 @@ export function AgentWizard({ onCreate, onCancel }: Props): JSX.Element {
             </>
           )}
 
+          {step === 'skills' && (
+            <>
+              <p className="modal__note">{t('settings.agentWizard.skillsHint')}</p>
+              {availableSkills.length === 0 ? (
+                <p className="modal__note">{t('settings.customAgents.skillsEmpty')}</p>
+              ) : (
+                <div className="custom-agent__skills">
+                  {availableSkills.map((s) => (
+                    <label key={s.id} className="custom-agent__skill" title={s.description}>
+                      <input
+                        type="checkbox"
+                        checked={selectedSkillIds.includes(s.id)}
+                        onChange={() => toggleSkill(s.id)}
+                        aria-label={s.name}
+                      />
+                      <span className="custom-agent__skill-name">{s.name}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+
           {step === 'review' && (
             <div className="agent-wizard__review">
               <p className="modal__note">{t('settings.agentWizard.reviewSummary')}</p>
@@ -315,6 +372,10 @@ export function AgentWizard({ onCreate, onCancel }: Props): JSX.Element {
                     </li>
                   </>
                 )}
+                <li>
+                  {t('settings.agentWizard.skills')}:{' '}
+                  <strong>{selectedSkillIds.length}</strong>
+                </li>
               </ul>
             </div>
           )}

--- a/src/renderer/src/components/settings/CliAgentSkillsField.tsx
+++ b/src/renderer/src/components/settings/CliAgentSkillsField.tsx
@@ -29,6 +29,7 @@ export function CliAgentSkillsField({
   const t = useT();
   const { showToast } = useToast();
   const [filter, setFilter] = useState('');
+  const [busy, setBusy] = useState(false);
 
   const matches = (s: ApiAgentSkillMeta): boolean => {
     const needle = filter.trim().toLowerCase();
@@ -42,6 +43,8 @@ export function CliAgentSkillsField({
       showToast(t('settings.customAgents.applySkillsEmpty'), { tone: 'info' });
       return;
     }
+    // Issue #1127: 適用中は二重起動を防ぐ。
+    setBusy(true);
     try {
       const res = await window.api.apiAgents.applySkillsToProject(ids);
       const applied = res.filter((r) => r.status === 'created' || r.status === 'updated').length;
@@ -55,6 +58,8 @@ export function CliAgentSkillsField({
         tone: 'error',
         duration: 8000
       });
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -79,13 +84,16 @@ export function CliAgentSkillsField({
                   type="checkbox"
                   checked={(agent.defaultSkillIds ?? []).includes(skill.id)}
                   onChange={() => onToggle(skill.id)}
+                  aria-label={skill.name}
                 />
                 <span className="custom-agent__skill-name">{skill.name}</span>
               </label>
             ))}
           </div>
-          <button type="button" className="toolbar__btn" onClick={apply}>
-            {t('settings.customAgents.applySkills')}
+          <button type="button" className="toolbar__btn" onClick={apply} disabled={busy}>
+            {busy
+              ? t('settings.customAgents.applySkillsBusy')
+              : t('settings.customAgents.applySkills')}
           </button>
         </>
       )}

--- a/src/renderer/src/lib/i18n.ts
+++ b/src/renderer/src/lib/i18n.ts
@@ -785,6 +785,9 @@ const ja: Dict = {
   'settings.agentWizard.typeCli': 'CLI コマンド',
   'settings.agentWizard.typeCliDesc': 'ターミナルで動く CLI エージェント (claude/codex 互換)',
   'settings.agentWizard.apiKeyOptional': 'API キー (任意・後で設定可)',
+  'settings.agentWizard.skills': 'Skill',
+  'settings.agentWizard.skillsHint':
+    '起動時に効かせる skill を選択します (任意)。未 import の場合は設定の Skill セクションから取り込めます。',
   'settings.agentWizard.reviewSummary': '以下の内容で作成します',
   'settings.agentWizard.next': '次へ',
   'settings.agentWizard.back': '戻る',
@@ -828,6 +831,7 @@ const ja: Dict = {
   'settings.customAgents.skillsAutoTeam': 'TeamHub 参加時は vibe-team skill が自動で追加されます。',
   'settings.customAgents.skillSearch': 'skill を検索',
   'settings.customAgents.applySkills': 'プロジェクトに適用',
+  'settings.customAgents.applySkillsBusy': '適用中…',
   'settings.customAgents.applySkillsEmpty': '適用する skill が選択されていません。',
   'settings.customAgents.applySkillsDone':
     '{count}/{total} 件の skill を .claude/skills に適用しました。',
@@ -1724,6 +1728,9 @@ const en: Dict = {
   'settings.agentWizard.typeCli': 'CLI command',
   'settings.agentWizard.typeCliDesc': 'A CLI agent that runs in a terminal (claude/codex compatible)',
   'settings.agentWizard.apiKeyOptional': 'API key (optional — can set later)',
+  'settings.agentWizard.skills': 'Skills',
+  'settings.agentWizard.skillsHint':
+    'Select skills to apply at launch (optional). Import more from the Skill section in settings.',
   'settings.agentWizard.reviewSummary': 'Will create with:',
   'settings.agentWizard.next': 'Next',
   'settings.agentWizard.back': 'Back',
@@ -1768,6 +1775,7 @@ const en: Dict = {
     'The vibe-team skill is added automatically when joining TeamHub.',
   'settings.customAgents.skillSearch': 'Search skills',
   'settings.customAgents.applySkills': 'Apply to project',
+  'settings.customAgents.applySkillsBusy': 'Applying…',
   'settings.customAgents.applySkillsEmpty': 'No skills selected to apply.',
   'settings.customAgents.applySkillsDone': 'Applied {count}/{total} skills to .claude/skills.',
   'settings.customAgents.applySkillsError': 'Failed to apply skills: {detail}',


### PR DESCRIPTION
## Summary
エージェント追加ウィザード (#1123) には skill 選択が無く、生成されたエージェントは **skill が空** のまま作られていた (後から設定エディタで手動追加が必要)。主動線がウィザードに一本化された今、ここで skill を設定できるようにする。

Closes #1127

## 何を変えたか
- **AgentWizard に `skills` ステップを追加** — `appearance` の後・`review` の前。`api_agent_skill_list()` で import 済み skill を列挙し複数選択。
  - CLI runtime → `defaultSkillIds` に反映 (engine 既定の skillInjection 経由で起動時注入)。
  - API runtime → `skillIds` に反映 (system prompt 注入)。
  - skill 0 件のときは空状態メッセージで import セクションへ誘導。
  - review にも選択数を表示。
- **`CliAgentSkillsField` の「適用」ボタンに busy 状態** — 処理中は `disabled` + ラベルを「適用中…」にして二重起動を防止。
- **チェックボックスに `aria-label`** (ウィザード / エディタ双方)。
- i18n (ja/en): `agentWizard.skills` / `agentWizard.skillsHint` / `customAgents.applySkillsBusy`。

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run` (492 passed)
- [x] `npm run lint:file-size` OK (i18n.ts のみ additive baseline +8) / eslint 0 problems
- [ ] `npm run dev` でウィザードから skill を選択 → 生成エージェントに反映されることを実機確認