### PR TITLE
fix(rust): #1181 Rust 1.97 Clippy lintを解消

### DIFF
--- a/src-tauri/src/commands/files/encoding.rs
+++ b/src-tauri/src/commands/files/encoding.rs
@@ -170,10 +170,8 @@ fn utf32_decode(bytes: &[u8], little_endian: bool) -> Option<String> {
         } else {
             u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]])
         };
-        match char::from_u32(u) {
-            Some(c) => out.push(c),
-            None => return None,
-        }
+        let c = char::from_u32(u)?;
+        out.push(c);
     }
     Some(out)
 }
@@ -197,6 +195,46 @@ mod detect_tests {
         assert!(!bin);
         assert_eq!(content, "hi");
         assert_eq!(enc, "utf-16le");
+    }
+
+    #[test]
+    fn utf32_le_with_bom_is_text() {
+        // "Aあ" in UTF-32 LE with BOM
+        let bytes = [
+            0xFF, 0xFE, 0x00, 0x00, 0x41, 0x00, 0x00, 0x00, 0x42, 0x30, 0x00, 0x00,
+        ];
+        let (bin, content, enc) = detect_text_or_binary(&bytes);
+        assert!(!bin);
+        assert_eq!(content, "Aあ");
+        assert_eq!(enc, "utf-32le");
+    }
+
+    #[test]
+    fn utf32_be_with_bom_is_text() {
+        // "Aあ" in UTF-32 BE with BOM
+        let bytes = [
+            0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, 0x41, 0x00, 0x00, 0x30, 0x42,
+        ];
+        let (bin, content, enc) = detect_text_or_binary(&bytes);
+        assert!(!bin);
+        assert_eq!(content, "Aあ");
+        assert_eq!(enc, "utf-32be");
+    }
+
+    #[test]
+    fn utf32_invalid_scalars_are_binary() {
+        let invalid_bodies = [
+            [0x00, 0xD8, 0x00, 0x00], // surrogate U+D800
+            [0x00, 0x00, 0x11, 0x00], // out of range U+110000
+        ];
+
+        for body in invalid_bodies {
+            let bytes = [0xFF, 0xFE, 0x00, 0x00, body[0], body[1], body[2], body[3]];
+            let (bin, content, enc) = detect_text_or_binary(&bytes);
+            assert!(bin);
+            assert!(content.is_empty());
+            assert_eq!(enc, "binary");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `utf32_decode` の手書き `Option` 分岐を、挙動を保ったまま Rust 1.97 の `clippy::question_mark` に準拠する `?` へ置換
- UTF-32 LE/BE の正常 decode と、surrogate・範囲外 scalar の binary fallback を回帰テストで固定
- Rust stable / `-D warnings` / CI workflow / `Cargo.lock` は変更せず、原因箇所だけを修正

Closes #1181

## Root Cause Confirmed
- 修正前証拠: [Actions run 29089194874](https://github.com/yusei531642/vibe-editor/actions/runs/29089194874) で Rust 1.97.0 の Linux `verify`、Windows/macOS `cargo-cfg` がすべて `src-tauri/src/commands/files/encoding.rs:173` の同一 lint で失敗
- 原因: `stable` 追従で新たに有効化された `clippy::question_mark` が `-D warnings` により error 化
- 修正接続: `None => return None` と等価な `char::from_u32(u)?` へ最小置換

## Test plan
- [x] `rustfmt +1.97.0 --check --edition 2021 src-tauri/src/commands/files/encoding.rs`
- [x] `cargo +1.97.0 check --locked --manifest-path src-tauri/Cargo.toml --all-targets`
- [x] `cargo +1.97.0 clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- [x] UTF-32 対象テスト 7 件（追加した LE/BE/無効 scalar を含む）
- [x] `cargo +1.97.0 test --locked --manifest-path src-tauri/Cargo.toml`（874 passed）
- [x] `npm run typecheck`
- [x] Tier C 多角レビュー: Lane 0 / Lane 4 = 2/2、`critical_open=0`
- [ ] PR Actions の Linux `verify` と Windows/macOS `cargo-cfg` が成功

注: 全体の `cargo +1.97.0 fmt --check` は `origin/main` と同一の既存未整形 77 ファイルで失敗します。今回変更した `encoding.rs` 単体の rustfmt は成功し、既存未整形ファイルには差分を加えていません。
