### PR TITLE
test(commands): #1149 file-size gateを復旧

### DIFF
--- a/src-tauri/src/commands/vibe_team_skill.rs
+++ b/src-tauri/src/commands/vibe_team_skill.rs
@@ -286,22 +286,6 @@ mod tests {
     fn active_root(path: Option<&Path>) -> ArcSwapOption<String> {
         ArcSwapOption::from(path.map(|path| Arc::new(path.to_string_lossy().into_owned())))
     }
-    #[tokio::test]
-    async fn non_directory_keeps_result_contract() {
-        let file = tempfile::NamedTempFile::new().expect("file");
-        let slot = active_root(Some(file.path()));
-        let result =
-            install_skill_for_active_root(&slot, file.path().to_string_lossy().as_ref(), false)
-                .await;
-        assert!(!result.ok);
-        assert!(result.path.is_none());
-        assert!(!result.skipped);
-        assert!(!result.overwritten);
-        assert!(result
-            .error
-            .as_deref()
-            .is_some_and(|error| error.starts_with("secure skill install failed:")));
-    }
 
     #[tokio::test]
     async fn active_root_install_preserves_result_contract() {

--- a/src-tauri/src/commands/vibe_team_skill/secure_install_tests.rs
+++ b/src-tauri/src/commands/vibe_team_skill/secure_install_tests.rs
@@ -8,6 +8,22 @@ fn assert_failed_without_path(result: &InstallSkillResult) {
     assert!(result.error.is_some());
 }
 
+#[tokio::test]
+async fn non_directory_keeps_active_root_result_contract() {
+    let file = tempfile::NamedTempFile::new().expect("file");
+    let slot = arc_swap::ArcSwapOption::from(Some(std::sync::Arc::new(
+        file.path().to_string_lossy().into_owned(),
+    )));
+    let result =
+        install_skill_for_active_root(&slot, file.path().to_string_lossy().as_ref(), false).await;
+
+    assert_failed_without_path(&result);
+    assert!(result
+        .error
+        .as_deref()
+        .is_some_and(|error| error.starts_with("secure skill install failed:")));
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn rejects_each_linked_parent_without_outside_write() {


### PR DESCRIPTION
## Summary

- PR #1189の独立レビューで強化した非directory契約テストを既存`secure_install_tests.rs`へ移動
- `vibe_team_skill.rs`を503行から486行へ縮小し、file-size ratchetをbaseline変更なしで復旧
- production codeとテスト内容・#1186 security fixtureの挙動は変更なし

Closes #1149

## Context

PR #1189はbot auto-mergeされましたが、merge直前のverifyでfile-size gateだけが失敗していました。本PRはその修正commitだけをmerged main基点へ載せたfollow-upです。mainへの直接push・手動mergeは行いません。

## Test plan

- [x] `npm run lint:file-size`
- [x] target rustfmt check
- [x] vibe-team skill tests 20/20
- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`
- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- [x] `git diff --check origin/main...HEAD`
