### PR TITLE
fix(canvas): 削除後の空き位置へカード追加

### DIFF
--- a/src/renderer/src/lib/hooks/use-canvas-add-card.ts
+++ b/src/renderer/src/lib/hooks/use-canvas-add-card.ts
@@ -1,6 +1,7 @@
 import type { Node } from '@xyflow/react';
 import type { CardData, CardType } from '../../stores/canvas';
-import { NODE_H, NODE_W, useCanvasStore } from '../../stores/canvas';
+import { useCanvasStore } from '../../stores/canvas';
+import { nextFallbackCardPosition } from '../../stores/canvas-card-identity';
 import { useUiStore } from '../../stores/ui';
 import { engineForAgentConfig } from '../agent-registry';
 import { useSettings } from '../settings-context';
@@ -15,7 +16,7 @@ interface UseCanvasAddCardOptions {
 }
 
 export interface CanvasAddCardApi {
-  /** 既存ノード数から staggered 配置座標を返す */
+  /** 既存ノードが占有していない staggered 配置座標を返す */
   stagger: (kind: CardType) => { x: number; y: number };
   addAgent: (agent: 'claude' | 'codex') => void;
   addCustomAgent: (agentId: string) => void;
@@ -39,20 +40,14 @@ export function useCanvasAddCard({ nodes, projectRoot }: UseCanvasAddCardOptions
 
   // Issue #166: Date.now() % 600 だと連続クリックで数 ms 差しか出ず、全カードが
   // ほぼ同じ x に積み重なって UI 上「追加されていない」ように見えていた。
-  // 既存ノード数 (現在 viewport 内に限らずグローバル) を 6 列グリッドに展開して
-  // staggered レイアウトを返す。
+  // 既存ノード (現在 viewport 内に限らずグローバル) の空き位置を6列グリッドから返す。
   // Issue #442: 旧実装は agent/terminal を 480+32 / 320+32、その他を 360+32 / 240+32 で
   // 並べていたが、addCard / addCards は全 type に NODE_W/NODE_H (= 640x400, Issue #253)
   // を style として付与するため、type 別ピッチは根拠が無くカードが重なっていた。
-  // ピッチを実カードサイズ NODE_W/NODE_H に統一する。
-  const stagger = (_kind: CardType): { x: number; y: number } => {
-    const idx = nodes.length; // 全 type 共通の連番でも視覚的に十分散る
-    const cols = 6;
-    return {
-      x: (idx % cols) * (NODE_W + 32),
-      y: Math.floor(idx / cols) * (NODE_H + 32)
-    };
-  };
+  // Issue #1141: nodes.length採番では削除後に既存slotへ重なるため、store fallbackと
+  // 同じ占有スロット探索を使う。kindに関係なく全カードは同じ既定寸法/ピッチを共有する。
+  const stagger = (_kind: CardType): { x: number; y: number } =>
+    nextFallbackCardPosition(nodes);
 
   const addAgent = (agent: 'claude' | 'codex'): void => {
     const cwd = projectRoot;

--- a/src/renderer/src/stores/__tests__/canvas-add-card-position.test.ts
+++ b/src/renderer/src/stores/__tests__/canvas-add-card-position.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { NODE_H, NODE_W, useCanvasStore } from '../canvas';
+import { nextFallbackCardPosition } from '../canvas-card-identity';
 
 const GAP = 32;
 
@@ -47,5 +48,35 @@ describe('useCanvasStore.addCard fallback placement (Issue #840)', () => {
     expect(useCanvasStore.getState().nodes.find((node) => node.id === id)?.position).toEqual(
       explicit
     );
+  });
+
+  it('削除後の明示position経路も共通空きスロット探索なら重複しない (#1141)', () => {
+    const store = useCanvasStore.getState();
+    const ids = Array.from({ length: 3 }, (_, index) =>
+      store.addCard({
+        type: 'terminal',
+        title: `Terminal ${index + 1}`,
+        payload: undefined,
+        position: nextFallbackCardPosition(useCanvasStore.getState().nodes)
+      })
+    );
+    store.removeCard(ids[1], { cascadeTeam: false });
+
+    const nextPosition = nextFallbackCardPosition(useCanvasStore.getState().nodes);
+    const nextId = store.addCard({
+      type: 'terminal',
+      title: 'Terminal next',
+      payload: undefined,
+      position: nextPosition
+    });
+
+    expect(useCanvasStore.getState().nodes.find((node) => node.id === nextId)?.position).toEqual({
+      x: NODE_W + GAP,
+      y: 0
+    });
+    const positions = useCanvasStore.getState().nodes.map(
+      (node) => `${node.position.x},${node.position.y}`
+    );
+    expect(new Set(positions).size).toBe(positions.length);
   });
 });

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -757,6 +757,31 @@ Branch: `feature/issue-452`
 
 #### 検証結果（代替で PASS 済み）
 - [x] `git diff --check`: PASS
+
+## Issue #1141 - カード削除後の追加位置重複を防止 (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1141
+
+### 計画
+
+- [x] hookのstagger計算とstoreの空きスロット探索を比較する。
+- [x] 単体追加経路を共通 `nextFallbackCardPosition` へ統一する。
+- [x] 削除後の明示position追加が重複しない退行テストを追加する。
+- [x] 関連テストと全品質ゲートを実行する。
+
+### Next Steps
+
+- [x] 検証結果を記録する。
+- [x] コミットして feature branch をpushする。
+
+### 検証結果
+
+- [x] カード位置 Vitest: PASS (3 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (86 files / 520 tests)
+- [x] `npm run lint`: PASS (0 errors / 既存 12 warnings)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
 - [x] `npm run typecheck`: PASS
 - [x] `npm run build:vite`: PASS（既存警告あり）
 - [x] targeted Vitest: PASS（2 files / 11 tests）


### PR DESCRIPTION
## Summary
- Issue #1141 の計画済み修正を、対象スコープ内で実装
- 変更規模: 3 files changed, 64 insertions(+), 13 deletions(-)（3 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1141

## Test plan
- [x] 変更対象のVitest
- [x] npm run typecheck
- [x] npm run test
- [x] npm run lint
- [x] npm run build:vite
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない