### PR TITLE
fix(ui): refresh失敗をエラー通知

### DIFF
--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -72,6 +72,7 @@ import {
 } from '../lib/terminal-render-gate';
 import { formatTerminalRuntimeStatus } from '../lib/terminal-status';
 import { useProject, useTabs, useTeam } from '../lib/app-state-context';
+import { reportRefreshFailure } from '../lib/refresh-error';
 
 export interface AppShellProps {
   /**
@@ -225,12 +226,16 @@ export function AppShell({
       const sess = await window.api.sessions.list(projectRoot);
       setSessions(sess);
     } catch (err) {
-      // #1147: authz rejectをcatch。toast UXは #1139 の対象なのでconsole診断を維持する。
-      console.warn('[app-shell] sessions.list failed:', err);
+      reportRefreshFailure(
+        'sessions.list',
+        err,
+        t('toast.sessionsRefreshFailed'),
+        showToast
+      );
     } finally {
       setSessionsLoading(false);
     }
-  }, [projectRoot]);
+  }, [projectRoot, setSessions, showToast, t]);
   useEffect(() => {
     if (sidebarView === 'sessions') void refreshSessions();
   }, [sidebarView, refreshSessions]);

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -226,12 +226,7 @@ export function AppShell({
       const sess = await window.api.sessions.list(projectRoot);
       setSessions(sess);
     } catch (err) {
-      reportRefreshFailure(
-        'sessions.list',
-        err,
-        t('toast.sessionsRefreshFailed'),
-        showToast
-      );
+      reportRefreshFailure('sessions.list', err, t('toast.sessionsRefreshFailed'), showToast);
     } finally {
       setSessionsLoading(false);
     }

--- a/src/renderer/src/lib/__tests__/refresh-error.test.ts
+++ b/src/renderer/src/lib/__tests__/refresh-error.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+import { reportRefreshFailure } from '../refresh-error';
+
+describe('reportRefreshFailure (Issue #1139)', () => {
+  it.each([
+    ['sessions.list', 'toast.sessionsRefreshFailed'],
+    ['git.status', 'toast.gitRefreshFailed']
+  ] as const)('logs and shows an error toast for %s', (scope, message) => {
+    const error = new Error('IPC failed');
+    const showToast = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    reportRefreshFailure(scope, error, message, showToast);
+
+    expect(warn).toHaveBeenCalledWith(`[refresh] ${scope} failed:`, error);
+    expect(showToast).toHaveBeenCalledWith(message, { tone: 'error' });
+  });
+});

--- a/src/renderer/src/lib/hooks/__tests__/use-project-loader.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-project-loader.test.tsx
@@ -188,4 +188,21 @@ describe('useProjectLoader', () => {
     expect(api.git.status).toHaveBeenLastCalledWith('/repo-next');
     expect(result.current.projectRoot).toBe('/repo-next');
   });
+
+  it('refreshGitのIPC失敗を処理してerror toastを表示する (#1139)', async () => {
+    const api = installApi();
+    api.app.restoreAuthorizedProjectRoot.mockResolvedValueOnce('/repo');
+    const showToast = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { result } = renderHook(() => useProjectLoader(options({ showToast })));
+    await waitFor(() => expect(result.current.projectRoot).toBe('/repo'));
+    const error = new Error('git IPC failed');
+    api.git.status.mockRejectedValueOnce(error);
+
+    await act(async () => result.current.refreshGit());
+
+    expect(warn).toHaveBeenCalledWith('[refresh] git.status failed:', error);
+    expect(showToast).toHaveBeenCalledWith('toast.gitRefreshFailed', { tone: 'error' });
+    expect(result.current.gitLoading).toBe(false);
+  });
 });

--- a/src/renderer/src/lib/hooks/use-project-loader.ts
+++ b/src/renderer/src/lib/hooks/use-project-loader.ts
@@ -9,6 +9,7 @@ import {
 } from '../settings-context';
 import { useUiStore } from '../../stores/ui';
 import { dedupPrepend, listContainsPath } from '../path-norm';
+import { reportRefreshFailure } from '../refresh-error';
 
 type ToastFn = (
   msg: string,
@@ -231,10 +232,17 @@ export function useProjectLoader(
     try {
       const gs = await window.api.git.status(projectRoot);
       setGitStatus(gs);
+    } catch (err) {
+      reportRefreshFailure(
+        'git.status',
+        err,
+        t('toast.gitRefreshFailed'),
+        optsRef.current.showToast
+      );
     } finally {
       setGitLoading(false);
     }
-  }, [projectRoot]);
+  }, [projectRoot, t]);
 
   // ---- Phase 2 (Issue #487): プロジェクトメニュー / ワークスペース ----
 

--- a/src/renderer/src/lib/i18n/en-shell.ts
+++ b/src/renderer/src/lib/i18n/en-shell.ts
@@ -256,6 +256,8 @@ export const enShell: Dict = {
   // ---------- Toast ----------
   'toast.reviewRequested': 'Review requested: {path}',
   'toast.sessionResumed': 'Resumed session: {title}',
+  'toast.sessionsRefreshFailed': 'Failed to refresh sessions',
+  'toast.gitRefreshFailed': 'Failed to refresh Git status',
   'toast.pathCopied': 'Path copied to clipboard',
   'toast.copyFailed': 'Failed to copy to clipboard',
   'toast.revealFailed': 'Failed to reveal in file manager',

--- a/src/renderer/src/lib/i18n/ja-shell.ts
+++ b/src/renderer/src/lib/i18n/ja-shell.ts
@@ -256,6 +256,8 @@ export const jaShell: Dict = {
   // ---------- Toast ----------
   'toast.reviewRequested': '差分レビューを依頼: {path}',
   'toast.sessionResumed': 'セッションに復帰: {title}',
+  'toast.sessionsRefreshFailed': 'セッション一覧の取得に失敗しました',
+  'toast.gitRefreshFailed': 'Gitの状態取得に失敗しました',
   'toast.pathCopied': 'パスをクリップボードにコピー',
   'toast.copyFailed': 'クリップボードへのコピーに失敗しました',
   'toast.revealFailed': 'ファイルマネージャでの表示に失敗しました',

--- a/src/renderer/src/lib/refresh-error.ts
+++ b/src/renderer/src/lib/refresh-error.ts
@@ -1,0 +1,15 @@
+type ShowToast = (
+  message: string,
+  options?: { tone?: 'info' | 'success' | 'warning' | 'error' }
+) => unknown;
+
+/** Issue #1139: refresh失敗を空データと誤認させない共通通知。 */
+export function reportRefreshFailure(
+  scope: 'sessions.list' | 'git.status',
+  error: unknown,
+  message: string,
+  showToast: ShowToast
+): void {
+  console.warn(`[refresh] ${scope} failed:`, error);
+  showToast(message, { tone: 'error' });
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -758,6 +758,32 @@ Branch: `feature/issue-452`
 #### 検証結果（代替で PASS 済み）
 - [x] `git diff --check`: PASS
 
+## PR #1208 - file-size ratchet修正 (2026-07-14 / Codex)
+
+### RCA結果
+
+- [x] 症状: `AppShell.tsx` が982行となり、baseline上限977行を超えてCIが失敗した。
+- [x] 再現: `npm run lint:file-size` が同じ982/977でFAILした。
+- [x] 原因: 共通通知処理は別moduleへ切り出し済みだが、その呼び出しを6行展開して行数を純増させた。
+- [x] 代替原因除外: baseline変更漏れではなく、branch差分の5行純増とCI計測値が一致した。
+- [x] 修正方針: 機能・責務・baselineを変えず、既存helper呼び出しだけを1行に整形する。
+- [x] 判定: A=YES、B=YES、C=YES、D=YES（Root Cause Confirmed）。
+
+### Next Steps
+
+- [x] 修正前と同じ `npm run lint:file-size` でPASSを確認する。
+- [x] 関連テスト、typecheck、lint、build、diff checkを実行する。
+- [ ] PR #1208へpushし、CIと再レビューを確認する。
+
+### 修正後検証
+
+- [x] `npm run lint:file-size`: PASS（485 files、baseline免除39件）。
+- [x] targeted Vitest: PASS（2 files / 5 tests）。
+- [x] `npm run typecheck`: PASS。
+- [x] `npm run lint`: PASS（0 errors / 既存11 warnings）。
+- [x] `npm run build:vite`: PASS（既存warningのみ）。
+- [x] `git diff --check`: PASS。
+
 ## Issue #1139 - セッション/Git再取得失敗を通知 (2026-07-14 / Codex)
 
 Issue: https://github.com/yusei531642/vibe-editor/issues/1139

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -757,6 +757,31 @@ Branch: `feature/issue-452`
 
 #### 検証結果（代替で PASS 済み）
 - [x] `git diff --check`: PASS
+
+## Issue #1139 - セッション/Git再取得失敗を通知 (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1139
+
+### 計画
+
+- [x] IDEのsessions/Git refresh失敗経路とCanvas側の処理状況を確認する。
+- [x] console.warnとerror toastの共通通知を追加する。
+- [x] Git refreshのrejection吸収・loading解除・通知をテストする。
+- [x] 関連テストと全品質ゲートを実行する。
+
+### Next Steps
+
+- [x] 検証結果を記録する。
+- [x] コミットして feature branch をpushする。
+
+### 検証結果
+
+- [x] 関連 Vitest: PASS (2 files / 5 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (87 files / 522 tests)
+- [x] `npm run lint`: PASS (0 errors / 既存 11 warnings)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
 - [x] `npm run typecheck`: PASS
 - [x] `npm run build:vite`: PASS（既存警告あり）
 - [x] targeted Vitest: PASS（2 files / 11 tests）


### PR DESCRIPTION
## Summary
- Issue #1139 の計画済み修正を、対象スコープ内で実装
- 変更規模: 8 files changed, 96 insertions(+), 4 deletions(-)（8 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1139

## Test plan
- [x] 変更対象のVitest
- [x] npm run typecheck
- [x] npm run test
- [x] npm run lint
- [x] npm run build:vite
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない