### PR TITLE
perf(deps): #1164 Zustandとmarkedを単一化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
       - name: CSS custom property lint
         run: npm run lint:css-vars
 
+      # Issue #1164: app と upstream が同じ Zustand / marked を共有し、
+      # nested copy が再導入されてbundleを膨らませないことを固定する。
+      - name: Dependency dedupe lint
+        run: npm run lint:dependency-dedupe
+
       # Issue #948: 永続化ファイルの生 serde parse 握りつぶし (`serde_json::from_*(...).ok()`)
       # を検出して fail させる。読込は safe_load 共通基盤 (#936) 経由を強制する。
       # 例外は該当行直前の `// safe-load-exempt: <理由>` で明示 opt-out。

--- a/build/check-dependency-dedupe.mjs
+++ b/build/check-dependency-dedupe.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+
+const lock = JSON.parse(readFileSync(new URL('../package-lock.json', import.meta.url), 'utf8'));
+const packages = lock.packages ?? {};
+
+const expected = new Map([
+  ['zustand', '4.5.7'],
+  ['marked', '14.0.0']
+]);
+
+const errors = [];
+for (const [name, version] of expected) {
+  const paths = Object.keys(packages).filter(
+    (path) => path === `node_modules/${name}` || path.endsWith(`/node_modules/${name}`)
+  );
+  const root = packages[`node_modules/${name}`];
+  if (paths.length !== 1) {
+    errors.push(`${name}: expected one lockfile copy, found ${paths.length} (${paths.join(', ')})`);
+  }
+  if (root?.version !== version) {
+    errors.push(`${name}: expected root ${version}, found ${root?.version ?? 'missing'}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Dependency dedupe violations:\n' + errors.map((error) => `- ${error}`).join('\n'));
+  process.exit(1);
+}
+
+console.log('Dependency dedupe OK (zustand 4.5.7, marked 14.0.0; one copy each)');

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,11 +24,11 @@
         "@xyflow/react": "^12.11.0",
         "dompurify": "^3.4.11",
         "lucide-react": "^1.11.0",
-        "marked": "^18.0.5",
+        "marked": "14.0.0",
         "monaco-editor": "^0.55.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "zustand": "^5.0.14"
+        "zustand": "4.5.7"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1302,9 +1302,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1322,9 +1319,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1342,9 +1336,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1362,9 +1353,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1382,9 +1370,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1402,9 +1387,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1422,9 +1404,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1442,9 +1421,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1462,9 +1438,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1488,9 +1461,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1514,9 +1484,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1540,9 +1507,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1566,9 +1530,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1592,9 +1553,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1618,9 +1576,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1644,9 +1599,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1954,9 +1906,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1974,9 +1923,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1994,9 +1940,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2014,9 +1957,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2034,9 +1974,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2054,9 +1991,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2825,34 +2759,6 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@xyflow/react/node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
-      "engines": {
-        "node": ">=12.7.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8",
-        "immer": ">=9.0.6",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
           "optional": true
         }
       }
@@ -4300,15 +4206,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       }
     },
     "node_modules/min-indent": {
@@ -4355,18 +4261,6 @@
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
-      }
-    },
-    "node_modules/monaco-editor/node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/ms": {
@@ -5465,18 +5359,20 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.14",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
-      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
       "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
       "engines": {
-        "node": ">=12.20.0"
+        "node": ">=12.7.0"
       },
       "peerDependencies": {
-        "@types/react": ">=18.0.0",
+        "@types/react": ">=16.8",
         "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
+        "react": ">=16.8"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -5486,9 +5382,6 @@
           "optional": true
         },
         "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint:safe-load": "node build/check-safe-load.mjs",
     "lint:file-size": "node build/check-file-size-ratchet.mjs",
     "lint:css-vars": "node build/check-css-custom-properties.mjs",
+    "lint:dependency-dedupe": "node build/check-dependency-dedupe.mjs",
     "lint:release-workflow": "node build/check-release-workflow.mjs",
     "lint:command-result": "node build/check-command-result.mjs",
     "lint:team-events": "node build/check-team-event-payloads.mjs",
@@ -42,11 +43,11 @@
     "@xyflow/react": "^12.11.0",
     "dompurify": "^3.4.11",
     "lucide-react": "^1.11.0",
-    "marked": "^18.0.5",
+    "marked": "14.0.0",
     "monaco-editor": "^0.55.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "zustand": "^5.0.14"
+    "zustand": "4.5.7"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -18,6 +18,42 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1146
 - [x] targeted Rust test: PASS（2 passed / 0 failed）
 - [x] `cargo check --locked --manifest-path src-tauri\\Cargo.toml --all-targets`: PASS
 - [x] `git diff --check`: PASS
+
+## Issue #1164 - Zustand / marked の重複依存解消 (2026-07-15 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1164
+
+### 計画
+
+- [x] npm registry と現行 lockfile から重複原因・互換範囲を再確認する。
+- [x] root の Zustand / marked を upstream が要求する版へ揃え、nested copy が消えることを確認する。
+- [x] Zustand store、Markdown preview、Monaco、Canvas の自動テストと全品質ゲートを通す。
+- [x] build artifact の module ownership とJS総量を変更前後で比較する。
+
+### Next Steps
+
+- [x] 依存版を最小変更し、lockfileを再生成する。
+- [x] `npm ls zustand marked --all` で単一化を実証する。
+- [x] CIに単一copy契約を追加し、将来のupstream更新による再重複を検出する。
+
+### 進捗
+
+- [x] rootを `zustand@4.5.7` / `marked@14.0.0` に固定し、upstreamと共有した。
+- [x] `@xyflow/react` 配下のZustandとMonaco配下のmarkedをlockfileから削除した。
+- [x] JS総量を 5,674,055 bytes から 5,669,172 bytesへ4,883 bytes削減した。
+- [x] production dependency auditは0 vulnerabilitiesだった。
+
+### 検証結果
+
+- [x] `npm run lint:dependency-dedupe`: PASS（各1 copy）
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS（105 files / 602 tests）
+- [x] `npm run lint`: PASS（0 errors / 既存warnings 11）
+- [x] `npm run lint:file-size`: PASS
+- [x] `npm run lint:css-vars`: PASS
+- [x] `npm run build:vite`: PASS
+- [x] `npm audit --omit=dev --audit-level=high`: PASS（0 vulnerabilities）
+- [x] `git diff --check`: PASS
 - [ ] repository-wide `cargo fmt --check`: FAIL（今回の差分外に既存不整形あり）
 
 ## #736 team_hub/state.rs god-file 分割 + team_send 段階関数化 (完了)


### PR DESCRIPTION
## Summary
- root の Zustand を 4.5.7、marked を 14.0.0 に固定し、upstream と同じcopyへdedupe
- lockfile上のnested copy 2件を削除
- 将来の再重複を検出する `lint:dependency-dedupe` をCIへ追加

Closes #1164

## Bundle comparison
- JS総量: 5,674,055 bytes → 5,669,172 bytes（4,883 bytes削減）
- `vendor-markdown`: 69,500 bytes → 63,372 bytes
- `npm ls zustand marked --all`: 各1 copy

## Test plan
- [x] `npm run lint:dependency-dedupe`
- [x] `npm run typecheck`
- [x] `npm run test`（105 files / 602 tests）
- [x] `npm run lint`（0 errors / 既存warnings 11）
- [x] `npm run lint:file-size`
- [x] `npm run lint:css-vars`
- [x] `npm run build:vite`
- [x] `npm audit --omit=dev --audit-level=high`（0 vulnerabilities）
- [x] `git diff --check`