### PR TITLE
ci: #1134 cargo audit の quick-xml advisory 2 件を ignore に追加 (verify 全 PR ブロック解除)

### DIFF
--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -1,5 +1,10 @@
 [advisories]
 ignore = [
+  # quick-xml (plist -> tauri の transitive)。fix は >=0.41 だが plist は最新 1.9.0 でも
+  # ^0.39.2 要求で追従不能 (Issue #1134)。DoS 系 2 件で、外部 XML を食わせる経路は無い。
+  # plist / tauri が quick-xml >=0.41 に移行したら ignore を外して版上げすること。
+  "RUSTSEC-2026-0194", # quick-xml: duplicate attribute check の quadratic run time
+  "RUSTSEC-2026-0195", # quick-xml: NsReader の unbounded namespace allocation (DoS)
   "RUSTSEC-2024-0413", # atk: gtk-rs GTK3 (wry/tauri 側の移行待ち)
   "RUSTSEC-2024-0416", # atk-sys: gtk-rs GTK3
   "RUSTSEC-2025-0057", # fxhash: selectors -> kuchikiki -> tauri-utils


### PR DESCRIPTION
## Summary
- Closes #1134
- CI `verify` の cargo audit が quick-xml 0.38.4 の RUSTSEC-2026-0194 / RUSTSEC-2026-0195 (いずれも DoS 系) で fail し、全 PR の verify をブロックしていた (PR #1132 / #1133 で観測)。
- quick-xml は plist → tauri 経由の transitive で、fix 版は >=0.41.0。plist は最新 1.9.0 でも `quick-xml ^0.39.2` 要求のため、`cargo update` / `[patch]` では解消不能 (crates.io で確認済み)。上流 (plist → tauri) の移行待ち。
- 既存の gtk-rs GTK3 系 advisory と同じ運用で、`src-tauri/.cargo/audit.toml` に理由コメント + 解除条件付きで ignore を追加。
- リスク評価: quick-xml は tauri が plist (property list) の XML パースに使用。vibe-editor に外部から悪意ある XML を食わせる経路は無く、DoS advisory の実害は低い。

## Test plan
- [x] audit.toml の構文は既存 entry と同型 (コメント + ID 追記のみ)
- [ ] CI の `verify` job (cargo audit ステップ) が green になること