### PR TITLE
fix(ui): オンボーディングをCanvas前面へ表示

### DIFF
--- a/src/renderer/src/styles/__tests__/onboarding-css-contract.test.ts
+++ b/src/renderer/src/styles/__tests__/onboarding-css-contract.test.ts
@@ -1,0 +1,47 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const stylesDir = dirname(testDir);
+
+function readStyleFile(pathFromStylesDir: string): string {
+  return readFileSync(join(stylesDir, pathFromStylesDir), 'utf8');
+}
+
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function readZIndexToken(tokens: string, name: string): number {
+  const match = tokens.match(new RegExp(String.raw`${name}\s*:\s*(\d+)\s*;`));
+  expect(match, `tokens.css must define ${name} as a plain number`).not.toBeNull();
+  return Number(match![1]);
+}
+
+describe('Onboarding CSS contract (Issue #1170)', () => {
+  it('stacks onboarding above Canvas and other active overlays', () => {
+    const tokens = stripCssComments(readStyleFile('tokens.css'));
+
+    const zOnboarding = readZIndexToken(tokens, '--z-onboarding');
+    const zPalette = readZIndexToken(tokens, '--z-palette');
+    const zContextMenu = readZIndexToken(tokens, '--z-context-menu');
+    const zCanvasRoot = readZIndexToken(tokens, '--z-canvas-root');
+
+    expect(zOnboarding).toBeGreaterThan(zPalette);
+    expect(zPalette).toBeGreaterThan(zContextMenu);
+    expect(zContextMenu).toBeGreaterThan(zCanvasRoot);
+  });
+
+  it('uses the shared onboarding layer token instead of a numeric z-index', () => {
+    const onboarding = stripCssComments(readStyleFile('components/onboarding.css'));
+    const rule = onboarding.match(/\.onboarding\s*\{([^}]*)\}/)?.[1];
+
+    expect(rule).toBeDefined();
+    expect(rule).toMatch(/z-index:\s*var\(--z-onboarding\)\s*;/);
+    expect(rule).not.toMatch(/z-index:\s*\d+/);
+  });
+});

--- a/src/renderer/src/styles/components/onboarding.css
+++ b/src/renderer/src/styles/components/onboarding.css
@@ -6,7 +6,7 @@
   position: fixed;
   /* Issue #307: Windows 最大化時の不可視リサイズ境界補正 */
   inset: var(--wf-top) var(--wf-x) var(--wf-bottom) var(--wf-x);
-  z-index: 9000;
+  z-index: var(--z-onboarding);
   display: grid;
   place-items: center;
   padding: 32px;

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -642,6 +642,7 @@ samp,
   --z-modal: 1000;
   --z-modal-elevated: 1500;
   --z-palette: 9600;
+  --z-onboarding: 9700;
   --z-toast: 9300;
   --z-toast-top: 9400;
   --z-noise-overlay: 9000;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -757,6 +757,7 @@ Branch: `feature/issue-452`
 
 #### 検証結果（代替で PASS 済み）
 - [x] `git diff --check`: PASS
+
 - [x] `npm run typecheck`: PASS
 - [x] `npm run build:vite`: PASS（既存警告あり）
 - [x] targeted Vitest: PASS（2 files / 11 tests）
@@ -1960,6 +1961,38 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1042
 
 - [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
 - [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`: PASS
+- [x] `git diff --check`: PASS
+
+## Issue #1170 - Canvas モードでオンボーディングを前面表示 (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1170
+
+### 計画
+
+- [x] Canvas root とオンボーディングのレイヤー順序を確認する。
+- [x] オンボーディング専用 z-index トークンを追加し、Canvas より前面へ移す。
+- [x] CSS 契約テストでトークン参照とレイヤー順序を固定する。
+- [x] 関連テストと品質ゲートを実行する。
+
+### Next Steps
+
+- [x] 最小差分を実装する。
+- [x] 検証結果を記録する。
+- [x] コミットして feature branch を push する。
+
+### 進捗
+
+- [x] `--z-onboarding: 9700` を追加し、Canvas / context menu / palette より前面にした。
+- [x] `.onboarding` の数値指定を共有トークン参照へ置き換えた。
+- [x] レイヤー順序と数値 z-index の再混入を検出する契約テストを追加した。
+
+### 検証結果
+
+- [x] 関連 Vitest: PASS (2 files / 5 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (87 files / 521 tests)
+- [x] `npm run lint`: PASS (0 errors / 既存 12 warnings)
+- [x] `npm run build:vite`: PASS
 - [x] `git diff --check`: PASS
 
 ## Release v1.6.6 startup hotfix (2026-06-15 / Codex)


### PR DESCRIPTION
## Summary
- Issue #1170 の計画済み修正を、対象スコープ内で実装
- 変更規模: 4 files changed, 82 insertions(+), 1 deletion(-)（4 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1170

## Test plan
- [x] 変更対象のVitest
- [x] npm run typecheck
- [x] npm run test
- [x] npm run lint
- [x] npm run build:vite
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない