### PR TITLE
chore(deps): #1163 DOMPurifyの重複型定義を削除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "@eslint/js": "^10.0.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
-        "@types/dompurify": "^3.0.5",
         "@types/node": "^25.9.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -2343,16 +2342,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/dompurify": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
-      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/trusted-types": "*"
-      }
-    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -2415,8 +2404,8 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.61.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@eslint/js": "^10.0.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
-    "@types/dompurify": "^3.0.5",
     "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",


### PR DESCRIPTION
## Summary
- 型定義を同梱している `dompurify` に対する古い `@types/dompurify` devDependency を削除
- package-lock から対象 entry を削除し、DOMPurify が必要とする `@types/trusted-types@2.0.7` は optional dependency として維持
- runtime の DOMPurify 本体、MarkdownPreview、sanitize policy は変更なし

Closes #1163

## Test plan
- [x] `npm ci --no-audit --no-fund`
- [x] dependency tree / lockfile assertion（変更 package key は root、削除対象、trusted-types metadata の3件のみ）
- [x] DOMPurify 同梱型 `./dist/purify.cjs.d.ts` の確認
- [x] `npm run typecheck`
- [x] 実 `MarkdownPreview` focused test（通常 Markdown heading/strong 描画、script/onerror/onclick 除去）: 2 tests
- [x] `npm test -- --run`: 84 files / 509 tests
- [x] `npm run build:vite`
- [x] `npm run lint`: 0 errors（既存 11 warnings）
- [x] `npm run lint:team-event-types`
- [x] `npm run lint:safe-load`
- [x] `npm run lint:file-size`
- [x] `npm run lint:command-result`
- [x] `npm run lint:team-events`
- [x] `npm audit --omit=dev --audit-level=moderate`: 0 vulnerabilities
- [x] `npm audit signatures`: 287 packages / 76 attestations
- [x] `git diff --check`
- [x] Tier C 独立レビュー: critical 0 / normal 0