### PR TITLE
fix(security): #1192 チーム履歴entryにproject identity snapshotを永続化

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -6,7 +6,7 @@
   "src-tauri/src/commands/git.rs": 534,
   "src-tauri/src/commands/handoffs.rs": 519,
   "src-tauri/src/commands/settings.rs": 877,
-  "src-tauri/src/commands/team_history.rs": 1222,
+  "src-tauri/src/commands/team_history.rs": 1114,
   "src-tauri/src/commands/team_state.rs": 596,
   "src-tauri/src/commands/terminal.rs": 1278,
   "src-tauri/src/commands/terminal/command_validation.rs": 916,
@@ -37,5 +37,5 @@
   "src/renderer/src/lib/hooks/use-xterm-bind.ts": 889,
   "src/renderer/src/lib/role-profiles-builtin.ts": 633,
   "src/renderer/src/stores/canvas.ts": 588,
-  "src/types/shared.ts": 1981
+  "src/types/shared.ts": 1994
 }

--- a/src-tauri/src/commands/authz/active_project.rs
+++ b/src-tauri/src/commands/authz/active_project.rs
@@ -12,6 +12,7 @@ use arc_swap::ArcSwapOption;
 pub(crate) struct AuthorizedActiveProjectRoot {
     canonical: ProjectRoot,
     active_raw: String,
+    approved_identity: ProjectRootIdentity,
 }
 
 impl AuthorizedActiveProjectRoot {
@@ -27,6 +28,15 @@ impl AuthorizedActiveProjectRoot {
     ///
     /// rawを再canonicalizeすると、gate後のsymlink retargetを新しいidentityとして採用して
     /// しまう。既存storageがraw project_rootをkeyに持つ場合だけ、このsnapshot keyを使う。
+    /// gate が照合に用いた native approval identity snapshot を返す。
+    ///
+    /// これは picker 承認時に記録された identity (slot 値) であり、gate 後の filesystem
+    /// 変化を含まない。storage が entry 単位の identity 照合 (Issue #1192) を行うときの
+    /// 比較基準にする。
+    pub(crate) fn approved_identity(&self) -> &ProjectRootIdentity {
+        &self.approved_identity
+    }
+
     pub(crate) fn active_raw_key(&self) -> String {
         let normalized = self.active_raw.replace('\\', "/");
         let stripped = normalized.trim_end_matches('/');
@@ -143,6 +153,7 @@ pub(crate) async fn assert_active_project_root_with_raw(
     Ok(AuthorizedActiveProjectRoot {
         canonical: ProjectRoot::from_canonical(active_canon),
         active_raw: active,
+        approved_identity: stored_identity,
     })
 }
 

--- a/src-tauri/src/commands/team_history.rs
+++ b/src-tauri/src/commands/team_history.rs
@@ -5,7 +5,6 @@
 
 use crate::commands::files::hash::{mtime_ms_of, sha256_hex};
 use crate::commands::team_state::TeamOrchestrationSummary;
-use crate::pty::path_norm::normalize_project_root;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -179,6 +178,20 @@ pub struct TeamHistoryEntry {
     /// Issue #470: TeamHub orchestration state の軽量要約。本体は team-state store に置く。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub orchestration: Option<TeamOrchestrationSummary>,
+    /// Issue #1192: 保存時点の project root filesystem identity snapshot。save gate が
+    /// native approval identity から付与し、renderer 入力値は常に上書きされる。
+    /// symlink retarget / directory 置換の後、path 表記が同じでも別 filesystem object の
+    /// 履歴を現 project へ帰属させないための比較基準。None は #1192 以前の legacy entry。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_identity: Option<crate::commands::project_authority::ProjectRootIdentity>,
+}
+
+/// Issue #1192: gate 時 active snapshot。storage selector の raw key と native approval
+/// identity を一体で運び、reader / writer が gate と別の時点の値を再取得しないようにする。
+#[derive(Clone, Debug)]
+pub(crate) struct ActiveHistoryScope {
+    pub(crate) raw_key: String,
+    pub(crate) identity: crate::commands::project_authority::ProjectRootIdentity,
 }
 
 #[derive(Serialize, Default)]
@@ -468,14 +481,16 @@ fn merge_entry(all: &mut Vec<TeamHistoryEntry>, entry: TeamHistoryEntry) {
         !(e.id == entry.id
             && list::normalize_stored_project_root(&e.project_root) == new_entry_raw_key)
     });
-    let new_entry_key = normalize_project_root(&entry.project_root);
+    // Issue #1192: cap 集計 key も canonicalize せず raw key で数える。現 filesystem での
+    // 再解決は retarget 後の別 project を同一視するし、STORE lock 内の blocking I/O も避ける。
+    let new_entry_key = list::normalize_stored_project_root(&entry.project_root);
     all.sort_by(|a, b| b.last_used_at.cmp(&a.last_used_at));
     let mut kept: Vec<TeamHistoryEntry> = Vec::with_capacity(all.len() + 1);
     kept.push(entry);
     let mut per_project_count: HashMap<String, usize> = HashMap::new();
     per_project_count.insert(new_entry_key, 1);
     for e in std::mem::take(all).into_iter() {
-        let key = normalize_project_root(&e.project_root);
+        let key = list::normalize_stored_project_root(&e.project_root);
         let count = per_project_count.entry(key).or_insert(0);
         if *count < MAX_ENTRIES_PER_PROJECT {
             *count += 1;
@@ -540,6 +555,7 @@ mod tests {
             canvas_state: None,
             latest_handoff: None,
             orchestration: None,
+            project_identity: None,
         }
     }
 
@@ -555,6 +571,7 @@ mod tests {
             canvas_state: None,
             latest_handoff: None,
             orchestration: None,
+            project_identity: None,
         };
         // summary 相当は orchestration.blocked_reason に詰めて差分を作る。
         if !summary.is_empty() {

--- a/src-tauri/src/commands/team_history/list.rs
+++ b/src-tauri/src/commands/team_history/list.rs
@@ -1,8 +1,8 @@
 //! `team_history_list` の認可境界とread path。
 
 use super::{
-    ensure_loaded, reconcile_external_changes, store_path, TeamHistoryEntry, TeamHistoryStore,
-    STORE,
+    ensure_loaded, reconcile_external_changes, store_path, ActiveHistoryScope, TeamHistoryEntry,
+    TeamHistoryStore, STORE,
 };
 use crate::commands::error::CommandResult;
 use crate::commands::project_authority::ProjectRootIdentity;
@@ -34,7 +34,7 @@ pub(crate) async fn team_history_list_via<R, Reader, Fut>(
     reader: Reader,
 ) -> CommandResult<R>
 where
-    Reader: FnOnce(String) -> Fut,
+    Reader: FnOnce(ActiveHistoryScope) -> Fut,
     Fut: std::future::Future<Output = R>,
 {
     let authorized = crate::commands::authz::assert_active_project_root_with_raw(
@@ -43,13 +43,17 @@ where
         &project_root,
     )
     .await?;
-    // Store lock前に同一authz snapshotのactive raw keyを確定する。requested rawをreaderへ
-    // 渡さず、key生成でもI/Oをしないため、待機中のsymlink retargetでidentityは変化しない。
-    let target = authorized.active_raw_key();
-    Ok(reader(target).await)
+    // Store lock前に同一authz snapshotのactive raw key + approval identityを確定する。
+    // requested rawをreaderへ渡さず、key生成でもI/Oをしないため、待機中のsymlink retargetで
+    // identityは変化しない (Issue #1147 / #1192)。
+    let scope = ActiveHistoryScope {
+        raw_key: authorized.active_raw_key(),
+        identity: authorized.approved_identity().clone(),
+    };
+    Ok(reader(scope).await)
 }
 
-async fn team_history_list_authorized(target: String) -> Vec<TeamHistoryEntry> {
+async fn team_history_list_authorized(scope: ActiveHistoryScope) -> Vec<TeamHistoryEntry> {
     // 拒否requestはここへ到達しない。STORE lockと全disk/cache処理はgateより後に置く。
     let mut store = STORE.lock().await;
     ensure_loaded(&mut store).await;
@@ -57,7 +61,7 @@ async fn team_history_list_authorized(target: String) -> Vec<TeamHistoryEntry> {
     let TeamHistoryStore { cache, sync_state } = &mut *store;
     let all = cache.as_mut().expect("ensured");
     let _ = reconcile_external_changes(&path, all, sync_state, &HashSet::new()).await;
-    filter_team_history_entries(&target, all)
+    filter_team_history_entries(&scope, all)
 }
 
 /// 既存entryのraw pathをI/Oなしで比較用に整形する。
@@ -76,13 +80,25 @@ pub(crate) fn normalize_stored_project_root(raw: &str) -> String {
 }
 
 /// entry側はI/Oなしで正規化し、selector identityだけgate時canonical snapshotへ固定する。
+///
+/// Issue #1192: raw key 一致に加えて、entry が identity snapshot を持つ場合は gate 時
+/// approval identity との完全一致まで要求する。directory 置換 / symlink retarget 後に
+/// path 表記が同じでも、別 filesystem object 時代の履歴を現 project へ帰属させない。
+/// None は #1192 以前の legacy entry で、互換のため raw key 一致だけで通す (次の save で
+/// 現 identity が刻印されて卒業する)。
 pub(crate) fn filter_team_history_entries(
-    target: &str,
+    scope: &ActiveHistoryScope,
     entries: &[TeamHistoryEntry],
 ) -> Vec<TeamHistoryEntry> {
     entries
         .iter()
-        .filter(|entry| normalize_stored_project_root(&entry.project_root) == target)
+        .filter(|entry| {
+            normalize_stored_project_root(&entry.project_root) == scope.raw_key
+                && entry
+                    .project_identity
+                    .as_ref()
+                    .is_none_or(|identity| identity == &scope.identity)
+        })
         .cloned()
         .collect()
 }

--- a/src-tauri/src/commands/team_history/mutate.rs
+++ b/src-tauri/src/commands/team_history/mutate.rs
@@ -9,8 +9,8 @@
 use super::list::normalize_stored_project_root;
 use super::{
     apply_with_disk_commit, ensure_loaded, hydrate_orchestration_summary, merge_entry,
-    reconcile_external_changes, store_path, validate_entry_size, MutationResult,
-    TeamHistoryEntry, TeamHistoryStore, STORE,
+    reconcile_external_changes, store_path, validate_entry_size, ActiveHistoryScope,
+    MutationResult, TeamHistoryEntry, TeamHistoryStore, STORE,
 };
 use crate::commands::error::{CommandError, CommandResult};
 use crate::commands::project_authority::ProjectRootIdentity;
@@ -88,7 +88,7 @@ pub(crate) async fn team_history_mutation_via<R, Writer, Fut>(
     writer: Writer,
 ) -> CommandResult<R>
 where
-    Writer: FnOnce(String) -> Fut,
+    Writer: FnOnce(ActiveHistoryScope) -> Fut,
     Fut: std::future::Future<Output = R>,
 {
     let Some((first, rest)) = entry_project_roots.split_first() else {
@@ -121,7 +121,11 @@ where
             "entry project_root must match the active project root notation",
         ));
     }
-    Ok(writer(target).await)
+    let scope = ActiveHistoryScope {
+        raw_key: target,
+        identity: authorized.approved_identity().clone(),
+    };
+    Ok(writer(scope).await)
 }
 
 /// 削除は id と gate 時 active raw key の両方が一致した entry だけを対象にする。
@@ -137,8 +141,14 @@ fn has_scoped_entry(entries: &[TeamHistoryEntry], target: &str, id: &str) -> boo
         .any(|e| e.id == id && normalize_stored_project_root(&e.project_root) == target)
 }
 
-async fn save_authorized(target: String, mut entry: TeamHistoryEntry) -> MutationResult {
-    debug_assert_eq!(normalize_stored_project_root(&entry.project_root), target);
+async fn save_authorized(scope: ActiveHistoryScope, mut entry: TeamHistoryEntry) -> MutationResult {
+    debug_assert_eq!(
+        normalize_stored_project_root(&entry.project_root),
+        scope.raw_key
+    );
+    // Issue #1192: 保存時点の native approval identity を刻印する。renderer が identity を
+    // 自称しても常に gate snapshot で上書きされる。
+    entry.project_identity = Some(scope.identity.clone());
     // Issue #624: DoS 防御 — 1 MiB 超の entry は merge 前に reject する。
     if let Err(e) = validate_entry_size(&entry) {
         return MutationResult {
@@ -179,12 +189,19 @@ async fn save_authorized(target: String, mut entry: TeamHistoryEntry) -> Mutatio
 }
 
 async fn save_batch_authorized(
-    target: String,
-    entries: Vec<TeamHistoryEntry>,
+    scope: ActiveHistoryScope,
+    mut entries: Vec<TeamHistoryEntry>,
 ) -> MutationResult {
+    // Issue #1192: 保存時点の native approval identity を全 entry に刻印する。
+    for entry in &mut entries {
+        entry.project_identity = Some(scope.identity.clone());
+    }
     // Issue #624: 各 entry を merge 前に validate (1 件でも巨大なら全体 reject)。
     for entry in &entries {
-        debug_assert_eq!(normalize_stored_project_root(&entry.project_root), target);
+        debug_assert_eq!(
+            normalize_stored_project_root(&entry.project_root),
+            scope.raw_key
+        );
         if let Err(e) = validate_entry_size(entry) {
             return MutationResult {
                 ok: false,
@@ -230,7 +247,8 @@ async fn save_batch_authorized(
     .await
 }
 
-async fn delete_authorized(target: String, id: String) -> MutationResult {
+async fn delete_authorized(scope: ActiveHistoryScope, id: String) -> MutationResult {
+    let target = scope.raw_key;
     // Issue #739: 旧 LOCK / CACHE / DISK_FINGERPRINT の 3 段ロックを STORE 1 ロックに統合。
     let mut store = STORE.lock().await;
     ensure_loaded(&mut store).await;
@@ -285,6 +303,7 @@ mod tests {
             canvas_state: None,
             latest_handoff: None,
             orchestration: None,
+            project_identity: None,
         }
     }
 

--- a/src-tauri/src/commands/tests/team_history_authz.rs
+++ b/src-tauri/src/commands/tests/team_history_authz.rs
@@ -20,7 +20,7 @@ async fn team_history_list_via_native_identity<R, Reader, Fut>(
     reader: Reader,
 ) -> crate::commands::error::CommandResult<R>
 where
-    Reader: FnOnce(String) -> Fut,
+    Reader: FnOnce(crate::commands::team_history::ActiveHistoryScope) -> Fut,
     Fut: std::future::Future<Output = R>,
 {
     let identity = match crate::state::current_project_root(slot) {
@@ -45,6 +45,7 @@ fn entry(id: &str, project_root: &str) -> TeamHistoryEntry {
         canvas_state: None,
         latest_handoff: None,
         orchestration: None,
+        project_identity: None,
     }
 }
 
@@ -53,7 +54,7 @@ async fn assert_authz_rejection_skips_store_reader(
     requested: String,
 ) {
     let called = AtomicBool::new(false);
-    let result = team_history_list_via_native_identity(slot, requested, |_target| async {
+    let result = team_history_list_via_native_identity(slot, requested, |_scope| async {
         called.store(true, Ordering::SeqCst);
         vec![entry("must-not-run", "/foreign")]
     })
@@ -77,8 +78,8 @@ async fn team_history_list_active_root_returns_reader_result() {
     let result = team_history_list_via_native_identity(
         &slot,
         active_raw.clone(),
-        move |target| async move {
-        filter_team_history_entries(&target, &[entry("active", &active_raw)])
+        move |scope| async move {
+        filter_team_history_entries(&scope, &[entry("active", &active_raw)])
         },
     )
     .await
@@ -124,9 +125,9 @@ async fn team_history_list_canonical_alias_returns_active_entry() {
     let alias_raw = active.path().join(".").to_string_lossy().into_owned();
     let slot = active_slot(Some(active.path()));
 
-    let result = team_history_list_via_native_identity(&slot, alias_raw, move |target| async move {
+    let result = team_history_list_via_native_identity(&slot, alias_raw, move |scope| async move {
         filter_team_history_entries(
-            &target,
+            &scope,
             &[
                 entry("active", &active_raw),
                 entry("foreign", "/definitely-not-the-active-project"),
@@ -157,11 +158,11 @@ async fn team_history_list_symlink_retarget_keeps_gate_time_identity() {
     let active_raw = requested.clone();
     let slot = active_slot(Some(&active_link));
 
-    let result = team_history_list_via_native_identity(&slot, requested, move |target| async move {
+    let result = team_history_list_via_native_identity(&slot, requested, move |scope| async move {
         std::fs::remove_file(&active_link).unwrap();
         symlink(&foreign, &active_link).unwrap();
         filter_team_history_entries(
-            &target,
+            &scope,
             &[
                 entry("active", &active_raw),
                 entry("foreign", foreign.to_string_lossy().as_ref()),
@@ -194,10 +195,10 @@ async fn team_history_list_requested_alias_uses_active_raw_snapshot_key() {
     let result = team_history_list_via_native_identity(
         &slot,
         alias_raw.clone(),
-        move |target| async move {
-        assert_eq!(target, active_raw);
+        move |scope| async move {
+        assert_eq!(scope.raw_key, active_raw);
         filter_team_history_entries(
-            &target,
+            &scope,
             &[
                 entry("active", &active_raw),
                 entry("alias-must-not-select", &alias_raw),
@@ -233,10 +234,10 @@ async fn team_history_list_retargeted_foreign_symlink_entry_is_not_disclosed() {
     let result = team_history_list_via_native_identity(
         &slot,
         active.to_string_lossy().into_owned(),
-        move |target| async move {
+        move |scope| async move {
             std::fs::remove_file(&historical_link).unwrap();
             symlink(&active, &historical_link).unwrap();
-            filter_team_history_entries(&target, &[entry("foreign", &historical_raw)])
+            filter_team_history_entries(&scope, &[entry("foreign", &historical_raw)])
         },
     )
     .await
@@ -255,7 +256,7 @@ async fn team_history_mutation_via_native_identity<R, Writer, Fut>(
     writer: Writer,
 ) -> crate::commands::error::CommandResult<R>
 where
-    Writer: FnOnce(String) -> Fut,
+    Writer: FnOnce(crate::commands::team_history::ActiveHistoryScope) -> Fut,
     Fut: std::future::Future<Output = R>,
 {
     let identity = match crate::state::current_project_root(slot) {
@@ -274,7 +275,7 @@ async fn assert_mutation_rejection_skips_writer(
 ) {
     let called = AtomicBool::new(false);
     let result =
-        team_history_mutation_via_native_identity(slot, entry_project_roots, |_target| async {
+        team_history_mutation_via_native_identity(slot, entry_project_roots, |_scope| async {
             called.store(true, Ordering::SeqCst);
             "must-not-run"
         })
@@ -301,15 +302,17 @@ async fn team_history_mutation_active_root_passes_snapshot_key_to_writer() {
     let target = team_history_mutation_via_native_identity(
         &slot,
         &[active_raw.as_str()],
-        |target| async move { target },
+        |scope| async move { scope },
     )
     .await
     .unwrap();
     // gate 時 active raw snapshot key (= slot 値の I/O なし正規化) と一致すること。
     assert_eq!(
-        target,
+        target.raw_key,
         crate::commands::team_history::list::normalize_stored_project_root(&expected)
     );
+    // Issue #1192: writer には gate と同一 snapshot の approval identity が渡ること。
+    assert!(!target.identity.platform_file_id.is_empty());
 }
 
 /// empty / active 未設定 / missing / foreign は authz で拒否し、writer (STORE lock /
@@ -355,4 +358,44 @@ async fn team_history_mutation_alias_notation_is_rejected() {
     let alias_raw = active.path().join(".").to_string_lossy().into_owned();
 
     assert_mutation_rejection_skips_writer(&slot, &[alias_raw.as_str()]).await;
+}
+
+// ---- Issue #1192: entry 単位の project identity 照合 ----
+
+/// directory 置換 (同一 path・別 filesystem object) 後、旧 identity 時代の entry は
+/// 新 identity の scope では列挙されない。identity 無しの legacy entry は互換で通る。
+#[tokio::test]
+async fn history_from_replaced_directory_is_not_attributed_to_new_identity() {
+    use crate::commands::team_history::list::normalize_stored_project_root;
+    use crate::commands::team_history::ActiveHistoryScope;
+
+    let sandbox = tempdir().unwrap();
+    let root = sandbox.path().join("project");
+    let parked = sandbox.path().join("parked");
+    tokio::fs::create_dir_all(&root).await.unwrap();
+    let old_identity = crate::commands::project_authority::capture_identity(&root)
+        .await
+        .unwrap();
+    // 同一 path のまま directory を置換する (= symlink retarget / restore 相当)。
+    tokio::fs::rename(&root, &parked).await.unwrap();
+    tokio::fs::create_dir_all(&root).await.unwrap();
+    let new_identity = crate::commands::project_authority::capture_identity(&root)
+        .await
+        .unwrap();
+    assert_ne!(old_identity, new_identity, "fixture premise");
+
+    let raw = root.to_string_lossy().into_owned();
+    let scope = ActiveHistoryScope {
+        raw_key: normalize_stored_project_root(&raw),
+        identity: new_identity.clone(),
+    };
+    let mut stale = entry("stale-era", &raw);
+    stale.project_identity = Some(old_identity);
+    let mut current = entry("current-era", &raw);
+    current.project_identity = Some(new_identity);
+    let legacy = entry("legacy-no-identity", &raw);
+
+    let listed = filter_team_history_entries(&scope, &[stale, current, legacy]);
+    let ids: Vec<&str> = listed.iter().map(|e| e.id.as_str()).collect();
+    assert_eq!(ids, vec!["current-era", "legacy-no-identity"]);
 }

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1107,6 +1107,19 @@ export interface TeamHistoryEntry {
   latestHandoff?: HandoffReference;
   /** Issue #470: TeamHub orchestration state の軽量要約 */
   orchestration?: TeamOrchestrationSummary;
+  /**
+   * Issue #1192: 保存時点の project root filesystem identity snapshot。
+   * backend の save gate が native approval identity から付与する読み取り専用値で、
+   * renderer が値を渡しても常に上書きされる。undefined は #1192 以前の legacy entry。
+   */
+  projectIdentity?: ProjectRootIdentitySnapshot;
+}
+
+/** Issue #1192: project root を path 表記ではなく filesystem object として識別する snapshot。 */
+export interface ProjectRootIdentitySnapshot {
+  version: number;
+  canonicalRoot: string;
+  platformFileId: string;
 }
 
 export interface TeamCanvasNode {


### PR DESCRIPTION
## Summary
- symlink retarget / directory 置換後に、path 表記が同じ別 filesystem object の履歴が現 project へ帰属しうる問題 (#1192) を修正
- `TeamHistoryEntry` に `projectIdentity` (native approval の filesystem identity snapshot) を追加。save / save_batch の gate 通過時に backend が刻印し、renderer 入力値は常に上書きされる
- `team_history_list` の selector は raw key 一致に加えて **identity 完全一致** まで要求。gate capability (`AuthorizedActiveProjectRoot`) に `approved_identity()` を追加し、reader/writer は gate と同一 snapshot の `ActiveHistoryScope` (raw key + identity) を受け取る
- `merge_entry` の per-project cap key を canonicalize 付き `normalize_project_root` から I/O なし raw key 比較へ変更 (retarget 後の別 project 同一視と STORE lock 内 blocking I/O を排除)

## Legacy 互換方針
- `projectIdentity` 無しの既存 entry は従来どおり raw key 一致のみで列挙する (隠さない)
- 同一チームの次回 save (`merge_entry` の同 id + 同 raw key 置換) で現 identity が刻印され、自然に移行する。一括 migration は行わない (置換前 directory の identity を後付けで推測できないため)
- disk schema は optional field 追加のみで旧バージョンとの相互読み書きに影響しない (serde default / unknown-field 無視)

## Test plan
- [x] directory 置換 fixture: 旧 identity entry が新 identity scope で列挙されないこと + legacy None entry は互換で通ること (`team_history_authz.rs`)
- [x] `cargo test` 925 passed / `cargo clippy --all-targets -- -D warnings`
- [x] `vitest` 519 passed / `npm run typecheck` / `npm run lint` (0 errors)
- [x] `lint:file-size` (shared.ts baseline +13 は共有型 `ProjectRootIdentitySnapshot` 追加分のみ、分割余地なし) / `lint:command-result` / `build:vite`

Closes #1192