### PR TITLE
fix(pty): registry終了競合を解消

### DIFF
--- a/src-tauri/src/pty/registry.rs
+++ b/src-tauri/src/pty/registry.rs
@@ -7,7 +7,7 @@ use crate::pty::session::SessionHandle;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::{Duration, Instant};
-
+mod lifecycle;
 /// Issue #293: 同時 PTY 数の上限。CLAUDE.md の「ターミナル最大 10 タブ」+ Canvas 上の
 /// agent ノード等を考慮しても十分余裕がある値として 100 を採用。renderer の暴走 / 悪意ある
 /// 連投で OS リソースを枯渇させない安全網。
@@ -206,6 +206,7 @@ impl SessionRegistry {
     pub fn insert_if_absent(&self, id: String, handle: SessionHandle) -> Result<(), SessionHandle> {
         let mut g = recover(self.inner.lock());
         if g.by_id.contains_key(&id) {
+            handle.registration.mark_rejected();
             return Err(handle);
         }
         Self::insert_locked(&mut g, id, handle);
@@ -262,14 +263,14 @@ impl SessionRegistry {
                 }
             }
         }
-        g.by_id.insert(id, Arc::new(handle));
+        let handle = Arc::new(handle);
+        g.by_id.insert(id, handle.clone()); // remove_if_same はこの lock 解放後に進む
+        handle.registration.mark_registered();
     }
-
     pub fn get(&self, id: &str) -> Option<Arc<SessionHandle>> {
         let g = recover(self.inner.lock());
         g.by_id.get(id).cloned()
     }
-
     /// agent_id 経由で取得 (TeamHub がメッセージ注入時に使う)
     pub fn get_by_agent(&self, agent_id: &str) -> Option<Arc<SessionHandle>> {
         let g = recover(self.inner.lock());
@@ -277,7 +278,6 @@ impl SessionRegistry {
             .get(agent_id)
             .and_then(|sid| g.by_id.get(sid).cloned())
     }
-
     /// Issue #271: HMR remount で attach 候補となる生存 PTY の session_id を探す。
     /// session_key を最優先 (Canvas 通常 Terminal は agent_id を持たないため)、
     /// 次に agent_id を見る。`by_id` に entry がない孤立 index は **その場で掃除する**。

--- a/src-tauri/src/pty/registry/lifecycle.rs
+++ b/src-tauri/src/pty/registry/lifecycle.rs
@@ -1,0 +1,110 @@
+use super::{recover, SessionRegistry};
+use crate::pty::session::{RegistrationLatch, SessionHandle};
+use std::sync::Arc;
+
+impl SessionRegistry {
+    /// exit watcher 自身の handle が現在の entry と同一の場合だけ削除する。
+    pub fn remove_if_same(
+        &self,
+        id: &str,
+        registration: &Arc<RegistrationLatch>,
+    ) -> Option<Arc<SessionHandle>> {
+        let removed = {
+            let mut inner = recover(self.inner.lock());
+            let is_same = inner
+                .by_id
+                .get(id)
+                .is_some_and(|handle| Arc::ptr_eq(&handle.registration, registration));
+            if !is_same {
+                return None;
+            }
+            let handle = inner.by_id.remove(id)?;
+            if let Some(agent_id) = &handle.agent_id {
+                if inner.by_agent.get(agent_id).map(String::as_str) == Some(id) {
+                    inner.by_agent.remove(agent_id);
+                }
+            }
+            if let Some(session_key) = &handle.session_key {
+                if inner.by_session_key.get(session_key).map(String::as_str) == Some(id) {
+                    inner.by_session_key.remove(session_key);
+                }
+            }
+            handle
+        };
+        let _ = removed.kill();
+        removed.cleanup_codex_broker_after_kill();
+        Some(removed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pty::session::test_support::handle_with;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn watcher_waits_until_registry_insert_completes_then_removes_own_handle() {
+        let registry = Arc::new(SessionRegistry::new());
+        let handle = handle_with(None, None, None, Arc::new(AtomicUsize::new(0)));
+        let registration = handle.registration.clone();
+        let registry_for_watcher = registry.clone();
+        let registration_for_watcher = registration.clone();
+        let (done_tx, done_rx) = mpsc::channel();
+
+        std::thread::spawn(move || {
+            let adopted = registration_for_watcher.wait_until_registered();
+            let removed = adopted
+                && registry_for_watcher
+                    .remove_if_same("instant-exit", &registration_for_watcher)
+                    .is_some();
+            done_tx.send(removed).unwrap();
+        });
+
+        assert!(done_rx.recv_timeout(Duration::from_millis(20)).is_err());
+        assert!(registry
+            .insert_if_absent("instant-exit".to_string(), handle)
+            .is_ok());
+        assert_eq!(done_rx.recv_timeout(Duration::from_secs(1)), Ok(true));
+        assert!(registry.get("instant-exit").is_none());
+    }
+
+    #[test]
+    fn stale_watcher_cannot_remove_different_handle_with_same_id() {
+        let registry = SessionRegistry::new();
+        let current = handle_with(None, None, None, Arc::new(AtomicUsize::new(0)));
+        let current_registration = current.registration.clone();
+        let stale = handle_with(None, None, None, Arc::new(AtomicUsize::new(0)));
+        let stale_registration = stale.registration.clone();
+
+        assert!(registry
+            .insert_if_absent("shared-id".into(), current)
+            .is_ok());
+        assert!(registry
+            .remove_if_same("shared-id", &stale_registration)
+            .is_none());
+        assert!(registry.get("shared-id").is_some());
+        assert!(registry
+            .remove_if_same("shared-id", &current_registration)
+            .is_some());
+    }
+
+    #[test]
+    fn rejected_collision_unblocks_watcher_without_removing_current_entry() {
+        let registry = SessionRegistry::new();
+        let current = handle_with(None, None, None, Arc::new(AtomicUsize::new(0)));
+        let rejected = handle_with(None, None, None, Arc::new(AtomicUsize::new(0)));
+        let rejected_registration = rejected.registration.clone();
+
+        assert!(registry
+            .insert_if_absent("collision".into(), current)
+            .is_ok());
+        assert!(registry
+            .insert_if_absent("collision".into(), rejected)
+            .is_err());
+        assert!(!rejected_registration.wait_until_registered());
+        assert!(registry.get("collision").is_some());
+    }
+}

--- a/src-tauri/src/pty/registry/lifecycle.rs
+++ b/src-tauri/src/pty/registry/lifecycle.rs
@@ -107,4 +107,22 @@ mod tests {
         assert!(!rejected_registration.wait_until_registered());
         assert!(registry.get("collision").is_some());
     }
+
+    #[test]
+    fn dropping_pending_handle_rejects_registration_and_unblocks_watcher() {
+        let handle = handle_with(None, None, None, Arc::new(AtomicUsize::new(0)));
+        let registration = handle.registration.clone();
+        let registration_for_watcher = registration.clone();
+        let (done_tx, done_rx) = mpsc::channel();
+
+        std::thread::spawn(move || {
+            done_tx
+                .send(registration_for_watcher.wait_until_registered())
+                .unwrap();
+        });
+
+        assert!(done_rx.recv_timeout(Duration::from_millis(20)).is_err());
+        drop(handle);
+        assert_eq!(done_rx.recv_timeout(Duration::from_secs(1)), Ok(false));
+    }
 }

--- a/src-tauri/src/pty/session/exit_watcher.rs
+++ b/src-tauri/src/pty/session/exit_watcher.rs
@@ -1,0 +1,72 @@
+use crate::pty::scrollback::scrollback_to_string;
+use crate::pty::SessionRegistry;
+use portable_pty::Child;
+use std::sync::{mpsc::Receiver, Arc};
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, Manager};
+
+use super::exit_info::{normalize_exit_code, summarize_exit_tail, TerminalExitInfo};
+use super::registration::RegistrationLatch;
+
+/// 子プロセス終了後、採用された自分自身のregistry entryだけを回収してexitを通知する。
+pub(super) fn spawn_exit_watcher(
+    app: AppHandle,
+    exit_event: String,
+    id: String,
+    mut child: Box<dyn Child + Send + Sync>,
+    batcher_done: Receiver<()>,
+    registry: Arc<SessionRegistry>,
+    registration: Arc<RegistrationLatch>,
+) {
+    std::thread::spawn(move || {
+        let exit_status = child.wait().ok();
+        let removed = if registration.wait_until_registered() {
+            registry.remove_if_same(&id, &registration)
+        } else {
+            None
+        };
+        let exit_record = removed.as_ref().and_then(|handle| {
+            handle
+                .team_id
+                .clone()
+                .zip(handle.agent_id.clone())
+                .map(|(team_id, agent_id)| (team_id, agent_id, handle.scrollback.clone()))
+        });
+        // ConPTY は master drop 後に reader EOFとなるため、flush待機前にremovedをdropする。
+        drop(removed);
+
+        match batcher_done.recv_timeout(Duration::from_secs(2)) {
+            Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => tracing::warn!(
+                "[pty] timed out waiting for final data flush before exit event: {exit_event}"
+            ),
+        }
+
+        let output_tail = exit_record
+            .as_ref()
+            .and_then(|(_, _, scrollback)| scrollback_to_string(scrollback));
+        let info = TerminalExitInfo {
+            exit_code: exit_status
+                .as_ref()
+                .map(|status| normalize_exit_code(status.exit_code()))
+                .unwrap_or(-1),
+            signal: None,
+            tail: summarize_exit_tail(output_tail.as_deref()),
+        };
+        if let Err(error) = app.emit(&exit_event, info.clone()) {
+            tracing::warn!("emit {exit_event} failed: {error}");
+        }
+        if let Some((team_id, agent_id, _)) = exit_record {
+            tauri::async_runtime::spawn(async move {
+                let Some(state) = app.try_state::<crate::state::AppState>() else {
+                    return;
+                };
+                state
+                    .team_hub
+                    .clone()
+                    .record_agent_process_exit(&team_id, &agent_id, info.exit_code, output_tail)
+                    .await;
+            });
+        }
+    });
+}

--- a/src-tauri/src/pty/session/exit_watcher.rs
+++ b/src-tauri/src/pty/session/exit_watcher.rs
@@ -20,11 +20,12 @@ pub(super) fn spawn_exit_watcher(
 ) {
     std::thread::spawn(move || {
         let exit_status = child.wait().ok();
-        let removed = if registration.wait_until_registered() {
-            registry.remove_if_same(&id, &registration)
-        } else {
-            None
-        };
+        if !registration.wait_until_registered() {
+            // registryに採用されなかった競合loser。idは別の生存handleが使用中のため、
+            // 同じterminal:exitイベントを通知してはならない。
+            return;
+        }
+        let removed = registry.remove_if_same(&id, &registration);
         let exit_record = removed.as_ref().and_then(|handle| {
             handle
                 .team_id

--- a/src-tauri/src/pty/session/handle.rs
+++ b/src-tauri/src/pty/session/handle.rs
@@ -256,7 +256,6 @@ impl SessionHandle {
         }
     }
 }
-
 /// Issue #144: SessionHandle が drop されたタイミングで child プロセスを必ず kill する。
 /// SessionRegistry::remove() は kill を呼ばずに Map から外すだけだったため、
 /// Arc の参照が残っている間 reader thread が PTY master を保持し続け、
@@ -266,6 +265,7 @@ impl SessionHandle {
 /// が確実に成立する。kill 時の Mutex poison でも inner を回収し、child kill だけは試みる。
 impl Drop for SessionHandle {
     fn drop(&mut self) {
+        self.registration.mark_rejected();
         // Issue #632: 明示 kill() を経ずに drop されるパスでも watcher を解放する。
         // 例: registry::insert_if_absent が Err を返して caller 側が handle を捨てるとき、
         //     terminal_create の早期 return パスで insert に到達しないとき、等。

--- a/src-tauri/src/pty/session/handle.rs
+++ b/src-tauri/src/pty/session/handle.rs
@@ -25,7 +25,7 @@ use std::time::Instant;
 
 use super::injecting_guard::InjectingGuard;
 use super::lock::{lock_poisoned, LockResult};
-
+use super::registration::RegistrationLatch;
 /// 1 セッションぶんの状態。kill / write / resize 用に master と writer を Mutex 保持。
 pub struct SessionHandle {
     /// 旧 Session.pty.write 相当
@@ -64,6 +64,7 @@ pub struct SessionHandle {
     /// 観測して即時 exit する。これにより「session が 1 秒で死んでも watcher が 60 秒
     /// 並走する」リソース蓄積を防ぐ。
     pub(super) watcher_cancel: Arc<AtomicBool>,
+    pub(crate) registration: Arc<RegistrationLatch>,
     /// Issue #950: child プロセスツリーを bind した kill-on-close Job Object。
     /// この handle の drop (= タブ close / kill_all / vibe-editor 異常死による OS の
     /// handle 強制 close) で job 内の全プロセス (孫含む) が OS により kill される。
@@ -76,7 +77,6 @@ pub struct SessionHandle {
     #[allow(dead_code)]
     pub(super) job: Option<crate::pty::win_job_object::KillOnCloseJob>,
 }
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UserWriteOutcome {
     Written,
@@ -84,7 +84,6 @@ pub enum UserWriteOutcome {
     DroppedTooLarge,
     DroppedRateLimited,
 }
-
 impl SessionHandle {
     /// 内部 / inject 経路用: フラグの状態にかかわらず常に書き込む。
     pub fn write(&self, data: &[u8]) -> Result<()> {
@@ -93,7 +92,6 @@ impl SessionHandle {
         w.flush()?;
         Ok(())
     }
-
     /// Issue #153 / #214:
     /// - inject 中は drop
     /// - 1 回の payload は 64 KiB 上限
@@ -301,6 +299,7 @@ impl Drop for SessionHandle {
 pub(crate) mod test_support {
     use super::SessionHandle;
     use crate::pty::scrollback::{new_scrollback, WriteBudget};
+    use crate::pty::session::RegistrationLatch;
     use portable_pty::{MasterPty, PtySize};
     use std::io::{Cursor, Read, Result as IoResult, Write};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -392,6 +391,7 @@ pub(crate) mod test_support {
             }),
             scrollback: new_scrollback(),
             watcher_cancel: Arc::new(AtomicBool::new(false)),
+            registration: Arc::new(RegistrationLatch::new()),
             #[cfg(windows)]
             job: None,
         }

--- a/src-tauri/src/pty/session/mod.rs
+++ b/src-tauri/src/pty/session/mod.rs
@@ -23,9 +23,11 @@ pub(crate) mod env_allowlist;
 // Issue #1098: exit イベント payload 型 (`TerminalExitInfo`) と exit code 正規化 /
 // 末尾出力サマリ生成。`spawn.rs` の exit watcher が参照する (外部からはパス参照しない)。
 mod exit_info;
+mod exit_watcher;
 mod handle;
 mod injecting_guard;
 mod lock;
+mod registration;
 pub(crate) mod spawn;
 pub(crate) mod spawn_metrics;
 #[cfg(not(windows))]
@@ -39,6 +41,7 @@ pub(crate) mod windows_resolve;
 // `TerminalExitInfo` (emit payload) と `InjectingGuard` (`begin_injecting` の戻り値型) は
 // `pub` のまま各サブモジュールに置く — 外部はパス参照しないため再エクスポート不要。
 pub use handle::{SessionHandle, UserWriteOutcome};
+pub(crate) use registration::RegistrationLatch;
 pub use spawn::{resolve_valid_cwd, spawn_session, SpawnOptions, TerminalWarning};
 
 // Issue #937: registry の kill_team テスト等が mock killer 付き handle を作れるよう、

--- a/src-tauri/src/pty/session/registration.rs
+++ b/src-tauri/src/pty/session/registration.rs
@@ -31,8 +31,10 @@ impl RegistrationLatch {
 
     fn set(&self, state: RegistrationState) {
         let mut current = self.state.lock().unwrap_or_else(|e| e.into_inner());
-        *current = state;
-        self.ready.notify_all();
+        if *current == RegistrationState::Pending {
+            *current = state;
+            self.ready.notify_all();
+        }
     }
 
     pub(crate) fn wait_until_registered(&self) -> bool {
@@ -41,5 +43,23 @@ impl RegistrationLatch {
             state = self.ready.wait(state).unwrap_or_else(|e| e.into_inner());
         }
         *state == RegistrationState::Registered
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registration_result_is_first_writer_wins() {
+        let registered = RegistrationLatch::new();
+        registered.mark_registered();
+        registered.mark_rejected();
+        assert!(registered.wait_until_registered());
+
+        let rejected = RegistrationLatch::new();
+        rejected.mark_rejected();
+        rejected.mark_registered();
+        assert!(!rejected.wait_until_registered());
     }
 }

--- a/src-tauri/src/pty/session/registration.rs
+++ b/src-tauri/src/pty/session/registration.rs
@@ -1,0 +1,45 @@
+use std::sync::{Condvar, Mutex};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegistrationState {
+    Pending,
+    Registered,
+    Rejected,
+}
+
+/// exit watcher と registry insert の順序を同期する one-shot latch。
+pub(crate) struct RegistrationLatch {
+    state: Mutex<RegistrationState>,
+    ready: Condvar,
+}
+
+impl RegistrationLatch {
+    pub(super) fn new() -> Self {
+        Self {
+            state: Mutex::new(RegistrationState::Pending),
+            ready: Condvar::new(),
+        }
+    }
+
+    pub(crate) fn mark_registered(&self) {
+        self.set(RegistrationState::Registered);
+    }
+
+    pub(crate) fn mark_rejected(&self) {
+        self.set(RegistrationState::Rejected);
+    }
+
+    fn set(&self, state: RegistrationState) {
+        let mut current = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        *current = state;
+        self.ready.notify_all();
+    }
+
+    pub(crate) fn wait_until_registered(&self) -> bool {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        while *state == RegistrationState::Pending {
+            state = self.ready.wait(state).unwrap_or_else(|e| e.into_inner());
+        }
+        *state == RegistrationState::Registered
+    }
+}

--- a/src-tauri/src/pty/session/spawn.rs
+++ b/src-tauri/src/pty/session/spawn.rs
@@ -9,8 +9,11 @@
 //! 一切変えていない。Windows 専用のパス解決は `super::windows_resolve` に分離した。
 
 use crate::pty::batcher::{spawn_batcher, PtyOutputObserver};
-use crate::pty::scrollback::{new_scrollback, scrollback_to_string, WriteBudget};
-use crate::{commands::terminal::command_validation, commands::terminal::shell_policy, util::log_redact::redact_home};
+use crate::pty::scrollback::{new_scrollback, WriteBudget};
+use crate::{
+    commands::terminal::command_validation, commands::terminal::shell_policy,
+    util::log_redact::redact_home,
+};
 use anyhow::{anyhow, Result};
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use serde::Serialize;
@@ -19,11 +22,11 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
-use tauri::{AppHandle, Emitter, Manager};
+use std::time::Instant;
+use tauri::{AppHandle, Manager};
 use tokio::sync::mpsc;
 
-use super::exit_info::{normalize_exit_code, summarize_exit_tail, TerminalExitInfo};
+use super::exit_watcher::spawn_exit_watcher;
 use super::handle::SessionHandle;
 use super::spawn_metrics::{build_cmd_label, engine_label, log_spawn_outcome, platform_label};
 
@@ -145,7 +148,9 @@ pub(crate) fn prepare_spawn_command(opts: &SpawnOptions) -> Result<PreparedSpawn
     }
     // Issue #933: シェルは対話セッション起動のみ許可 (allowlist 契約 / shell_policy.rs)
     let registered = shell_policy::settings_registered_command_lines();
-    if let Some(reason) = shell_policy::reject_non_interactive_shell_args(&command, &args, &registered) {
+    if let Some(reason) =
+        shell_policy::reject_non_interactive_shell_args(&command, &args, &registered)
+    {
         return Err(anyhow!("{reason}"));
     }
     let sanctioned_flags = command_validation::settings_sanctioned_danger_flags(&command);
@@ -289,7 +294,7 @@ pub fn spawn_session(
     let started = Instant::now();
     let spawn_result = pair.slave.spawn_command(cmd);
     let elapsed_ms = started.elapsed().as_millis() as u64;
-    let mut child = match spawn_result {
+    let child = match spawn_result {
         Ok(child) => {
             log_spawn_outcome(&cmd_label, engine, platform, elapsed_ms, None);
             child
@@ -309,10 +314,9 @@ pub fn spawn_session(
     // クラッシュ / 強制終了でも OS が handle close 経由で子プロセスツリーを回収できる
     // ようにする。作成 / assign 失敗は warn のみ (従来の taskkill 経路で回収継続)。
     #[cfg(windows)]
-    let job = process_id
-        .and_then(|pid| {
-            crate::pty::win_job_object::KillOnCloseJob::create().filter(|job| job.assign_pid(pid))
-        });
+    let job = process_id.and_then(|pid| {
+        crate::pty::win_job_object::KillOnCloseJob::create().filter(|job| job.assign_pid(pid))
+    });
 
     // reader thread (blocking IO -> mpsc)
     let mut reader = pair.master.try_clone_reader()?;
@@ -435,67 +439,17 @@ pub fn spawn_session(
 
     let batcher_done = spawn_batcher(app.clone(), data_event, rx, scrollback.clone(), on_output);
 
-    // exit watcher (blocking child.wait → emit exit event)
-    // Issue #152: child.wait() の後に registry からも remove して、孤立 entry が
-    // residual に残らないようにする (renderer が落ちて terminal_kill が呼ばれない経路で必要)。
-    let app_for_exit = app.clone();
-    let exit_event_clone = exit_event.clone();
-    let registry_for_exit = registry.clone();
-    let id_for_exit = id.clone();
-    std::thread::spawn(move || {
-        let exit_status = child.wait().ok();
-        // child.wait() 後は kill 不要だが registry::remove が handle.kill() を呼ぶ (二重 kill は no-op で安全)。
-        let removed = registry_for_exit.remove(&id_for_exit);
-        let exit_record = removed.as_ref().and_then(|handle| {
-            if let (Some(team_id), Some(agent_id)) =
-                (handle.team_id.clone(), handle.agent_id.clone())
-            {
-                Some((team_id, agent_id, handle.scrollback.clone()))
-            } else {
-                None
-            }
-        });
-        // Windows ConPTY は master drop 後に reader EOF → batcher final flush となる (removed 保持中は master が残り進まない)。
-        drop(removed);
+    let registration = Arc::new(super::RegistrationLatch::new());
 
-        let exit_flush_wait_timeout = Duration::from_secs(2);
-        match batcher_done.recv_timeout(exit_flush_wait_timeout) {
-            Ok(()) => {}
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                tracing::warn!(
-                    "[pty] timed out waiting for final data flush before exit event: {exit_event_clone}"
-                );
-            }
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {}
-        }
-
-        let output_tail = exit_record
-            .as_ref()
-            .and_then(|(_, _, scrollback)| scrollback_to_string(scrollback));
-
-        let info = TerminalExitInfo {
-            exit_code: exit_status
-                .as_ref()
-                .map(|s| normalize_exit_code(s.exit_code()))
-                .unwrap_or(-1),
-            signal: None,
-            tail: summarize_exit_tail(output_tail.as_deref()),
-        };
-        if let Err(e) = app_for_exit.emit(&exit_event_clone, info.clone()) {
-            tracing::warn!("emit {exit_event_clone} failed: {e}");
-        }
-        if let Some((team_id, agent_id, _)) = exit_record {
-            let app = app_for_exit.clone();
-            tauri::async_runtime::spawn(async move {
-                let Some(state) = app.try_state::<crate::state::AppState>() else {
-                    return;
-                };
-                let hub = state.team_hub.clone();
-                hub.record_agent_process_exit(&team_id, &agent_id, info.exit_code, output_tail)
-                    .await;
-            });
-        }
-    });
+    spawn_exit_watcher(
+        app.clone(),
+        exit_event,
+        id,
+        child,
+        batcher_done,
+        registry,
+        registration.clone(),
+    );
 
     Ok(SessionHandle {
         writer: Mutex::new(writer),
@@ -518,6 +472,7 @@ pub fn spawn_session(
         scrollback,
         // Issue #632: watcher cancel token は session 起動と同寿命。kill() / Drop で flip。
         watcher_cancel: Arc::new(AtomicBool::new(false)),
+        registration,
         #[cfg(windows)]
         job,
     })

--- a/tasks/fortress-implement/issue-1155/mission-brief.md
+++ b/tasks/fortress-implement/issue-1155/mission-brief.md
@@ -1,0 +1,55 @@
+# Issue #1155 Mission Brief
+
+## 目的
+
+PTY セッションの登録と終了監視の競合を解消し、即時終了または同一 ID の競合が起きても、稼働中セッションを誤削除せず、終了済みハンドルを registry に残さない。
+
+## 観測可能な合格条件
+
+- 終了監視は registry への登録完了後に有効になる。
+- 同一 ID の古い watcher は、別ハンドルへ置換済みの registry entry を削除しない。
+- 登録競合で採用されなかったハンドルは、既存 entry を変更せず安全に回収される。
+- 即時終了、同一 ID 競合、通常終了の回帰テストが PASS する。
+- terminal / PTY 関連テスト、`cargo check`、`cargo clippy -D warnings` が PASS する。
+
+## Non-goals
+
+- PTY API 全体の再設計。
+- terminal UI、再接続 UX、ログ形式の変更。
+- Issue #1178 の一括対応。#1178 は本修正を前提に、終了理由と renderer 側の起動制御を別 PR で扱う。
+
+## 前提・依存
+
+- 対象は `src-tauri/src/pty/registry.rs`、`src-tauri/src/pty/session/spawn.rs`、必要最小限の handle / terminal 統合コード。
+- 現在の外部 API とイベント名は維持する。
+- Issue #1155 のみを対象にし、Issue #1178やUI変更へ拡張しない。
+
+## Tier 判定
+
+- Tier: I1
+- スコア: 8
+- 根拠: 3 層にまたがる変更 3 点、既存テスト不足 3 点、競合の実環境 E2E が難しい 2 点。
+
+## Slice 計画
+
+### Slice 1: registry の所有権と identity-safe removal
+
+- RED: 同一 ID の異なる handle が現 entry を削除できないテスト。
+- GREEN: handle identity を確認する remove API と、登録完了を境界にした watcher 起動。
+- REFACTOR: registry の責務を登録・同一性確認付き削除へ限定する。
+- 検証: registry / session の単体テスト、`cargo check`、`cargo clippy`。
+- rollback: Slice 1 のコミットを revert。
+
+### Slice 2: spawn / terminal 統合と競合回収
+
+- 前提: Slice 1 が PASS。
+- RED: 即時終了と登録競合 loser が既存 entry を壊さないテスト。
+- GREEN: loser を静かに回収し、既存の terminal retry 境界を保つ最小統合。
+- 検証: terminal 117 tests、PTY 169 tests、all-target check / clippy。
+- rollback: Slice 2 のコミットを revert。Slice 1 単独でも API は内部限定とする。
+
+## 成功・停止条件
+
+- 各 Slice の RED → GREEN 証跡を保存する。
+- テストが仮説と異なる場合は実装を続けず、Mission Brief を更新して再承認を求める。
+- Scope が #1178、UI、再接続設計へ広がる場合は停止する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -757,6 +757,34 @@ Branch: `feature/issue-452`
 
 #### 検証結果（代替で PASS 済み）
 - [x] `git diff --check`: PASS
+
+## Issue #1155 - PTY registry lifecycle race (2026-07-14 / Codex)
+
+### 計画
+
+- [x] 現行の registry 登録、終了 watcher、同一 ID 競合の順序を確認する。
+- [x] `tasks/fortress-implement/issue-1155/mission-brief.md` に Mission Brief と Slice 境界を記録する。
+- [x] Slice 1 を RED → GREEN で実装する。
+- [x] Slice 1 の検証後、Slice 2 を実装し全品質ゲートを実行する。
+
+### Next Steps
+
+- [x] registry採否latchとidentity-safe removalを実装する。
+- [x] 即死、同一ID競合、collision loserの回帰テストを追加する。
+
+### RCA結果
+
+- [x] Root Cause Confirmed: exit watcherがregistry insert前に開始し、終了時にIDだけで無条件removeしていた。
+- [x] 即死時はremove(None)後にdead handleがinsertされ、衝突時は古いwatcherが別handleを削除できることをコード経路と回帰テストで固定した。
+
+### 検証結果
+
+- [x] lifecycle回帰テスト: PASS（3 tests）
+- [x] PTY全体テスト: PASS（130 passed / 2 ignored）
+- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`: PASS
+- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
+- [x] `npm run lint:file-size`: PASS（spawn.rs 733 → 688行）
+- [x] `npm run typecheck`: PASS（`npm ci`で依存をlockfileへ同期後に再実行）
 - [x] `npm run typecheck`: PASS
 - [x] `npm run build:vite`: PASS（既存警告あり）
 - [x] targeted Vitest: PASS（2 files / 11 tests）


### PR DESCRIPTION
## 概要

- exit watcherをregistryの採否確定まで待機させます
- 登録中のhandleと同じidentityの場合だけentryを削除します
- 即時終了・同一IDの古いwatcher・登録競合loserの回帰テストを追加します
- exit watcherとregistration責務を専用モジュールへ分離し、file-size ratchetを維持します

## 検証

- cargo test --manifest-path src-tauri/Cargo.toml --lib lifecycle::tests
- cargo test --manifest-path src-tauri/Cargo.toml --lib pty::
- cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets
- cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
- npm run lint:file-size
- npm run typecheck
- git diff --check

Closes #1155