### PR TITLE
fix(api-agents): セッション削除失敗を伝播

### DIFF
--- a/src-tauri/src/commands/api_agents.rs
+++ b/src-tauri/src/commands/api_agents.rs
@@ -138,8 +138,14 @@ pub async fn api_agent_session_load(session_id: String) -> CommandResult<Option<
 pub async fn api_agent_session_delete(session_id: String) -> CommandResult<()> {
     validate_id("sessionId", &session_id)?;
     let path = session_path(&session_id)?;
-    match tokio::fs::remove_file(path).await {
-        Ok(()) | Err(_) => Ok(()),
+    map_session_delete_result(tokio::fs::remove_file(path).await)
+}
+
+fn map_session_delete_result(result: std::io::Result<()>) -> CommandResult<()> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(CommandError::Io(error.to_string())),
     }
 }
 

--- a/src-tauri/src/commands/api_agents.rs
+++ b/src-tauri/src/commands/api_agents.rs
@@ -15,6 +15,7 @@ mod providers;
 pub mod skills;
 pub mod models;
 mod project_docs;
+mod session_delete;
 mod tools;
 mod tools_exec;
 mod tools_search;
@@ -26,6 +27,7 @@ pub mod types;
 mod tests;
 
 use self::providers::{call_provider, provider_preset, TeamToolCtx, ToolRuntime};
+use self::session_delete::map_session_delete_result;
 use self::types::*;
 use crate::state::{current_project_root, AppState};
 use tauri::State;
@@ -139,14 +141,6 @@ pub async fn api_agent_session_delete(session_id: String) -> CommandResult<()> {
     validate_id("sessionId", &session_id)?;
     let path = session_path(&session_id)?;
     map_session_delete_result(tokio::fs::remove_file(path).await)
-}
-
-fn map_session_delete_result(result: std::io::Result<()>) -> CommandResult<()> {
-    match result {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(CommandError::Io(error.to_string())),
-    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/api_agents/session_delete.rs
+++ b/src-tauri/src/commands/api_agents/session_delete.rs
@@ -1,0 +1,9 @@
+use crate::commands::error::{CommandError, CommandResult};
+
+pub(super) fn map_session_delete_result(result: std::io::Result<()>) -> CommandResult<()> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(CommandError::Io(error.to_string())),
+    }
+}

--- a/src-tauri/src/commands/api_agents/tests.rs
+++ b/src-tauri/src/commands/api_agents/tests.rs
@@ -40,6 +40,26 @@ fn session_path_rejects_traversal_ids() {
 }
 
 #[test]
+fn session_delete_result_accepts_success_and_not_found() {
+    assert!(map_session_delete_result(Ok(())).is_ok());
+    assert!(
+        map_session_delete_result(Err(std::io::Error::from(std::io::ErrorKind::NotFound))).is_ok()
+    );
+}
+
+#[test]
+fn session_delete_result_propagates_other_io_errors() {
+    let error = map_session_delete_result(Err(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        "session file is locked",
+    )))
+    .expect_err("permission errors must not be reported as successful deletion");
+
+    assert_eq!(error.code(), "io");
+    assert!(error.to_string().contains("session file is locked"));
+}
+
+#[test]
 fn build_skills_context_truncates_to_budget_and_stays_utf8() {
     // MAX_SKILL_BYTES を大きく超えるマルチバイト本文でも panic せず、
     // 出力は valid UTF-8 で概ね予算内に収まる。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,25 @@
 # vibe-editor Tauri ハイブリッド移行 + 無限キャンバス UI 革新 TODO
 
+## Issue #1146 - API agent session削除失敗を伝播 (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1146
+
+### 計画
+
+- [x] 現行の削除処理・エラー型・既存テスト構成を確認する。
+- [x] `NotFound` のみ成功扱いにし、その他のI/Oエラーを伝播する。
+- [x] 成功・NotFound・その他エラーのunit testを追加する。
+- [x] Rust関連品質ゲートを実行する。
+
+### Next Steps
+
+- [x] 検証結果を記録する。
+- [ ] コミットして feature branch をpushする。
+- [x] targeted Rust test: PASS（2 passed / 0 failed）
+- [x] `cargo check --locked --manifest-path src-tauri\\Cargo.toml --all-targets`: PASS
+- [x] `git diff --check`: PASS
+- [ ] repository-wide `cargo fmt --check`: FAIL（今回の差分外に既存不整形あり）
+
 ## #736 team_hub/state.rs god-file 分割 + team_send 段階関数化 (完了)
 
 方針: 振る舞いを一切変えない純粋なリファクタ。lock の取得/解放タイミング・


### PR DESCRIPTION
## Summary
- Issue #1146 の計画済み修正を、対象スコープ内で実装
- 変更規模: 3 files changed, 48 insertions(+), 2 deletions(-)（3 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1146

## Test plan
- [x] 関連Rustテスト
- [x] cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets
- [x] cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない