### PR TITLE
fix(i18n): プリセット説明を言語設定へ同期

### DIFF
--- a/src/renderer/src/components/canvas/CanvasSpawnFab.tsx
+++ b/src/renderer/src/components/canvas/CanvasSpawnFab.tsx
@@ -168,6 +168,7 @@ export function CanvasSpawnFab({
                   key={preset.id}
                   preset={preset}
                   label={t(preset.i18nKey)}
+                  description={t(preset.descriptionI18nKey)}
                   agentCountLabel={formatOrganizationAgentCount(
                     presetOrganizationCount(preset),
                     presetMemberCount(preset),

--- a/src/renderer/src/components/canvas/CanvasSpawnItems.tsx
+++ b/src/renderer/src/components/canvas/CanvasSpawnItems.tsx
@@ -30,11 +30,13 @@ function RoleDot({
 export function BuiltinPresetItem({
   preset,
   label,
+  description,
   agentCountLabel,
   onClick
 }: {
   preset: WorkspacePreset;
   label: string;
+  description: string;
   agentCountLabel: string;
   onClick: () => void;
 }): JSX.Element {
@@ -44,6 +46,7 @@ export function BuiltinPresetItem({
         <span className="canvas-popover__preset-title">{label}</span>
         <span className="canvas-popover__preset-sub">{agentCountLabel}</span>
       </span>
+      <span className="canvas-popover__preset-desc">{description}</span>
       <span className="canvas-popover__preset-roles">
         {(preset.organizations ?? [{ id: 'primary', color: '', members: preset.members }]).map(
           (org, orgIndex) => (

--- a/src/renderer/src/components/canvas/VoiceControlButton.tsx
+++ b/src/renderer/src/components/canvas/VoiceControlButton.tsx
@@ -13,7 +13,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Mic, MicOff } from 'lucide-react';
-import { useT } from '../../lib/i18n';
+import { translate, useT } from '../../lib/i18n';
 import { useSettings } from '../../lib/settings-context';
 import { useVoiceStore } from '../../stores/voice';
 import { useVoiceRealtime } from '../../lib/hooks/use-voice-realtime';
@@ -23,6 +23,16 @@ import { VoiceVisualizer } from './VoiceVisualizer';
 import { VoiceConfirmModal } from './VoiceConfirmModal';
 
 const INLINE_TRAIL_HOLD_MS = 3000;
+
+export function buildVoiceAvailablePresets(
+  language: 'ja' | 'en'
+): VoiceAvailablePreset[] {
+  return BUILTIN_PRESETS.map((preset) => ({
+    id: preset.id,
+    label: preset.id,
+    description: translate(language, preset.descriptionI18nKey)
+  }));
+}
 
 export interface VoiceControlButtonProps {
   /**
@@ -78,16 +88,11 @@ export function VoiceControlButton({
   const errorMessage = useVoiceStore((s) => s.errorMessage);
   const pendingFunctionCall = useVoiceStore((s) => s.pendingFunctionCall);
 
-  // BUILTIN_PRESETS から AI に見せる summary を組み立てる。i18n には依存させず id ベース。
-  // (AI には id を渡すだけで OK で、ユーザー向けラベルは spawn 時に CanvasLayout 側で解決される)
+  // BUILTIN_PRESETS から AI に見せる summary を現在の UI 言語で組み立てる。
+  // id は安定値のまま維持し、説明だけ locale 切替へ追従させる。
   const availablePresets = useMemo<VoiceAvailablePreset[]>(
-    () =>
-      BUILTIN_PRESETS.map((p) => ({
-        id: p.id,
-        label: p.id,
-        description: p.description
-      })),
-    []
+    () => buildVoiceAvailablePresets(settings.language ?? 'ja'),
+    [settings.language]
   );
 
   const { toggle, approvePending, cancelPending, disconnect } = useVoiceRealtime(

--- a/src/renderer/src/components/canvas/__tests__/CanvasSpawnItems.test.tsx
+++ b/src/renderer/src/components/canvas/__tests__/CanvasSpawnItems.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { TeamPreset } from '../../../../../types/shared';
+import { BUILTIN_PRESETS } from '../../../lib/workspace-presets';
+import { BuiltinPresetItem, SavedPresetItem } from '../CanvasSpawnItems';
+
+describe('CanvasSpawnItems', () => {
+  afterEach(cleanup);
+
+  it('組み込みプリセットへ翻訳済みの説明を表示する', () => {
+    render(
+      <BuiltinPresetItem
+        preset={BUILTIN_PRESETS[0]}
+        label="Leader only"
+        description="Starts with only a Claude Code leader."
+        agentCountLabel="1 agent"
+        onClick={() => undefined}
+      />
+    );
+
+    expect(screen.getByText('Starts with only a Claude Code leader.')).toBeInTheDocument();
+  });
+
+  it('保存プリセットの自由入力説明をそのまま表示する', () => {
+    const preset = {
+      id: 'saved',
+      name: 'Saved preset',
+      description: 'ユーザーが入力した原文',
+      roles: [{ roleProfileId: 'leader', agent: 'claude' }]
+    } as TeamPreset;
+
+    render(
+      <SavedPresetItem
+        preset={preset}
+        agentCountLabel="1 agent"
+        onClick={() => undefined}
+      />
+    );
+
+    expect(screen.getByText('ユーザーが入力した原文')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/src/lib/__tests__/workspace-presets.test.ts
+++ b/src/renderer/src/lib/__tests__/workspace-presets.test.ts
@@ -8,6 +8,8 @@ import {
   presetPosition
 } from '../workspace-presets';
 import { NODE_H, NODE_W } from '../../stores/canvas';
+import { translate } from '../i18n';
+import { buildVoiceAvailablePresets } from '../../components/canvas/VoiceControlButton';
 
 const t = (key: string): string => key;
 
@@ -38,6 +40,18 @@ describe('workspace presets', () => {
     expect(presetMemberCount(preset!)).toBe(1);
     expect(organizations).toHaveLength(1);
     expect(organizations[0].members[0]?.agent).toBe('codex');
+  });
+
+  it('組み込み説明と voice metadata を日本語・英語へ切り替える', () => {
+    for (const preset of BUILTIN_PRESETS) {
+      expect(translate('ja', preset.descriptionI18nKey)).toMatch(/のみで起動/);
+      expect(translate('en', preset.descriptionI18nKey)).toMatch(/^Starts with only/);
+    }
+
+    expect(buildVoiceAvailablePresets('ja').every((preset) => preset.description.includes('起動')))
+      .toBe(true);
+    expect(buildVoiceAvailablePresets('en').every((preset) => preset.description.startsWith('Starts')))
+      .toBe(true);
   });
 
   // Issue #442: presetPosition のピッチは実カードサイズ NODE_W/NODE_H に追随する。

--- a/src/renderer/src/lib/i18n/en-canvas.ts
+++ b/src/renderer/src/lib/i18n/en-canvas.ts
@@ -66,6 +66,10 @@ export const enCanvas: Dict = {
   'canvas.preset': 'Preset',
   'canvas.preset.leaderClaude': 'Leader only (Claude Code)',
   'canvas.preset.leaderCodex': 'Leader only (Codex)',
+  'canvas.preset.leaderClaude.description':
+    'Starts with only a Claude Code leader. The leader recruits members as needed.',
+  'canvas.preset.leaderCodex.description':
+    'Starts with only a Codex leader. The leader recruits members as needed.',
   'canvas.preset.builtinHeader': 'Built-in',
   'canvas.preset.savedHeader': 'Saved',
   'canvas.preset.leaderCustom': 'Leader only ({name})',

--- a/src/renderer/src/lib/i18n/ja-canvas.ts
+++ b/src/renderer/src/lib/i18n/ja-canvas.ts
@@ -66,6 +66,10 @@ export const jaCanvas: Dict = {
   'canvas.preset': 'プリセット',
   'canvas.preset.leaderClaude': 'Leader のみで起動 (Claude Code)',
   'canvas.preset.leaderCodex': 'Leader のみで起動 (Codex)',
+  'canvas.preset.leaderClaude.description':
+    'Leader (Claude Code) のみで起動。必要なメンバーは Leader が動的に呼び出します。',
+  'canvas.preset.leaderCodex.description':
+    'Leader (Codex) のみで起動。必要なメンバーは Leader が動的に呼び出します。',
   'canvas.preset.builtinHeader': '組み込み',
   'canvas.preset.savedHeader': '保存済み',
   'canvas.preset.leaderCustom': 'Leader のみで起動 ({name})',

--- a/src/renderer/src/lib/workspace-presets.ts
+++ b/src/renderer/src/lib/workspace-presets.ts
@@ -23,7 +23,8 @@ export interface WorkspacePreset {
   id: string;
   /** ローカライズキー (i18n.ts の `canvas.preset.<id>`) */
   i18nKey: string;
-  description: string;
+  /** 組み込み説明のローカライズキー。ユーザー保存 preset の自由入力とは別契約。 */
+  descriptionI18nKey: string;
   /** 各メンバーをどのプリセット名でユーザに見せるか (大カテゴリ) */
   category: 'pair' | 'team';
   members: PresetMember[];
@@ -49,14 +50,14 @@ export const BUILTIN_PRESETS: WorkspacePreset[] = [
   {
     id: 'leader-claude',
     i18nKey: 'canvas.preset.leaderClaude',
-    description: 'Leader (Claude Code) のみで起動。必要なメンバーは Leader が動的に呼び出す。',
+    descriptionI18nKey: 'canvas.preset.leaderClaude.description',
     category: 'team',
     members: [{ role: 'leader', agent: 'claude', col: 0, row: 0 }]
   },
   {
     id: 'leader-codex',
     i18nKey: 'canvas.preset.leaderCodex',
-    description: 'Leader (Codex) のみで起動。必要なメンバーは Leader が動的に呼び出す。',
+    descriptionI18nKey: 'canvas.preset.leaderCodex.description',
     category: 'team',
     members: [{ role: 'leader', agent: 'codex', col: 0, row: 0 }]
   }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2037,3 +2037,35 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1045
 - [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
 - [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`: PASS
 - [x] `git diff --check`: PASS
+
+## Issue #1143 - 組み込みプリセット説明の i18n (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1143
+
+### 計画
+
+- [x] 組み込みプリセットの説明を生文字列から翻訳キーへ置き換える。
+- [x] Canvas の組み込み項目と voice metadata を現在の言語へ同期する。
+- [x] ユーザー保存プリセットの自由入力説明は原文のまま維持する。
+- [x] 翻訳契約と表示経路の回帰テストを追加し、品質ゲートを実行する。
+
+### Next Steps
+
+- [x] 最小差分を実装する。
+- [x] typecheck、対象テスト、全テスト、lint、Vite build を実行する。
+- [ ] feature branch を push し、PR 作成の明示承認を待つ。
+
+### 進捗
+
+- [x] 組み込み2プリセットの説明を `descriptionI18nKey` へ置換した。
+- [x] Canvas popover と voice metadata を ja/en 辞書へ接続した。
+- [x] 保存プリセットの自由入力説明を変更しない回帰テストを追加した。
+
+### 検証結果
+
+- [x] `npm run typecheck`: PASS
+- [x] 対象 Vitest: PASS (2 files / 6 tests)
+- [x] `npm run test`: PASS (87 files / 522 tests)
+- [x] `npm run lint`: PASS (0 errors / 既存 warnings 12)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS


### PR DESCRIPTION
## Summary
- Issue #1143 の計画済み修正を、対象スコープ内で実装
- 変更規模: 9 files changed, 119 insertions(+), 13 deletions(-)（9 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1143

## Test plan
- [x] 変更対象のVitest
- [x] npm run typecheck
- [x] npm run test
- [x] npm run lint
- [x] npm run build:vite
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない