### PR TITLE
fix(persistence): sync失敗時の置換を中止

### DIFF
--- a/src-tauri/src/commands/atomic_write.rs
+++ b/src-tauri/src/commands/atomic_write.rs
@@ -184,10 +184,7 @@ mod tests {
         let file = fs::OpenOptions::new().write(true).open(&tmp).await.unwrap();
 
         let error = sync_temp_file(file, &tmp, &target, |_file| async {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "injected sync failure",
-            ))
+            Err(std::io::Error::other("injected sync failure"))
         })
         .await
         .expect_err("sync failure must abort the atomic replacement");

--- a/src-tauri/src/commands/atomic_write.rs
+++ b/src-tauri/src/commands/atomic_write.rs
@@ -14,6 +14,7 @@
 // Windows は no-op で fallback。Windows ACL 強制は別 issue で対応)。
 
 use anyhow::{anyhow, Result};
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
@@ -89,7 +90,10 @@ pub async fn atomic_write_with_mode(
         f.write_all(bytes).await?;
         f.flush().await?;
         // sync_all で metadata も含めてディスクへ flush
-        f.sync_all().await.ok();
+        sync_temp_file(f, &tmp, target, |file| async move {
+            file.sync_all().await
+        })
+        .await?;
     }
 
     // rename で atomic 置換。Windows は同 volume 内なら既存ファイルの置換もアトミック
@@ -121,6 +125,27 @@ pub async fn atomic_write_with_mode(
     Ok(())
 }
 
+async fn sync_temp_file<F, Fut>(file: fs::File, tmp: &Path, target: &Path, sync: F) -> Result<()>
+where
+    F: FnOnce(fs::File) -> Fut,
+    Fut: Future<Output = std::io::Result<()>>,
+{
+    let result = sync(file).await;
+    if let Err(error) = result {
+        if let Err(cleanup_error) = fs::remove_file(tmp).await {
+            tracing::warn!(
+                "[atomic_write] temp cleanup after sync failure failed for {}: {cleanup_error}",
+                tmp.display()
+            );
+        }
+        return Err(anyhow!(
+            "atomic_write sync failed before replacing {}: {error}",
+            target.display()
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,6 +172,29 @@ mod tests {
         let got = fs::read(&target).await.unwrap();
         assert_eq!(&got, b"v2");
         let _ = fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn sync_failure_preserves_target_and_removes_temp() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("settings.json");
+        let tmp = dir.path().join(".settings.json.tmp.test");
+        fs::write(&target, b"old").await.unwrap();
+        fs::write(&tmp, b"new").await.unwrap();
+        let file = fs::OpenOptions::new().write(true).open(&tmp).await.unwrap();
+
+        let error = sync_temp_file(file, &tmp, &target, |_file| async {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "injected sync failure",
+            ))
+        })
+        .await
+        .expect_err("sync failure must abort the atomic replacement");
+
+        assert!(error.to_string().contains("injected sync failure"));
+        assert_eq!(fs::read(&target).await.unwrap(), b"old");
+        assert!(!fs::try_exists(&tmp).await.unwrap());
     }
 
     #[tokio::test]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,25 @@
 # vibe-editor Tauri ハイブリッド移行 + 無限キャンバス UI 革新 TODO
 
+## Issue #1151 - atomic writeのsync失敗を伝播 (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1151
+
+### 計画
+
+- [x] `sync_all`失敗の握り潰しと既存atomic write契約を確認する。
+- [x] sync失敗時にrenameせず、handle close後にtempを掃除してErrを返す。
+- [x] fault injectionで旧target保持・temp削除・error伝播を検証する。
+- [x] Rust関連品質ゲートを実行する。
+
+### Next Steps
+
+- [x] 検証結果を記録する。
+- [ ] コミットして feature branch をpushする。
+- [x] `cargo test --locked --manifest-path src-tauri\\Cargo.toml --lib commands::atomic_write`: PASS（5 passed / 0 failed）
+- [x] `cargo check --locked --manifest-path src-tauri\\Cargo.toml --all-targets`: PASS
+- [x] `git diff --check`: PASS
+- [x] `sync_all().await.ok()` 残存確認: 0件
+
 ## #736 team_hub/state.rs god-file 分割 + team_send 段階関数化 (完了)
 
 方針: 振る舞いを一切変えない純粋なリファクタ。lock の取得/解放タイミング・


### PR DESCRIPTION
## Summary
- Issue #1151 の計画済み修正を、対象スコープ内で実装
- 変更規模: 2 files changed, 69 insertions(+), 1 deletion(-)（2 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1151

## Test plan
- [x] 関連Rustテスト
- [x] cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets
- [x] cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない