### PR TITLE
fix(renderer): #1136 ファイル再選択の回帰を修正

### DIFF
--- a/src/renderer/src/lib/hooks/__tests__/use-file-tabs.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-file-tabs.test.tsx
@@ -19,9 +19,21 @@ type TestWindow = Window &
 interface MockApi {
   files: {
     read: ReturnType<typeof vi.fn>;
+    write: ReturnType<typeof vi.fn>;
   };
 }
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
 function fileReadResult(path: string, content: string): FileReadResult {
   return {
     ok: true,
@@ -35,12 +47,26 @@ function fileReadResult(path: string, content: string): FileReadResult {
   };
 }
 
+function fileReadError(path: string, error: string): FileReadResult {
+  return {
+    ...fileReadResult(path, ''),
+    ok: false,
+    error
+  };
+}
+
 function installApi(): MockApi {
   const api: MockApi = {
     files: {
       read: vi.fn(async (_rootPath: string, relPath: string) =>
         fileReadResult(relPath, 'disk content')
-      )
+      ),
+      write: vi.fn(async (_rootPath: string, _relPath: string, content: string) => ({
+        ok: true,
+        mtimeMs: 2,
+        sizeBytes: content.length,
+        contentHash: `saved:${content}`
+      }))
     }
   };
   (window as TestWindow).api = api;
@@ -94,15 +120,16 @@ describe('useFileTabs.openEditorTab', () => {
     });
   });
 
-  it('dirtyな既存タブの再選択では再読込せず編集内容を保持する', async () => {
+  it('別タブからdirtyな既存タブを再選択するとactive化してrecent先頭へ移し、編集内容を保持する', async () => {
     const api = installApi();
     const { result } = renderHook(() => useFileTabs(options()));
 
     await act(async () => {
       await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+      await result.current.openEditorTab('/workspace/a', 'src/other.ts');
     });
 
-    const tabId = result.current.editorTabs[0]!.id;
+    const tabId = result.current.editorTabs.find((tab) => tab.relPath === 'src/file.ts')!.id;
     act(() => {
       result.current.updateEditorContent(tabId, 'unsaved edit');
     });
@@ -114,16 +141,341 @@ describe('useFileTabs.openEditorTab', () => {
       await result.current.openEditorTab('/workspace/a', 'src/file.ts');
     });
 
-    expect(api.files.read).toHaveBeenCalledTimes(1);
+    expect(api.files.read).toHaveBeenCalledTimes(2);
     expect(result.current.activeTabId).toBe(tabId);
-    expect(result.current.editorTabs[0]).toMatchObject({
+    expect(result.current.editorTabs.find((tab) => tab.id === tabId)).toMatchObject({
       content: 'unsaved edit',
       originalContent: 'disk content'
     });
     expect(result.current.dirtyEditorTabs.map((tab) => tab.id)).toEqual([tabId]);
     expect(result.current.recentFiles).toEqual([
-      { rootPath: '/workspace/a', relPath: 'src/file.ts' }
+      { rootPath: '/workspace/a', relPath: 'src/file.ts' },
+      { rootPath: '/workspace/a', relPath: 'src/other.ts' }
     ]);
+  });
+
+  it('loading中の既存タブを再選択してもreadを重複実行しない', async () => {
+    const api = installApi();
+    const pendingRead = deferred<FileReadResult>();
+    api.files.read.mockReturnValueOnce(pendingRead.promise);
+    const { result } = renderHook(() => useFileTabs(options()));
+    let firstOpen!: Promise<void>;
+
+    await act(async () => {
+      firstOpen = result.current.openEditorTab('/workspace/a', 'src/file.ts');
+      await Promise.resolve();
+    });
+
+    expect(result.current.editorTabs[0]).toMatchObject({ loading: true, error: null });
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(1);
+
+    pendingRead.resolve(fileReadResult('src/file.ts', 'loaded once'));
+    await act(async () => {
+      await firstOpen;
+    });
+
+    expect(result.current.editorTabs[0]).toMatchObject({
+      loading: false,
+      content: 'loaded once',
+      originalContent: 'loaded once'
+    });
+  });
+
+  it('cleanな既存タブの再選択ではディスク内容を再読込する', async () => {
+    const api = installApi();
+    api.files.read
+      .mockResolvedValueOnce(fileReadResult('src/file.ts', 'initial disk content'))
+      .mockResolvedValueOnce(fileReadResult('src/file.ts', 'external disk change'));
+    const { result } = renderHook(() => useFileTabs(options()));
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(2);
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'external disk change',
+      originalContent: 'external disk change',
+      error: null
+    });
+  });
+
+  it('clean再読込のerrorでは既存内容を保持し、再選択するとreadを再試行する', async () => {
+    const api = installApi();
+    api.files.read
+      .mockResolvedValueOnce(fileReadResult('src/file.ts', 'initial disk content'))
+      .mockResolvedValueOnce(fileReadError('src/file.ts', 'temporary read failure'))
+      .mockResolvedValueOnce(fileReadResult('src/file.ts', 'recovered content'))
+      .mockResolvedValueOnce(fileReadResult('src/file.ts', 'later disk content'));
+    const { result } = renderHook(() => useFileTabs(options()));
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'initial disk content',
+      originalContent: 'initial disk content',
+      contentHash: 'hash:initial disk content',
+      loading: false,
+      error: 'temporary read failure'
+    });
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(3);
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'recovered content',
+      originalContent: 'recovered content',
+      loading: false,
+      error: null
+    });
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(4);
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'later disk content',
+      originalContent: 'later disk content',
+      error: null
+    });
+  });
+
+  it('readがthrowしても次の再選択で再試行できる', async () => {
+    const api = installApi();
+    api.files.read
+      .mockRejectedValueOnce(new Error('IPC unavailable'))
+      .mockResolvedValueOnce(fileReadResult('src/file.ts', 'recovered after throw'));
+    const { result } = renderHook(() => useFileTabs(options()));
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+    expect(result.current.editorTabs[0]).toMatchObject({
+      loading: false,
+      error: 'Error: IPC unavailable'
+    });
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(2);
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'recovered after throw',
+      originalContent: 'recovered after throw',
+      error: null
+    });
+  });
+
+  it('同一render内の並行openを1回のreadへ集約する', async () => {
+    const api = installApi();
+    const pendingRead = deferred<FileReadResult>();
+    api.files.read
+      .mockReturnValueOnce(pendingRead.promise)
+      .mockResolvedValueOnce(fileReadResult('src/file.ts', 'unexpected second response'));
+    const { result } = renderHook(() => useFileTabs(options()));
+    let firstOpen!: Promise<void>;
+    let secondOpen!: Promise<void>;
+
+    await act(async () => {
+      firstOpen = result.current.openEditorTab('/workspace/a', 'src/file.ts');
+      secondOpen = result.current.openEditorTab('/workspace/a', 'src/file.ts');
+      await secondOpen;
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(1);
+    expect(result.current.editorTabs).toHaveLength(1);
+
+    pendingRead.resolve(fileReadResult('src/file.ts', 'authoritative response'));
+    await act(async () => {
+      await firstOpen;
+    });
+
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'authoritative response',
+      originalContent: 'authoritative response',
+      loading: false,
+      error: null
+    });
+  });
+
+  it('clean再読込の待機中に編集された場合は応答でdirty内容を上書きしない', async () => {
+    const api = installApi();
+    const pendingReload = deferred<FileReadResult>();
+    api.files.read
+      .mockResolvedValueOnce(fileReadResult('src/file.ts', 'initial content'))
+      .mockReturnValueOnce(pendingReload.promise);
+    const { result } = renderHook(() => useFileTabs(options()));
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+    const tabId = result.current.editorTabs[0]!.id;
+    let reload!: Promise<void>;
+
+    await act(async () => {
+      reload = result.current.openEditorTab('/workspace/a', 'src/file.ts');
+      await Promise.resolve();
+    });
+    act(() => {
+      result.current.updateEditorContent(tabId, 'edit while reload is pending');
+    });
+
+    pendingReload.resolve(fileReadResult('src/file.ts', 'late disk response'));
+    await act(async () => {
+      await reload;
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(2);
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'edit while reload is pending',
+      originalContent: 'initial content',
+      loading: false,
+      error: null
+    });
+    expect(result.current.dirtyEditorTabs.map((tab) => tab.id)).toEqual([tabId]);
+  });
+
+  it('clean再読込の待機中に編集・保存しても古い応答で保存済み内容を上書きしない', async () => {
+    const api = installApi();
+    const pendingReload = deferred<FileReadResult>();
+    api.files.read
+      .mockResolvedValueOnce(fileReadResult('src/file.ts', 'initial content'))
+      .mockReturnValueOnce(pendingReload.promise);
+    const { result } = renderHook(() => useFileTabs(options()));
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+    const tabId = result.current.editorTabs[0]!.id;
+    let reload!: Promise<void>;
+
+    await act(async () => {
+      reload = result.current.openEditorTab('/workspace/a', 'src/file.ts');
+      await Promise.resolve();
+    });
+    act(() => {
+      result.current.updateEditorContent(tabId, 'saved while reload is pending');
+    });
+    await act(async () => {
+      await result.current.saveEditorTab(tabId);
+    });
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'saved while reload is pending',
+      originalContent: 'saved while reload is pending',
+      contentHash: 'saved:saved while reload is pending'
+    });
+
+    pendingReload.resolve(fileReadResult('src/file.ts', 'stale disk response'));
+    await act(async () => {
+      await reload;
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(2);
+    expect(api.files.write).toHaveBeenCalledTimes(1);
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'saved while reload is pending',
+      originalContent: 'saved while reload is pending',
+      contentHash: 'saved:saved while reload is pending',
+      error: null
+    });
+  });
+
+  it('read中に閉じて同じファイルを再度開いてもplaceholderを復元しreadを重複しない', async () => {
+    const api = installApi();
+    const pendingRead = deferred<FileReadResult>();
+    api.files.read.mockReturnValueOnce(pendingRead.promise);
+    const { result } = renderHook(() => useFileTabs(options()));
+    let firstOpen!: Promise<void>;
+
+    await act(async () => {
+      firstOpen = result.current.openEditorTab('/workspace/a', 'src/file.ts');
+      await Promise.resolve();
+    });
+    const tabId = result.current.editorTabs[0]!.id;
+
+    await act(async () => {
+      await result.current.closeTab(tabId);
+    });
+    expect(result.current.editorTabs).toHaveLength(0);
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(1);
+    expect(result.current.activeTabId).toBe(tabId);
+    expect(result.current.editorTabs).toHaveLength(1);
+    expect(result.current.editorTabs[0]).toMatchObject({
+      id: tabId,
+      loading: true,
+      error: null
+    });
+
+    pendingRead.resolve(fileReadResult('src/file.ts', 'reopened content'));
+    await act(async () => {
+      await firstOpen;
+    });
+
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'reopened content',
+      originalContent: 'reopened content',
+      loading: false,
+      error: null
+    });
+  });
+
+  it('project reset前の古いread応答を同じidの新しいタブへ適用しない', async () => {
+    const api = installApi();
+    const staleRead = deferred<FileReadResult>();
+    api.files.read
+      .mockReturnValueOnce(staleRead.promise)
+      .mockResolvedValueOnce(fileReadResult('src/file.ts', 'fresh project content'));
+    const { result } = renderHook(() => useFileTabs(options()));
+    let oldOpen!: Promise<void>;
+
+    await act(async () => {
+      oldOpen = result.current.openEditorTab('/workspace/a', 'src/file.ts');
+      await Promise.resolve();
+    });
+    act(() => {
+      result.current.resetForProjectSwitch();
+    });
+
+    await act(async () => {
+      await result.current.openEditorTab('/workspace/a', 'src/file.ts');
+    });
+
+    expect(api.files.read).toHaveBeenCalledTimes(2);
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'fresh project content',
+      originalContent: 'fresh project content'
+    });
+
+    staleRead.resolve(fileReadResult('src/file.ts', 'stale project content'));
+    await act(async () => {
+      await oldOpen;
+    });
+
+    expect(result.current.editorTabs[0]).toMatchObject({
+      content: 'fresh project content',
+      originalContent: 'fresh project content'
+    });
   });
 
   it('別rootの同一relPathは別タブとしてそれぞれ読み込む', async () => {

--- a/src/renderer/src/lib/hooks/file-tab-state.ts
+++ b/src/renderer/src/lib/hooks/file-tab-state.ts
@@ -1,0 +1,68 @@
+import type { FileReadResult } from '../../../../types/shared';
+import type { EditorTab } from './use-file-tabs';
+
+export interface EditorTabReadSnapshot {
+  content: string;
+  originalContent: string;
+}
+
+export function createLoadingEditorTab(
+  id: string,
+  rootPath: string,
+  relPath: string
+): EditorTab {
+  return {
+    id,
+    rootPath,
+    relPath,
+    content: '',
+    originalContent: '',
+    isBinary: false,
+    lossyEncoding: false,
+    encoding: 'utf-8',
+    loading: true,
+    error: null,
+    pinned: false
+  };
+}
+
+function matchesReadSnapshot(tab: EditorTab, snapshot: EditorTabReadSnapshot): boolean {
+  return (
+    tab.content === snapshot.content && tab.originalContent === snapshot.originalContent
+  );
+}
+
+export function applyEditorTabReadResult(
+  tab: EditorTab,
+  result: FileReadResult,
+  lossyEncoding: boolean,
+  snapshot: EditorTabReadSnapshot
+): EditorTab {
+  if (!matchesReadSnapshot(tab, snapshot)) return tab;
+  if (!result.ok) {
+    return { ...tab, loading: false, error: result.error ?? 'error' };
+  }
+  return {
+    ...tab,
+    loading: false,
+    error: null,
+    content: result.content,
+    originalContent: result.content,
+    isBinary: result.isBinary,
+    lossyEncoding,
+    encoding: result.encoding || 'utf-8',
+    mtimeMs: result.mtimeMs,
+    sizeBytes: result.sizeBytes,
+    contentHash: result.contentHash
+  };
+}
+
+export function applyEditorTabReadError(
+  tab: EditorTab,
+  error: unknown,
+  snapshot: EditorTabReadSnapshot
+): EditorTab {
+  return matchesReadSnapshot(tab, snapshot)
+    ? { ...tab, loading: false, error: String(error) }
+    : tab;
+}

--- a/src/renderer/src/lib/hooks/use-file-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-file-tabs.ts
@@ -6,6 +6,11 @@ import type {
 } from '../../../../types/shared';
 import { useT } from '../i18n';
 import { useNativeConfirm } from '../use-native-confirm';
+import {
+  applyEditorTabReadError,
+  applyEditorTabReadResult,
+  createLoadingEditorTab
+} from './file-tab-state';
 
 export interface DiffTab {
   id: string;
@@ -131,7 +136,7 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
 
   const optsRef = useRef(opts);
   optsRef.current = opts;
-
+  const editorReadTokensRef = useRef<Map<string, symbol>>(new Map());
   // tabs: diff タブと editor タブを並立させ、id プレフィックスで判別する
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
   const [diffTabs, setDiffTabs] = useState<DiffTab[]>([]);
@@ -253,35 +258,36 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
       // Issue #4: 同じ相対パスが別ルートに存在しうるので id に root も混ぜる
       const id = `edit:${effectiveRoot}\u0001${relPath}`;
       setActiveTabId(id);
-      // Issue #480/#1136: active/recent は更新するが、既存タブの内容は再読込しない
+      // Issue #480/#1136: 再選択時も active/recent は必ず更新する
       setRecentFiles((prev) => {
         const filtered = prev.filter(
           (entry) => !(entry.rootPath === effectiveRoot && entry.relPath === relPath)
         );
         return [{ rootPath: effectiveRoot, relPath }, ...filtered].slice(0, RECENT_FILES_LIMIT);
       });
-      if (editorTabs.some((tab) => tab.id === id)) return;
-      setEditorTabs((prev) => {
-        if (prev.some((t) => t.id === id)) return prev;
-        return [
-          ...prev,
-          {
-            id,
-            rootPath: effectiveRoot,
-            relPath,
-            content: '',
-            originalContent: '',
-            isBinary: false,
-            lossyEncoding: false,
-            encoding: 'utf-8',
-            loading: true,
-            error: null,
-            pinned: false
-          }
-        ];
-      });
+      const existingTab = editorTabs.find((tab) => tab.id === id);
+      const isDirty = Boolean(
+        existingTab && !existingTab.isBinary && existingTab.content !== existingTab.originalContent
+      );
+      const readSnapshot = {
+        content: existingTab?.content ?? '',
+        originalContent: existingTab?.originalContent ?? ''
+      };
+      // 未保存編集と進行中の読込は保持する。clean/error は従来どおり再読込・再試行する。
+      if (existingTab?.loading || isDirty) return;
+      // in-flight 中にタブが閉じられていた場合も、再選択で表示先を復元する。
+      setEditorTabs((prev) =>
+        prev.some((tab) => tab.id === id)
+          ? prev
+          : [...prev, createLoadingEditorTab(id, effectiveRoot, relPath)]
+      );
+      // 同一 render 内では editorTabs の closure が更新されないため、ref で二重 read を防ぐ。
+      if (editorReadTokensRef.current.has(id)) return;
+      const requestToken = Symbol(id);
+      editorReadTokensRef.current.set(id, requestToken);
       try {
         const res = await window.api.files.read(effectiveRoot, relPath);
+        if (editorReadTokensRef.current.get(id) !== requestToken) return;
         const lossy = res.encoding === 'lossy';
         // Issue #35: lossy 読み込み時はユーザーに明示的に通知する
         if (lossy) {
@@ -292,29 +298,20 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
         }
         setEditorTabs((prev) =>
           prev.map((tab) =>
-            tab.id === id
-              ? {
-                  ...tab,
-                  loading: false,
-                  error: res.ok ? null : res.error ?? 'error',
-                  content: res.content,
-                  originalContent: res.content,
-                  isBinary: res.isBinary,
-                  lossyEncoding: lossy,
-                  encoding: res.encoding || 'utf-8',
-                  mtimeMs: res.mtimeMs,
-                  sizeBytes: res.sizeBytes,
-                  contentHash: res.contentHash
-                }
-              : tab
+            tab.id === id ? applyEditorTabReadResult(tab, res, lossy, readSnapshot) : tab
           )
         );
       } catch (err) {
+        if (editorReadTokensRef.current.get(id) !== requestToken) return;
         setEditorTabs((prev) =>
           prev.map((tab) =>
-            tab.id === id ? { ...tab, loading: false, error: String(err) } : tab
+            tab.id === id ? applyEditorTabReadError(tab, err, readSnapshot) : tab
           )
         );
+      } finally {
+        if (editorReadTokensRef.current.get(id) === requestToken) {
+          editorReadTokensRef.current.delete(id);
+        }
       }
     },
     [editorTabs, t]
@@ -484,6 +481,7 @@ export function useFileTabs(opts: UseFileTabsOptions): UseFileTabsResult {
   );
 
   const resetForProjectSwitch = useCallback(() => {
+    editorReadTokensRef.current.clear();
     setDiffTabs([]);
     setEditorTabs([]);
     setRecentlyClosed([]);


### PR DESCRIPTION
## Summary
- PR #1180 のフォローアップとして、dirty/loading の既存タブだけを短絡し、clean reload と error retry を復旧
- request token と read 開始時 snapshot で同一renderの二重read、遅い応答、project reset跨ぎのstale応答を防止
- active tab / recent files 順序、multi-root/new file、reload中の編集・保存を含む12経路をhookテストで固定

Preceding PR: #1180

## Root cause
- PR #1180 の全existing tab早期returnがclean/error経路も遮断していた
- React state closureだけでは同一renderの並行openを識別できず、遅いread応答が新しい状態を上書きできた

## Test plan
- [x] focused hook test: 12/12 PASS
- [x] full test: 84 files / 509 tests PASS
- [x] `npm run typecheck`
- [x] `npm run lint`（0 errors、既存warning 11件）
- [x] `npm run lint:file-size`
- [x] `npm run build:vite`
- [x] `git diff --check origin/main...HEAD`
- [x] Tier C review: Lane 0 + Lane 4 = 2/2、critical_open=0

Closes #1136