### PR TITLE
fix(ui): サイドバー一覧へ情報密度を反映

### DIFF
--- a/src/renderer/src/styles/__tests__/density-list-rows-css-contract.test.ts
+++ b/src/renderer/src/styles/__tests__/density-list-rows-css-contract.test.ts
@@ -1,0 +1,33 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const stylesDir = dirname(testDir);
+
+function readTokens(): string {
+  return readFileSync(join(stylesDir, 'tokens.css'), 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function densityRule(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = css.match(new RegExp(`:root\\[data-density\\]\\s+${escaped}\\s*\\{([^}]*)\\}`));
+  expect(match, `density rule for ${selector}`).not.toBeNull();
+  return match![1];
+}
+
+describe('Density-aware sidebar list rows (Issue #1171)', () => {
+  it.each(['.gitfile', '.session', '.team-history-item__main'])(
+    'wires row height, padding, and gap tokens into %s',
+    (selector) => {
+      const rule = densityRule(readTokens(), selector);
+
+      expect(rule).toContain('var(--row-h)');
+      expect(rule).toContain('var(--pad)');
+      expect(rule).toContain('var(--gap)');
+    },
+  );
+});

--- a/src/renderer/src/styles/tokens.css
+++ b/src/renderer/src/styles/tokens.css
@@ -703,6 +703,34 @@ samp,
   gap: calc(var(--gap) - 4px);
 }
 
+/* ---- sidebar list rows (changes / sessions / team history) ---- */
+:root[data-density] .gitfile {
+  min-height: calc(var(--row-h) + 2px);
+  gap: var(--gap);
+  padding-top: 0;
+  padding-bottom: 0;
+  padding-left: calc(var(--pad) + 1px);
+  padding-right: calc(var(--pad) + 2px);
+}
+
+:root[data-density] .session {
+  min-height: var(--row-h);
+  gap: max(3px, calc(var(--gap) - 5px));
+  padding-top: var(--pad);
+  padding-bottom: var(--pad);
+  padding-left: calc(var(--pad) + 4px);
+  padding-right: calc(var(--pad) + 4px);
+}
+
+:root[data-density] .team-history-item__main {
+  min-height: var(--row-h);
+  gap: max(2px, calc(var(--gap) - 7px));
+  padding-top: max(4px, calc(var(--pad) - 2px));
+  padding-bottom: max(4px, calc(var(--pad) - 2px));
+  padding-left: var(--pad);
+  padding-right: var(--pad);
+}
+
 /* ---- tab bar (エディタ/ターミナルタブ) ---- */
 :root[data-density] .tabbar__tab {
   min-height: var(--row-h);

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -757,6 +757,37 @@ Branch: `feature/issue-452`
 
 #### 検証結果（代替で PASS 済み）
 - [x] `git diff --check`: PASS
+
+## Issue #1171 - サイドバー一覧へ情報密度設定を反映 (2026-07-14 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1171
+
+### 計画
+
+- [x] 固定値のまま残る変更・セッション・チーム履歴の3行を確認する。
+- [x] normal の現行寸法を維持しながら `--row-h` / `--pad` / `--gap` を配線する。
+- [x] 3セレクタへのトークン配線をCSS契約テストで固定する。
+- [x] 関連テストと品質ゲートを実行する。
+
+### Next Steps
+
+- [x] 検証結果を記録する。
+- [x] コミットして feature branch を push する。
+
+### 進捗
+
+- [x] 3一覧行へ density の行高・余白・gapトークンを配線した。
+- [x] normal の既存寸法を維持し、compact / comfortable のみ連動させた。
+- [x] 対象3セレクタ以外のスタイルとDOMは変更していない。
+
+### 検証結果
+
+- [x] 契約 Vitest: PASS (1 file / 3 tests)
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS (87 files / 522 tests)
+- [x] `npm run lint`: PASS (0 errors / 既存 12 warnings)
+- [x] `npm run build:vite`: PASS
+- [x] `git diff --check`: PASS
 - [x] `npm run typecheck`: PASS
 - [x] `npm run build:vite`: PASS（既存警告あり）
 - [x] targeted Vitest: PASS（2 files / 11 tests）


### PR DESCRIPTION
## Summary
- Issue #1171 の計画済み修正を、対象スコープ内で実装
- 変更規模: 3 files changed, 92 insertions(+)（3 files）
- 実装・検証の詳細は tasks/todo.md に記録

Closes #1171

## Test plan
- [x] 変更対象のVitest
- [x] npm run typecheck
- [x] npm run test
- [x] npm run lint
- [x] npm run build:vite
- [x] git diff --check
- [ ] GitHub Actions の必須check
- [ ] vibe-editor-reviewerの本レビュー

## Merge gate
- reviewerの指摘解消と必須check成功後、現在のHEADを提示してユーザーの明示承認を得るまでマージしない