### PR TITLE
ci: #1162 main pushの品質ゲートを復旧

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: ci
 
 on:
   push:
+    branches:
+      - main
     tags-ignore:
       - 'v*'
   pull_request:


### PR DESCRIPTION
## Summary

- CI workflowのbranch push対象を `main` のみに明示します。
- 現行の `tags-ignore` のみの設定ではGitHub Actions公式仕様上branch pushが全て対象外となり、PR merge後を含むmain更新時のCIが起動していませんでした。
- `pull_request`、`v*` tag除外、concurrency、`verify` / `cargo-cfg` / `secrets-scan` の構成は維持します。

Closes #1162

## RCA

- GitHub APIで `ci.yml` の `event=push` runが0件であることを確認しました。
- GitHub公式仕様ではtag filterだけを定義すると、未定義側のbranch refイベントではworkflowが実行されません。
- 原因行へ `push.branches: [main]` を追加する最小修正です。

## Event matrix

- feature branch push: CIなし
- pull_request open / synchronize / reopen: CIあり
- main branch push: CIあり
- `v*` tag push: CIなし
- 非 `v*` tag push: 従来どおりCIあり

## Test plan

- [x] actionlint 1.7.12
- [x] YAML parse・trigger/job構造・イベント行列検証
- [x] `npm run typecheck`
- [x] `npm run lint`（error 0、既存warning 11）
- [x] 全lint guard
- [x] `npm test -- --run`（84 files / 509 tests）
- [x] `npm run build:vite`
- [x] `git diff --check`
- [ ] PR runが `pull_request` 1セットだけ作成されることを確認
- [ ] bot merge後、同じmerge commitに対するmain `push` runが1セット作成されることを確認
