### PR TITLE
fix(terminal): 復元タブIDを同期確定

### DIFF
--- a/src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx
@@ -94,6 +94,20 @@ describe('useTerminalTabs', () => {
 
   // ---- Issue #588: addTerminalTab の同期連打レース ----
 
+  it('returns every assigned id during synchronous batched adds (#1137)', () => {
+    const { result } = renderHook(() => useTerminalTabs(options()));
+    const assigned: Array<number | null> = [];
+
+    act(() => {
+      assigned.push(result.current.addTerminalTab({ agent: 'claude' }));
+      assigned.push(result.current.addTerminalTab({ agent: 'codex' }));
+      assigned.push(result.current.addTerminalTab({ agent: 'claude' }));
+    });
+
+    expect(assigned).toEqual([1, 2, 3]);
+    expect(result.current.terminalTabs.map((tab) => tab.id)).toEqual(assigned);
+  });
+
   it('caps terminal count at MAX_TERMINALS even when invoked synchronously beyond the limit (#588)', () => {
     const showToast = vi.fn();
     const { result } = renderHook(() => useTerminalTabs(options({ showToast })));

--- a/src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-terminal-tabs.test.tsx
@@ -108,6 +108,22 @@ describe('useTerminalTabs', () => {
     expect(result.current.terminalTabs.map((tab) => tab.id)).toEqual(assigned);
   });
 
+  it('accepts an add after a synchronous batched delete at the terminal limit', () => {
+    const { result } = renderHook(() => useTerminalTabs(options()));
+    act(() => {
+      for (let i = 0; i < MAX_TERMINALS; i += 1) result.current.addTerminalTab();
+    });
+
+    let assigned: number | null = null;
+    act(() => {
+      result.current.setTerminalTabs((prev) => prev.slice(0, -1));
+      assigned = result.current.addTerminalTab({ agent: 'codex' });
+    });
+
+    expect(assigned).toBe(MAX_TERMINALS + 1);
+    expect(result.current.terminalTabs).toHaveLength(MAX_TERMINALS);
+  });
+
   it('caps terminal count at MAX_TERMINALS even when invoked synchronously beyond the limit (#588)', () => {
     const showToast = vi.fn();
     const { result } = renderHook(() => useTerminalTabs(options({ showToast })));

--- a/src/renderer/src/lib/hooks/use-terminal-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs.ts
@@ -188,11 +188,19 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
   const optsRef = useRef(opts);
   optsRef.current = opts;
 
-  const [terminalTabs, setTerminalTabs] = useState<TerminalTab[]>([]);
+  const [terminalTabs, setTerminalTabsState] = useState<TerminalTab[]>([]);
+  const terminalTabsRef = useRef(terminalTabs);
+  terminalTabsRef.current = terminalTabs;
+  const setTerminalTabs = useCallback<React.Dispatch<React.SetStateAction<TerminalTab[]>>>(
+    (action) => {
+      const next = typeof action === 'function' ? action(terminalTabsRef.current) : action;
+      terminalTabsRef.current = next;
+      setTerminalTabsState(next);
+    },
+    [],
+  );
   const [activeTerminalTabId, setActiveTerminalTabId] = useState<number>(0);
   const nextTerminalIdRef = useRef(1);
-  const terminalTabCountRef = useRef(terminalTabs.length);
-  terminalTabCountRef.current = terminalTabs.length;
 
   // Issue #363: hasActivity を terminalTabs に持たせると PTY data 受信ごとに
   // setTerminalTabs が走り、TerminalView の親 App 全体が ~16ms 周期で再レンダーする。
@@ -253,7 +261,7 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
       // cwd/size mapのkeyに使うため、そのタブが次のauto-saveで既定値に破壊されていた。
       // 同期予約数をrefで管理し、上限判定と採番をupdaterより前に確定する。これにより#588の
       // 「同期連打でも上限を超えず、reject時にidを消費しない」契約も維持する。
-      if (terminalTabCountRef.current >= MAX_TERMINALS) {
+      if (terminalTabsRef.current.length >= MAX_TERMINALS) {
         optsRef.current.showToast(
           t('terminal.limitReached', { max: MAX_TERMINALS }),
           { tone: 'warning' }
@@ -261,7 +269,6 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
         return null;
       }
       const id = nextTerminalIdRef.current++;
-      terminalTabCountRef.current += 1;
       const agentType = addOpts?.agent ?? 'claude';
       // Issue #660: client-side UUID 事前注入。
       //   - resumeSessionId が外部指定 (team-history resume / 永続化復元) → そのまま使い
@@ -329,7 +336,7 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
       setActiveTerminalTabId(id);
       return id;
     },
-    [t]
+    [t, setTerminalTabs]
   );
 
   const doCloseTab = useCallback((tabId: number) => {
@@ -347,7 +354,7 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
       });
       return next;
     });
-  }, []);
+  }, [setTerminalTabs]);
 
   const closeTerminalTab = useCallback(
     (tabId: number) => {
@@ -377,7 +384,7 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
           : t
       )
     );
-  }, []);
+  }, [setTerminalTabs]);
 
   /**
    * Issue #660: Claude session が jsonl に永続化された (= `onSessionId` 受信) 時点で呼び、
@@ -392,7 +399,7 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
       next[idx] = { ...prev[idx], freshSessionId: false };
       return next;
     });
-  }, []);
+  }, [setTerminalTabs]);
 
   const restartTerminal = useCallback(() => {
     restartTerminalTab(activeTerminalTabId);
@@ -439,13 +446,13 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
         setDragOverTabId(null);
       }
     }),
-    []
+    [setTerminalTabs]
   );
 
   const resetForProjectSwitch = useCallback(() => {
     setTerminalTabs([]);
     setActiveTerminalTabId(0);
-  }, []);
+  }, [setTerminalTabs]);
 
   return {
     terminalTabs,

--- a/src/renderer/src/lib/hooks/use-terminal-tabs.ts
+++ b/src/renderer/src/lib/hooks/use-terminal-tabs.ts
@@ -191,6 +191,8 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
   const [terminalTabs, setTerminalTabs] = useState<TerminalTab[]>([]);
   const [activeTerminalTabId, setActiveTerminalTabId] = useState<number>(0);
   const nextTerminalIdRef = useRef(1);
+  const terminalTabCountRef = useRef(terminalTabs.length);
+  terminalTabCountRef.current = terminalTabs.length;
 
   // Issue #363: hasActivity を terminalTabs に持たせると PTY data 受信ごとに
   // setTerminalTabs が走り、TerminalView の親 App 全体が ~16ms 周期で再レンダーする。
@@ -246,19 +248,20 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
 
   const addTerminalTab = useCallback(
     (addOpts?: AddTerminalTabOptions): number | null => {
-      // Issue #588: 旧実装は updater 外で `nextTerminalIdRef.current++` と
-      // `let accepted = false` を行い、updater 内で `accepted = true` をセットしていた。
-      // React 18 の自動 batching 下では setState の updater は同期実行されないことがあり、
-      // 同期で N 回連打した場合に
-      //   (a) `accepted` が false のまま return null されて `setActiveTerminalTabId` がスキップ、
-      //   (b) reject 分まで `nextTerminalIdRef.current` が無駄消費される
-      // という race が起きていた。
-      //
-      // 修正: id 採番と active 切替を updater 内に閉じ込め、reject 時は (return prev で) 純粋に
-      // 何も起こらない設計に変える。これで updater が直列に走ってもタブ数は MAX_TERMINALS で
-      // 確実に頭打ちになり、id ref も accepted 数しか進まない。`setActiveTerminalTabId` を
-      // updater 内から呼ぶのは「同コンポーネント内の setState を queue する」だけなので
-      // strict mode の二重実行下でも同じ id を再代入するだけで idempotent。
+      // Issue #1137: id を state updater 内で採番すると、React batching 中の2回目以降は
+      // updaterが同期実行されず、タブ自体は追加されても戻り値が null になる。復元側は戻り値を
+      // cwd/size mapのkeyに使うため、そのタブが次のauto-saveで既定値に破壊されていた。
+      // 同期予約数をrefで管理し、上限判定と採番をupdaterより前に確定する。これにより#588の
+      // 「同期連打でも上限を超えず、reject時にidを消費しない」契約も維持する。
+      if (terminalTabCountRef.current >= MAX_TERMINALS) {
+        optsRef.current.showToast(
+          t('terminal.limitReached', { max: MAX_TERMINALS }),
+          { tone: 'warning' }
+        );
+        return null;
+      }
+      const id = nextTerminalIdRef.current++;
+      terminalTabCountRef.current += 1;
       const agentType = addOpts?.agent ?? 'claude';
       // Issue #660: client-side UUID 事前注入。
       //   - resumeSessionId が外部指定 (team-history resume / 永続化復元) → そのまま使い
@@ -266,7 +269,7 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
       //   - 未指定 & claude → UUID v4 を採番して `--session-id` 経路で起動 (新規 jsonl 作成)
       //   - 未指定 & codex/その他 → resumeSessionId は null (--session-id も --resume も付けない)
       // updater の外で生成するのは副作用 (UUID) のため。strict mode 二重呼び出しでも同 UUID で
-      // idempotent。MAX_TERMINALS で reject されたら 1 個無駄になるが極小コストなので許容。
+      // idempotent。上限判定後なのでrejectされた追加ではUUIDを生成しない。
       let resumeSessionId: string | null;
       let freshSessionId: boolean;
       if (addOpts?.resumeSessionId !== undefined) {
@@ -279,17 +282,7 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
         resumeSessionId = null;
         freshSessionId = false;
       }
-      let assignedId: number | null = null;
       setTerminalTabs((prev) => {
-        if (prev.length >= MAX_TERMINALS) {
-          optsRef.current.showToast(
-            t('terminal.limitReached', { max: MAX_TERMINALS }),
-            { tone: 'warning' }
-          );
-          return prev;
-        }
-        const id = nextTerminalIdRef.current++;
-        assignedId = id;
         // ラベル自動生成: チームロール or 連番
         let label: string;
         if (addOpts?.role) {
@@ -331,12 +324,10 @@ export function useTerminalTabs(opts: UseTerminalTabsOptions): UseTerminalTabsRe
             { tone: 'info' }
           );
         }
-        // 新タブを active に切り替える。reject パスは return prev で先に抜けているので、
-        // ここに到達する = タブ追加が確定している。
-        setActiveTerminalTabId(id);
         return [...prev, tab];
       });
-      return assignedId;
+      setActiveTerminalTabId(id);
+      return id;
     },
     [t]
   );

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -765,7 +765,7 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1137
 ### 計画
 
 - [x] `addTerminalTab` の同期戻り値と永続化mapの依存関係を確認する。
-- [x] 同期予約数refで上限判定とID採番をupdater前に確定する。
+- [x] stateと同期更新するrefで上限判定とID採番をupdater前に確定する。
 - [x] 同一batchの連続追加が全IDを同期返却する退行テストを追加する。
 - [x] #588上限契約を含む関連テストと全品質ゲートを実行する。
 
@@ -776,7 +776,7 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1137
 
 ### 検証結果
 
-- [x] `use-terminal-tabs` Vitest: PASS (10 tests)
+- [x] `use-terminal-tabs` Vitest: PASS (11 tests、同一batchの削除→追加を含む)
 - [x] `npm run typecheck`: PASS
 - [x] `npm run test`: PASS (86 files / 520 tests)
 - [x] `npm run lint`: PASS (0 errors / 既存 12 warnings)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -757,6 +757,31 @@ Branch: `feature/issue-452`
 
 #### 検証結果（代替で PASS 済み）
 - [x] `git diff --check`: PASS
+
+## Issue #1137 - 複数タブ復元時のcwdマッピング破壊を防止 (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1137
+
+### 計画
+
+- [x] `addTerminalTab` の同期戻り値と永続化mapの依存関係を確認する。
+- [x] 同期予約数refで上限判定とID採番をupdater前に確定する。
+- [x] 同一batchの連続追加が全IDを同期返却する退行テストを追加する。
+- [x] #588上限契約を含む関連テストと全品質ゲートを実行する。
+
+### Next Steps
+
+- [x] 検証結果を記録する。
+- [x] コミットして feature branch を push する。
+
+### 検証結果
+
+- [x] `use-terminal-tabs` Vitest: PASS (10 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (86 files / 520 tests)
+- [x] `npm run lint`: PASS (0 errors / 既存 12 warnings)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
 - [x] `npm run typecheck`: PASS
 - [x] `npm run build:vite`: PASS（既存警告あり）
 - [x] targeted Vitest: PASS（2 files / 11 tests）


### PR DESCRIPTION
## Summary
- Issue #1137 の計画済み修正を、対象スコープ内で実装
- 変更規模: 3 files changed, 58 insertions(+), 28 deletions(-)（3 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1137

## Test plan
- [x] 変更対象のVitest
- [x] npm run typecheck
- [x] npm run test
- [x] npm run lint
- [x] npm run build:vite
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない