### PR TITLE
refactor(commands): #1149 パス認可と解決を非同期化

### DIFF
--- a/src-tauri/src/commands/dialog.rs
+++ b/src-tauri/src/commands/dialog.rs
@@ -53,14 +53,21 @@ pub async fn dialog_open_file(
 /// Issue #137 (Security): 任意 path をクエリして OS / FS の fingerprint に使われるのを防ぐため、
 /// 「ユーザーホーム配下」または「現在のプロジェクトルート / その祖先」だけを許可する。
 /// /etc, /sys, /proc, C:\Windows などのシステム領域は早期 reject。
-fn is_path_safe_to_query(path: &std::path::Path) -> bool {
-    let Ok(canon) = path.canonicalize() else {
-        return false; // 存在しないパスも reject (fingerprint 防止)
-    };
+async fn is_path_safe_to_query(path: &std::path::Path) -> bool {
     let Some(home) = dirs::home_dir() else {
         return false;
     };
-    let home_canon = home.canonicalize().unwrap_or(home);
+    is_path_safe_to_query_with_home(path, &home).await
+}
+
+async fn is_path_safe_to_query_with_home(path: &std::path::Path, home: &std::path::Path) -> bool {
+    // Issue #1149: path と home は独立して解決できるため並列に待ち、Tokio worker を
+    // std::fs::canonicalize でブロックしない。どちらか一方でも失敗したら fail-closed。
+    let (path_result, home_result) =
+        tokio::join!(tokio::fs::canonicalize(path), tokio::fs::canonicalize(home));
+    let (Ok(canon), Ok(home_canon)) = (path_result, home_result) else {
+        return false; // 存在しないパスも reject (fingerprint 防止)
+    };
     if canon.starts_with(&home_canon) {
         return true;
     }
@@ -100,7 +107,7 @@ fn is_path_safe_to_query(path: &std::path::Path) -> bool {
 /// Issue #137: 加えて、ホーム外/システム領域のパスは fingerprint 防止のため拒否する。
 #[tauri::command]
 pub async fn dialog_is_folder_empty(folder_path: String) -> bool {
-    if !is_path_safe_to_query(std::path::Path::new(&folder_path)) {
+    if !is_path_safe_to_query(std::path::Path::new(&folder_path)).await {
         tracing::warn!(
             "[dialog_is_folder_empty] rejecting query outside allowed area: {folder_path:?}"
         );
@@ -116,4 +123,66 @@ pub async fn dialog_is_folder_empty(folder_path: String) -> bool {
         }
     };
     matches!(rd.next_entry().await, Ok(None))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn safe_query_allows_existing_home_descendant() {
+        let home = tempfile::tempdir().expect("home");
+        let child = home.path().join("project");
+        tokio::fs::create_dir(&child).await.expect("child");
+
+        assert!(is_path_safe_to_query_with_home(&child, home.path()).await);
+    }
+
+    #[tokio::test]
+    async fn safe_query_rejects_missing_path_or_home() {
+        let home = tempfile::tempdir().expect("home");
+        let missing_path = home.path().join("missing");
+        assert!(!is_path_safe_to_query_with_home(&missing_path, home.path()).await);
+
+        let existing = tempfile::tempdir().expect("existing");
+        let missing_home = existing.path().join("missing-home");
+        assert!(!is_path_safe_to_query_with_home(existing.path(), &missing_home).await);
+    }
+
+    #[tokio::test]
+    async fn safe_query_rejects_home_external_and_system_paths() {
+        let home = tempfile::tempdir().expect("home");
+        let outside = tempfile::tempdir().expect("outside");
+        assert!(!is_path_safe_to_query_with_home(outside.path(), home.path()).await);
+
+        #[cfg(unix)]
+        assert!(!is_path_safe_to_query_with_home(std::path::Path::new("/etc"), home.path()).await);
+
+        #[cfg(windows)]
+        if let Some(windows_dir) = std::env::var_os("WINDIR") {
+            assert!(
+                !is_path_safe_to_query_with_home(std::path::Path::new(&windows_dir), home.path(),)
+                    .await
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn folder_empty_keeps_fail_closed_contract() {
+        let home = dirs::home_dir().expect("home directory");
+        let root = tempfile::Builder::new()
+            .prefix("vibe-dialog-empty-")
+            .tempdir_in(home)
+            .expect("home tempdir");
+
+        assert!(dialog_is_folder_empty(root.path().to_string_lossy().into_owned()).await);
+        tokio::fs::write(root.path().join("entry"), b"x")
+            .await
+            .expect("entry");
+        assert!(!dialog_is_folder_empty(root.path().to_string_lossy().into_owned()).await);
+        assert!(
+            !dialog_is_folder_empty(root.path().join("missing").to_string_lossy().into_owned())
+                .await
+        );
+    }
 }

--- a/src-tauri/src/commands/vibe_team_skill.rs
+++ b/src-tauri/src/commands/vibe_team_skill.rs
@@ -15,6 +15,7 @@
 // 配置タイミング: setup_team_mcp で「実チーム」を初めて起動するときに 1 回書き出す。
 // _init / 空 team_id ではスキップする。既存ファイルを上書きするかは forceOverwrite で制御。
 
+use crate::commands::authz::assert_active_project_root;
 use crate::state::AppState;
 use serde::Serialize;
 use std::path::{Path, PathBuf};
@@ -218,54 +219,26 @@ pub async fn app_install_vibe_team_skill(
     force_overwrite: Option<bool>,
 ) -> crate::commands::error::CommandResult<InstallSkillResult> {
     let force = force_overwrite.unwrap_or(false);
-    let trimmed = project_root.trim();
-    if trimmed.is_empty() {
-        return Ok(InstallSkillResult {
-            ok: false,
-            error: Some("project_root is empty".into()),
-            ..Default::default()
-        });
-    }
     // Issue #135 (Security): renderer から来る project_root が AppState の現在値と一致
     // するか canonicalize 比較する。一致しないとユーザー HOME 等の任意ディレクトリ配下に
     // .claude/skills/vibe-team/SKILL.md を作成できてしまい AI hijack 経路になる。
-    // Issue #739: ArcSwapOption の lock-free load で現在値を読む。
-    let active = crate::state::current_project_root(&state.project_root).unwrap_or_default();
-    if active.trim().is_empty() {
-        return Ok(InstallSkillResult {
+    // Issue #1149: 認可をauthz helperへ一本化し、認可失敗は従来どおりresult.errorで返す。
+    Ok(install_skill_for_active_root(&state.project_root, &project_root, force).await)
+}
+
+async fn install_skill_for_active_root(
+    project_root_slot: &arc_swap::ArcSwapOption<String>,
+    project_root: &str,
+    force: bool,
+) -> InstallSkillResult {
+    match assert_active_project_root(project_root_slot, project_root).await {
+        Ok(root) => install_skill_at(root.as_path(), force).await,
+        Err(error) => InstallSkillResult {
             ok: false,
-            error: Some("no active project_root configured".into()),
+            error: Some(error.to_string()),
             ..Default::default()
-        });
+        },
     }
-    let req_canon = match std::fs::canonicalize(trimmed) {
-        Ok(p) => p,
-        Err(e) => {
-            return Ok(InstallSkillResult {
-                ok: false,
-                error: Some(format!("canonicalize requested project_root failed: {e}")),
-                ..Default::default()
-            });
-        }
-    };
-    let active_canon = match std::fs::canonicalize(active.trim()) {
-        Ok(p) => p,
-        Err(e) => {
-            return Ok(InstallSkillResult {
-                ok: false,
-                error: Some(format!("canonicalize active project_root failed: {e}")),
-                ..Default::default()
-            });
-        }
-    };
-    if req_canon != active_canon {
-        return Ok(InstallSkillResult {
-            ok: false,
-            error: Some("project_root does not match active project".into()),
-            ..Default::default()
-        });
-    }
-    Ok(install_skill_at(&req_canon, force).await)
 }
 
 /// 内部呼び出し版 (setup_team_mcp など他コマンドから使う)。force=false。
@@ -275,7 +248,7 @@ pub async fn install_skill_best_effort(project_root: &str) {
     if trimmed.is_empty() {
         return;
     }
-    let root = match std::fs::canonicalize(trimmed) {
+    let root = match tokio::fs::canonicalize(trimmed).await {
         Ok(p) => p,
         Err(e) => {
             tracing::warn!("[skill] canonicalize failed (best-effort): {e}");
@@ -293,6 +266,8 @@ pub async fn install_skill_best_effort(project_root: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arc_swap::ArcSwapOption;
+    use std::sync::Arc;
 
     /// 指定の本文を temp dir 配下の `.claude/skills/vibe-team/SKILL.md` に書き出す。
     async fn write_skill(root: &Path, body: &str) {
@@ -306,6 +281,92 @@ mod tests {
     /// `<!-- vibe-team-skill-version: VER -->` ヘッダ付きの本文を組み立てる。
     fn versioned(ver: &str, extra_body: &str) -> String {
         format!("<!-- vibe-team-skill-version: {ver} -->\n{extra_body}\n")
+    }
+
+    fn active_root(path: Option<&Path>) -> ArcSwapOption<String> {
+        ArcSwapOption::from(path.map(|path| Arc::new(path.to_string_lossy().into_owned())))
+    }
+    #[tokio::test]
+    async fn non_directory_keeps_result_contract() {
+        let file = tempfile::NamedTempFile::new().expect("file");
+        let slot = active_root(Some(file.path()));
+        let result =
+            install_skill_for_active_root(&slot, file.path().to_string_lossy().as_ref(), false)
+                .await;
+        assert!(!result.ok);
+        assert!(result.path.is_none());
+        assert!(!result.skipped);
+        assert!(!result.overwritten);
+        assert!(result
+            .error
+            .as_deref()
+            .is_some_and(|error| error.starts_with("secure skill install failed:")));
+    }
+
+    #[tokio::test]
+    async fn active_root_install_preserves_result_contract() {
+        let project = tempfile::tempdir().expect("project");
+        let slot = active_root(Some(project.path()));
+
+        let result =
+            install_skill_for_active_root(&slot, project.path().to_string_lossy().as_ref(), false)
+                .await;
+
+        assert!(result.ok);
+        assert!(!result.skipped);
+        assert!(!result.overwritten);
+        assert!(result.error.is_none());
+        let canonical_project = tokio::fs::canonicalize(project.path())
+            .await
+            .expect("canonical project");
+        let expected_path = skill_path(&canonical_project);
+        assert_eq!(
+            result.path.as_deref(),
+            Some(expected_path.to_string_lossy().as_ref())
+        );
+    }
+
+    #[tokio::test]
+    async fn active_root_install_rejects_empty_missing_and_mismatch() {
+        let active = tempfile::tempdir().expect("active");
+        let foreign = tempfile::tempdir().expect("foreign");
+        let slot = active_root(Some(active.path()));
+
+        let empty = install_skill_for_active_root(&slot, "  ", false).await;
+        assert!(!empty.ok);
+        assert_eq!(empty.error.as_deref(), Some("project_root is empty"));
+
+        let unconfigured = install_skill_for_active_root(
+            &active_root(None),
+            active.path().to_string_lossy().as_ref(),
+            false,
+        )
+        .await;
+        assert!(!unconfigured.ok);
+        assert_eq!(
+            unconfigured.error.as_deref(),
+            Some("no active project_root configured")
+        );
+
+        let missing_path = active.path().join("missing");
+        let missing =
+            install_skill_for_active_root(&slot, missing_path.to_string_lossy().as_ref(), false)
+                .await;
+        assert!(!missing.ok);
+        assert!(missing
+            .error
+            .as_deref()
+            .is_some_and(|error| error.starts_with("canonicalize requested project_root failed:")));
+
+        let mismatch =
+            install_skill_for_active_root(&slot, foreign.path().to_string_lossy().as_ref(), false)
+                .await;
+        assert!(!mismatch.ok);
+        assert_eq!(
+            mismatch.error.as_deref(),
+            Some("project_root does not match active project")
+        );
+        assert!(!skill_path(foreign.path()).exists());
     }
 
     /// Issue #1109: bundled 本文 (SKILL_VERSION + vibe_team_skill_body.md) と、リポジトリの


### PR DESCRIPTION
## Summary

- vibe-team skill導入の手書きactive-root認可を`assert_active_project_root`へ統合
- best-effort canonicalizeとdialog safe-queryをTokio async FSへ移行
- #1186のcapability-bound secure installerとFIFO/reparse/race防御を維持し、非directory契約を回帰テストで固定

Closes #1149

## Security / compatibility

- `secure_install`、`spawn_blocking`、返却path/file identity、FIFO non-blocking、Windows reparse拒否を維持
- 公開IPC signature、invoke登録、renderer wrapper、shared typeは変更なし
- missing / mismatch / home外 / system領域はfail-closedを維持
- 対象async経路の同期canonicalize / `root.is_dir()` 呼出しは0件

## Test plan

- [x] vibe-team skill 20/20、dialog 4/4、authz 15/15
- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`
- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml`（896/896）
- [x] `npm run typecheck`
- [x] `npm run lint`（0 errors、既存warning 11件）
- [x] `npm test -- --run`（84 files / 509 tests）
- [x] `npm run build:vite`
- [x] `npm run lint:safe-load`
- [x] `npm run lint:command-result`
- [x] target rustfmt / diff check / file-size ratchet
- [x] 独立レビュー（critical 0 / normal 0、suggestion反映済み）
