### PR TITLE
docs: 開発環境の記述を現行構成へ同期

### DIFF
--- a/.claude/skills/vibeeditor/SKILL.md
+++ b/.claude/skills/vibeeditor/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: vibeeditor
-description: vibe-editor (Tauri 2 + React 18 製の Claude Code / Codex 専用エディタ) で作業する際に必ず参照するプロジェクト全体ガイド。アーキテクチャ (Rust 側コマンド / React 側 UI / IPC 経由)、ディレクトリ構成、命名規則、頻出コマンド (npm run dev / typecheck / build)、テーマ・i18n・設定永続化・PTY・Canvas モード・自動アップデート等の実装パターンと注意点をまとめる。vibe-editor リポジトリ内で「機能追加」「バグ修正」「リファクタ」「IPC コマンドを足す」「設定項目を追加」「テーマを足す」「Canvas を触る」「ターミナル/PTY を触る」「セッション履歴」「TeamHub」「shared.ts に型を足す」「tauri-api.ts」「@tauri-apps/api/core」「invoke / listen」等のキーワードや作業に少しでも触れるとき、また vibe-editor プロジェクトでコードを書く前に必ずこの skill を起動すること。
+description: vibe-editor (Tauri 2 + React 19 製の Claude Code / Codex 専用エディタ) で作業する際に必ず参照するプロジェクト全体ガイド。アーキテクチャ (Rust 側コマンド / React 側 UI / IPC 経由)、ディレクトリ構成、命名規則、頻出コマンド (npm run dev / typecheck / build)、テーマ・i18n・設定永続化・PTY・Canvas モード・自動アップデート等の実装パターンと注意点をまとめる。vibe-editor リポジトリ内で「機能追加」「バグ修正」「リファクタ」「IPC コマンドを足す」「設定項目を追加」「テーマを足す」「Canvas を触る」「ターミナル/PTY を触る」「セッション履歴」「TeamHub」「shared.ts に型を足す」「tauri-api」「@tauri-apps/api/core」「invoke / listen」等のキーワードや作業に少しでも触れるとき、また vibe-editor プロジェクトでコードを書く前に必ずこの skill を起動すること。
 ---
 
 # vibeeditor
 
-vibe-editor (Tauri 2 + Vite 5 + React 18 + TypeScript 5.6) で開発するときに最初に読み込むナビゲーションスキル。
+vibe-editor (Tauri 2 + Vite 8 + React 19 + TypeScript 6) で開発するときに最初に読み込むナビゲーションスキル。正確なpatch版は `package.json` を参照する。
 個別タスクのフローは別 skill (pullrequest / vibe-team / claude-design など) に委譲し、ここでは「どこに何があるか」「どのレイヤを触るか」を素早く判断するための地図を提供する。
 
 ---
@@ -17,11 +17,11 @@ vibe-editor (Tauri 2 + Vite 5 + React 18 + TypeScript 5.6) で開発するとき
 ```
 ┌─────────────────────────────────────────────────┐
 │ Renderer (src/renderer/) — UI 描画のみ           │
-│   React 18 + TS strict + zustand + Monaco        │
+│   React 19 + TS strict + zustand + Monaco        │
 │   状態: hooks + Context (Settings, Toast)        │
 │        + zustand (canvas / ui)                   │
 └──────────────────┬──────────────────────────────┘
-                   │ window.api (tauri-api.ts 互換層)
+                   │ window.api (lib/tauri-api/ 互換層)
                    │ ↓ invoke() / listen()
 ┌──────────────────┴──────────────────────────────┐
 │ Tauri main (src-tauri/) — Rust                  │
@@ -41,7 +41,7 @@ vibe-editor (Tauri 2 + Vite 5 + React 18 + TypeScript 5.6) で開発するとき
 
 | 触りたいもの                       | 場所                                                         |
 |------------------------------------|--------------------------------------------------------------|
-| Rust IPC コマンド                  | `src-tauri/src/commands/{app,git,terminal,settings,dialog,sessions,team_history,files}.rs` |
+| Rust IPC コマンド                  | `src-tauri/src/commands/` (`src/lib.rs` で登録を確認) |
 | PTY / xterm 連携 (portable-pty)    | `src-tauri/src/pty/`                                         |
 | マルチエージェント socket hub      | `src-tauri/src/team_hub/`                                    |
 | 自動アップデート                   | `src-tauri/src/updater*` (tauri-plugin-updater)              |
@@ -49,7 +49,7 @@ vibe-editor (Tauri 2 + Vite 5 + React 18 + TypeScript 5.6) で開発するとき
 | Canvas モード専用 React            | `src/renderer/src/components/canvas/`                        |
 | レイアウト (CanvasLayout 等)       | `src/renderer/src/layouts/`                                  |
 | zustand store                      | `src/renderer/src/stores/{ui,canvas}.ts`                     |
-| Tauri 互換 API ラッパ              | `src/renderer/src/lib/tauri-api.ts`                          |
+| Tauri 互換 API ラッパ              | `src/renderer/src/lib/tauri-api/`                            |
 | 設定 Context                       | `src/renderer/src/lib/settings-context.tsx`                  |
 | テーマ (CSS 変数)                  | `src/renderer/src/lib/themes*` + `src/renderer/src/styles/`  |
 | i18n (ja/en)                       | `src/renderer/src/lib/i18n*`                                 |
@@ -65,7 +65,7 @@ vibe-editor (Tauri 2 + Vite 5 + React 18 + TypeScript 5.6) で開発するとき
 ```bash
 npm run dev          # = cargo tauri dev (Rust ビルド込み起動)
 npm run build        # = cargo tauri build (リリースビルド)
-npm run typecheck    # tsc --noEmit
+npm run typecheck    # tsc -b --force
 npm run dev:vite     # レンダラーだけ vite で起動 (UI 単体確認用)
 ```
 
@@ -79,7 +79,7 @@ npm run dev:vite     # レンダラーだけ vite で起動 (UI 単体確認用)
 1. `src/types/shared.ts` に Request / Response 型を追加 (camelCase)。
 2. `src-tauri/src/commands/<領域>.rs` に同名構造体を `#[derive(Serialize, Deserialize)] #[serde(rename_all = "camelCase")]` で追加。
 3. `#[tauri::command] async fn ...` を実装し、`tauri::Builder` の `invoke_handler!` に登録。
-4. `src/renderer/src/lib/tauri-api.ts` に `window.api.<名前>` のラッパを追加 (引数・戻り値型は shared.ts のものを使う)。
+4. `src/renderer/src/lib/tauri-api/` の該当領域に `window.api.<名前>` のラッパを追加 (引数・戻り値型は shared.ts のものを使う)。
 5. 呼び出し側 React から `window.api.xxx(...)` で利用。
 6. `npm run typecheck` で両側の型整合を確認。
 
@@ -107,7 +107,7 @@ Rust 側で `app.emit(event_name, payload)` を呼ぶタイミングが「receiv
 | 初期出力が **重要でない** / イベントが定期的に流れ続ける | `subscribeEvent` (sync) | listener 登録完了前の数十 ms は無視しても影響なし。書き心地優先 |
 | 補助: Rust 側で初回 flush を意図的に遅延 | batcher delay | 単独で race を完全排除はできない。pre-subscribe と併用する補助策 |
 
-### 4. tauri-api.ts に subscribe helper を足す
+### 4. tauri-api 互換層に subscribe helper を足す
 
 ```ts
 // 同期版 (post-subscribe race を許容するイベント用)
@@ -187,7 +187,7 @@ async fn terminal_create(opts: TerminalCreateOptions) -> Result<String, String> 
 | ターミナル (最大 10 タブ)     | `src-tauri/src/pty/` + `components/Terminal*`                           |
 | セッション履歴                | `src-tauri/src/commands/sessions.rs` + `~/.claude/projects/<encoded>/`  |
 | コマンドパレット (Ctrl+Shift+P) | `src/renderer/src/lib/commands*` + `components/CommandPalette*`        |
-| テーマ切替 (5 種)             | `lib/themes*` + `styles/themes/`                                        |
+| テーマ切替 (6 種)             | `lib/themes*` + `styles/themes/`                                        |
 | i18n (ja/en)                  | `lib/i18n*`                                                             |
 | 設定モーダル                  | `components/SettingsModal*`                                             |
 | TeamHub (複数エージェント)    | `src-tauri/src/team_hub/` + `components/team*`                          |
@@ -202,7 +202,7 @@ async fn terminal_create(opts: TerminalCreateOptions) -> Result<String, String> 
 - **`src-tauri/target/` と `src-tauri/gen/schemas/` は gitignore 済み**。間違ってコミットしない。
 - **Monaco は CDN ではなく npm パッケージ** (選択的インポートで 27 言語のみ)。新言語が必要なら登録漏れチェック。
 - **node-pty 系の electron-rebuild は不要** (portable-pty を使っているので)。Electron 文脈の解決策をそのまま持ち込まない。
-- **OS は Windows 11**。Rust 側のパス処理・改行・PTY 周りは Windows ネイティブを優先動作確認する。
+- 配布対象は Windows / macOS / Linux。OS 固有のパス処理・改行・PTY を変更した場合は、該当OSのrunnerまたは実機で確認する。
 - **ショートカット**は CLAUDE.md の表が正。新しいショートカットを足したら `commands*` と CLAUDE.md の両方を更新する。
 
 ---
@@ -211,7 +211,7 @@ async fn terminal_create(opts: TerminalCreateOptions) -> Result<String, String> 
 
 このリポジトリで **常に成り立っていてほしい性質**。レビューや実装中の自問はこの欄に照らす。
 
-- **shared.ts の型 ⇄ Rust struct ⇄ tauri-api.ts ラッパは常に同期している**。片側だけ変えない。
+- **shared.ts の型 ⇄ Rust struct ⇄ tauri-api ラッパは常に同期している**。片側だけ変えない。
 - **Renderer は OS リソース (fs / 外部プロセス / network) に直接アクセスしない**。必ず Rust 側コマンド経由。
 - **設定の永続化は Rust 側 (`~/.vibe-editor/settings.json`) を Single Source of Truth とする**。renderer がローカル state にコピーを持つ場合、Rust 側を最新としてこれに合わせる。
 - **IPC event の listener 登録は emit より先に完了させる責務が caller 側にある**。初期出力が重要なイベントは `subscribeEventReady` + client-generated id 経路で pre-subscribe する (Issue #285 / PR #291)。
@@ -224,8 +224,8 @@ async fn terminal_create(opts: TerminalCreateOptions) -> Result<String, String> 
 ## 関連 skill
 
 - **PR を出す / レビュー対応 / merge まで見届ける** → `pullrequest` skill (必ずこちらを使う)
-- **複数 issue をまとめて修正する** → `issue-fix` skill
-- **何度も試したのに直らない最終手段の修正** → `finalfix` skill
+- **Issue の計画を作る** → `issue-plan` skill
+- **PTY の起動問題を調査する** → `pty-portable-debugging` skill
 - **UI を Claude.ai / Claude Code 風にする** → `claude-design` skill
 - **TeamHub を絡めたマルチエージェント作業** → `vibe-team` skill
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # vibe-editor
 
-Tauri ベースの Claude Code / Codex 専用エディタ (v1.4.x)
+Tauri ベースの Claude Code / Codex 専用エディタ。正確なアプリ版は `package.json`、`src-tauri/Cargo.toml`、`src-tauri/tauri.conf.json` を参照する。
 
 ## 必須スキル
 このリポジトリで作業する前に、以下の skill を必ず起動すること。
@@ -63,11 +63,11 @@ Tauri ベースの Claude Code / Codex 専用エディタ (v1.4.x)
 ## アーキテクチャ原則
 - Rust 側 (`src-tauri/`): ファイル I/O、git、PTY (portable-pty)、設定永続化、TeamHub、MCP 設定、updater
 - レンダラー (`src/renderer/`): UI 描画のみ
-- IPC: `@tauri-apps/api/core` の `invoke()` + `listen()`。renderer からは `window.api` 互換層 (`src/renderer/src/lib/tauri-api.ts`) を経由
+- IPC: `@tauri-apps/api/core` の `invoke()` + `listen()`。renderer からは `window.api` 互換層 (`src/renderer/src/lib/tauri-api/`) を経由
 - 状態管理: React hooks + Context (Settings, Toast) + zustand (canvas / ui)
 
 ## 技術スタック
-- Tauri 2 + Vite 8 + React 18 + TypeScript 5.6
+- Tauri 2 + Vite 8 + React 19 + TypeScript 6
 - Rust 1.85 (tokio, portable-pty, notify, anyhow, serde, encoding_rs, sha2)
 - Monaco Editor (diff + エディタ、選択的言語インポート)
 - xterm.js + portable-pty (ターミナル)
@@ -78,7 +78,7 @@ Tauri ベースの Claude Code / Codex 専用エディタ (v1.4.x)
 
 ## ディレクトリ構成
 - `src-tauri/` — Rust 側
-  - `src/commands/` — IPC handler (app, git, terminal, settings, dialog, sessions, team_history, files, fs_watch, atomic_write, role_profiles, vibe_team_skill)
+  - `src/commands/` — IPC handler。正確なモジュール一覧は同ディレクトリと `src/lib.rs` の登録を参照
   - `src/pty/` — portable-pty + batcher + claude session watcher
   - `src/team_hub/` — マルチエージェント用の socket hub
   - `src/mcp_config/` — MCP サーバー設定 (codex 連携用)
@@ -110,7 +110,7 @@ Tauri ベースの Claude Code / Codex 専用エディタ (v1.4.x)
 - [x] ターミナル統合 (xterm.js + portable-pty、複数タブ同時実行)
 - [x] セッション履歴 (過去の Claude Code セッション閲覧・再開)
 - [x] コマンドパレット (Ctrl+Shift+P、ファジー検索)
-- [x] 複数テーマ対応 (claude-dark/light, dark, midnight, light)
+- [x] 6テーマ対応 (claude-dark, claude-light, dark, midnight, light, glass)
 - [x] i18n (日本語/英語)
 - [x] 情報密度設定 (compact/normal/comfortable)
 - [x] 設定モーダル (テーマ、フォント、密度、Claude/Codex オプション、MCP 設定)

--- a/README-ja.md
+++ b/README-ja.md
@@ -143,7 +143,7 @@ Tauri が Claude Code ターミナル1つで起動します。左上のプロジ
 ### その他のスクリプト
 
 ```bash
-npm run typecheck    # tsc --noEmit (strict)
+npm run typecheck    # tsc -b --force (strict)
 npm run dev:vite     # レンダラーのみ起動 (Rust なし)
 npm run build        # cargo tauri build → src-tauri/target/release/bundle/
 npm run icons        # build/icon.svg から ICO を再生成
@@ -165,12 +165,12 @@ src-tauri/                       # Rust 側 (Tauri ホスト)
 ├── Cargo.toml
 └── tauri.conf.json
 
-src/renderer/src/                # React 18 + TypeScript, UI 専用
+src/renderer/src/                # React 19 + TypeScript 6, UI 専用
 ├── App.tsx
 ├── components/                  # UI コンポーネント
 ├── components/canvas/           # @xyflow/react 無限キャンバスモード
 ├── stores/                      # zustand (ui, canvas)
-└── lib/                         # themes, i18n, tauri-api, commands, …
+└── lib/                         # themes, i18n, tauri-api/, commands, …
 ```
 
 ### TeamHub の仕組み

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Tauri launches with a single Claude Code terminal tab. Open any folder via the p
 ### Other scripts
 
 ```bash
-npm run typecheck    # tsc --noEmit (strict)
+npm run typecheck    # tsc -b --force (strict)
 npm run dev:vite     # Renderer only (no Rust)
 npm run build        # cargo tauri build → src-tauri/target/release/bundle/
 npm run icons        # Regenerate build/icon.ico from build/icon.svg
@@ -227,7 +227,7 @@ src-tauri/                       # Rust side (Tauri host)
 ├── Cargo.toml
 └── tauri.conf.json
 
-src/renderer/src/                # React 18 + TypeScript, UI only
+src/renderer/src/                # React 19 + TypeScript 6, UI only
 ├── App.tsx
 ├── components/
 │   ├── canvas/                  # @xyflow/react infinite-canvas mode
@@ -235,7 +235,7 @@ src/renderer/src/                # React 18 + TypeScript, UI only
 │   └── …
 ├── layouts/                     # CanvasLayout, …
 ├── stores/                      # zustand (ui, canvas)
-└── lib/                         # themes, i18n, tauri-api, commands, role-profiles, …
+└── lib/                         # themes, i18n, tauri-api/, commands, role-profiles, …
 ```
 
 ### How TeamHub works

--- a/src/renderer/src/lib/__tests__/documentation-contract.test.ts
+++ b/src/renderer/src/lib/__tests__/documentation-contract.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const documentPaths = [
+  'CLAUDE.md',
+  '.claude/skills/vibeeditor/SKILL.md',
+  'README.md',
+  'README-ja.md'
+] as const;
+
+const readDocument = (path: (typeof documentPaths)[number]) =>
+  readFileSync(resolve(root, path), 'utf8');
+
+describe('project documentation contract', () => {
+  it('does not reintroduce obsolete stack or command descriptions', () => {
+    const obsoletePatterns = [
+      /React 18/,
+      /TypeScript 5\.6/,
+      /Vite 5/,
+      /v1\.4\.x/,
+      /tsc --noEmit/
+    ];
+
+    for (const path of documentPaths) {
+      const content = readDocument(path);
+      for (const pattern of obsoletePatterns) {
+        expect(content, `${path} contains ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('keeps the required project guides aligned with manifest majors', () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(root, 'package.json'), 'utf8')
+    ) as {
+      dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
+      scripts: Record<string, string>;
+    };
+    const claude = readDocument('CLAUDE.md');
+    const vibeeditor = readDocument('.claude/skills/vibeeditor/SKILL.md');
+
+    expect(packageJson.dependencies.react).toMatch(/^\^19\./);
+    expect(packageJson.devDependencies.typescript).toMatch(/^\^6\./);
+    expect(packageJson.devDependencies.vite).toMatch(/^\^8\./);
+    expect(packageJson.scripts.typecheck).toBe('tsc -b --force');
+
+    for (const content of [claude, vibeeditor]) {
+      expect(content).toContain('Tauri 2');
+      expect(content).toContain('Vite 8');
+      expect(content).toContain('React 19');
+      expect(content).toContain('TypeScript 6');
+    }
+    expect(vibeeditor).toContain('npm run typecheck    # tsc -b --force');
+  });
+
+  it('references only the replacement project skills', () => {
+    const vibeeditor = readDocument('.claude/skills/vibeeditor/SKILL.md');
+
+    expect(vibeeditor).not.toContain('`issue-fix` skill');
+    expect(vibeeditor).not.toContain('`finalfix` skill');
+    for (const skill of ['pullrequest', 'issue-plan', 'pty-portable-debugging', 'claude-design', 'vibe-team']) {
+      expect(existsSync(resolve(root, `.claude/skills/${skill}/SKILL.md`)), skill).toBe(true);
+    }
+  });
+});

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2037,3 +2037,88 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1045
 - [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
 - [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`: PASS
 - [x] `git diff --check`: PASS
+## Open Issue / PR cleanup and merge sweep (2026-07-14 / Codex)
+
+Repository: https://github.com/yusei531642/vibe-editor
+
+### 計画
+
+- [x] 実行モード、repo root、`main` HEAD、dirty state、GitHub live stateを確認する。
+- [x] repoの `AGENTS.md`、`CLAUDE.md`、manifest、品質ゲートを確認する。
+- [ ] `orchestrate-frontier-team` を通常より一段低い推論設定で実行し、Issue/PR分類を独立レビューする。
+- [ ] open Issueを本文・コメント・重複・関連PR・現行コードで棚卸しし、根拠を示せる過剰/無効/重複Issueだけcloseする。
+- [ ] open PRごとにhead SHA、mergeability、required checks、review、未解決thread、関連Issueを確認する。
+- [ ] stale/重複/包含済みなど、マージすべきでないPRは根拠コメント付きでcloseする。
+- [ ] 残すPRを低リスク・依存関係順に処理し、競合は最新`main`を取り込んで最小差分で解消する。
+- [ ] 競合解消や修正を行ったPRは、変更範囲に対応するlint・typecheck・test・Rust checkを実行してpushする。
+- [ ] 各PRのlive state、head SHA、checks、review、未解決threadを再確認してからmergeする。
+- [ ] 関連Issueのcloseout条件を確認し、満たす場合だけ根拠コメント・ラベル遷移・close・`CLOSED`再確認を行う。
+- [ ] 最後にopen Issue/PR、`main` HEAD、作業ツリー、未完了gateを再棚卸しする。
+
+### Next Steps
+
+- [x] ユーザー確認後、Issue/PRの分類結果を確定してGitHubのclose/merge操作を開始する。
+
+### 現時点の確認結果
+
+- `main` HEAD: `aea5f41ade3c32ab2ac58a7128af0add383171e6`
+- open PR: 18件（2026-07-14開始時点）。機能PR #1078 / #1079 / #1105 は `DIRTY`、残り15件はDependabot。
+- `vibeeditor` / `pullrequest` skillはrepo内の `.claude/skills/` に実在し、全文を確認済み。
+- Issueタイトルだけでcloseせず、本文・重複・関連PR・現行実装まで確認して判定する。
+
+### 進捗
+
+- [x] `orchestrate-frontier-team` のSol / Fable laneを通常より一段低い推論設定で実行し、終了後にskill本体の設定を復元した。
+- [x] Issue #1188 を情報不足・ローカル設定事象として `invalid / NOT_PLANNED` でcloseし、`CLOSED`を確認した。
+- [x] Dependabot PR 15件を、各head SHA・CI・mergeability・未解決threadのlive gate後にsquash mergeした。
+- [x] PR #1105 は後発PR #1132でIssue #1032が実装済みのため、supersededとしてcloseした。
+- [x] PR #1079 は最新mainとの競合2件を解消し、ローカル検証とCI run `29308201188` PASS後にmergeした。
+- [x] PR #1078 は後発PR #1099 / #1100 / #1101で3件すべて実装済みのため、supersededとしてcloseした。
+- [x] 最終GitHub実状態でopen PRが0件、main HEADが`af7e6ba13685f81697c65c09727cd213ba1f3c89`であることを確認した。
+
+### 検証結果
+
+- [x] PR #1079: `cargo test --locked --manifest-path src-tauri/Cargo.toml --lib team_hub::`: PASS。
+- [x] PR #1079: `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS。
+- [x] PR #1079: `npm run typecheck`: PASS。
+- [x] PR #1079: `npm run test`: PASS（86 files / 519 tests）。
+- [x] PR #1079: CI run `29308201188`: verify / Windows cargo-cfg / macOS cargo-cfg / secrets-scan 全PASS。
+- [ ] PR #1079の最新review warning 2件はmergeと同時刻に到着し、未解決のまま残った。Critical/Highではないが、`since_id`上限と初回watermark再送を残存リスクとして報告する。
+
+### Next Tasks
+
+- [ ] PR #1079 reviewer warning 2件を別Issueとして追跡するか、人間が判断する。
+
+## Issue #1159 文書環境記述の同期 (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1159
+
+### 計画
+
+- [x] Issue本文・既存計画・現行manifest・対象文書のdriftを実測する。
+- [x] `vibeeditor`、`pullrequest`、`orchestrate-frontier-team` skillを確認する。
+- [x] standard riskでfrontier-teamのSol baselineを完了する。Fableは未認証のためadaptive degradedとして記録する。
+- [x] `CLAUDE.md`、`.claude/skills/vibeeditor/SKILL.md`、`README.md`、`README-ja.md`を現行SSOTへ同期する。
+- [x] 古い主要version・OS固定・非実在skill参照の再混入を検出するcontract testを追加する。
+- [x] 対象test、`npm run typecheck`、`npm run lint`、`npm run test`、`git diff --check`を実行する。
+- [x] 差分を再読し、allowed paths外の機能変更と検証済みblockerがないことを確認する。Fable post-diff reviewは未認証のため未実行。
+- [ ] feature branchへcommit/pushし、PR draftをユーザーへ提示して作成承認を得る。
+
+### スコープ境界
+
+- allowed: `CLAUDE.md`、`.claude/skills/vibeeditor/SKILL.md`、`README.md`、`README-ja.md`、`src/renderer/src/lib/__tests__/documentation-contract.test.ts`、`tasks/todo.md`
+- non-goals: dependency更新、アプリ挙動変更、全ドキュメントの全面リライト、他Issueの同時修正
+- merge: PR・HEAD・品質ゲートを提示し、ユーザーの明示承認後のみ実行する
+
+### Next Steps
+
+- [ ] commit/push後、PR title/body draftを提示して作成承認を得る。
+
+### 検証結果
+
+- [x] `npm run test -- src/renderer/src/lib/__tests__/documentation-contract.test.ts`: 3 tests PASS
+- [x] `npm run typecheck`: PASS
+- [x] `npm run lint`: PASS（error 0、既存warning 12件）
+- [x] `npm run test`: 87 files / 522 tests PASS
+- [x] `git diff --check`: PASS
+- [x] 旧表記検索: 対象4文書で該当0件


### PR DESCRIPTION
## Summary
- Issue #1159 の計画済み修正を、対象スコープ内で実装
- 変更規模: 6 files changed, 178 insertions(+), 25 deletions(-)（6 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1159

## Test plan
- [x] documentation contract tests
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run test
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない