### PR TITLE
fix(renderer): #1136 再選択時の未保存編集を保持

### DIFF
--- a/src/renderer/src/lib/hooks/__tests__/use-file-tabs.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-file-tabs.test.tsx
@@ -1,0 +1,147 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FileReadResult } from '../../../../../types/shared';
+import { useFileTabs, type UseFileTabsOptions } from '../use-file-tabs';
+
+vi.mock('../../i18n', () => ({
+  useT: () => (key: string) => key
+}));
+
+vi.mock('../../use-native-confirm', () => ({
+  useNativeConfirm: () => vi.fn(async () => true)
+}));
+
+type TestWindow = Window &
+  typeof globalThis & {
+    api?: MockApi;
+  };
+
+interface MockApi {
+  files: {
+    read: ReturnType<typeof vi.fn>;
+  };
+}
+
+function fileReadResult(path: string, content: string): FileReadResult {
+  return {
+    ok: true,
+    path,
+    content,
+    isBinary: false,
+    encoding: 'utf-8',
+    mtimeMs: 1,
+    sizeBytes: content.length,
+    contentHash: `hash:${content}`
+  };
+}
+
+function installApi(): MockApi {
+  const api: MockApi = {
+    files: {
+      read: vi.fn(async (_rootPath: string, relPath: string) =>
+        fileReadResult(relPath, 'disk content')
+      )
+    }
+  };
+  (window as TestWindow).api = api;
+  return api;
+}
+
+function options(overrides: Partial<UseFileTabsOptions> = {}): UseFileTabsOptions {
+  return {
+    projectRoot: '/workspace/a',
+    refreshGit: vi.fn(async () => undefined),
+    gitStatus: null,
+    showToast: vi.fn(),
+    ...overrides
+  };
+}
+
+describe('useFileTabs.openEditorTab', () => {
+  let originalApi: MockApi | undefined;
+
+  beforeEach(() => {
+    originalApi = (window as TestWindow).api;
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (originalApi === undefined) {
+      delete (window as TestWindow).api;
+    } else {
+      (window as TestWindow).api = originalApi;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('新規ファイルを1回だけ読み込んでタブを作成する', async () => {
+    const api = installApi();
+    const { result } = renderHook(() => useFileTabs(options()));
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(1);
+    expect(api.files.read).toHaveBeenCalledWith('/workspace/a', 'src/file.ts');
+    expect(result.current.editorTabs).toHaveLength(1);
+    expect(result.current.editorTabs[0]).toMatchObject({
+      rootPath: '/workspace/a',
+      relPath: 'src/file.ts',
+      content: 'disk content',
+      originalContent: 'disk content',
+      loading: false
+    });
+  });
+
+  it('dirtyな既存タブの再選択では再読込せず編集内容を保持する', async () => {
+    const api = installApi();
+    const { result } = renderHook(() => useFileTabs(options()));
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+
+    const tabId = result.current.editorTabs[0]!.id;
+    act(() => {
+      result.current.updateEditorContent(tabId, 'unsaved edit');
+    });
+    api.files.read.mockResolvedValueOnce(
+      fileReadResult('src/file.ts', 'changed disk content')
+    );
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(1);
+    expect(result.current.activeTabId).toBe(tabId);
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'unsaved edit',
+      originalContent: 'disk content'
+    });
+    expect(result.current.dirtyEditorTabs.map((tab) => tab.id)).toEqual([tabId]);
+    expect(result.current.recentFiles).toEqual([
+      { rootPath: '/workspace/a', relPath: 'src/file.ts' }
+    ]);
+  });
+
+  it('別rootの同一relPathは別タブとしてそれぞれ読み込む', async () => {
+    const api = installApi();
+    const { result } = renderHook(() => useFileTabs(options()));
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+      await result.current.openEditorTab('/workspace/b', 'src/file.ts');
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(2);
+    expect(api.files.read).toHaveBeenNthCalledWith(1, '/workspace/a', 'src/file.ts');
+    expect(api.files.read).toHaveBeenNthCalledWith(2, '/workspace/b', 'src/file.ts');
+    expect(result.current.editorTabs.map((tab) => tab.rootPath)).toEqual([
+      '/workspace/a',
+      '/workspace/b'
+    ]);
+    expect(result.current.editorTabs[0]!.id).not.toBe(result.current.editorTabs[1]!.id);
+  });
+});

--- a/src/renderer/src/lib/hooks/use-file-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-file-tabs.ts
@@ -253,13 +253,14 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
       // Issue #4: 同じ相対パスが別ルートに存在しうるので id に root も混ぜる
       const id = `edit:${effectiveRoot}\u0001${relPath}`;
       setActiveTabId(id);
-      // Issue #480: 最近開いたファイル履歴を更新 (先頭へ移動、上限制限)
+      // Issue #480/#1136: active/recent は更新するが、既存タブの内容は再読込しない
       setRecentFiles((prev) => {
         const filtered = prev.filter(
           (entry) => !(entry.rootPath === effectiveRoot && entry.relPath === relPath)
         );
         return [{ rootPath: effectiveRoot, relPath }, ...filtered].slice(0, RECENT_FILES_LIMIT);
       });
+      if (editorTabs.some((tab) => tab.id === id)) return;
       setEditorTabs((prev) => {
         if (prev.some((t) => t.id === id)) return prev;
         return [
@@ -316,9 +317,8 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
         );
       }
     },
-    [t]
+    [editorTabs, t]
   );
-
   const updateEditorContent = useCallback((id: string, content: string) => {
     setEditorTabs((prev) =>
       prev.map((t) => (t.id === id ? { ...t, content } : t))


### PR DESCRIPTION
## Summary
- 既存の editor tab を再選択した場合、active tab と recent files の更新後に処理を終了し、disk read を行わないように変更
- 未保存の `content` / `originalContent` と dirty 状態を保持し、ファイルツリー・最近開いたファイルの共通経路でのデータ消失を防止
- 新規 open、dirty tab 再選択、別 workspace root の同一相対パスを hook 回帰テストで固定

Closes #1136

## Test plan
- [x] 修正前テストで既存 tab 再選択時の `files.read` 2回目を再現
- [x] `npx vitest run src/renderer/src/lib/hooks/__tests__/use-file-tabs.test.tsx` (3 tests)
- [x] `npm test` (84 files / 500 tests)
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors、既存 warning 11件)
- [x] `npm run lint:file-size`
- [x] `npm run build:vite`
- [ ] Phase B: `npm run dev` でツリー再クリック・最近開いたファイル再クリック時の内容/dirty marker保持を確認
