### PR TITLE
fix(security): #1200 PTY/MCP起動境界でcwd identityをfreshに再検証

### DIFF
--- a/build/file-size-baseline.json
+++ b/build/file-size-baseline.json
@@ -8,7 +8,7 @@
   "src-tauri/src/commands/settings.rs": 877,
   "src-tauri/src/commands/team_history.rs": 1114,
   "src-tauri/src/commands/team_state.rs": 596,
-  "src-tauri/src/commands/terminal.rs": 1278,
+  "src-tauri/src/commands/terminal.rs": 1002,
   "src-tauri/src/commands/terminal/command_validation.rs": 916,
   "src-tauri/src/commands/terminal_tabs.rs": 817,
   "src-tauri/src/commands/voice.rs": 550,

--- a/src-tauri/src/commands/app/team_mcp.rs
+++ b/src-tauri/src/commands/app/team_mcp.rs
@@ -176,10 +176,10 @@ pub async fn app_setup_team_mcp(
     team_name: String,
     members: Vec<TeamMcpMember>,
 ) -> crate::commands::error::CommandResult<SetupTeamMcpResult> {
-    // Issue #1193: TeamHub登録・MCP設定・inbox watcher はすべて副作用である。renderer由来の
-    // rootを先に登録してから認可する旧順序では、foreign rootが永続stateへ残った。
-    // 最初にnative authority付きactive rootを解決し、失敗時は副作用を一切起こさない。
-    let authorized_root = match crate::commands::authz::assert_active_project_root(
+    // Issue #1193: TeamHub登録・MCP設定・inbox watcher はすべて副作用なので、最初にnative
+    // authority付きactive rootを解決し (Issue #1200: MCP 起動境界なので TTL キャッシュを
+    // 使わず fresh に identity を再照合)、失敗時は副作用を一切起こさない。
+    let authorized_root = match crate::commands::authz::assert_active_project_root_fresh(
         &state.project_root,
         &state.project_root_identity,
         &project_root,

--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -24,7 +24,7 @@ use crate::state::current_project_root;
 use crate::team_hub::TeamHub;
 
 mod active_project;
-pub use active_project::{assert_active_project_root, invalidate_identity_recheck};
+pub use active_project::{assert_active_project_root, assert_active_project_root_fresh, assert_spawn_cwd_identity, invalidate_identity_recheck};
 pub(crate) use active_project::{assert_active_project_root_with_raw, AuthorizedActiveProjectRoot};
 
 /// canonicalize 済み、かつ AppState の active project_root あるいは許可済み workspace folder と

--- a/src-tauri/src/commands/authz/active_project.rs
+++ b/src-tauri/src/commands/authz/active_project.rs
@@ -196,6 +196,78 @@ pub(crate) async fn assert_active_project_root_policy(
     })
 }
 
+/// PTY spawn 直前の cwd 再検証 (Issue #1200)。
+///
+/// resume が返した canonical cwd と実際の spawn の間に、同一 path の directory が別 project
+/// へ置換される check-to-use gap を塞ぐ。cwd が active root / 承認済み workspace root と
+/// 同一 directory を指す場合に限り、TTL キャッシュを使わず platform identity を取り直して
+/// native approval と照合し、不一致なら起動を拒否する (fail-closed)。project 外 cwd
+/// (home fallback 等) と project 未選択時は従来どおり対象外。
+pub async fn assert_spawn_cwd_identity(
+    project_root_slot: &ArcSwapOption<String>,
+    project_root_identity_slot: &ArcSwapOption<ProjectRootIdentity>,
+    cwd: &str,
+) -> CommandResult<()> {
+    let cwd_canon = match tokio::fs::canonicalize(cwd.trim()).await {
+        Ok(path) => path,
+        Err(error) => {
+            // resolve_valid_cwd 通過後に消えた = 置換・削除の最中。推測せず fail-closed。
+            tracing::warn!(
+                cwd = %clamp_for_log(cwd),
+                error = %error,
+                "[authz] spawn cwd rejected: canonicalize failed after validation"
+            );
+            return Err(CommandError::authz(
+                "spawn cwd disappeared while being verified",
+            ));
+        }
+    };
+    let cwd_key = crate::commands::project_identity::canonical_root_key(&cwd_canon);
+
+    let active_root = current_project_root(project_root_slot).unwrap_or_default();
+    if !active_root.trim().is_empty() && active_root == cwd_key {
+        // active root と同一 directory: native approval identity と fresh に照合する。
+        let Some(stored) = current_project_root_identity(project_root_identity_slot) else {
+            return Err(CommandError::authz(
+                "active project root has no native authority identity",
+            ));
+        };
+        let observed =
+            crate::commands::project_authority::capture_identity(&cwd_canon).await?;
+        if observed != stored {
+            tracing::warn!(
+                cwd = %clamp_for_log(&cwd_key),
+                "[authz] spawn cwd rejected: active root identity changed before spawn"
+            );
+            return Err(CommandError::authz(
+                "spawn cwd identity no longer matches its native approval",
+            ));
+        }
+        record_identity_verified(&stored);
+        return Ok(());
+    }
+
+    if let Some(known) =
+        crate::commands::project_authority::workspace_identity_for(&cwd_key).await
+    {
+        let observed =
+            crate::commands::project_authority::capture_identity(&cwd_canon).await?;
+        if observed != known {
+            tracing::warn!(
+                cwd = %clamp_for_log(&cwd_key),
+                "[authz] spawn cwd rejected: workspace root identity changed before spawn"
+            );
+            return Err(CommandError::authz(
+                "spawn cwd identity no longer matches its workspace approval",
+            ));
+        }
+        return Ok(());
+    }
+
+    // project 管理外の cwd は #1200 の対象外 (従来挙動を維持)。
+    Ok(())
+}
+
 /// identity 再照合 (blocking canonicalize×2 + platform file id×2) の短TTLキャッシュ。
 ///
 /// `files_list` / `git_status` 等の高頻度IPCが毎回 blocking I/O を踏むと、低速ストレージで

--- a/src-tauri/src/commands/authz/active_project.rs
+++ b/src-tauri/src/commands/authz/active_project.rs
@@ -59,11 +59,50 @@ pub async fn assert_active_project_root(
         .map(|authorized| authorized.canonical)
 }
 
+/// identity 再照合キャッシュの利用可否。PTY / MCP の起動境界 (Issue #1200) は必ず
+/// `Fresh` を使い、check-to-use 間の directory 置換を TTL 内でも見逃さない。
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum RecheckPolicy {
+    CachedTtl,
+    Fresh,
+}
+
 /// strict gateと同一snapshotのcanonical capability + active rawを返すcrate内helper。
 pub(crate) async fn assert_active_project_root_with_raw(
     project_root_slot: &ArcSwapOption<String>,
     project_root_identity_slot: &ArcSwapOption<ProjectRootIdentity>,
     given: &str,
+) -> CommandResult<AuthorizedActiveProjectRoot> {
+    assert_active_project_root_policy(
+        project_root_slot,
+        project_root_identity_slot,
+        given,
+        RecheckPolicy::CachedTtl,
+    )
+    .await
+}
+
+/// 起動境界用: identity 再照合の TTL キャッシュを使わず必ず platform identity を取り直す。
+pub async fn assert_active_project_root_fresh(
+    project_root_slot: &ArcSwapOption<String>,
+    project_root_identity_slot: &ArcSwapOption<ProjectRootIdentity>,
+    given: &str,
+) -> CommandResult<ProjectRoot> {
+    assert_active_project_root_policy(
+        project_root_slot,
+        project_root_identity_slot,
+        given,
+        RecheckPolicy::Fresh,
+    )
+    .await
+    .map(|authorized| authorized.canonical)
+}
+
+pub(crate) async fn assert_active_project_root_policy(
+    project_root_slot: &ArcSwapOption<String>,
+    project_root_identity_slot: &ArcSwapOption<ProjectRootIdentity>,
+    given: &str,
+    policy: RecheckPolicy,
 ) -> CommandResult<AuthorizedActiveProjectRoot> {
     let trimmed = given.trim();
     if trimmed.is_empty() {
@@ -135,7 +174,7 @@ pub(crate) async fn assert_active_project_root_with_raw(
             "active project root has no native authority identity",
         ));
     };
-    if !identity_recently_verified(&stored_identity) {
+    if policy == RecheckPolicy::Fresh || !identity_recently_verified(&stored_identity) {
         let observed_identity =
             crate::commands::project_authority::capture_identity(&active_canon).await?;
         if observed_identity != stored_identity {

--- a/src-tauri/src/commands/project_authority.rs
+++ b/src-tauri/src/commands/project_authority.rs
@@ -353,6 +353,16 @@ pub async fn app_restore_authorized_project_root(app: AppHandle) -> String {
     crate::state::current_project_root(&app.state::<AppState>().project_root).unwrap_or_default()
 }
 
+/// 起動境界の fresh 照合用 (Issue #1200)。TTL キャッシュを使わず ledger を読み直し、
+/// canonical key が一致する workspace grant の identity を返す。
+pub async fn workspace_identity_for(canonical_key: &str) -> Option<ProjectRootIdentity> {
+    let ledger = load_ledger().await.ok()?;
+    ledger
+        .workspace_roots
+        .into_iter()
+        .find(|known| known.canonical_root == canonical_key)
+}
+
 /// files系のworkspace gate用。settings.jsonではなくnative ledgerのidentity一致だけを認める。
 pub async fn is_authorized_workspace_root(requested_canonical: &Path) -> bool {
     let canonical_key = canonical_root_key(requested_canonical);

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -5,50 +5,19 @@
 
 pub(crate) mod command_validation;
 pub(crate) mod shell_policy;
+mod codex_prompt;
 mod paste_image;
 mod prompt_files;
 
 use crate::pty::session::TerminalWarning;
 use crate::pty::{spawn_session, SpawnOptions, UserWriteOutcome};
 use crate::state::AppState;
-use crate::team_hub::inject::build_chunks;
+use codex_prompt::inject_codex_prompt_to_pty;
 use crate::util::log_redact::redact_home;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Duration;
 use tauri::{AppHandle, State};
 use uuid::Uuid;
-
-/// Issue #739: `inject_codex_prompt_to_pty` が PTY 注入を始める前に待つ初期スリープ (ミリ秒)。
-///
-/// Codex の TUI が起動してから prompt 入力を受け付ける状態になるまでの猶予。旧実装は
-/// `sleep(Duration::from_millis(1800))` の magic number 直書きだった。短すぎると注入文字が
-/// TUI 初期化中に取りこぼされ、長すぎると初手の指示が遅れて UX が悪化するため、この 1 箇所で
-/// 調整できるよう定数化する。
-const CODEX_INITIAL_PROMPT_DELAY_MS: u64 = 1800;
-
-/// Issue #739: `inject_codex_prompt_to_pty` のチャンク間 / 末尾 `\r` 送出前スリープ (ミリ秒)。
-///
-/// ConPTY のリングバッファ事故を避けつつ Codex TUI が paste sequence を 1 件として
-/// バンドルできる時間的余裕を確保するための値。`team_hub::protocol::consts::INJECT_CHUNK_DELAY_MS`
-/// と意図的に同値だが、当該定数は `pub(in crate::team_hub)` で `commands` から不可視のため、
-/// terminal 側のチャンク注入用にローカル定数として持つ (旧実装は `15` の直書きだった)。
-const CODEX_PROMPT_CHUNK_DELAY_MS: u64 = 15;
-
-/// Issue #1077: codex 初手プロンプト注入の末尾確定 `\r` を送る試行回数 (初回 + retry)。
-///
-/// 本文 (bracketed paste) は届いたのに最終 `\r` だけ失敗すると、codex TUI は入力欄に
-/// 貼られた表示のまま confirm されず「起動したのに何も始まらない」状態になる。ConPTY
-/// back-pressure 等で `\r` が一過性に失敗するケースに備え、確定 write を最大この回数まで
-/// 再試行する (team_hub の inject は #378 で最終 `\r` 失敗を `FinalCrFailed` として伝播
-/// 済みだが、本経路は fire-and-forget task のため retry で復旧を図る)。
-const CODEX_FINAL_CR_MAX_ATTEMPTS: u32 = 3;
-
-/// Issue #1077: 末尾確定 `\r` の retry 間に挟むスリープ (ミリ秒)。
-///
-/// back-pressure が解ける猶予を与えてから再送するための短い待ち。
-const CODEX_FINAL_CR_RETRY_DELAY_MS: u64 = 30;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -209,188 +178,6 @@ fn filter_codex_resume_id_in_place(is_codex: bool, args: Vec<String>) -> Vec<Str
             args.into_iter().skip(1).collect()
         }
     }
-}
-
-/// Issue #1077: codex 初手プロンプトの確定 `\r` 送出 retry の最終結果。
-///
-/// session 消滅由来の打ち切りと「全試行が write 失敗で尽きた」を区別し、ログの文言と
-/// レベルを出し分けるために使う (code review M1)。
-#[derive(Debug, PartialEq, Eq)]
-enum FinalCrOutcome {
-    /// `\r` write が確定した (成功)。
-    Confirmed,
-    /// retry 途中で session が消えた (codex は既に exit 済みの可能性) → 確定待ちではない。
-    SessionGone,
-    /// 全試行が write 失敗で尽きた → codex が確定待ちのまま固まる恐れ。
-    Exhausted,
-}
-
-/// Issue #1077: 確定 `\r` を最大 `max_attempts` 回試行する汎用 retry ループ。
-///
-/// `spawn_blocking` / 実 PTY 依存を `write_cr` / `session_alive` の closure 境界の外に出す
-/// ことで、試行回数・retry 打ち切り条件・session 消滅検知をユニットテスト可能にする。
-///
-/// - `write_cr(attempt)`: 1 回分の `\r` write を行う。`true` で確定成功。失敗時の warn ログは
-///   呼び出し側 closure 内で出す。
-/// - `session_alive()`: retry sleep に入る前に session がまだ生きているか確認する。生きて
-///   いなければ SessionGone で即打ち切る。
-async fn write_final_cr_with_retry<WFut, W, A>(
-    max_attempts: u32,
-    retry_delay: Duration,
-    mut write_cr: W,
-    mut session_alive: A,
-) -> FinalCrOutcome
-where
-    W: FnMut(u32) -> WFut,
-    WFut: std::future::Future<Output = bool>,
-    A: FnMut() -> bool,
-{
-    for attempt in 1..=max_attempts {
-        if write_cr(attempt).await {
-            return FinalCrOutcome::Confirmed;
-        }
-        if attempt < max_attempts {
-            // session がもう無ければ再送しても無駄。codex は確定前に exit 済みと判断して打ち切る。
-            if !session_alive() {
-                return FinalCrOutcome::SessionGone;
-            }
-            tokio::time::sleep(retry_delay).await;
-        }
-    }
-    FinalCrOutcome::Exhausted
-}
-
-/// Codex の system prompt を、PTY (TUI) に直接「最初の入力」として注入する fallback 経路。
-///
-/// 動作:
-///   1. spawn 直後 1.8 秒スリープして Codex の TUI が prompt 入力を受け付ける状態になるのを待つ。
-///   2. team_hub::inject::build_chunks で ConPTY-safe チャンク (64B / 15ms / UTF-8 境界保護) に
-///      整形 (banner は空文字)。
-///   3. 各チャンクを順に書き込み、最後に \r で確定送信。
-///
-/// チームメッセージの inject() と違って banner は付けない (Codex に対する初手のユーザー指示として届く)。
-///
-/// Issue #620: `SessionHandle::write` は内部で `std::sync::Mutex::lock` + 同期 `write_all`/`flush`
-/// なので、tokio multi-thread runtime の async task 内から直接呼ぶと ConPTY back-pressure 時に
-/// worker thread を 1 本占有してしまう。`team_hub::inject::inject_once` と同じく
-/// `tokio::task::spawn_blocking` で blocking pool に逃がし、async runtime を解放する。
-async fn inject_codex_prompt_to_pty(
-    registry: Arc<crate::pty::SessionRegistry>,
-    term_id: String,
-    instructions: String,
-) {
-    use tokio::time::sleep;
-    sleep(Duration::from_millis(CODEX_INITIAL_PROMPT_DELAY_MS)).await;
-    let Some(session) = registry.get(&term_id) else {
-        return;
-    };
-    // Issue #153 / #619: 注入中はユーザーの xterm 入力 (terminal_write) を抑止する。
-    // RAII guard (`begin_injecting`) を使うことで、関数を抜けるあらゆる経路 (early return /
-    // panic / `?` 伝播 / 正常終了) で `injecting` フラグが必ず false に戻る。
-    // build_chunks は banner 込みで分割するが、Codex 注入では banner 不要なので空文字を渡す。
-    let _inject_guard = session.begin_injecting();
-    let chunks = build_chunks("", &instructions);
-    if chunks.is_empty() {
-        return;
-    }
-    let mut iter = chunks.into_iter();
-    if let Some(first) = iter.next() {
-        // Issue #620: spawn_blocking で同期 write を blocking pool に逃がす。
-        // Issue #619: 早期 return しても `_inject_guard` の Drop で injecting=false に戻る。
-        let s = session.clone();
-        match tokio::task::spawn_blocking(move || s.write(&first)).await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                tracing::warn!(
-                    "[terminal] codex prompt write(first) failed for {term_id}: {e}"
-                );
-                return;
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "[terminal] codex prompt spawn_blocking(first) failed for {term_id}: {e}"
-                );
-                return;
-            }
-        }
-    }
-    for chunk in iter {
-        sleep(Duration::from_millis(CODEX_PROMPT_CHUNK_DELAY_MS)).await;
-        if registry.get(&term_id).is_none() {
-            return;
-        }
-        // Issue #620: 各チャンクの write も spawn_blocking 経由。
-        // Issue #619: 早期 return / panic でも guard Drop が injecting=false に戻す。
-        let s = session.clone();
-        match tokio::task::spawn_blocking(move || s.write(&chunk)).await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                tracing::warn!(
-                    "[terminal] codex prompt write(chunk) failed for {term_id}: {e}"
-                );
-                return;
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "[terminal] codex prompt spawn_blocking(chunk) failed for {term_id}: {e}"
-                );
-                return;
-            }
-        }
-    }
-    sleep(Duration::from_millis(CODEX_PROMPT_CHUNK_DELAY_MS)).await;
-    // Issue #620: 末尾の確定 `\r` も spawn_blocking 経由で送る。
-    // Issue #1077: 旧実装は `\r` 失敗を warn のみで握り潰しており、本文 paste は届いたのに
-    // Enter 未確定で codex が起動指示を実行しないまま待機する事故 (「起動したのに何も
-    // 始まらない」) を招いていた。ConPTY back-pressure 等の一過性失敗に備え、確定 `\r` を
-    // write_final_cr_with_retry で最大 CODEX_FINAL_CR_MAX_ATTEMPTS 回まで再試行する。
-    let outcome = write_final_cr_with_retry(
-        CODEX_FINAL_CR_MAX_ATTEMPTS,
-        Duration::from_millis(CODEX_FINAL_CR_RETRY_DELAY_MS),
-        |attempt| {
-            let s = session.clone();
-            let term_id = term_id.clone();
-            async move {
-                match tokio::task::spawn_blocking(move || s.write(b"\r")).await {
-                    Ok(Ok(())) => true,
-                    Ok(Err(e)) => {
-                        tracing::warn!(
-                            "[terminal] codex prompt write(\\r) attempt {attempt}/{CODEX_FINAL_CR_MAX_ATTEMPTS} failed for {term_id}: {e}"
-                        );
-                        false
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "[terminal] codex prompt spawn_blocking(\\r) attempt {attempt}/{CODEX_FINAL_CR_MAX_ATTEMPTS} failed for {term_id}: {e}"
-                        );
-                        false
-                    }
-                }
-            }
-        },
-        || registry.get(&term_id).is_some(),
-    )
-    .await;
-    match outcome {
-        FinalCrOutcome::Confirmed => {}
-        FinalCrOutcome::SessionGone => {
-            // session が消えている = codex は確定前に既に exit 済み。確定待ちではないので
-            // warn 止まり (「unconfirmed で固まっている」誤解を生む error を出さない)。
-            tracing::warn!(
-                "[terminal] codex prompt final \\r aborted for {term_id} — session already gone (codex likely exited before confirm)"
-            );
-        }
-        FinalCrOutcome::Exhausted => {
-            // 全試行が write 失敗で尽きた。codex は確定待ちのまま固まる可能性が高い。
-            tracing::error!(
-                "[terminal] codex prompt final \\r never confirmed for {term_id} after {CODEX_FINAL_CR_MAX_ATTEMPTS} attempts — codex may be waiting unconfirmed"
-            );
-        }
-    }
-    tracing::info!(
-        "[terminal] codex prompt injected into pty {term_id} ({} bytes)",
-        instructions.len()
-    );
 }
 
 #[tauri::command]
@@ -656,6 +443,23 @@ pub async fn terminal_create(
         opts.team_id.as_deref(),
         opts.agent_id.as_deref(),
     );
+
+    // Issue #1200: resume が返した cwd と spawn の check-to-use gap を塞ぐ。cwd が
+    // active / workspace root と同一 directory を指す場合のみ、TTL キャッシュを使わず
+    // platform identity を再照合し、置換されていれば起動しない (fail-closed)。
+    if let Err(error) = crate::commands::authz::assert_spawn_cwd_identity(
+        &state.project_root,
+        &state.project_root_identity,
+        &cwd,
+    )
+    .await
+    {
+        return Ok(TerminalCreateResult {
+            ok: false,
+            error: Some(format!("spawn cwd authorization failed: {error}")),
+            ..Default::default()
+        });
+    }
 
     let spawn_opts = SpawnOptions {
         command: command.clone(),
@@ -1131,86 +935,6 @@ mod codex_resume_filter_tests {
         let input = s(&["-c", "k=v", "resume", "abc;rm -rf /"]);
         let out = filter_codex_resume_id_in_place(true, input.clone());
         assert_eq!(out, input);
-    }
-}
-
-#[cfg(test)]
-mod final_cr_retry_tests {
-    use super::{write_final_cr_with_retry, FinalCrOutcome};
-    use std::cell::Cell;
-    use std::time::Duration;
-
-    // retry delay は 0 にして、テストが実時間 sleep しないようにする。
-    const NO_DELAY: Duration = Duration::from_millis(0);
-
-    #[tokio::test]
-    async fn confirmed_on_first_attempt() {
-        let calls = Cell::new(0u32);
-        let outcome = write_final_cr_with_retry(
-            3,
-            NO_DELAY,
-            |_attempt| {
-                calls.set(calls.get() + 1);
-                async { true }
-            },
-            || true,
-        )
-        .await;
-        assert_eq!(outcome, FinalCrOutcome::Confirmed);
-        assert_eq!(calls.get(), 1, "成功すれば 1 回で打ち切るはず");
-    }
-
-    #[tokio::test]
-    async fn confirmed_after_transient_failures() {
-        // Issue #1077 の本命: 最初の 2 回失敗 → 3 回目で確定。
-        let calls = Cell::new(0u32);
-        let outcome = write_final_cr_with_retry(
-            3,
-            NO_DELAY,
-            |attempt| {
-                calls.set(calls.get() + 1);
-                async move { attempt == 3 }
-            },
-            || true,
-        )
-        .await;
-        assert_eq!(outcome, FinalCrOutcome::Confirmed);
-        assert_eq!(calls.get(), 3, "3 回目で成功するまで retry するはず");
-    }
-
-    #[tokio::test]
-    async fn exhausted_when_all_attempts_fail() {
-        let calls = Cell::new(0u32);
-        let outcome = write_final_cr_with_retry(
-            3,
-            NO_DELAY,
-            |_attempt| {
-                calls.set(calls.get() + 1);
-                async { false }
-            },
-            || true, // session は生存し続ける
-        )
-        .await;
-        assert_eq!(outcome, FinalCrOutcome::Exhausted);
-        assert_eq!(calls.get(), 3, "max_attempts ぶん試行して尽きるはず");
-    }
-
-    #[tokio::test]
-    async fn aborts_when_session_gone() {
-        // session 消滅時は retry せず即 SessionGone (Exhausted の error 文言を出さない / M1)。
-        let calls = Cell::new(0u32);
-        let outcome = write_final_cr_with_retry(
-            3,
-            NO_DELAY,
-            |_attempt| {
-                calls.set(calls.get() + 1);
-                async { false }
-            },
-            || false, // 1 回目失敗後の生存確認で「消滅」を返す
-        )
-        .await;
-        assert_eq!(outcome, FinalCrOutcome::SessionGone);
-        assert_eq!(calls.get(), 1, "session 消滅を検知したら追加 retry しないはず");
     }
 }
 

--- a/src-tauri/src/commands/terminal/codex_prompt.rs
+++ b/src-tauri/src/commands/terminal/codex_prompt.rs
@@ -1,0 +1,300 @@
+//! Issue #739 / #1077: Codex 初手プロンプトの PTY 注入経路。
+//! terminal.rs の file-size ratchet (Issue #939) に伴い自己完結モジュールとして分離。
+
+use crate::team_hub::inject::build_chunks;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Issue #739: `inject_codex_prompt_to_pty` が PTY 注入を始める前に待つ初期スリープ (ミリ秒)。
+///
+/// Codex の TUI が起動してから prompt 入力を受け付ける状態になるまでの猶予。旧実装は
+/// `sleep(Duration::from_millis(1800))` の magic number 直書きだった。短すぎると注入文字が
+/// TUI 初期化中に取りこぼされ、長すぎると初手の指示が遅れて UX が悪化するため、この 1 箇所で
+/// 調整できるよう定数化する。
+const CODEX_INITIAL_PROMPT_DELAY_MS: u64 = 1800;
+
+/// Issue #739: `inject_codex_prompt_to_pty` のチャンク間 / 末尾 `\r` 送出前スリープ (ミリ秒)。
+///
+/// ConPTY のリングバッファ事故を避けつつ Codex TUI が paste sequence を 1 件として
+/// バンドルできる時間的余裕を確保するための値。`team_hub::protocol::consts::INJECT_CHUNK_DELAY_MS`
+/// と意図的に同値だが、当該定数は `pub(in crate::team_hub)` で `commands` から不可視のため、
+/// terminal 側のチャンク注入用にローカル定数として持つ (旧実装は `15` の直書きだった)。
+const CODEX_PROMPT_CHUNK_DELAY_MS: u64 = 15;
+
+/// Issue #1077: codex 初手プロンプト注入の末尾確定 `\r` を送る試行回数 (初回 + retry)。
+///
+/// 本文 (bracketed paste) は届いたのに最終 `\r` だけ失敗すると、codex TUI は入力欄に
+/// 貼られた表示のまま confirm されず「起動したのに何も始まらない」状態になる。ConPTY
+/// back-pressure 等で `\r` が一過性に失敗するケースに備え、確定 write を最大この回数まで
+/// 再試行する (team_hub の inject は #378 で最終 `\r` 失敗を `FinalCrFailed` として伝播
+/// 済みだが、本経路は fire-and-forget task のため retry で復旧を図る)。
+const CODEX_FINAL_CR_MAX_ATTEMPTS: u32 = 3;
+
+/// Issue #1077: 末尾確定 `\r` の retry 間に挟むスリープ (ミリ秒)。
+///
+/// back-pressure が解ける猶予を与えてから再送するための短い待ち。
+const CODEX_FINAL_CR_RETRY_DELAY_MS: u64 = 30;
+
+/// Issue #1077: codex 初手プロンプトの確定 `\r` 送出 retry の最終結果。
+///
+/// session 消滅由来の打ち切りと「全試行が write 失敗で尽きた」を区別し、ログの文言と
+/// レベルを出し分けるために使う (code review M1)。
+#[derive(Debug, PartialEq, Eq)]
+enum FinalCrOutcome {
+    /// `\r` write が確定した (成功)。
+    Confirmed,
+    /// retry 途中で session が消えた (codex は既に exit 済みの可能性) → 確定待ちではない。
+    SessionGone,
+    /// 全試行が write 失敗で尽きた → codex が確定待ちのまま固まる恐れ。
+    Exhausted,
+}
+
+/// Issue #1077: 確定 `\r` を最大 `max_attempts` 回試行する汎用 retry ループ。
+///
+/// `spawn_blocking` / 実 PTY 依存を `write_cr` / `session_alive` の closure 境界の外に出す
+/// ことで、試行回数・retry 打ち切り条件・session 消滅検知をユニットテスト可能にする。
+///
+/// - `write_cr(attempt)`: 1 回分の `\r` write を行う。`true` で確定成功。失敗時の warn ログは
+///   呼び出し側 closure 内で出す。
+/// - `session_alive()`: retry sleep に入る前に session がまだ生きているか確認する。生きて
+///   いなければ SessionGone で即打ち切る。
+async fn write_final_cr_with_retry<WFut, W, A>(
+    max_attempts: u32,
+    retry_delay: Duration,
+    mut write_cr: W,
+    mut session_alive: A,
+) -> FinalCrOutcome
+where
+    W: FnMut(u32) -> WFut,
+    WFut: std::future::Future<Output = bool>,
+    A: FnMut() -> bool,
+{
+    for attempt in 1..=max_attempts {
+        if write_cr(attempt).await {
+            return FinalCrOutcome::Confirmed;
+        }
+        if attempt < max_attempts {
+            // session がもう無ければ再送しても無駄。codex は確定前に exit 済みと判断して打ち切る。
+            if !session_alive() {
+                return FinalCrOutcome::SessionGone;
+            }
+            tokio::time::sleep(retry_delay).await;
+        }
+    }
+    FinalCrOutcome::Exhausted
+}
+
+/// Codex の system prompt を、PTY (TUI) に直接「最初の入力」として注入する fallback 経路。
+///
+/// 動作:
+///   1. spawn 直後 1.8 秒スリープして Codex の TUI が prompt 入力を受け付ける状態になるのを待つ。
+///   2. team_hub::inject::build_chunks で ConPTY-safe チャンク (64B / 15ms / UTF-8 境界保護) に
+///      整形 (banner は空文字)。
+///   3. 各チャンクを順に書き込み、最後に \r で確定送信。
+///
+/// チームメッセージの inject() と違って banner は付けない (Codex に対する初手のユーザー指示として届く)。
+///
+/// Issue #620: `SessionHandle::write` は内部で `std::sync::Mutex::lock` + 同期 `write_all`/`flush`
+/// なので、tokio multi-thread runtime の async task 内から直接呼ぶと ConPTY back-pressure 時に
+/// worker thread を 1 本占有してしまう。`team_hub::inject::inject_once` と同じく
+/// `tokio::task::spawn_blocking` で blocking pool に逃がし、async runtime を解放する。
+pub(super) async fn inject_codex_prompt_to_pty(
+    registry: Arc<crate::pty::SessionRegistry>,
+    term_id: String,
+    instructions: String,
+) {
+    use tokio::time::sleep;
+    sleep(Duration::from_millis(CODEX_INITIAL_PROMPT_DELAY_MS)).await;
+    let Some(session) = registry.get(&term_id) else {
+        return;
+    };
+    // Issue #153 / #619: 注入中はユーザーの xterm 入力 (terminal_write) を抑止する。
+    // RAII guard (`begin_injecting`) を使うことで、関数を抜けるあらゆる経路 (early return /
+    // panic / `?` 伝播 / 正常終了) で `injecting` フラグが必ず false に戻る。
+    // build_chunks は banner 込みで分割するが、Codex 注入では banner 不要なので空文字を渡す。
+    let _inject_guard = session.begin_injecting();
+    let chunks = build_chunks("", &instructions);
+    if chunks.is_empty() {
+        return;
+    }
+    let mut iter = chunks.into_iter();
+    if let Some(first) = iter.next() {
+        // Issue #620: spawn_blocking で同期 write を blocking pool に逃がす。
+        // Issue #619: 早期 return しても `_inject_guard` の Drop で injecting=false に戻る。
+        let s = session.clone();
+        match tokio::task::spawn_blocking(move || s.write(&first)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    "[terminal] codex prompt write(first) failed for {term_id}: {e}"
+                );
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[terminal] codex prompt spawn_blocking(first) failed for {term_id}: {e}"
+                );
+                return;
+            }
+        }
+    }
+    for chunk in iter {
+        sleep(Duration::from_millis(CODEX_PROMPT_CHUNK_DELAY_MS)).await;
+        if registry.get(&term_id).is_none() {
+            return;
+        }
+        // Issue #620: 各チャンクの write も spawn_blocking 経由。
+        // Issue #619: 早期 return / panic でも guard Drop が injecting=false に戻す。
+        let s = session.clone();
+        match tokio::task::spawn_blocking(move || s.write(&chunk)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    "[terminal] codex prompt write(chunk) failed for {term_id}: {e}"
+                );
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[terminal] codex prompt spawn_blocking(chunk) failed for {term_id}: {e}"
+                );
+                return;
+            }
+        }
+    }
+    sleep(Duration::from_millis(CODEX_PROMPT_CHUNK_DELAY_MS)).await;
+    // Issue #620: 末尾の確定 `\r` も spawn_blocking 経由で送る。
+    // Issue #1077: 旧実装は `\r` 失敗を warn のみで握り潰しており、本文 paste は届いたのに
+    // Enter 未確定で codex が起動指示を実行しないまま待機する事故 (「起動したのに何も
+    // 始まらない」) を招いていた。ConPTY back-pressure 等の一過性失敗に備え、確定 `\r` を
+    // write_final_cr_with_retry で最大 CODEX_FINAL_CR_MAX_ATTEMPTS 回まで再試行する。
+    let outcome = write_final_cr_with_retry(
+        CODEX_FINAL_CR_MAX_ATTEMPTS,
+        Duration::from_millis(CODEX_FINAL_CR_RETRY_DELAY_MS),
+        |attempt| {
+            let s = session.clone();
+            let term_id = term_id.clone();
+            async move {
+                match tokio::task::spawn_blocking(move || s.write(b"\r")).await {
+                    Ok(Ok(())) => true,
+                    Ok(Err(e)) => {
+                        tracing::warn!(
+                            "[terminal] codex prompt write(\\r) attempt {attempt}/{CODEX_FINAL_CR_MAX_ATTEMPTS} failed for {term_id}: {e}"
+                        );
+                        false
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "[terminal] codex prompt spawn_blocking(\\r) attempt {attempt}/{CODEX_FINAL_CR_MAX_ATTEMPTS} failed for {term_id}: {e}"
+                        );
+                        false
+                    }
+                }
+            }
+        },
+        || registry.get(&term_id).is_some(),
+    )
+    .await;
+    match outcome {
+        FinalCrOutcome::Confirmed => {}
+        FinalCrOutcome::SessionGone => {
+            // session が消えている = codex は確定前に既に exit 済み。確定待ちではないので
+            // warn 止まり (「unconfirmed で固まっている」誤解を生む error を出さない)。
+            tracing::warn!(
+                "[terminal] codex prompt final \\r aborted for {term_id} — session already gone (codex likely exited before confirm)"
+            );
+        }
+        FinalCrOutcome::Exhausted => {
+            // 全試行が write 失敗で尽きた。codex は確定待ちのまま固まる可能性が高い。
+            tracing::error!(
+                "[terminal] codex prompt final \\r never confirmed for {term_id} after {CODEX_FINAL_CR_MAX_ATTEMPTS} attempts — codex may be waiting unconfirmed"
+            );
+        }
+    }
+    tracing::info!(
+        "[terminal] codex prompt injected into pty {term_id} ({} bytes)",
+        instructions.len()
+    );
+}
+
+
+#[cfg(test)]
+mod final_cr_retry_tests {
+    use super::{write_final_cr_with_retry, FinalCrOutcome};
+    use std::cell::Cell;
+    use std::time::Duration;
+
+    // retry delay は 0 にして、テストが実時間 sleep しないようにする。
+    const NO_DELAY: Duration = Duration::from_millis(0);
+
+    #[tokio::test]
+    async fn confirmed_on_first_attempt() {
+        let calls = Cell::new(0u32);
+        let outcome = write_final_cr_with_retry(
+            3,
+            NO_DELAY,
+            |_attempt| {
+                calls.set(calls.get() + 1);
+                async { true }
+            },
+            || true,
+        )
+        .await;
+        assert_eq!(outcome, FinalCrOutcome::Confirmed);
+        assert_eq!(calls.get(), 1, "成功すれば 1 回で打ち切るはず");
+    }
+
+    #[tokio::test]
+    async fn confirmed_after_transient_failures() {
+        // Issue #1077 の本命: 最初の 2 回失敗 → 3 回目で確定。
+        let calls = Cell::new(0u32);
+        let outcome = write_final_cr_with_retry(
+            3,
+            NO_DELAY,
+            |attempt| {
+                calls.set(calls.get() + 1);
+                async move { attempt == 3 }
+            },
+            || true,
+        )
+        .await;
+        assert_eq!(outcome, FinalCrOutcome::Confirmed);
+        assert_eq!(calls.get(), 3, "3 回目で成功するまで retry するはず");
+    }
+
+    #[tokio::test]
+    async fn exhausted_when_all_attempts_fail() {
+        let calls = Cell::new(0u32);
+        let outcome = write_final_cr_with_retry(
+            3,
+            NO_DELAY,
+            |_attempt| {
+                calls.set(calls.get() + 1);
+                async { false }
+            },
+            || true, // session は生存し続ける
+        )
+        .await;
+        assert_eq!(outcome, FinalCrOutcome::Exhausted);
+        assert_eq!(calls.get(), 3, "max_attempts ぶん試行して尽きるはず");
+    }
+
+    #[tokio::test]
+    async fn aborts_when_session_gone() {
+        // session 消滅時は retry せず即 SessionGone (Exhausted の error 文言を出さない / M1)。
+        let calls = Cell::new(0u32);
+        let outcome = write_final_cr_with_retry(
+            3,
+            NO_DELAY,
+            |_attempt| {
+                calls.set(calls.get() + 1);
+                async { false }
+            },
+            || false, // 1 回目失敗後の生存確認で「消滅」を返す
+        )
+        .await;
+        assert_eq!(outcome, FinalCrOutcome::SessionGone);
+        assert_eq!(calls.get(), 1, "session 消滅を検知したら追加 retry しないはず");
+    }
+}
+

--- a/src-tauri/src/commands/tests/mod.rs
+++ b/src-tauri/src/commands/tests/mod.rs
@@ -12,5 +12,6 @@
 mod git;
 mod sessions;
 mod sessions_authz;
+mod spawn_cwd_authz;
 mod settings;
 mod team_history_authz;

--- a/src-tauri/src/commands/tests/spawn_cwd_authz.rs
+++ b/src-tauri/src/commands/tests/spawn_cwd_authz.rs
@@ -1,0 +1,117 @@
+//! Issue #1200: PTY spawn 境界の cwd fresh identity 再照合の回帰テスト。
+//!
+//! resume が返した canonical cwd と spawn の間に同一 path の directory が置換される
+//! check-to-use gap を、TTL キャッシュを使わない再照合で fail-closed に塞ぐことを固定する。
+
+use crate::commands::authz::assert_spawn_cwd_identity;
+use crate::commands::project_authority::ProjectRootIdentity;
+use arc_swap::ArcSwapOption;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+async fn slots_for(
+    root: &std::path::Path,
+) -> (
+    ArcSwapOption<String>,
+    ArcSwapOption<ProjectRootIdentity>,
+    ProjectRootIdentity,
+) {
+    let identity = crate::commands::project_authority::capture_identity(root)
+        .await
+        .unwrap();
+    let root_slot = ArcSwapOption::from(Some(Arc::new(identity.canonical_root.clone())));
+    let identity_slot = ArcSwapOption::from(Some(Arc::new(identity.clone())));
+    (root_slot, identity_slot, identity)
+}
+
+/// 置換されていない active root への spawn は通る。
+#[tokio::test]
+async fn intact_active_root_cwd_is_allowed() {
+    let sandbox = tempdir().unwrap();
+    let root = sandbox.path().join("project");
+    tokio::fs::create_dir_all(&root).await.unwrap();
+    let (root_slot, identity_slot, _) = slots_for(&root).await;
+
+    assert_spawn_cwd_identity(&root_slot, &identity_slot, root.to_string_lossy().as_ref())
+        .await
+        .unwrap();
+}
+
+/// activate 後に同一 path の directory が置換されたら、TTL キャッシュの状態に関わらず
+/// spawn 直前の fresh 再照合で拒否する (Issue #1200 の本体)。
+#[tokio::test]
+async fn replaced_active_root_cwd_is_rejected_before_spawn() {
+    let sandbox = tempdir().unwrap();
+    let root = sandbox.path().join("project");
+    let parked = sandbox.path().join("parked");
+    tokio::fs::create_dir_all(&root).await.unwrap();
+    let (root_slot, identity_slot, identity) = slots_for(&root).await;
+
+    // 通常 IPC 相当の照合を先に成功させ、TTL キャッシュが温まった状態を作る。
+    assert_spawn_cwd_identity(&root_slot, &identity_slot, root.to_string_lossy().as_ref())
+        .await
+        .unwrap();
+
+    // 同一 path のまま directory を置換する (= resume 返却後の rename/delete + 再作成)。
+    tokio::fs::rename(&root, &parked).await.unwrap();
+    tokio::fs::create_dir_all(&root).await.unwrap();
+    let replaced = crate::commands::project_authority::capture_identity(&root)
+        .await
+        .unwrap();
+    assert_ne!(identity, replaced, "fixture premise");
+
+    let error =
+        assert_spawn_cwd_identity(&root_slot, &identity_slot, root.to_string_lossy().as_ref())
+            .await
+            .expect_err("replaced directory must not be spawnable");
+    assert_eq!(error.code(), "authz");
+}
+
+/// active root と identity が両方未設定でも、project 管理外 cwd は従来どおり通る。
+#[tokio::test]
+async fn out_of_project_cwd_is_out_of_scope() {
+    let sandbox = tempdir().unwrap();
+    let cwd = sandbox.path().join("scratch");
+    tokio::fs::create_dir_all(&cwd).await.unwrap();
+    let root_slot: ArcSwapOption<String> = ArcSwapOption::from(None);
+    let identity_slot: ArcSwapOption<ProjectRootIdentity> = ArcSwapOption::from(None);
+
+    assert_spawn_cwd_identity(&root_slot, &identity_slot, cwd.to_string_lossy().as_ref())
+        .await
+        .unwrap();
+}
+
+/// active root と同一 directory なのに native identity が無い場合は fail-closed。
+#[tokio::test]
+async fn active_root_without_identity_is_rejected() {
+    let sandbox = tempdir().unwrap();
+    let root = sandbox.path().join("project");
+    tokio::fs::create_dir_all(&root).await.unwrap();
+    let (root_slot, _identity_slot, _) = slots_for(&root).await;
+    let empty_identity: ArcSwapOption<ProjectRootIdentity> = ArcSwapOption::from(None);
+
+    let error =
+        assert_spawn_cwd_identity(&root_slot, &empty_identity, root.to_string_lossy().as_ref())
+            .await
+            .expect_err("identity-less active root must not be spawnable");
+    assert_eq!(error.code(), "authz");
+}
+
+/// 検証中に cwd が消えた場合も推測せず拒否する。
+#[tokio::test]
+async fn vanished_cwd_is_rejected() {
+    let sandbox = tempdir().unwrap();
+    let root = sandbox.path().join("project");
+    tokio::fs::create_dir_all(&root).await.unwrap();
+    let (root_slot, identity_slot, _) = slots_for(&root).await;
+    let missing = sandbox.path().join("missing");
+
+    let error = assert_spawn_cwd_identity(
+        &root_slot,
+        &identity_slot,
+        missing.to_string_lossy().as_ref(),
+    )
+    .await
+    .expect_err("missing cwd must not be spawnable");
+    assert_eq!(error.code(), "authz");
+}


### PR DESCRIPTION
## Summary
- resume が返した canonical cwd と PTY/MCP 起動の間に同一 path の directory が別 project へ置換される check-to-use gap (#1200) を fail-closed に塞ぐ
- `assert_spawn_cwd_identity` (authz) を新設し、`terminal_create` の spawn 直前に配線。cwd が **active root / 承認済み workspace root と同一 directory** を指す場合のみ、TTL キャッシュを使わず platform identity (Unix: dev+inode / Windows: volume serial+file index) を取り直して native approval と照合し、不一致・消失時は起動しない
- `app_setup_team_mcp` の active root 解決を `assert_active_project_root_fresh` (TTL キャッシュをバイパスする新変種) に変更し、MCP 設定書き出し境界でも再検証する
- project 管理外の cwd (home fallback 等) と project 未選択時は従来挙動を維持 (スコープ外)

## 実装メモ
- `RecheckPolicy { CachedTtl, Fresh }` で既存の高頻度 IPC 向け TTL キャッシュ (#1202 review) と起動境界の fresh 照合を両立
- directory handle の受け渡し (check-to-use の完全排除) は portable-pty が cwd を path 文字列でしか受けないため今回は見送り、spawn 直前再検証で窓を最小化する方針 (issue 想定スコープ内)
- ratchet 対応で `terminal.rs` の codex prompt 注入経路を自己完結の `terminal/codex_prompt.rs` へ分離 (1278 → 1002 行、baseline 引き下げ)

## Test plan
- [x] spawn 境界回帰テスト 5 件: directory 置換後の起動拒否 (キャッシュ温存状態でも fresh 照合で検知) / 置換なし許可 / project 外 cwd は対象外 / identity 欠落 active root は拒否 / 検証中に消えた cwd は拒否
- [x] `cargo test` 930 passed / `cargo clippy --all-targets -- -D warnings`
- [x] `vitest` 519 passed / `npm run typecheck` / `npm run lint` (0 errors)
- [x] `lint:file-size` / `lint:command-result` / `build:vite`

Closes #1200