### PR TITLE
fix(canvas): 破損保存データを退避

### DIFF
--- a/src/renderer/src/layouts/CanvasLayout.tsx
+++ b/src/renderer/src/layouts/CanvasLayout.tsx
@@ -40,6 +40,8 @@ import { useCanvasMenuActions } from '../lib/hooks/use-canvas-menu-actions';
 import { useCanvasSpawn } from '../lib/hooks/use-canvas-spawn';
 import { useLayoutResize } from '../lib/hooks/use-layout-resize';
 import { useProject } from '../lib/app-state-context';
+import { useToast } from '../lib/toast-context';
+import { takeCanvasRecoveryNotice } from '../stores/canvas-persistence';
 
 export function CanvasLayout(): JSX.Element {
   const setViewMode = useUiStore((s) => s.setViewMode);
@@ -69,6 +71,22 @@ export function CanvasLayout(): JSX.Element {
   const { settings, update: updateSettings, reset: resetSettings } = useSettings();
   const { projectRoot } = useProject();
   const t = useT();
+  const { showToast } = useToast();
+  useEffect(() => {
+    const notice = takeCanvasRecoveryNotice();
+    if (!notice) return;
+    if (notice.backupKey) {
+      showToast(t('canvas.persistence.corruptBackedUp', { key: notice.backupKey }), {
+        tone: 'warning',
+        duration: 12000
+      });
+      return;
+    }
+    showToast(t('canvas.persistence.corruptBackupFailed'), {
+      tone: 'error',
+      duration: 12000
+    });
+  }, [showToast, t]);
   const settingsOpen = useUiStore((s) => s.settingsOpen);
   const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
   const setPaletteOpen = useUiStore((s) => s.setPaletteOpen);

--- a/src/renderer/src/lib/i18n/en-canvas.ts
+++ b/src/renderer/src/lib/i18n/en-canvas.ts
@@ -6,6 +6,10 @@ import type { Dict } from './types';
  * 追加キーは領域の合うファイルへ。merge は index.ts 側で行う。
  */
 export const enCanvas: Dict = {
+  'canvas.persistence.corruptBackedUp':
+    'Canvas data was corrupt and was reset. The original data was backed up as "{key}"',
+  'canvas.persistence.corruptBackupFailed':
+    'Canvas data is corrupt and could not be backed up. Automatic saving is disabled to protect it',
   // ---------- Canvas HUD ----------
   'canvas.apiAgent.teamRole': 'Team role',
   'canvas.apiAgent.teamRolePlaceholder': 'e.g. reviewer',

--- a/src/renderer/src/lib/i18n/ja-canvas.ts
+++ b/src/renderer/src/lib/i18n/ja-canvas.ts
@@ -6,6 +6,10 @@ import type { Dict } from './types';
  * 追加キーは領域の合うファイルへ。merge は index.ts 側で行う。
  */
 export const jaCanvas: Dict = {
+  'canvas.persistence.corruptBackedUp':
+    'Canvasの保存データが破損していたため初期化しました。原文は「{key}」へ退避しました',
+  'canvas.persistence.corruptBackupFailed':
+    'Canvasの保存データが破損し、退避にも失敗しました。データ保護のため自動保存を停止しています',
   // ---------- Canvas HUD ----------
   'canvas.apiAgent.teamRole': 'チームロール',
   'canvas.apiAgent.teamRolePlaceholder': '例: reviewer',

--- a/src/renderer/src/lib/i18n/ja-canvas.ts
+++ b/src/renderer/src/lib/i18n/ja-canvas.ts
@@ -7,7 +7,7 @@ import type { Dict } from './types';
  */
 export const jaCanvas: Dict = {
   'canvas.persistence.corruptBackedUp':
-    'Canvasの保存データが破損していたため初期化しました。原文は「{key}」へ退避しました',
+    'Canvasの保存データが破損していたため初期化しました。元のデータは「{key}」へ退避しました',
   'canvas.persistence.corruptBackupFailed':
     'Canvasの保存データが破損し、退避にも失敗しました。データ保護のため自動保存を停止しています',
   // ---------- Canvas HUD ----------

--- a/src/renderer/src/stores/__tests__/canvas-corrupt-persistence.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-corrupt-persistence.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CANVAS_CORRUPT_BACKUP_PREFIX,
+  CANVAS_PERSIST_NAME,
+  canvasPersistStorage,
+  takeCanvasRecoveryNotice
+} from '../canvas-persistence';
+
+describe('Canvas corrupt persistence recovery (Issue #1140)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    canvasPersistStorage.removeItem(CANVAS_PERSIST_NAME);
+    takeCanvasRecoveryNotice();
+    vi.restoreAllMocks();
+  });
+
+  it('backs up invalid JSON byte-for-byte before clearing the live key', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_721_000_000_000);
+    const corrupt = '{"state":{"nodes":[';
+    localStorage.setItem(CANVAS_PERSIST_NAME, corrupt);
+
+    expect(canvasPersistStorage.getItem(CANVAS_PERSIST_NAME)).toBeNull();
+
+    const backupKey = `${CANVAS_CORRUPT_BACKUP_PREFIX}1721000000000`;
+    expect(localStorage.getItem(backupKey)).toBe(corrupt);
+    expect(localStorage.getItem(CANVAS_PERSIST_NAME)).toBeNull();
+    expect(takeCanvasRecoveryNotice()).toEqual({ backupKey });
+    expect(takeCanvasRecoveryNotice()).toBeNull();
+  });
+
+  it('blocks empty-state writes when the corrupt payload cannot be backed up', () => {
+    const corrupt = '{not-json';
+    localStorage.setItem(CANVAS_PERSIST_NAME, corrupt);
+    const originalSetItem = Storage.prototype.setItem;
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (key, value) {
+      if (String(key).startsWith(CANVAS_CORRUPT_BACKUP_PREFIX)) {
+        throw new DOMException('quota exceeded', 'QuotaExceededError');
+      }
+      return originalSetItem.call(this, key, value);
+    });
+
+    expect(canvasPersistStorage.getItem(CANVAS_PERSIST_NAME)).toBeNull();
+    canvasPersistStorage.setItem(CANVAS_PERSIST_NAME, {
+      state: {} as never,
+      version: 6
+    });
+
+    expect(localStorage.getItem(CANVAS_PERSIST_NAME)).toBe(corrupt);
+    expect(takeCanvasRecoveryNotice()).toEqual({ backupKey: null });
+  });
+});

--- a/src/renderer/src/stores/__tests__/canvas-corrupt-persistence.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-corrupt-persistence.test.ts
@@ -48,4 +48,27 @@ describe('Canvas corrupt persistence recovery (Issue #1140)', () => {
     expect(localStorage.getItem(CANVAS_PERSIST_NAME)).toBe(corrupt);
     expect(takeCanvasRecoveryNotice()).toEqual({ backupKey: null });
   });
+
+  it('recovers when only the persisted recovery notice cannot be written', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_721_000_000_001);
+    const corrupt = '{broken-json';
+    localStorage.setItem(CANVAS_PERSIST_NAME, corrupt);
+    const originalSetItem = Storage.prototype.setItem;
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (key, value) {
+      if (key === 'vibe-editor:canvas:recovery-notice') {
+        throw new DOMException('quota exceeded', 'QuotaExceededError');
+      }
+      return originalSetItem.call(this, key, value);
+    });
+
+    expect(canvasPersistStorage.getItem(CANVAS_PERSIST_NAME)).toBeNull();
+
+    const backupKey = `${CANVAS_CORRUPT_BACKUP_PREFIX}1721000000001`;
+    expect(localStorage.getItem(backupKey)).toBe(corrupt);
+    expect(localStorage.getItem(CANVAS_PERSIST_NAME)).toBeNull();
+    expect(takeCanvasRecoveryNotice()).toEqual({ backupKey });
+
+    canvasPersistStorage.setItem(CANVAS_PERSIST_NAME, { state: {} as never, version: 6 });
+    expect(localStorage.getItem(CANVAS_PERSIST_NAME)).not.toBeNull();
+  });
 });

--- a/src/renderer/src/stores/canvas-persistence.ts
+++ b/src/renderer/src/stores/canvas-persistence.ts
@@ -7,6 +7,15 @@ import {
 
 export const CANVAS_PERSIST_NAME = 'vibe-editor:canvas';
 export const CANVAS_PERSIST_VERSION = 6;
+export const CANVAS_CORRUPT_BACKUP_PREFIX = `${CANVAS_PERSIST_NAME}:corrupt-backup:`;
+const CANVAS_RECOVERY_NOTICE_KEY = `${CANVAS_PERSIST_NAME}:recovery-notice`;
+
+export interface CanvasRecoveryNotice {
+  backupKey: string | null;
+}
+
+let pendingRecoveryNotice: CanvasRecoveryNotice | null = null;
+const writeBlockedKeys = new Set<string>();
 
 type CanvasPersistState = Pick<
   CanvasState,
@@ -24,20 +33,61 @@ function canvasStorage(): Storage | null {
 
 export const canvasPersistStorage: PersistStorage<CanvasPersistState> = {
   getItem: (name) => {
-    const raw = canvasStorage()?.getItem(name);
+    const storage = canvasStorage();
+    const raw = storage?.getItem(name);
     if (!raw) return null;
-    return JSON.parse(raw) as StorageValue<CanvasPersistState>;
+    try {
+      return JSON.parse(raw) as StorageValue<CanvasPersistState>;
+    } catch (error) {
+      const backupKey = `${CANVAS_CORRUPT_BACKUP_PREFIX}${Date.now()}`;
+      try {
+        storage?.setItem(backupKey, raw);
+        storage?.setItem(
+          CANVAS_RECOVERY_NOTICE_KEY,
+          JSON.stringify({ backupKey } satisfies CanvasRecoveryNotice)
+        );
+        storage?.removeItem(name);
+        writeBlockedKeys.delete(name);
+        pendingRecoveryNotice = { backupKey };
+      } catch (backupError) {
+        writeBlockedKeys.add(name);
+        pendingRecoveryNotice = { backupKey: null };
+        console.error('[canvas-persistence] corrupt data backup failed:', backupError);
+      }
+      console.error('[canvas-persistence] corrupt data detected:', error);
+      return null;
+    }
   },
   setItem: (name, value) => {
     // Issue #864/#835: drag 中は nodes が毎フレーム変わるため、localStorage への
     // JSON.stringify が UI スレッドを詰まらせる。drag 終了時に明示 flush する。
     if (canvasPersistPaused()) return;
+    if (writeBlockedKeys.has(name)) return;
     canvasStorage()?.setItem(name, JSON.stringify(value));
   },
   removeItem: (name) => {
+    writeBlockedKeys.delete(name);
     canvasStorage()?.removeItem(name);
   }
 };
+
+export function takeCanvasRecoveryNotice(): CanvasRecoveryNotice | null {
+  if (pendingRecoveryNotice) {
+    const notice = pendingRecoveryNotice;
+    pendingRecoveryNotice = null;
+    canvasStorage()?.removeItem(CANVAS_RECOVERY_NOTICE_KEY);
+    return notice;
+  }
+  const storage = canvasStorage();
+  const raw = storage?.getItem(CANVAS_RECOVERY_NOTICE_KEY);
+  if (!raw) return null;
+  storage?.removeItem(CANVAS_RECOVERY_NOTICE_KEY);
+  try {
+    return JSON.parse(raw) as CanvasRecoveryNotice;
+  } catch {
+    return null;
+  }
+}
 
 let isPaused = false;
 

--- a/src/renderer/src/stores/canvas-persistence.ts
+++ b/src/renderer/src/stores/canvas-persistence.ts
@@ -42,13 +42,17 @@ export const canvasPersistStorage: PersistStorage<CanvasPersistState> = {
       const backupKey = `${CANVAS_CORRUPT_BACKUP_PREFIX}${Date.now()}`;
       try {
         storage?.setItem(backupKey, raw);
-        storage?.setItem(
-          CANVAS_RECOVERY_NOTICE_KEY,
-          JSON.stringify({ backupKey } satisfies CanvasRecoveryNotice)
-        );
         storage?.removeItem(name);
         writeBlockedKeys.delete(name);
         pendingRecoveryNotice = { backupKey };
+        try {
+          storage?.setItem(
+            CANVAS_RECOVERY_NOTICE_KEY,
+            JSON.stringify({ backupKey } satisfies CanvasRecoveryNotice)
+          );
+        } catch (noticeError) {
+          console.error('[canvas-persistence] recovery notice persist failed:', noticeError);
+        }
       } catch (backupError) {
         writeBlockedKeys.add(name);
         pendingRecoveryNotice = { backupKey: null };

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -757,6 +757,32 @@ Branch: `feature/issue-452`
 
 #### 検証結果（代替で PASS 済み）
 - [x] `git diff --check`: PASS
+
+## Issue #1140 - 破損Canvasデータの上書き消失を防止 (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1140
+
+### 計画
+
+- [x] localStorage parse失敗とZustand persistの保存境界を確認する。
+- [x] 破損原文をtimestamp付き別キーへbyte-for-byteで退避する。
+- [x] 退避失敗時は本キーへの自動保存をfail-closedする。
+- [x] CanvasLayoutで復旧結果を1回通知する。
+- [x] 関連テストと全品質ゲートを実行する。
+
+### Next Steps
+
+- [x] 検証結果を記録する。
+- [x] コミットして feature branch をpushする。
+
+### 検証結果
+
+- [x] 破損永続化 Vitest: PASS (2 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (87 files / 521 tests)
+- [x] `npm run lint`: PASS (0 errors / 既存 12 warnings)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
 - [x] `npm run typecheck`: PASS
 - [x] `npm run build:vite`: PASS（既存警告あり）
 - [x] targeted Vitest: PASS（2 files / 11 tests）

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -767,6 +767,7 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1140
 - [x] localStorage parse失敗とZustand persistの保存境界を確認する。
 - [x] 破損原文をtimestamp付き別キーへbyte-for-byteで退避する。
 - [x] 退避失敗時は本キーへの自動保存をfail-closedする。
+- [x] 退避成功後の通知保存だけが失敗した場合は復旧を継続する。
 - [x] CanvasLayoutで復旧結果を1回通知する。
 - [x] 関連テストと全品質ゲートを実行する。
 
@@ -777,7 +778,7 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1140
 
 ### 検証結果
 
-- [x] 破損永続化 Vitest: PASS (2 tests)
+- [x] 破損永続化 Vitest: PASS (3 tests)
 - [x] `npm run typecheck`: PASS
 - [x] `npm run test`: PASS (87 files / 521 tests)
 - [x] `npm run lint`: PASS (0 errors / 既存 12 warnings)


### PR DESCRIPTION
## Summary
- Issue #1140 の計画済み修正を、対象スコープ内で実装
- 変更規模: 6 files changed, 155 insertions(+), 2 deletions(-)（6 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1140

## Test plan
- [x] 変更対象のVitest
- [x] npm run typecheck
- [x] npm run test
- [x] npm run lint
- [x] npm run build:vite
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない