### PR TITLE
fix(team): IDE再開の二重起動を防止

### DIFF
--- a/src/renderer/src/lib/hooks/__tests__/use-team-history-sync.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-team-history-sync.test.tsx
@@ -166,6 +166,40 @@ describe('useTeamHistorySync', () => {
     expect(showToast).toHaveBeenCalledWith('teamHistory.alreadyOpen', { tone: 'info' });
   });
 
+  it('keeps the resume reservation when only an exited team tab remains (#1138)', async () => {
+    const api = installApi();
+    mocks.mcpAutoSetup = true;
+    let resolveSetup!: (value: { changed: boolean }) => void;
+    const setupPromise = new Promise<{ changed: boolean }>((resolve) => {
+      resolveSetup = resolve;
+    });
+    (api as MockApi & { app: { setupTeamMcp: ReturnType<typeof vi.fn> } }).app = {
+      setupTeamMcp: vi.fn(() => setupPromise)
+    };
+    const addTerminalTab = vi.fn(() => 1);
+    const showToast = vi.fn();
+    let terminalTabs = [
+      { teamId: 'team-1', exited: true } as UseTeamHistorySyncOptions['terminalTabs'][number]
+    ];
+    const { result, rerender } = renderHook(() =>
+      useTeamHistorySync(options({ terminalTabs, addTerminalTab, showToast }))
+    );
+    const entry = teamEntry();
+
+    let firstResume!: Promise<void>;
+    act(() => {
+      firstResume = result.current.handleResumeTeam(entry);
+    });
+    terminalTabs = [...terminalTabs];
+    rerender();
+    await act(async () => result.current.handleResumeTeam(entry));
+    resolveSetup({ changed: false });
+    await act(async () => firstResume);
+
+    expect(addTerminalTab).toHaveBeenCalledTimes(entry.members.length);
+    expect(showToast).toHaveBeenCalledWith('teamHistory.alreadyOpen', { tone: 'info' });
+  });
+
   it('does not reserve a team rejected for another project', async () => {
     installApi();
     const addTerminalTab = vi.fn(() => 1);

--- a/src/renderer/src/lib/hooks/__tests__/use-team-history-sync.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-team-history-sync.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -17,6 +17,7 @@ import {
   useTeamHistorySync,
   type UseTeamHistorySyncOptions
 } from '../use-team-history-sync';
+import type { TeamHistoryEntry } from '../../../../../types/shared';
 
 type MockApi = {
   teamHistory: {
@@ -59,6 +60,24 @@ function options(
   };
 }
 
+function teamEntry(): TeamHistoryEntry {
+  return {
+    id: 'team-1',
+    name: 'Test Team',
+    projectRoot: '/workspace/active',
+    createdAt: '2026-07-14T00:00:00.000Z',
+    lastUsedAt: '2026-07-14T00:00:00.000Z',
+    members: [
+      {
+        role: 'leader',
+        agent: 'claude',
+        agentId: 'leader-1',
+        sessionId: 'session-1'
+      }
+    ]
+  };
+}
+
 describe('useTeamHistorySync', () => {
   let originalApi: MockApi | undefined;
 
@@ -92,5 +111,42 @@ describe('useTeamHistorySync', () => {
       expect(warn).toHaveBeenCalledWith('[teamHistory] list failed:', authzError);
     });
     expect(result.current.teamHistoryEntries).toEqual([]);
+  });
+
+  it('does not resume a team that already has an IDE terminal tab (#1138)', async () => {
+    installApi();
+    const addTerminalTab = vi.fn(() => 2);
+    const showToast = vi.fn();
+    const existingTab = {
+      teamId: 'team-1'
+    } as UseTeamHistorySyncOptions['terminalTabs'][number];
+    const { result } = renderHook(() =>
+      useTeamHistorySync(options({ terminalTabs: [existingTab], addTerminalTab, showToast }))
+    );
+
+    await act(async () => result.current.handleResumeTeam(teamEntry()));
+
+    expect(addTerminalTab).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith('teamHistory.alreadyOpen', { tone: 'info' });
+  });
+
+  it('reserves the team id so rapid resume clicks spawn members only once (#1138)', async () => {
+    installApi();
+    const addTerminalTab = vi.fn(() => 1);
+    const showToast = vi.fn();
+    const { result } = renderHook(() =>
+      useTeamHistorySync(options({ addTerminalTab, showToast }))
+    );
+    const entry = teamEntry();
+
+    await act(async () => {
+      await Promise.all([
+        result.current.handleResumeTeam(entry),
+        result.current.handleResumeTeam(entry)
+      ]);
+    });
+
+    expect(addTerminalTab).toHaveBeenCalledTimes(entry.members.length);
+    expect(showToast).toHaveBeenCalledWith('teamHistory.alreadyOpen', { tone: 'info' });
   });
 });

--- a/src/renderer/src/lib/hooks/__tests__/use-team-history-sync.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-team-history-sync.test.tsx
@@ -130,6 +130,22 @@ describe('useTeamHistorySync', () => {
     expect(showToast).toHaveBeenCalledWith('teamHistory.alreadyOpen', { tone: 'info' });
   });
 
+  it('allows resuming a team whose previous IDE terminal tab has exited (#1138)', async () => {
+    installApi();
+    const addTerminalTab = vi.fn(() => 2);
+    const exitedTab = {
+      teamId: 'team-1',
+      exited: true
+    } as UseTeamHistorySyncOptions['terminalTabs'][number];
+    const { result } = renderHook(() =>
+      useTeamHistorySync(options({ terminalTabs: [exitedTab], addTerminalTab }))
+    );
+
+    await act(async () => result.current.handleResumeTeam(teamEntry()));
+
+    expect(addTerminalTab).toHaveBeenCalledTimes(teamEntry().members.length);
+  });
+
   it('reserves the team id so rapid resume clicks spawn members only once (#1138)', async () => {
     installApi();
     const addTerminalTab = vi.fn(() => 1);

--- a/src/renderer/src/lib/hooks/__tests__/use-team-history-sync.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-team-history-sync.test.tsx
@@ -149,4 +149,18 @@ describe('useTeamHistorySync', () => {
     expect(addTerminalTab).toHaveBeenCalledTimes(entry.members.length);
     expect(showToast).toHaveBeenCalledWith('teamHistory.alreadyOpen', { tone: 'info' });
   });
+
+  it('does not reserve a team rejected for another project', async () => {
+    installApi();
+    const addTerminalTab = vi.fn(() => 1);
+    const { result } = renderHook(() => useTeamHistorySync(options({ addTerminalTab })));
+    const entry = { ...teamEntry(), projectRoot: '/workspace/other' };
+
+    await act(async () => result.current.handleResumeTeam(entry));
+    await act(async () =>
+      result.current.handleResumeTeam({ ...entry, projectRoot: '/workspace/active' }),
+    );
+
+    expect(addTerminalTab).toHaveBeenCalledTimes(entry.members.length);
+  });
 });

--- a/src/renderer/src/lib/hooks/use-team-history-sync.ts
+++ b/src/renderer/src/lib/hooks/use-team-history-sync.ts
@@ -123,7 +123,9 @@ export function useTeamHistorySync(
   // optsRef.current.terminalTabsがまだ空のため、既存タブ判定だけでは二重起動を防げない。
   useEffect(() => {
     const openTeamIds = new Set(
-      opts.terminalTabs.flatMap((tab) => (tab.teamId ? [tab.teamId] : []))
+      opts.terminalTabs.flatMap((tab) =>
+        tab.teamId && !tab.exited ? [tab.teamId] : []
+      )
     );
     for (const teamId of resumingTeamIdsRef.current) {
       if (openTeamIds.has(teamId)) resumingTeamIdsRef.current.delete(teamId);
@@ -236,7 +238,7 @@ export function useTeamHistorySync(
         if (id !== null) addedTabs += 1;
       }
 
-      // 容量競合などで1件も追加できなかった場合は、次の明示操作で再試行可能にする。
+      // 容量競合などで1件も追加できなかった場合は、次の明示的な操作で再試行可能にする。
       if (addedTabs === 0) resumingTeamIdsRef.current.delete(entry.id);
 
       showToast(t('teamHistory.resumed', { name: entry.name }), { tone: 'info' });

--- a/src/renderer/src/lib/hooks/use-team-history-sync.ts
+++ b/src/renderer/src/lib/hooks/use-team-history-sync.ts
@@ -53,6 +53,7 @@ export function useTeamHistorySync(
 
   const optsRef = useRef(opts);
   optsRef.current = opts;
+  const resumingTeamIdsRef = useRef(new Set<string>());
 
   const [teamHistoryEntries, setTeamHistoryEntries] = useState<TeamHistoryEntry[]>(
     []
@@ -118,6 +119,17 @@ export function useTeamHistorySync(
     void refreshTeamHistory();
   }, [opts.projectRoot, refreshTeamHistory]);
 
+  // Issue #1138: resume予約はタブがstateへ反映されるまで保持する。同一tickの連打では
+  // optsRef.current.terminalTabsがまだ空のため、既存タブ判定だけでは二重起動を防げない。
+  useEffect(() => {
+    const openTeamIds = new Set(
+      opts.terminalTabs.flatMap((tab) => (tab.teamId ? [tab.teamId] : []))
+    );
+    for (const teamId of resumingTeamIdsRef.current) {
+      if (openTeamIds.has(teamId)) resumingTeamIdsRef.current.delete(teamId);
+    }
+  }, [opts.terminalTabs]);
+
   const handleResumeTeam = useCallback(
     async (entry: TeamHistoryEntry) => {
       const {
@@ -129,10 +141,20 @@ export function useTeamHistorySync(
         setTeams
       } = optsRef.current;
       if (!projectRoot) return;
+      if (
+        resumingTeamIdsRef.current.has(entry.id) ||
+        terminalTabs.some((tab) => tab.teamId === entry.id)
+      ) {
+        showToast(t('teamHistory.alreadyOpen', { name: entry.name || entry.id }), {
+          tone: 'info'
+        });
+        return;
+      }
       if (!entry.members || entry.members.length === 0) {
         showToast(t('teamHistory.resume.emptyMembers'), { tone: 'warning' });
         return;
       }
+      resumingTeamIdsRef.current.add(entry.id);
       if (entry.projectRoot && entry.projectRoot !== projectRoot) {
         showToast(
           t('teamHistory.resume.otherProject', {
@@ -199,9 +221,10 @@ export function useTeamHistorySync(
       }
 
       // 各メンバーをタブとしてスポーン (sessionId があれば --resume 付き、customLabel があれば復元)
+      let addedTabs = 0;
       for (let i = 0; i < entry.members.length; i++) {
         const m = entry.members[i];
-        addTerminalTab({
+        const id = addTerminalTab({
           agent: m.agent,
           role: m.role,
           teamId: entry.id,
@@ -210,7 +233,11 @@ export function useTeamHistorySync(
           teamHistoryMemberIdx: i,
           customLabel: m.customLabel ?? null
         });
+        if (id !== null) addedTabs += 1;
       }
+
+      // 容量競合などで1件も追加できなかった場合は、次の明示操作で再試行可能にする。
+      if (addedTabs === 0) resumingTeamIdsRef.current.delete(entry.id);
 
       showToast(t('teamHistory.resumed', { name: entry.name }), { tone: 'info' });
     },

--- a/src/renderer/src/lib/hooks/use-team-history-sync.ts
+++ b/src/renderer/src/lib/hooks/use-team-history-sync.ts
@@ -143,7 +143,7 @@ export function useTeamHistorySync(
       if (!projectRoot) return;
       if (
         resumingTeamIdsRef.current.has(entry.id) ||
-        terminalTabs.some((tab) => tab.teamId === entry.id)
+        terminalTabs.some((tab) => tab.teamId === entry.id && !tab.exited)
       ) {
         showToast(t('teamHistory.alreadyOpen', { name: entry.name || entry.id }), {
           tone: 'info'

--- a/src/renderer/src/lib/hooks/use-team-history-sync.ts
+++ b/src/renderer/src/lib/hooks/use-team-history-sync.ts
@@ -154,7 +154,6 @@ export function useTeamHistorySync(
         showToast(t('teamHistory.resume.emptyMembers'), { tone: 'warning' });
         return;
       }
-      resumingTeamIdsRef.current.add(entry.id);
       if (entry.projectRoot && entry.projectRoot !== projectRoot) {
         showToast(
           t('teamHistory.resume.otherProject', {
@@ -171,6 +170,7 @@ export function useTeamHistorySync(
         });
         return;
       }
+      resumingTeamIdsRef.current.add(entry.id);
 
       // 再利用時刻を更新
       const updated: TeamHistoryEntry = {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -757,6 +757,31 @@ Branch: `feature/issue-452`
 
 #### 検証結果（代替で PASS 済み）
 - [x] `git diff --check`: PASS
+
+## Issue #1138 - IDEチーム再開の二重起動を防止 (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1138
+
+### 計画
+
+- [x] IDE再開経路とCanvas側の既存ガードを比較する。
+- [x] 既存teamIdタブとin-flight resume予約を同時に検査する。
+- [x] 既存チーム再開と高速二重クリックの退行テストを追加する。
+- [x] 関連テストと全品質ゲートを実行する。
+
+### Next Steps
+
+- [x] 検証結果を記録する。
+- [x] コミットして feature branch を push する。
+
+### 検証結果
+
+- [x] `use-team-history-sync` Vitest: PASS (3 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (86 files / 521 tests)
+- [x] `npm run lint`: PASS (0 errors / 既存 12 warnings)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
 - [x] `npm run typecheck`: PASS
 - [x] `npm run build:vite`: PASS（既存警告あり）
 - [x] targeted Vitest: PASS（2 files / 11 tests）

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -764,7 +764,8 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1138
 
 - [x] 既存teamIdタブとin-flight resume予約を同時に検査する。
 - [x] 既存チーム再開と高速二重クリックの退行テストを追加する。
-- [x] `use-team-history-sync` Vitest: PASS (3 tests)
+- [x] 拒否された再開では予約を残さず、条件解消後に再試行できるようにする。
+- [x] `use-team-history-sync` Vitest: PASS (4 tests)
 - [x] `npm run typecheck`: PASS
 - [x] `npm run lint:file-size`: PASS
 - [x] 最新mainを取り込み、再CI対象にする。


### PR DESCRIPTION
## Summary
- Issue #1138 の計画済み修正を、対象スコープ内で実装
- 変更規模: 3 files changed, 110 insertions(+), 2 deletions(-)（3 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1138

## Test plan
- [x] 変更対象のVitest
- [x] npm run typecheck
- [x] npm run test
- [x] npm run lint
- [x] npm run build:vite
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない