### PR TITLE
fix(security): スキル導入のリンク越境を防止

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +411,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
 ]
 
 [[package]]
@@ -1184,6 +1208,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2001,6 +2036,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,6 +2414,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -3719,6 +3782,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -5532,6 +5605,7 @@ dependencies = [
  "assert_matches",
  "base64 0.22.1",
  "bytes",
+ "cap-primitives",
  "chrono",
  "dirs",
  "encoding_rs",
@@ -6437,6 +6511,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.11.1",
  "windows-sys 0.59.0",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,7 +35,7 @@ notify = "8"
 # --- error / logging ---
 anyhow = "1"
 # Issue #1186: 認可済み project root の directory handle から相対 I/O だけを行い、
-# 子 symlink / junction / reparse と検査後差替えによる越境を防ぐ。高水準の cap-std
+# 子 symlink / junction / reparse と検査後差し替えによる越境を防ぐ。高水準の cap-std
 # wrapper は不要なので、必要な openat 相当 primitive だけを完全固定で直接利用する。
 cap-primitives = "=4.0.2"
 tracing = "0.1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,10 @@ notify = "8"
 
 # --- error / logging ---
 anyhow = "1"
+# Issue #1186: 認可済み project root の directory handle から相対 I/O だけを行い、
+# 子 symlink / junction / reparse と検査後差替えによる越境を防ぐ。高水準の cap-std
+# wrapper は不要なので、必要な openat 相当 primitive だけを完全固定で直接利用する。
+cap-primitives = "=4.0.2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Issue #326: 設定モーダルからログを閲覧できるように、stderr に加えて
@@ -86,6 +90,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Pipes",
     "Win32_System_Threading",
     "Win32_Security",
+    "Win32_Storage_FileSystem",
     # Issue #950: PTY child の kill-on-close Job Object
     "Win32_System_JobObjects",
 ] }

--- a/src-tauri/src/commands/vibe_team_skill.rs
+++ b/src-tauri/src/commands/vibe_team_skill.rs
@@ -22,6 +22,8 @@ use std::path::{Path, PathBuf};
 use tauri::State;
 use tokio::fs;
 
+mod secure_install;
+
 /// Skill ファイル本文の現行バージョン。SKILL.md 先頭に埋め込んでおき、
 /// Rust 側がファイルを見たときに「ユーザーが手で編集したか / 古いバンドル版か」を判別できるようにする。
 const SKILL_VERSION: &str = "1.6.5";
@@ -114,6 +116,13 @@ async fn install_skill_at(root: &Path, force: bool) -> InstallSkillResult {
                 "project_root is not a directory: {}",
                 root.display()
             )),
+            ..Default::default()
+        };
+    }
+    if let Err(error) = secure_install::open_skill_dir(root) {
+        return InstallSkillResult {
+            ok: false,
+            error: Some(format!("secure skill directory open failed: {error}")),
             ..Default::default()
         };
     }
@@ -344,6 +353,34 @@ mod tests {
         assert_eq!(
             parse_skill_version("<!-- vibe-team-skill-version: 1.6 -->"),
             None
+        );
+    }
+
+    /// Issue #1186: 認可済み root 配下でも `.claude` が外部 directory への link なら、
+    /// ambient path の create/write は project 外へ到達する。installer は fail closed とし、
+    /// outside canary と書込先を一切変更してはならない。
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rejects_claude_symlink_without_outside_write() {
+        use std::os::unix::fs::symlink;
+
+        let project = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let canary = outside.path().join("canary");
+        std::fs::write(&canary, b"unchanged").unwrap();
+        symlink(outside.path(), project.path().join(".claude")).unwrap();
+
+        let result = install_skill_at(project.path(), false).await;
+
+        assert!(
+            !result.ok,
+            "linked parent must fail closed: {:?}",
+            result.error
+        );
+        assert_eq!(std::fs::read(&canary).unwrap(), b"unchanged");
+        assert!(
+            !outside.path().join("skills/vibe-team/SKILL.md").exists(),
+            "installer must not create a file outside the authorized project"
         );
     }
 

--- a/src-tauri/src/commands/vibe_team_skill.rs
+++ b/src-tauri/src/commands/vibe_team_skill.rs
@@ -15,14 +15,20 @@
 // 配置タイミング: setup_team_mcp で「実チーム」を初めて起動するときに 1 回書き出す。
 // _init / 空 team_id ではスキップする。既存ファイルを上書きするかは forceOverwrite で制御。
 
-use crate::commands::atomic_write::atomic_write;
 use crate::state::AppState;
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 use tauri::State;
+
+#[cfg(test)]
+use crate::commands::atomic_write::atomic_write;
+#[cfg(test)]
 use tokio::fs;
 
 mod secure_install;
+#[cfg(test)]
+#[path = "vibe_team_skill/secure_install_tests.rs"]
+mod secure_install_tests;
 
 /// Skill ファイル本文の現行バージョン。SKILL.md 先頭に埋め込んでおき、
 /// Rust 側がファイルを見たときに「ユーザーが手で編集したか / 古いバンドル版か」を判別できるようにする。
@@ -109,47 +115,22 @@ fn parse_semver(s: &str) -> Option<(u64, u64, u64)> {
 /// 実際の書き出し処理。境界チェックを通過した後の root を渡すこと。
 /// renderer から直接呼ばせない (state を経由した command 経由でのみ呼ばれる)。
 async fn install_skill_at(root: &Path, force: bool) -> InstallSkillResult {
-    if !root.is_dir() {
-        return InstallSkillResult {
-            ok: false,
-            error: Some(format!(
-                "project_root is not a directory: {}",
-                root.display()
-            )),
-            ..Default::default()
-        };
-    }
-    if let Err(error) = secure_install::open_skill_dir(root) {
-        return InstallSkillResult {
-            ok: false,
-            error: Some(format!("secure skill directory open failed: {error}")),
-            ..Default::default()
-        };
-    }
-    let dir = skill_dir(root);
     let path = skill_path(root);
-
     let new_text = current_skill_text();
     let header_prefix = header_line();
-    let mut overwritten = false;
-
-    if let Ok(existing) = fs::read_to_string(&path).await {
+    let root = root.to_path_buf();
+    let outcome = tokio::task::spawn_blocking(move || {
+        secure_install::install(&root, new_text.as_bytes(), |existing| {
         let starts_with_current_header = existing.starts_with(&header_prefix);
         if starts_with_current_header && existing == new_text {
-            // 内容まで完全一致 → no-op
-            return InstallSkillResult {
-                ok: true,
-                path: Some(path.to_string_lossy().into_owned()),
-                skipped: true,
-                ..Default::default()
-            };
+                    return secure_install::ExistingAction::Skip;
         }
         // Issue #1108: on-disk が bundled より「新しい」版なら、force=true でも縮退上書き
         // しない。on-disk ヘッダの版を parse して bundled SKILL_VERSION と semver 比較し、
         // disk が厳密に新しい場合だけ skip する。版が無い / 同等以下の場合は guard を
         // 素通りさせ、従来挙動 (下の force / ユーザー編集判定) を保守的に維持する。
         if let (Some(disk_ver), Some(bundled_ver)) =
-            (parse_skill_version(&existing), parse_semver(SKILL_VERSION))
+            (parse_skill_version(existing), parse_semver(SKILL_VERSION))
         {
             if disk_ver > bundled_ver {
                 // Issue #1108 / PR #1111: 縮退 skip を可観測化する。force=true は明示的な
@@ -167,37 +148,40 @@ async fn install_skill_at(root: &Path, force: bool) -> InstallSkillResult {
                         "[skill] vibe-team SKILL.md install skipped: on-disk version {disk} is newer than bundled {bundled}; preserving to avoid downgrade"
                     );
                 }
-                return InstallSkillResult {
-                    ok: true,
-                    path: Some(path.to_string_lossy().into_owned()),
-                    skipped: true,
-                    ..Default::default()
-                };
+                    return secure_install::ExistingAction::Skip;
             }
         }
         if !force && !starts_with_current_header {
-            // ユーザー編集を上書きしない
+                return secure_install::ExistingAction::Skip;
+        }
+            secure_install::ExistingAction::Replace
+        })
+    })
+    .await;
+
+    let outcome = match outcome {
+        Ok(Ok(outcome)) => outcome,
+        Ok(Err(error)) => {
             return InstallSkillResult {
-                ok: true,
-                path: Some(path.to_string_lossy().into_owned()),
-                skipped: true,
+                ok: false,
+                error: Some(format!("secure skill install failed: {error}")),
                 ..Default::default()
             };
         }
-        overwritten = true;
-    }
+        Err(_) => {
+            return InstallSkillResult {
+                ok: false,
+                error: Some("secure skill install task failed".into()),
+                ..Default::default()
+            };
+        }
+    };
 
-    if let Err(e) = fs::create_dir_all(&dir).await {
+    if outcome.skipped {
         return InstallSkillResult {
-            ok: false,
-            error: Some(format!("create_dir_all failed: {e}")),
-            ..Default::default()
-        };
-    }
-    if let Err(e) = atomic_write(&path, new_text.as_bytes()).await {
-        return InstallSkillResult {
-            ok: false,
-            error: Some(format!("atomic_write failed: {e:#}")),
+            ok: true,
+            path: Some(path.to_string_lossy().into_owned()),
+            skipped: true,
             ..Default::default()
         };
     }
@@ -205,7 +189,8 @@ async fn install_skill_at(root: &Path, force: bool) -> InstallSkillResult {
     // INFO はマスク済み path、DEBUG にだけ生 path を残す。
     tracing::info!(
         "[skill] vibe-team SKILL.md installed at {} (overwrite={overwritten})",
-        crate::util::log_redact::redact_home(&path.to_string_lossy())
+        crate::util::log_redact::redact_home(&path.to_string_lossy()),
+        overwritten = outcome.overwritten
     );
     tracing::debug!(
         "[skill] vibe-team SKILL.md installed at (raw) {}",
@@ -214,7 +199,7 @@ async fn install_skill_at(root: &Path, force: bool) -> InstallSkillResult {
     InstallSkillResult {
         ok: true,
         path: Some(path.to_string_lossy().into_owned()),
-        overwritten,
+        overwritten: outcome.overwritten,
         skipped: false,
         error: None,
     }
@@ -353,34 +338,6 @@ mod tests {
         assert_eq!(
             parse_skill_version("<!-- vibe-team-skill-version: 1.6 -->"),
             None
-        );
-    }
-
-    /// Issue #1186: 認可済み root 配下でも `.claude` が外部 directory への link なら、
-    /// ambient path の create/write は project 外へ到達する。installer は fail closed とし、
-    /// outside canary と書込先を一切変更してはならない。
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn rejects_claude_symlink_without_outside_write() {
-        use std::os::unix::fs::symlink;
-
-        let project = tempfile::tempdir().unwrap();
-        let outside = tempfile::tempdir().unwrap();
-        let canary = outside.path().join("canary");
-        std::fs::write(&canary, b"unchanged").unwrap();
-        symlink(outside.path(), project.path().join(".claude")).unwrap();
-
-        let result = install_skill_at(project.path(), false).await;
-
-        assert!(
-            !result.ok,
-            "linked parent must fail closed: {:?}",
-            result.error
-        );
-        assert_eq!(std::fs::read(&canary).unwrap(), b"unchanged");
-        assert!(
-            !outside.path().join("skills/vibe-team/SKILL.md").exists(),
-            "installer must not create a file outside the authorized project"
         );
     }
 

--- a/src-tauri/src/commands/vibe_team_skill.rs
+++ b/src-tauri/src/commands/vibe_team_skill.rs
@@ -127,13 +127,13 @@ async fn install_skill_at(root: &Path, force: bool) -> InstallSkillResult {
             }
             // Issue #1108: on-disk が bundled より「新しい」版なら、force=true でも縮退上書き
             // しない。on-disk ヘッダの版を parse して bundled SKILL_VERSION と semver 比較し、
-            // disk が厳密に新しい場合だけ skip する。版が無い / 同等以下の場合は guard を
+            // disk が厳密に新しい場合だけ skip する。版がない / 同等以下の場合は guard を
             // 素通りさせ、従来挙動 (下の force / ユーザー編集判定) を保守的に維持する。
             if let (Some(disk_ver), Some(bundled_ver)) =
                 (parse_skill_version(existing), parse_semver(SKILL_VERSION))
             {
                 if disk_ver > bundled_ver {
-                    // Issue #1108 / PR #1111: 縮退 skip を可観測化する。force=true は明示的な
+                    // Issue #1108 / PR #1111: 縮退 skip を観測可能にする。force=true は明示的な
                     // reinstall (self-heal) が newer on-disk により抑止されたケース = 潜在的な
                     // tamper / downgrade-skip なので WARN で監査可能にする。force=false は
                     // best-effort の通常スキップなので INFO に留める。skip 判定の挙動は不変。
@@ -159,24 +159,30 @@ async fn install_skill_at(root: &Path, force: bool) -> InstallSkillResult {
     })
     .await;
 
+    match outcome {
+        Ok(outcome) => map_install_result(&path, outcome),
+        Err(_) => InstallSkillResult {
+            ok: false,
+            error: Some("secure skill install task failed".into()),
+            ..Default::default()
+        },
+    }
+}
+
+fn map_install_result(
+    path: &Path,
+    outcome: std::io::Result<secure_install::InstallOutcome>,
+) -> InstallSkillResult {
     let outcome = match outcome {
-        Ok(Ok(outcome)) => outcome,
-        Ok(Err(error)) => {
+        Ok(outcome) => outcome,
+        Err(error) => {
             return InstallSkillResult {
                 ok: false,
                 error: Some(format!("secure skill install failed: {error}")),
                 ..Default::default()
             };
         }
-        Err(_) => {
-            return InstallSkillResult {
-                ok: false,
-                error: Some("secure skill install task failed".into()),
-                ..Default::default()
-            };
-        }
     };
-
     if outcome.skipped {
         return InstallSkillResult {
             ok: true,

--- a/src-tauri/src/commands/vibe_team_skill.rs
+++ b/src-tauri/src/commands/vibe_team_skill.rs
@@ -121,39 +121,39 @@ async fn install_skill_at(root: &Path, force: bool) -> InstallSkillResult {
     let root = root.to_path_buf();
     let outcome = tokio::task::spawn_blocking(move || {
         secure_install::install(&root, new_text.as_bytes(), |existing| {
-        let starts_with_current_header = existing.starts_with(&header_prefix);
-        if starts_with_current_header && existing == new_text {
-                    return secure_install::ExistingAction::Skip;
-        }
-        // Issue #1108: on-disk が bundled より「新しい」版なら、force=true でも縮退上書き
-        // しない。on-disk ヘッダの版を parse して bundled SKILL_VERSION と semver 比較し、
-        // disk が厳密に新しい場合だけ skip する。版が無い / 同等以下の場合は guard を
-        // 素通りさせ、従来挙動 (下の force / ユーザー編集判定) を保守的に維持する。
-        if let (Some(disk_ver), Some(bundled_ver)) =
-            (parse_skill_version(existing), parse_semver(SKILL_VERSION))
-        {
-            if disk_ver > bundled_ver {
-                // Issue #1108 / PR #1111: 縮退 skip を可観測化する。force=true は明示的な
-                // reinstall (self-heal) が newer on-disk により抑止されたケース = 潜在的な
-                // tamper / downgrade-skip なので WARN で監査可能にする。force=false は
-                // best-effort の通常スキップなので INFO に留める。skip 判定の挙動は不変。
-                let disk = format!("{}.{}.{}", disk_ver.0, disk_ver.1, disk_ver.2);
-                let bundled = format!("{}.{}.{}", bundled_ver.0, bundled_ver.1, bundled_ver.2);
-                if force {
-                    tracing::warn!(
-                        "[skill] vibe-team SKILL.md force install skipped: on-disk version {disk} is newer than bundled {bundled}; preserving to avoid downgrade (verify on-disk file if unexpected)"
-                    );
-                } else {
-                    tracing::info!(
-                        "[skill] vibe-team SKILL.md install skipped: on-disk version {disk} is newer than bundled {bundled}; preserving to avoid downgrade"
-                    );
-                }
-                    return secure_install::ExistingAction::Skip;
-            }
-        }
-        if !force && !starts_with_current_header {
+            let starts_with_current_header = existing.starts_with(&header_prefix);
+            if starts_with_current_header && existing == new_text {
                 return secure_install::ExistingAction::Skip;
-        }
+            }
+            // Issue #1108: on-disk が bundled より「新しい」版なら、force=true でも縮退上書き
+            // しない。on-disk ヘッダの版を parse して bundled SKILL_VERSION と semver 比較し、
+            // disk が厳密に新しい場合だけ skip する。版が無い / 同等以下の場合は guard を
+            // 素通りさせ、従来挙動 (下の force / ユーザー編集判定) を保守的に維持する。
+            if let (Some(disk_ver), Some(bundled_ver)) =
+                (parse_skill_version(existing), parse_semver(SKILL_VERSION))
+            {
+                if disk_ver > bundled_ver {
+                    // Issue #1108 / PR #1111: 縮退 skip を可観測化する。force=true は明示的な
+                    // reinstall (self-heal) が newer on-disk により抑止されたケース = 潜在的な
+                    // tamper / downgrade-skip なので WARN で監査可能にする。force=false は
+                    // best-effort の通常スキップなので INFO に留める。skip 判定の挙動は不変。
+                    let disk = format!("{}.{}.{}", disk_ver.0, disk_ver.1, disk_ver.2);
+                    let bundled = format!("{}.{}.{}", bundled_ver.0, bundled_ver.1, bundled_ver.2);
+                    if force {
+                        tracing::warn!(
+                            "[skill] vibe-team SKILL.md force install skipped: on-disk version {disk} is newer than bundled {bundled}; preserving to avoid downgrade (verify on-disk file if unexpected)"
+                        );
+                    } else {
+                        tracing::info!(
+                            "[skill] vibe-team SKILL.md install skipped: on-disk version {disk} is newer than bundled {bundled}; preserving to avoid downgrade"
+                        );
+                    }
+                    return secure_install::ExistingAction::Skip;
+                }
+            }
+            if !force && !starts_with_current_header {
+                return secure_install::ExistingAction::Skip;
+            }
             secure_install::ExistingAction::Replace
         })
     })

--- a/src-tauri/src/commands/vibe_team_skill/secure_install.rs
+++ b/src-tauri/src/commands/vibe_team_skill/secure_install.rs
@@ -152,6 +152,8 @@ fn ensure_return_path_identity(
     installed_dir: &File,
     installed_file: &File,
 ) -> io::Result<()> {
+    // A safe handle-bound write is not enough: the lexical path returned to the
+    // renderer must still identify both the same directory and the same final file.
     let returned_dir = reopen_skill_dir(root)?;
     let returned_file = open_final_regular(&returned_dir)?;
     if same_file(installed_dir, &returned_dir)? && same_file(installed_file, &returned_file)? {

--- a/src-tauri/src/commands/vibe_team_skill/secure_install.rs
+++ b/src-tauri/src/commands/vibe_team_skill/secure_install.rs
@@ -6,10 +6,79 @@
 
 use cap_primitives::fs::{self as cap_fs, DirOptions, FollowSymlinks};
 use std::fs::File;
-use std::io;
+use std::io::{self, Read, Write};
 use std::path::Path;
 
 const COMPONENTS: [&str; 3] = [".claude", "skills", "vibe-team"];
+const FINAL_NAME: &str = "SKILL.md";
+
+pub(super) enum ExistingAction {
+    Skip,
+    Replace,
+}
+
+pub(super) struct InstallOutcome {
+    pub skipped: bool,
+    pub overwritten: bool,
+}
+
+enum ExistingState {
+    Missing,
+    Text(String),
+    Unreadable,
+}
+
+pub(super) fn install<F>(
+    root: &Path,
+    contents: &[u8],
+    mut decide_existing: F,
+) -> io::Result<InstallOutcome>
+where
+    F: FnMut(&str) -> ExistingAction,
+{
+    install_with_hook(root, contents, &mut decide_existing, |_| {})
+}
+
+fn install_with_hook<F, H>(
+    root: &Path,
+    contents: &[u8],
+    decide_existing: &mut F,
+    mut hook: H,
+) -> io::Result<InstallOutcome>
+where
+    F: FnMut(&str) -> ExistingAction,
+    H: FnMut(TestHookPoint),
+{
+    let dir = open_skill_dir(root)?;
+    hook(TestHookPoint::AfterDirectoryOpen);
+    let existing = read_existing(&dir)?;
+    if let ExistingState::Text(text) = &existing {
+        if matches!(decide_existing(text), ExistingAction::Skip) {
+            return Ok(InstallOutcome {
+                skipped: true,
+                overwritten: false,
+            });
+        }
+    }
+
+    // Historical InstallSkillResult semantics only marked overwritten when
+    // read_to_string succeeded. An unreadable/non-UTF8 regular file was
+    // replaced but reported overwritten=false; preserve that public contract.
+    let overwritten = matches!(existing, ExistingState::Text(_));
+    let _ = final_entry_exists(&dir)?;
+    hook(TestHookPoint::BeforeAtomicReplace);
+    atomic_replace(&dir, contents)?;
+    Ok(InstallOutcome {
+        skipped: false,
+        overwritten,
+    })
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum TestHookPoint {
+    AfterDirectoryOpen,
+    BeforeAtomicReplace,
+}
 
 pub(super) fn open_skill_dir(root: &Path) -> io::Result<File> {
     let mut current = open_root_nofollow(root)?;
@@ -52,6 +121,114 @@ fn open_or_create_dir(parent: &File, component: &str) -> io::Result<File> {
             )
         }
     })
+}
+
+fn read_existing(dir: &File) -> io::Result<ExistingState> {
+    match cap_fs::stat(dir, Path::new(FINAL_NAME), FollowSymlinks::No) {
+        Ok(metadata) => {
+            if metadata.is_symlink() || !metadata.is_file() {
+                return Err(unsafe_final_entry());
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(ExistingState::Missing),
+        Err(error) => return Err(error),
+    }
+
+    let mut options = cap_fs::OpenOptions::new();
+    options.read(true);
+    let mut file = match cap_fs::open(dir, Path::new(FINAL_NAME), &options) {
+        Ok(file) => file,
+        Err(_) => return Ok(ExistingState::Unreadable),
+    };
+    let mut text = String::new();
+    match file.read_to_string(&mut text) {
+        Ok(_) => Ok(ExistingState::Text(text)),
+        // Preserve the previous contract: every read_to_string error skipped
+        // the content guards and proceeded to the atomic replacement path.
+        Err(_) => Ok(ExistingState::Unreadable),
+    }
+}
+
+fn final_entry_exists(dir: &File) -> io::Result<bool> {
+    match cap_fs::stat(dir, Path::new(FINAL_NAME), FollowSymlinks::No) {
+        Ok(metadata) if metadata.is_symlink() || !metadata.is_file() => Err(unsafe_final_entry()),
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+fn atomic_replace(dir: &File, contents: &[u8]) -> io::Result<()> {
+    atomic_replace_with(dir, contents, |dir, temp_path| {
+        cap_fs::rename(dir, temp_path, dir, Path::new(FINAL_NAME))
+    })
+}
+
+fn atomic_replace_with<R>(dir: &File, contents: &[u8], rename: R) -> io::Result<()>
+where
+    R: FnOnce(&File, &Path) -> io::Result<()>,
+{
+    let temp_name = format!(
+        ".{FINAL_NAME}.tmp.{}.{}",
+        std::process::id(),
+        uuid::Uuid::new_v4().simple()
+    );
+    let temp_path = Path::new(&temp_name);
+    let result = (|| {
+        let mut options = cap_fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        let mut temp = cap_fs::open(dir, temp_path, &options)?;
+        temp.write_all(contents)?;
+        temp.flush()?;
+        temp.sync_all()?;
+        drop(temp);
+
+        // Reject a statically linked final entry. If it is raced in after this
+        // check, rename replaces that directory entry without following it.
+        let _ = final_entry_exists(dir)?;
+        rename(dir, temp_path)
+    })();
+
+    if result.is_err() {
+        let _ = cap_fs::remove_file(dir, temp_path);
+    }
+    result
+}
+
+#[cfg(test)]
+pub(super) fn install_with_test_hook<F, H>(
+    root: &Path,
+    contents: &[u8],
+    mut decide_existing: F,
+    mut hook: H,
+) -> io::Result<InstallOutcome>
+where
+    F: FnMut(&str) -> ExistingAction,
+    H: FnMut(&str),
+{
+    install_with_hook(root, contents, &mut decide_existing, |point| {
+        hook(match point {
+            TestHookPoint::AfterDirectoryOpen => "after-directory-open",
+            TestHookPoint::BeforeAtomicReplace => "before-atomic-replace",
+        });
+    })
+}
+
+#[cfg(test)]
+pub(super) fn atomic_replace_with_forced_rename_failure(
+    dir: &File,
+    contents: &[u8],
+) -> io::Result<()> {
+    atomic_replace_with(dir, contents, |_, _| {
+        Err(io::Error::other("injected rename failure"))
+    })
+}
+
+fn unsafe_final_entry() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::PermissionDenied,
+        "SKILL.md is not a safe regular file",
+    )
 }
 
 #[cfg(unix)]

--- a/src-tauri/src/commands/vibe_team_skill/secure_install.rs
+++ b/src-tauri/src/commands/vibe_team_skill/secure_install.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 
 const COMPONENTS: [&str; 3] = [".claude", "skills", "vibe-team"];
 const FINAL_NAME: &str = "SKILL.md";
+static INSTALL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 pub(super) enum ExistingAction {
     Skip,
@@ -24,7 +25,7 @@ pub(super) struct InstallOutcome {
 
 enum ExistingState {
     Missing,
-    Text(String),
+    Text { text: String, file: File },
     Unreadable,
 }
 
@@ -36,6 +37,9 @@ pub(super) fn install<F>(
 where
     F: FnMut(&str) -> ExistingAction,
 {
+    let _guard = INSTALL_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     install_with_hook(root, contents, &mut decide_existing, |_| {})
 }
 
@@ -52,8 +56,9 @@ where
     let dir = open_skill_dir(root)?;
     hook(TestHookPoint::AfterDirectoryOpen);
     let existing = read_existing(&dir)?;
-    if let ExistingState::Text(text) = &existing {
+    if let ExistingState::Text { text, file } = &existing {
         if matches!(decide_existing(text), ExistingAction::Skip) {
+            ensure_return_path_identity(root, &dir, file)?;
             return Ok(InstallOutcome {
                 skipped: true,
                 overwritten: false,
@@ -64,10 +69,12 @@ where
     // Historical InstallSkillResult semantics only marked overwritten when
     // read_to_string succeeded. An unreadable/non-UTF8 regular file was
     // replaced but reported overwritten=false; preserve that public contract.
-    let overwritten = matches!(existing, ExistingState::Text(_));
+    let overwritten = matches!(existing, ExistingState::Text { .. });
     let _ = final_entry_exists(&dir)?;
     hook(TestHookPoint::BeforeAtomicReplace);
-    atomic_replace(&dir, contents)?;
+    let installed_file = atomic_replace(&dir, contents)?;
+    hook(TestHookPoint::AfterAtomicReplace);
+    ensure_return_path_identity(root, &dir, &installed_file)?;
     Ok(InstallOutcome {
         skipped: false,
         overwritten,
@@ -78,6 +85,7 @@ where
 enum TestHookPoint {
     AfterDirectoryOpen,
     BeforeAtomicReplace,
+    AfterAtomicReplace,
 }
 
 pub(super) fn open_skill_dir(root: &Path) -> io::Result<File> {
@@ -123,6 +131,70 @@ fn open_or_create_dir(parent: &File, component: &str) -> io::Result<File> {
     })
 }
 
+fn reopen_skill_dir(root: &Path) -> io::Result<File> {
+    let mut current = open_root_nofollow(root)?;
+    for component in COMPONENTS {
+        let path = Path::new(component);
+        let metadata = cap_fs::stat(&current, path, FollowSymlinks::No)?;
+        if metadata.is_symlink() || !metadata.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "returned skill path no longer identifies the installed directory",
+            ));
+        }
+        current = cap_fs::open_dir_nofollow(&current, path)?;
+    }
+    Ok(current)
+}
+
+fn ensure_return_path_identity(
+    root: &Path,
+    installed_dir: &File,
+    installed_file: &File,
+) -> io::Result<()> {
+    let returned_dir = reopen_skill_dir(root)?;
+    let returned_file = open_final_regular(&returned_dir)?;
+    if same_file(installed_dir, &returned_dir)? && same_file(installed_file, &returned_file)? {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "returned skill path no longer identifies the installed directory",
+        ))
+    }
+}
+
+#[cfg(unix)]
+fn same_file(left: &File, right: &File) -> io::Result<bool> {
+    use std::os::unix::fs::MetadataExt;
+
+    let left = left.metadata()?;
+    let right = right.metadata()?;
+    Ok(left.dev() == right.dev() && left.ino() == right.ino())
+}
+
+#[cfg(windows)]
+fn same_file(left: &File, right: &File) -> io::Result<bool> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+    };
+
+    fn identity(file: &File) -> io::Result<(u32, u64)> {
+        let mut info: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+        let ok = unsafe {
+            GetFileInformationByHandle(file.as_raw_handle() as _, std::ptr::addr_of_mut!(info))
+        };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let index = (u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow);
+        Ok((info.dwVolumeSerialNumber, index))
+    }
+
+    Ok(identity(left)? == identity(right)?)
+}
+
 fn read_existing(dir: &File) -> io::Result<ExistingState> {
     match cap_fs::stat(dir, Path::new(FINAL_NAME), FollowSymlinks::No) {
         Ok(metadata) => {
@@ -134,19 +206,60 @@ fn read_existing(dir: &File) -> io::Result<ExistingState> {
         Err(error) => return Err(error),
     }
 
-    let mut options = cap_fs::OpenOptions::new();
-    options.read(true);
+    let options = final_read_options();
     let mut file = match cap_fs::open(dir, Path::new(FINAL_NAME), &options) {
         Ok(file) => file,
         Err(_) => return Ok(ExistingState::Unreadable),
     };
+    if !is_safe_regular_file(&file.metadata()?) {
+        return Err(unsafe_final_entry());
+    }
     let mut text = String::new();
     match file.read_to_string(&mut text) {
-        Ok(_) => Ok(ExistingState::Text(text)),
+        Ok(_) => Ok(ExistingState::Text { text, file }),
         // Preserve the previous contract: every read_to_string error skipped
         // the content guards and proceeded to the atomic replacement path.
         Err(_) => Ok(ExistingState::Unreadable),
     }
+}
+
+fn final_read_options() -> cap_fs::OpenOptions {
+    let mut options = cap_fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use cap_primitives::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    #[cfg(windows)]
+    {
+        use cap_primitives::fs::OpenOptionsExt;
+        use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+    options
+}
+
+fn open_final_regular(dir: &File) -> io::Result<File> {
+    let file = cap_fs::open(dir, Path::new(FINAL_NAME), &final_read_options())?;
+    if is_safe_regular_file(&file.metadata()?) {
+        Ok(file)
+    } else {
+        Err(unsafe_final_entry())
+    }
+}
+
+#[cfg(unix)]
+fn is_safe_regular_file(metadata: &std::fs::Metadata) -> bool {
+    metadata.is_file()
+}
+
+#[cfg(windows)]
+fn is_safe_regular_file(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+    metadata.is_file() && metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT == 0
 }
 
 fn final_entry_exists(dir: &File) -> io::Result<bool> {
@@ -158,13 +271,13 @@ fn final_entry_exists(dir: &File) -> io::Result<bool> {
     }
 }
 
-fn atomic_replace(dir: &File, contents: &[u8]) -> io::Result<()> {
+fn atomic_replace(dir: &File, contents: &[u8]) -> io::Result<File> {
     atomic_replace_with(dir, contents, |dir, temp_path| {
         cap_fs::rename(dir, temp_path, dir, Path::new(FINAL_NAME))
     })
 }
 
-fn atomic_replace_with<R>(dir: &File, contents: &[u8], rename: R) -> io::Result<()>
+fn atomic_replace_with<R>(dir: &File, contents: &[u8], rename: R) -> io::Result<File>
 where
     R: FnOnce(&File, &Path) -> io::Result<()>,
 {
@@ -181,12 +294,11 @@ where
         temp.write_all(contents)?;
         temp.flush()?;
         temp.sync_all()?;
-        drop(temp);
-
         // Reject a statically linked final entry. If it is raced in after this
         // check, rename replaces that directory entry without following it.
         let _ = final_entry_exists(dir)?;
-        rename(dir, temp_path)
+        rename(dir, temp_path)?;
+        Ok(temp)
     })();
 
     if result.is_err() {
@@ -195,7 +307,7 @@ where
     result
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 pub(super) fn install_with_test_hook<F, H>(
     root: &Path,
     contents: &[u8],
@@ -210,6 +322,7 @@ where
         hook(match point {
             TestHookPoint::AfterDirectoryOpen => "after-directory-open",
             TestHookPoint::BeforeAtomicReplace => "before-atomic-replace",
+            TestHookPoint::AfterAtomicReplace => "after-atomic-replace",
         });
     })
 }
@@ -222,6 +335,7 @@ pub(super) fn atomic_replace_with_forced_rename_failure(
     atomic_replace_with(dir, contents, |_, _| {
         Err(io::Error::other("injected rename failure"))
     })
+    .map(|_| ())
 }
 
 fn unsafe_final_entry() -> io::Error {

--- a/src-tauri/src/commands/vibe_team_skill/secure_install.rs
+++ b/src-tauri/src/commands/vibe_team_skill/secure_install.rs
@@ -1,0 +1,101 @@
+//! Capability-bound filesystem primitives for vibe-team skill installation.
+//!
+//! The only ambient operation is opening the already-authorized project root with
+//! an OS no-follow directory handle. Every child lookup is relative to an open
+//! directory handle and processes exactly one fixed component.
+
+use cap_primitives::fs::{self as cap_fs, DirOptions, FollowSymlinks};
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+const COMPONENTS: [&str; 3] = [".claude", "skills", "vibe-team"];
+
+pub(super) fn open_skill_dir(root: &Path) -> io::Result<File> {
+    let mut current = open_root_nofollow(root)?;
+    for component in COMPONENTS {
+        current = open_or_create_dir(&current, component)?;
+    }
+    Ok(current)
+}
+
+fn open_or_create_dir(parent: &File, component: &str) -> io::Result<File> {
+    let path = Path::new(component);
+    match cap_fs::stat(parent, path, FollowSymlinks::No) {
+        Ok(metadata) => {
+            if metadata.is_symlink() || !metadata.is_dir() {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "skill path component is not a safe directory",
+                ));
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            match cap_fs::create_dir(parent, path, &DirOptions::new()) {
+                Ok(()) => {}
+                // Another installer may have created the component. Re-stat and
+                // no-follow open below; an attacker-created link still fails closed.
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Err(error) => return Err(error),
+    }
+
+    cap_fs::open_dir_nofollow(parent, path).map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            error
+        } else {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "skill path component could not be opened safely",
+            )
+        }
+    })
+}
+
+#[cfg(unix)]
+fn open_root_nofollow(root: &Path) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut options = std::fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    let file = options.open(root)?;
+    if !file.metadata()?.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "authorized project root is not a directory",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(windows)]
+fn open_root_nofollow(root: &Path) -> io::Result<File> {
+    use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        // Deliberately omit FILE_SHARE_DELETE so the root cannot be renamed or
+        // deleted while capability-relative lookups are in progress.
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .open(root)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_dir() || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "authorized project root is not a safe directory",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(not(any(unix, windows)))]
+compile_error!("secure skill installation requires Unix or Windows no-follow directory handles");

--- a/src-tauri/src/commands/vibe_team_skill/secure_install_tests.rs
+++ b/src-tauri/src/commands/vibe_team_skill/secure_install_tests.rs
@@ -1,0 +1,253 @@
+use super::*;
+
+fn assert_failed_without_path(result: &InstallSkillResult) {
+    assert!(!result.ok, "unsafe install unexpectedly succeeded");
+    assert!(result.path.is_none());
+    assert!(!result.skipped);
+    assert!(!result.overwritten);
+    assert!(result.error.is_some());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn rejects_each_linked_parent_without_outside_write() {
+    use std::os::unix::fs::symlink;
+
+    for position in 0..3 {
+        let project = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let canary = outside.path().join("canary");
+        std::fs::write(&canary, b"unchanged").unwrap();
+
+        let parents = [
+            project.path().join(".claude"),
+            project.path().join(".claude/skills"),
+            project.path().join(".claude/skills/vibe-team"),
+        ];
+        if let Some(parent) = parents[position].parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        symlink(outside.path(), &parents[position]).unwrap();
+
+        let result = install_skill_at(project.path(), false).await;
+        assert_failed_without_path(&result);
+        let error = result.error.as_deref().unwrap();
+        assert!(!error.contains(&project.path().to_string_lossy().to_string()));
+        assert!(!error.contains(&outside.path().to_string_lossy().to_string()));
+        assert_eq!(std::fs::read(&canary).unwrap(), b"unchanged");
+        assert!(
+            !outside.path().join("SKILL.md").exists()
+                && !outside.path().join("skills/vibe-team/SKILL.md").exists()
+        );
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn rejects_final_symlink_without_touching_outside_canary() {
+    use std::os::unix::fs::symlink;
+
+    let project = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(skill_dir(project.path())).unwrap();
+    let canary = outside.path().join("outside-skill");
+    std::fs::write(&canary, b"unchanged").unwrap();
+    symlink(&canary, skill_path(project.path())).unwrap();
+
+    let result = install_skill_at(project.path(), true).await;
+    assert_failed_without_path(&result);
+    let error = result.error.as_deref().unwrap();
+    assert!(!error.contains(&project.path().to_string_lossy().to_string()));
+    assert!(!error.contains(&outside.path().to_string_lossy().to_string()));
+    assert_eq!(std::fs::read(&canary).unwrap(), b"unchanged");
+}
+
+#[tokio::test]
+async fn new_install_then_identical_reinstall_preserves_contract() {
+    let project = tempfile::tempdir().unwrap();
+    let first = install_skill_at(project.path(), false).await;
+    assert!(first.ok && !first.skipped && !first.overwritten);
+    assert_eq!(
+        first.path.as_deref(),
+        Some(skill_path(project.path()).to_string_lossy().as_ref())
+    );
+
+    let second = install_skill_at(project.path(), false).await;
+    assert!(second.ok && second.skipped && !second.overwritten);
+    assert_eq!(
+        std::fs::read_to_string(skill_path(project.path())).unwrap(),
+        current_skill_text()
+    );
+}
+
+#[tokio::test]
+async fn rejects_non_regular_final_entry() {
+    let project = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(skill_path(project.path())).unwrap();
+    let result = install_skill_at(project.path(), true).await;
+    assert_failed_without_path(&result);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn unreadable_existing_file_keeps_historical_replace_result_shape() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let project = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(skill_dir(project.path())).unwrap();
+    std::fs::write(skill_path(project.path()), b"old").unwrap();
+    std::fs::set_permissions(
+        skill_path(project.path()),
+        std::fs::Permissions::from_mode(0o000),
+    )
+    .unwrap();
+
+    let result = install_skill_at(project.path(), true).await;
+
+    assert!(
+        result.ok,
+        "force self-heal must preserve the prior contract"
+    );
+    assert!(!result.overwritten, "historical read-error shape is false");
+    assert_eq!(
+        std::fs::read_to_string(skill_path(project.path())).unwrap(),
+        current_skill_text()
+    );
+}
+
+#[tokio::test]
+async fn concurrent_installs_are_complete_and_leave_no_temp_files() {
+    let project = tempfile::tempdir().unwrap();
+    let root = std::sync::Arc::new(project.path().to_path_buf());
+    let mut tasks = Vec::new();
+    for _ in 0..16 {
+        let root = root.clone();
+        tasks.push(tokio::spawn(
+            async move { install_skill_at(&root, true).await },
+        ));
+    }
+    for task in tasks {
+        assert!(task.await.unwrap().ok);
+    }
+
+    assert_eq!(
+        std::fs::read_to_string(skill_path(&root)).unwrap(),
+        current_skill_text()
+    );
+    let entries: Vec<_> = std::fs::read_dir(skill_dir(&root))
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    assert_eq!(entries, [std::ffi::OsString::from("SKILL.md")]);
+}
+
+#[cfg(unix)]
+#[test]
+fn parent_swap_after_open_stays_bound_to_original_directory_handles() {
+    use std::os::unix::fs::symlink;
+
+    let project = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let moved = project.path().join(".claude-open-handle");
+    let result = secure_install::install_with_test_hook(
+        project.path(),
+        b"safe body",
+        |_| secure_install::ExistingAction::Replace,
+        |point| {
+            if point == "after-directory-open" {
+                std::fs::rename(project.path().join(".claude"), &moved).unwrap();
+                symlink(outside.path(), project.path().join(".claude")).unwrap();
+            }
+        },
+    );
+
+    assert!(result.is_ok());
+    assert_eq!(
+        std::fs::read(moved.join("skills/vibe-team/SKILL.md")).unwrap(),
+        b"safe body"
+    );
+    assert!(!outside.path().join("skills/vibe-team/SKILL.md").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn final_swap_before_atomic_replace_fails_without_outside_write_or_temp_debris() {
+    use std::os::unix::fs::symlink;
+
+    let project = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(skill_dir(project.path())).unwrap();
+    std::fs::write(skill_path(project.path()), b"old").unwrap();
+    let canary = outside.path().join("canary");
+    std::fs::write(&canary, b"unchanged").unwrap();
+
+    let result = secure_install::install_with_test_hook(
+        project.path(),
+        b"new",
+        |_| secure_install::ExistingAction::Replace,
+        |point| {
+            if point == "before-atomic-replace" {
+                std::fs::remove_file(skill_path(project.path())).unwrap();
+                symlink(&canary, skill_path(project.path())).unwrap();
+            }
+        },
+    );
+
+    assert!(result.is_err());
+    assert_eq!(std::fs::read(&canary).unwrap(), b"unchanged");
+    let names: Vec<_> = std::fs::read_dir(skill_dir(project.path()))
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    assert_eq!(names, [std::ffi::OsString::from("SKILL.md")]);
+}
+
+#[test]
+fn rename_failure_preserves_old_content_and_cleans_temp() {
+    let project = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(skill_dir(project.path())).unwrap();
+    std::fs::write(skill_path(project.path()), b"old").unwrap();
+    let dir = secure_install::open_skill_dir(project.path()).unwrap();
+
+    let result = secure_install::atomic_replace_with_forced_rename_failure(&dir, b"new");
+
+    assert!(result.is_err());
+    assert_eq!(std::fs::read(skill_path(project.path())).unwrap(), b"old");
+    let names: Vec<_> = std::fs::read_dir(skill_dir(project.path()))
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    assert_eq!(names, [std::ffi::OsString::from("SKILL.md")]);
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn rejects_each_parent_directory_junction() {
+    use std::process::Command;
+
+    for position in 0..3 {
+        let project = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let parents = [
+            project.path().join(".claude"),
+            project.path().join(".claude/skills"),
+            project.path().join(".claude/skills/vibe-team"),
+        ];
+        if let Some(parent) = parents[position].parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let status = Command::new("cmd")
+            .arg("/C")
+            .arg("mklink")
+            .arg("/J")
+            .arg(&parents[position])
+            .arg(outside.path())
+            .status()
+            .unwrap();
+        assert!(status.success(), "junction fixture creation failed");
+
+        let result = install_skill_at(project.path(), false).await;
+        assert_failed_without_path(&result);
+        assert!(!outside.path().join("SKILL.md").exists());
+    }
+}

--- a/src-tauri/src/commands/vibe_team_skill/secure_install_tests.rs
+++ b/src-tauri/src/commands/vibe_team_skill/secure_install_tests.rs
@@ -161,12 +161,72 @@ fn parent_swap_after_open_stays_bound_to_original_directory_handles() {
         },
     );
 
-    assert!(result.is_ok());
+    assert!(
+        result.is_err(),
+        "a returned ambient path must not identify a different directory"
+    );
     assert_eq!(
         std::fs::read(moved.join("skills/vibe-team/SKILL.md")).unwrap(),
         b"safe body"
     );
     assert!(!outside.path().join("skills/vibe-team/SKILL.md").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn regular_to_fifo_swap_is_rejected_without_blocking() {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let _worker = std::thread::spawn(move || {
+        let project = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(skill_dir(project.path())).unwrap();
+        std::fs::write(skill_path(project.path()), b"old").unwrap();
+        let skill = skill_path(project.path());
+        let result = secure_install::install_with_test_hook(
+            project.path(),
+            b"new",
+            |_| secure_install::ExistingAction::Replace,
+            |point| {
+                if point == "after-directory-open" {
+                    std::fs::remove_file(&skill).unwrap();
+                    let path = CString::new(skill.as_os_str().as_bytes()).unwrap();
+                    let status = unsafe { libc::mkfifo(path.as_ptr(), 0o600) };
+                    assert_eq!(status, 0, "FIFO fixture creation failed");
+                }
+            },
+        );
+        let _ = sender.send(result.is_err());
+    });
+
+    let rejected = receiver
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("FIFO差し替え時も installer は5秒以内に応答する必要があります");
+    assert!(rejected, "FIFO entry must fail closed");
+}
+
+#[cfg(unix)]
+#[test]
+fn final_file_swap_after_rename_clears_top_level_returned_path() {
+    let project = tempfile::tempdir().unwrap();
+    let result = secure_install::install_with_test_hook(
+        project.path(),
+        b"installed",
+        |_| secure_install::ExistingAction::Replace,
+        |point| {
+            if point == "after-atomic-replace" {
+                std::fs::remove_file(skill_path(project.path())).unwrap();
+                std::fs::write(skill_path(project.path()), b"attacker replacement").unwrap();
+            }
+        },
+    );
+    let public = map_install_result(&skill_path(project.path()), result);
+
+    assert!(!public.ok);
+    assert!(public.path.is_none());
+    assert!(!public.skipped);
+    assert!(!public.overwritten);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- 認可済み project root を OS no-follow directory handle として開き、`.claude/skills/vibe-team` の各 component を capability 相対で検証・作成
- `SKILL.md` の読込と UUID temp の create-new / flush / sync / rename / cleanup を final directory handle 内に封じ込め
- 親・最終 link、決定的 TOCTOU、並行導入、rename failure、Windows junction の security regression test を追加
- 公開 IPC、既存 version/force/no-op/best-effort 契約を維持

Closes #1186

## Test plan

- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml` (889 passed)
- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`
- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- [x] 対象3 Rust file `rustfmt --check`
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors)
- [x] `npm test` (84 files / 509 tests)
- [x] `npm run build:vite`
- [x] `npm run lint:file-size`
- [x] Rust 1.85 / stable の Windows cfg minimal compile
- [x] Tier A fortress review 5観点: CRITICAL/HIGH/MEDIUM/LOW = 0, RCA PASS, Go
- [x] Security follow-up (returned-path identity / FIFO nonblocking race): CRITICAL/HIGH/MEDIUM = 0

## Notes

- #1149 の未merge差分は含めていません。#1186 merge後に #1149 を rebaseします。
- リポジトリ全体の Rust 1.85 check は既存 lockfile の高MSRV依存で停止しますが、新規 `cap-primitives 4.0.2` と production helper source は Rust 1.85でmacOS/Windows双方のcompile gateを通過しています。
