### PR TITLE
fix(terminal): 画像pasteの書込失敗を通知

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -75,6 +75,33 @@ pub struct TerminalCreateResult {
     pub replay: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TerminalWriteOutcome {
+    Written,
+    SuppressedInjecting,
+    DroppedTooLarge,
+    DroppedRateLimited,
+    SessionNotFound,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalWriteResult {
+    pub outcome: TerminalWriteOutcome,
+}
+
+impl From<UserWriteOutcome> for TerminalWriteOutcome {
+    fn from(value: UserWriteOutcome) -> Self {
+        match value {
+            UserWriteOutcome::Written => Self::Written,
+            UserWriteOutcome::SuppressedInjecting => Self::SuppressedInjecting,
+            UserWriteOutcome::DroppedTooLarge => Self::DroppedTooLarge,
+            UserWriteOutcome::DroppedRateLimited => Self::DroppedRateLimited,
+        }
+    }
+}
+
 #[derive(Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SavePastedImageResult {
@@ -622,7 +649,7 @@ pub async fn terminal_write(
     state: State<'_, AppState>,
     id: String,
     data: String,
-) -> crate::commands::error::CommandResult<()> {
+) -> crate::commands::error::CommandResult<TerminalWriteResult> {
     if let Some(s) = state.pty_registry.get(&id) {
         let data_len = data.len();
         let data_bytes = data.into_bytes();
@@ -645,8 +672,13 @@ pub async fn terminal_write(
                 );
             }
         }
+        return Ok(TerminalWriteResult {
+            outcome: outcome.into(),
+        });
     }
-    Ok(())
+    Ok(TerminalWriteResult {
+        outcome: TerminalWriteOutcome::SessionNotFound,
+    })
 }
 
 /// Issue #1076: `terminal_resize` の下限クランプ値。spawn 経路 (`session/spawn.rs` の
@@ -935,6 +967,45 @@ mod codex_resume_filter_tests {
         let input = s(&["-c", "k=v", "resume", "abc;rm -rf /"]);
         let out = filter_codex_resume_id_in_place(true, input.clone());
         assert_eq!(out, input);
+    }
+}
+
+#[cfg(test)]
+mod terminal_write_outcome_tests {
+    use super::{TerminalWriteOutcome, UserWriteOutcome};
+
+    #[test]
+    fn maps_all_internal_write_outcomes_to_ipc_contract() {
+        let cases = [
+            (UserWriteOutcome::Written, TerminalWriteOutcome::Written),
+            (
+                UserWriteOutcome::SuppressedInjecting,
+                TerminalWriteOutcome::SuppressedInjecting,
+            ),
+            (
+                UserWriteOutcome::DroppedTooLarge,
+                TerminalWriteOutcome::DroppedTooLarge,
+            ),
+            (
+                UserWriteOutcome::DroppedRateLimited,
+                TerminalWriteOutcome::DroppedRateLimited,
+            ),
+        ];
+        for (internal, expected) in cases {
+            assert_eq!(TerminalWriteOutcome::from(internal), expected);
+        }
+    }
+
+    #[test]
+    fn serializes_write_outcomes_as_camel_case_strings() {
+        assert_eq!(
+            serde_json::to_string(&TerminalWriteOutcome::SuppressedInjecting).unwrap(),
+            r#""suppressedInjecting""#
+        );
+        assert_eq!(
+            serde_json::to_string(&TerminalWriteOutcome::SessionNotFound).unwrap(),
+            r#""sessionNotFound""#
+        );
     }
 }
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -8,9 +8,10 @@ pub(crate) mod shell_policy;
 mod codex_prompt;
 mod paste_image;
 mod prompt_files;
+pub(crate) mod write_outcome;
 
 use crate::pty::session::TerminalWarning;
-use crate::pty::{spawn_session, SpawnOptions, UserWriteOutcome};
+use crate::pty::{spawn_session, SpawnOptions};
 use crate::state::AppState;
 use codex_prompt::inject_codex_prompt_to_pty;
 use crate::util::log_redact::redact_home;
@@ -73,33 +74,6 @@ pub struct TerminalCreateResult {
     /// emit 済みで listener には届かないため、直前 64 KiB を文字列で同梱して replay させる。
     /// 新規 spawn 経路や attach 不発 (snapshot 空) では None。
     pub replay: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub enum TerminalWriteOutcome {
-    Written,
-    SuppressedInjecting,
-    DroppedTooLarge,
-    DroppedRateLimited,
-    SessionNotFound,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TerminalWriteResult {
-    pub outcome: TerminalWriteOutcome,
-}
-
-impl From<UserWriteOutcome> for TerminalWriteOutcome {
-    fn from(value: UserWriteOutcome) -> Self {
-        match value {
-            UserWriteOutcome::Written => Self::Written,
-            UserWriteOutcome::SuppressedInjecting => Self::SuppressedInjecting,
-            UserWriteOutcome::DroppedTooLarge => Self::DroppedTooLarge,
-            UserWriteOutcome::DroppedRateLimited => Self::DroppedRateLimited,
-        }
-    }
 }
 
 #[derive(Serialize, Default)]
@@ -644,43 +618,6 @@ pub async fn terminal_create(
     }
 }
 
-#[tauri::command]
-pub async fn terminal_write(
-    state: State<'_, AppState>,
-    id: String,
-    data: String,
-) -> crate::commands::error::CommandResult<TerminalWriteResult> {
-    if let Some(s) = state.pty_registry.get(&id) {
-        let data_len = data.len();
-        let data_bytes = data.into_bytes();
-        let outcome = tokio::task::spawn_blocking(move || s.user_write(&data_bytes))
-            .await
-            .map_err(|e| format!("[terminal] terminal_write spawn_blocking failed for {id}: {e}"))?
-            .map_err(|e| e.to_string())?;
-        match outcome {
-            UserWriteOutcome::Written | UserWriteOutcome::SuppressedInjecting => {}
-            UserWriteOutcome::DroppedTooLarge => {
-                tracing::warn!(
-                    "[terminal] dropped oversized terminal_write payload for {id}: {} bytes",
-                    data_len
-                );
-            }
-            UserWriteOutcome::DroppedRateLimited => {
-                tracing::warn!(
-                    "[terminal] rate-limited terminal_write for {id}: {} bytes",
-                    data_len
-                );
-            }
-        }
-        return Ok(TerminalWriteResult {
-            outcome: outcome.into(),
-        });
-    }
-    Ok(TerminalWriteResult {
-        outcome: TerminalWriteOutcome::SessionNotFound,
-    })
-}
-
 /// Issue #1076: `terminal_resize` の下限クランプ値。spawn 経路 (`session/spawn.rs` の
 /// `openpty` で `cols.max(20)` / `rows.max(5)`) と揃える。
 ///
@@ -967,45 +904,6 @@ mod codex_resume_filter_tests {
         let input = s(&["-c", "k=v", "resume", "abc;rm -rf /"]);
         let out = filter_codex_resume_id_in_place(true, input.clone());
         assert_eq!(out, input);
-    }
-}
-
-#[cfg(test)]
-mod terminal_write_outcome_tests {
-    use super::{TerminalWriteOutcome, UserWriteOutcome};
-
-    #[test]
-    fn maps_all_internal_write_outcomes_to_ipc_contract() {
-        let cases = [
-            (UserWriteOutcome::Written, TerminalWriteOutcome::Written),
-            (
-                UserWriteOutcome::SuppressedInjecting,
-                TerminalWriteOutcome::SuppressedInjecting,
-            ),
-            (
-                UserWriteOutcome::DroppedTooLarge,
-                TerminalWriteOutcome::DroppedTooLarge,
-            ),
-            (
-                UserWriteOutcome::DroppedRateLimited,
-                TerminalWriteOutcome::DroppedRateLimited,
-            ),
-        ];
-        for (internal, expected) in cases {
-            assert_eq!(TerminalWriteOutcome::from(internal), expected);
-        }
-    }
-
-    #[test]
-    fn serializes_write_outcomes_as_camel_case_strings() {
-        assert_eq!(
-            serde_json::to_string(&TerminalWriteOutcome::SuppressedInjecting).unwrap(),
-            r#""suppressedInjecting""#
-        );
-        assert_eq!(
-            serde_json::to_string(&TerminalWriteOutcome::SessionNotFound).unwrap(),
-            r#""sessionNotFound""#
-        );
     }
 }
 

--- a/src-tauri/src/commands/terminal/write_outcome.rs
+++ b/src-tauri/src/commands/terminal/write_outcome.rs
@@ -1,0 +1,102 @@
+use crate::pty::UserWriteOutcome;
+use crate::state::AppState;
+use serde::Serialize;
+use tauri::State;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TerminalWriteOutcome {
+    Written,
+    SuppressedInjecting,
+    DroppedTooLarge,
+    DroppedRateLimited,
+    SessionNotFound,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalWriteResult {
+    pub outcome: TerminalWriteOutcome,
+}
+
+impl From<UserWriteOutcome> for TerminalWriteOutcome {
+    fn from(value: UserWriteOutcome) -> Self {
+        match value {
+            UserWriteOutcome::Written => Self::Written,
+            UserWriteOutcome::SuppressedInjecting => Self::SuppressedInjecting,
+            UserWriteOutcome::DroppedTooLarge => Self::DroppedTooLarge,
+            UserWriteOutcome::DroppedRateLimited => Self::DroppedRateLimited,
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn terminal_write(
+    state: State<'_, AppState>,
+    id: String,
+    data: String,
+) -> crate::commands::error::CommandResult<TerminalWriteResult> {
+    let Some(session) = state.pty_registry.get(&id) else {
+        return Ok(TerminalWriteResult {
+            outcome: TerminalWriteOutcome::SessionNotFound,
+        });
+    };
+    let data_len = data.len();
+    let outcome = tokio::task::spawn_blocking(move || session.user_write(data.as_bytes()))
+        .await
+        .map_err(|error| {
+            format!("[terminal] terminal_write spawn_blocking failed for {id}: {error}")
+        })?
+        .map_err(|error| error.to_string())?;
+    match outcome {
+        UserWriteOutcome::Written | UserWriteOutcome::SuppressedInjecting => {}
+        UserWriteOutcome::DroppedTooLarge => tracing::warn!(
+            "[terminal] dropped oversized terminal_write payload for {id}: {data_len} bytes"
+        ),
+        UserWriteOutcome::DroppedRateLimited => {
+            tracing::warn!("[terminal] rate-limited terminal_write for {id}: {data_len} bytes")
+        }
+    }
+    Ok(TerminalWriteResult {
+        outcome: outcome.into(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_all_internal_write_outcomes_to_ipc_contract() {
+        let cases = [
+            (UserWriteOutcome::Written, TerminalWriteOutcome::Written),
+            (
+                UserWriteOutcome::SuppressedInjecting,
+                TerminalWriteOutcome::SuppressedInjecting,
+            ),
+            (
+                UserWriteOutcome::DroppedTooLarge,
+                TerminalWriteOutcome::DroppedTooLarge,
+            ),
+            (
+                UserWriteOutcome::DroppedRateLimited,
+                TerminalWriteOutcome::DroppedRateLimited,
+            ),
+        ];
+        for (internal, expected) in cases {
+            assert_eq!(TerminalWriteOutcome::from(internal), expected);
+        }
+    }
+
+    #[test]
+    fn serializes_write_outcomes_as_camel_case_strings() {
+        assert_eq!(
+            serde_json::to_string(&TerminalWriteOutcome::SuppressedInjecting).unwrap(),
+            r#""suppressedInjecting""#
+        );
+        assert_eq!(
+            serde_json::to_string(&TerminalWriteOutcome::SessionNotFound).unwrap(),
+            r#""sessionNotFound""#
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -265,7 +265,7 @@ pub fn run() {
             commands::logs::logs_open_dir,
             // ---- terminal ----
             commands::terminal::terminal_create,
-            commands::terminal::terminal_write,
+            commands::terminal::write_outcome::terminal_write,
             commands::terminal::terminal_resize,
             commands::terminal::terminal_kill,
             commands::terminal::terminal_save_pasted_image,

--- a/src/renderer/src/components/TerminalView.tsx
+++ b/src/renderer/src/components/TerminalView.tsx
@@ -274,6 +274,11 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
         void window.api.terminal.write(ptyIdRef.current, text);
       }
     };
+    const writePastedImageToPty = async (text: string) => {
+      const id = ptyIdRef.current;
+      if (!id) return { outcome: 'sessionNotFound' as const };
+      return window.api.terminal.write(id, text);
+    };
 
     // --- initialMessage の自動送信 ---
     const { observeChunk: observeInitialMessage } = useAutoInitialMessage({
@@ -319,6 +324,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       termRef,
       containerRef,
       writeToPty,
+      writePastedImageToPty,
       langRef
     });
 

--- a/src/renderer/src/lib/__tests__/paste-image-client.test.ts
+++ b/src/renderer/src/lib/__tests__/paste-image-client.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { insertPastedImageToPty } from '../paste-image-client';
+
+type TestWindow = Window & typeof globalThis & { api?: unknown };
+
+describe('insertPastedImageToPty', () => {
+  const originalApi = (window as TestWindow).api;
+
+  afterEach(() => {
+    if (originalApi === undefined) delete (window as TestWindow).api;
+    else (window as TestWindow).api = originalApi;
+    vi.restoreAllMocks();
+  });
+
+  it('writtenのときだけ画像パス挿入を成功扱いにする', async () => {
+    (window as TestWindow).api = {
+      terminal: {
+        savePastedImage: vi.fn(async () => ({ ok: true, path: 'C:\\tmp\\shot image.png' }))
+      }
+    };
+    const write = vi.fn(async () => ({ outcome: 'written' as const }));
+
+    await expect(
+      insertPastedImageToPty(new Blob(['image']), 'image/png', write)
+    ).resolves.toEqual({ ok: true });
+    expect(write).toHaveBeenCalledWith('"C:\\tmp\\shot image.png" ');
+  });
+
+  it.each([
+    'suppressedInjecting',
+    'droppedTooLarge',
+    'droppedRateLimited',
+    'sessionNotFound'
+  ] as const)('%sを成功扱いにしない', async (outcome) => {
+    (window as TestWindow).api = {
+      terminal: {
+        savePastedImage: vi.fn(async () => ({ ok: true, path: '/tmp/image.png' }))
+      }
+    };
+
+    await expect(
+      insertPastedImageToPty(new Blob(['image']), 'image/png', async () => ({ outcome }))
+    ).resolves.toEqual({
+      ok: false,
+      error: outcome,
+      errorKey: `terminal.pasteImage.${outcome}`
+    });
+  });
+});

--- a/src/renderer/src/lib/i18n/en-shell.ts
+++ b/src/renderer/src/lib/i18n/en-shell.ts
@@ -285,6 +285,10 @@ export const enShell: Dict = {
 
   // ---------- Terminal (paste errors) ----------
   'terminal.pasteImageFailed': 'Paste image failed',
+  'terminal.pasteImage.suppressedInjecting': 'Could not insert while prompt injection is active',
+  'terminal.pasteImage.droppedTooLarge': 'The inserted data is too large',
+  'terminal.pasteImage.droppedRateLimited': 'Could not insert because input was rate-limited',
+  'terminal.pasteImage.sessionNotFound': 'The terminal session was not found',
   'terminal.pasteException': 'Paste exception',
 
 

--- a/src/renderer/src/lib/i18n/ja-shell.ts
+++ b/src/renderer/src/lib/i18n/ja-shell.ts
@@ -285,7 +285,7 @@ export const jaShell: Dict = {
   'terminal.pasteImageFailed': '画像の貼り付け失敗',
   'terminal.pasteImage.suppressedInjecting': 'プロンプト注入中のため挿入できませんでした',
   'terminal.pasteImage.droppedTooLarge': '挿入データが大きすぎます',
-  'terminal.pasteImage.droppedRateLimited': '入力が集中したため挿入できませんでした',
+  'terminal.pasteImage.droppedRateLimited': '入力が多すぎたため挿入できませんでした',
   'terminal.pasteImage.sessionNotFound': 'ターミナル接続が見つかりません',
   'terminal.pasteException': 'ペースト例外',
 

--- a/src/renderer/src/lib/i18n/ja-shell.ts
+++ b/src/renderer/src/lib/i18n/ja-shell.ts
@@ -282,7 +282,11 @@ export const jaShell: Dict = {
 
 
   // ---------- Terminal (pasteエラー等) ----------
-  'terminal.pasteImageFailed': '画像保存失敗',
+  'terminal.pasteImageFailed': '画像の貼り付け失敗',
+  'terminal.pasteImage.suppressedInjecting': 'プロンプト注入中のため挿入できませんでした',
+  'terminal.pasteImage.droppedTooLarge': '挿入データが大きすぎます',
+  'terminal.pasteImage.droppedRateLimited': '入力が集中したため挿入できませんでした',
+  'terminal.pasteImage.sessionNotFound': 'ターミナル接続が見つかりません',
   'terminal.pasteException': 'ペースト例外',
 
 

--- a/src/renderer/src/lib/paste-image-client.ts
+++ b/src/renderer/src/lib/paste-image-client.ts
@@ -11,8 +11,8 @@
 export async function insertPastedImageToPty(
   blob: Blob,
   mime: string,
-  writeToPty: (text: string) => void | Promise<void>
-): Promise<{ ok: true } | { ok: false; error: string }> {
+  writeToPty: (text: string) => Promise<TerminalWriteResult>
+): Promise<{ ok: true } | { ok: false; error: string; errorKey?: string }> {
   // Issue #160: 旧実装は 32KB チャンクで Array.from(Uint8Array) → String.fromCharCode.apply
   // を回しており、20MB クラスのスクショで Array.from が 20M 要素配列を作成 → UI ハング。
   // FileReader.readAsDataURL で base64 をネイティブ実装一発で取得する方が圧倒的に速い。
@@ -37,6 +37,11 @@ export async function insertPastedImageToPty(
   const p = res.path;
   const needQuote = /\s/.test(p);
   const inserted = (needQuote ? `"${p}"` : p) + ' ';
-  await writeToPty(inserted);
+  const writeResult = await writeToPty(inserted);
+  if (writeResult.outcome !== 'written') {
+    const errorKey = `terminal.pasteImage.${writeResult.outcome}`;
+    return { ok: false, error: writeResult.outcome, errorKey };
+  }
   return { ok: true };
 }
+import type { TerminalWriteResult } from '../../../types/shared';

--- a/src/renderer/src/lib/tauri-api/terminal.ts
+++ b/src/renderer/src/lib/tauri-api/terminal.ts
@@ -5,7 +5,8 @@ import { subscribeEvent, subscribeEventReady } from '../subscribe-event';
 import type {
   TerminalCreateOptions,
   TerminalCreateResult,
-  TerminalExitInfo
+  TerminalExitInfo,
+  TerminalWriteResult
 } from '../../../../types/shared';
 
 export interface SavePastedImageResult {
@@ -17,7 +18,7 @@ export interface SavePastedImageResult {
 export const terminal = {
   create: (opts: TerminalCreateOptions): Promise<TerminalCreateResult> =>
     invokeCommand('terminal_create', { opts }),
-  write: (id: string, data: string): Promise<void> =>
+  write: (id: string, data: string): Promise<TerminalWriteResult> =>
     invokeCommand('terminal_write', { id, data }),
   resize: (id: string, cols: number, rows: number): Promise<void> =>
     invokeCommand('terminal_resize', { id, cols, rows }),

--- a/src/renderer/src/lib/use-terminal-clipboard.ts
+++ b/src/renderer/src/lib/use-terminal-clipboard.ts
@@ -4,6 +4,7 @@ import type { Terminal } from '@xterm/xterm';
 import { insertPastedImageToPty } from './paste-image-client';
 import { translate } from './i18n';
 import type { Language } from '../../../types/shared';
+import type { TerminalWriteResult } from '../../../types/shared';
 
 /**
  * ターミナルのコピー＆ペースト制御を担当するフック。
@@ -23,12 +24,14 @@ export function useTerminalClipboard(options: {
   containerRef: RefObject<HTMLDivElement | null>;
   /** 文字列を pty に書き込むコールバック (pty id が無ければ no-op) */
   writeToPty: (text: string) => void | Promise<void>;
+  /** 画像パス挿入専用。backendのwrite outcomeを呼び元へ返す。 */
+  writePastedImageToPty: (text: string) => Promise<TerminalWriteResult>;
   /** Issue #338: 言語の current を ref 経由で受け取る。
    *  内部 hook が React Context を直接引くと HMR で Context 分裂時にクラッシュ連鎖するため、
    *  caller 側で settings.language を ref に詰めて渡す。 */
   langRef: MutableRefObject<Language>;
 }): void {
-  const { termRef, containerRef, writeToPty, langRef } = options;
+  const { termRef, containerRef, writeToPty, writePastedImageToPty, langRef } = options;
 
   const writeRef = useRef(writeToPty);
   writeRef.current = writeToPty;
@@ -43,9 +46,12 @@ export function useTerminalClipboard(options: {
     };
 
     const handleImageBlob = async (blob: Blob, mime: string): Promise<void> => {
-      const res = await insertPastedImageToPty(blob, mime, (text) => writeRef.current(text));
+      const res = await insertPastedImageToPty(blob, mime, writePastedImageToPty);
       if (!res.ok) {
-        writeError(translate(langRef.current, 'terminal.pasteImageFailed'), res.error);
+        const message = res.errorKey
+          ? translate(langRef.current, res.errorKey)
+          : res.error;
+        writeError(translate(langRef.current, 'terminal.pasteImageFailed'), message);
       }
     };
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1606,6 +1606,17 @@ export interface TerminalCreateResult {
   replay?: string;
 }
 
+export type TerminalWriteOutcome =
+  | 'written'
+  | 'suppressedInjecting'
+  | 'droppedTooLarge'
+  | 'droppedRateLimited'
+  | 'sessionNotFound';
+
+export interface TerminalWriteResult {
+  outcome: TerminalWriteOutcome;
+}
+
 export interface TerminalExitInfo {
   exitCode: number;
   signal?: number;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1,6 +1,6 @@
 // main/preload/renderer で共有する型定義
 import type { FileLockConflictSnapshot } from './generated/team-events';
-
+export type { TerminalWriteOutcome, TerminalWriteResult } from './terminal-write';
 export type ThemeName =
   | 'claude-dark'
   | 'claude-light'
@@ -1604,17 +1604,6 @@ export interface TerminalCreateResult {
    * 新規 spawn 経路 / snapshot が空のときは undefined。
    */
   replay?: string;
-}
-
-export type TerminalWriteOutcome =
-  | 'written'
-  | 'suppressedInjecting'
-  | 'droppedTooLarge'
-  | 'droppedRateLimited'
-  | 'sessionNotFound';
-
-export interface TerminalWriteResult {
-  outcome: TerminalWriteOutcome;
 }
 
 export interface TerminalExitInfo {

--- a/src/types/terminal-write.ts
+++ b/src/types/terminal-write.ts
@@ -1,0 +1,10 @@
+export type TerminalWriteOutcome =
+  | 'written'
+  | 'suppressedInjecting'
+  | 'droppedTooLarge'
+  | 'droppedRateLimited'
+  | 'sessionNotFound';
+
+export interface TerminalWriteResult {
+  outcome: TerminalWriteOutcome;
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,30 @@
 # vibe-editor Tauri ハイブリッド移行 + 無限キャンバス UI 革新 TODO
 
+## Issue #1156 - 画像pasteのwrite結果を可視化 (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1156
+
+### 計画
+
+- [x] backendで判別済みのwrite outcomeがIPCで消える経路を確認する。
+- [x] terminal_writeの結果を構造化し、session不在を含めてrendererへ返す。
+- [x] 画像paste経路だけ結果を判定し、非writtenを現在言語で表示する。
+- [x] Rust/JS関連テストと全品質ゲートを実行する。
+
+### Next Steps
+
+- [x] 検証結果を記録する。
+- [ ] コミットして feature branch をpushする。
+- [x] Rust outcome tests: PASS（2 passed / 0 failed）
+- [x] targeted Vitest: PASS（1 file / 5 tests）
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS（87 files / 524 tests）
+- [x] `npm run lint`: PASS（0 errors / 既存12 warnings）
+- [x] `npm run build:vite`: PASS
+- [x] `cargo check --locked --manifest-path src-tauri\\Cargo.toml --all-targets`: PASS
+- [x] `cargo clippy --locked --manifest-path src-tauri\\Cargo.toml --all-targets -- -D warnings`: PASS
+- [x] `git diff --check`: PASS
+
 ## #736 team_hub/state.rs god-file 分割 + team_send 段階関数化 (完了)
 
 方針: 振る舞いを一切変えない純粋なリファクタ。lock の取得/解放タイミング・

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14,7 +14,7 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1156
 ### Next Steps
 
 - [x] 検証結果を記録する。
-- [ ] コミットして feature branch をpushする。
+- [ ] CI修正をコミットして feature branch をpushする。
 - [x] Rust outcome tests: PASS（2 passed / 0 failed）
 - [x] targeted Vitest: PASS（1 file / 5 tests）
 - [x] `npm run typecheck`: PASS
@@ -24,6 +24,7 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1156
 - [x] `cargo check --locked --manifest-path src-tauri\\Cargo.toml --all-targets`: PASS
 - [x] `cargo clippy --locked --manifest-path src-tauri\\Cargo.toml --all-targets -- -D warnings`: PASS
 - [x] `git diff --check`: PASS
+- [x] `npm run lint:file-size`: PASS（terminal.rs 971/1002、shared.ts 1994/1994）
 
 ## #736 team_hub/state.rs god-file 分割 + team_send 段階関数化 (完了)
 


### PR DESCRIPTION
## Summary
- Issue #1156 の計画済み修正を、対象スコープ内で実装
- 変更規模: 10 files changed, 193 insertions(+), 11 deletions(-)（10 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1156

## Test plan
- [x] 関連Rustテスト / Vitest
- [x] npm run typecheck
- [x] npm run test
- [x] cargo check / cargo clippy -D warnings
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない