### PR TITLE
fix(terminal): watcherへ実際のcwdを渡す

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -550,22 +550,14 @@ pub async fn terminal_create(
             let is_claude_command = command.to_lowercase().contains("claude");
             if is_claude_command || is_codex_command {
                 let watcher_id = id.clone();
-                // Issue #739: ArcSwapOption の lock-free load で現在値を読む。
-                let watcher_root =
-                    crate::state::current_project_root(&state.project_root).unwrap_or_default();
-                let actual_root = if watcher_root.is_empty() {
-                    // PTY spawn 時の cwd を流用
-                    std::env::current_dir()
-                        .map(|p| p.to_string_lossy().into_owned())
-                        .unwrap_or_default()
-                } else {
-                    watcher_root
-                };
                 // Issue #632: SessionHandle が公開する watcher_cancel token を渡す。
                 // PTY が `kill()` / `Drop` で寿命終了した瞬間に flip され、watcher は
                 // 100ms 以内に exit する。registry.get(...).is_some() を 500ms ごとに
                 // polling していた旧実装より反応が早く、cleanup の遅延を解消する。
                 if let Some(handle) = state.pty_registry.get(&watcher_id) {
+                    // Issue #1154: watcherの照合対象はactive projectではなく、このPTYを
+                    // 実際にspawnしたcwd。resolve_valid_cwd後のSSOTをhandleから読む。
+                    let actual_root = handle.cwd.clone();
                     let cancel = handle.watcher_cancel_token();
                     if is_codex_command {
                         crate::pty::codex_watcher::spawn_watcher(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,26 @@
 # vibe-editor Tauri ハイブリッド移行 + 無限キャンバス UI 革新 TODO
 
+## Issue #1154 - session watcherへspawn cwdを渡す (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1154
+
+### 計画
+
+- [x] watcher rootと実spawn cwdの乖離を確認する。
+- [x] SessionHandleのcwdをClaude/Codex watcherへ渡す。
+- [x] watcher・terminal関連テストとRust品質ゲートを実行する。
+
+### Next Steps
+
+- [x] 検証結果を記録する。
+- [ ] コミットして feature branch をpushする。
+- [x] Claude watcher tests: PASS（6 passed / 0 failed）
+- [x] Codex watcher tests: PASS（11 passed / 0 failed）
+- [x] terminal tests: PASS（117 passed / 0 failed）
+- [x] `cargo check --locked --manifest-path src-tauri\\Cargo.toml --all-targets`: PASS
+- [x] `cargo clippy --locked --manifest-path src-tauri\\Cargo.toml --all-targets -- -D warnings`: PASS
+- [x] `git diff --check`: PASS
+
 ## #736 team_hub/state.rs god-file 分割 + team_send 段階関数化 (完了)
 
 方針: 振る舞いを一切変えない純粋なリファクタ。lock の取得/解放タイミング・


### PR DESCRIPTION
## Summary
- Issue #1154 の計画済み修正を、対象スコープ内で実装
- 変更規模: 2 files changed, 24 insertions(+), 11 deletions(-)（2 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1154

## Test plan
- [x] 関連Rustテスト
- [x] cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets
- [x] cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない