### PR TITLE
fix: AppStateProvider境界違反による起動不能を解消

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -12,15 +12,16 @@
  *   - `AppShell` (components/AppShell.tsx) — 画面本体 (巨大 JSX + 画面ローカル
  *     state / derived / handler)。3 consumer hook で状態を購読する。
  *
- * よって App はこの「Provider tree + 画面本体マウント」だけを担う。ref ブリッジは
- * 完全に AppStateProvider 内部へ閉じ込められ、ここからは見えない (callbacks-down /
- * events-up の依存性逆転)。
+ * App は Provider tree と IDE / Canvas の両画面をマウントする。両画面を同じ
+ * AppStateProvider の子に置くため、ref ブリッジは完全に Provider 内部へ閉じ込められ、
+ * 両者は同じ project / tabs / team state を購読する。
  */
 import { useCallback, useState } from 'react';
 import type { SessionInfo } from '../../types/shared';
 import { useWindowFrameInsets } from './lib/use-window-frame-insets';
 import { AppStateProvider } from './lib/app-state-context';
 import { AppShell } from './components/AppShell';
+import { CanvasLayout } from './layouts/CanvasLayout';
 
 export function App(): JSX.Element {
   // Issue #307: Windows 11 フレームレス最大化時の不可視リサイズ境界を CSS 変数で補正。
@@ -51,6 +52,7 @@ export function App(): JSX.Element {
         activeSessionId={activeSessionId}
         setActiveSessionId={setActiveSessionId}
       />
+      <CanvasLayout />
     </AppStateProvider>
   );
 }

--- a/src/renderer/src/__tests__/main-provider-boundary.test.tsx
+++ b/src/renderer/src/__tests__/main-provider-boundary.test.tsx
@@ -1,0 +1,368 @@
+import React, { type ReactElement, type ReactNode } from 'react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const harness = vi.hoisted(() => ({
+  renderedTree: null as unknown,
+  canvasChildMounts: 0,
+  canvasChildUnmounts: 0,
+  providerSequence: 0,
+  tabsSequence: 0,
+  teamSequence: 0
+}));
+
+vi.mock('react-dom/client', () => ({
+  default: {
+    createRoot: () => ({
+      render: (tree: unknown) => {
+        harness.renderedTree = tree;
+      }
+    })
+  }
+}));
+
+vi.mock('../lib/tauri-api', () => ({}));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => vi.fn()) }));
+
+vi.mock('../components/AppErrorBoundary', () => ({
+  AppErrorBoundary: ({ children }: { children: ReactNode }) => children
+}));
+
+vi.mock('../lib/settings-context', () => {
+  const settings = {
+    language: 'ja',
+    mcpAutoSetup: false,
+    customAgents: [],
+    recentProjects: []
+  };
+  return {
+    SettingsProvider: ({ children }: { children: ReactNode }) => children,
+    useSettings: () => ({ settings, update: vi.fn(), reset: vi.fn() })
+  };
+});
+
+vi.mock('../lib/toast-context', () => ({
+  ToastProvider: ({ children }: { children: ReactNode }) => children,
+  useToast: () => ({ showToast: vi.fn(), dismissToast: vi.fn() })
+}));
+
+vi.mock('../lib/role-profiles-context', () => ({
+  RoleProfilesProvider: ({ children }: { children: ReactNode }) => children
+}));
+
+vi.mock('../lib/filetree-state-context', () => ({
+  FileTreeStateProvider: ({ children }: { children: ReactNode }) => children
+}));
+
+vi.mock('../lib/i18n', () => ({
+  resolveBootstrapLanguage: () => 'ja',
+  translate: (_language: string, key: string) => key,
+  useT: () => (key: string) => key
+}));
+
+vi.mock('../lib/webview-zoom', () => ({
+  webviewZoom: { in: vi.fn(), out: vi.fn(), reset: vi.fn() }
+}));
+
+vi.mock('../lib/use-window-frame-insets', () => ({ useWindowFrameInsets: vi.fn() }));
+
+vi.mock('../lib/hooks/use-project-loader', async () => {
+  const ReactModule = await import('react');
+  return {
+    useProjectLoader: (options: { onProjectSwitched: (root: string) => void }) => {
+      const marker = ReactModule.useRef<string | null>(null);
+      if (marker.current === null) {
+        marker.current = `project-provider-${++harness.providerSequence}`;
+      }
+      const [projectRoot, setProjectRoot] = ReactModule.useState('C:\\project-a');
+      const loadProject = async (root: string): Promise<boolean> => {
+        setProjectRoot(root);
+        options.onProjectSwitched(root);
+        return true;
+      };
+      return {
+        instanceMarker: marker.current,
+        projectRoot,
+        loadProject,
+        refreshGit: vi.fn(async () => undefined),
+        gitStatus: null,
+        gitLoading: false,
+        workspaceFolders: [],
+        handleNewProject: vi.fn(async () => undefined),
+        handleOpenFolder: vi.fn(async () => undefined),
+        handleOpenFile: vi.fn(async () => undefined),
+        handleOpenRecent: loadProject,
+        handleClearRecent: vi.fn(),
+        handleAddWorkspaceFolder: vi.fn(async () => undefined),
+        handleRemoveWorkspaceFolder: vi.fn(async () => undefined)
+      };
+    }
+  };
+});
+
+vi.mock('../lib/hooks/use-file-tabs', async () => {
+  const ReactModule = await import('react');
+  return {
+    useFileTabs: ({ projectRoot }: { projectRoot: string }) => {
+      const marker = ReactModule.useRef<string | null>(null);
+      if (marker.current === null) marker.current = `tabs-provider-${++harness.tabsSequence}`;
+      return {
+        instanceMarker: marker.current,
+        projectMarker: projectRoot,
+        editorTabs: [],
+        setEditorTabs: vi.fn(),
+        diffTabs: [],
+        refreshDiffTabsForPath: vi.fn(async () => undefined),
+        confirmDiscardEditorTabs: vi.fn(async () => true),
+        resetForProjectSwitch: vi.fn()
+      };
+    }
+  };
+});
+
+vi.mock('../lib/hooks/use-terminal-tabs', async () => {
+  const ReactModule = await import('react');
+  return {
+    useTerminalTabs: () => ({
+      terminalTabs: [],
+      setTerminalTabs: vi.fn(),
+      activeTerminalTabId: null,
+      setActiveTerminalTabId: vi.fn(),
+      addTerminalTab: vi.fn(),
+      doCloseTab: vi.fn(),
+      nextTerminalIdRef: ReactModule.useRef(1),
+      resetForProjectSwitch: vi.fn()
+    })
+  };
+});
+
+vi.mock('../lib/hooks/use-terminal-tabs-persistence', () => ({
+  useTerminalTabsPersistence: () => ({ reportSize: vi.fn() })
+}));
+
+vi.mock('../lib/hooks/use-team-management', async () => {
+  const ReactModule = await import('react');
+  return {
+    useTeamManagement: ({ projectRoot }: { projectRoot: string }) => {
+      const marker = ReactModule.useRef<string | null>(null);
+      if (marker.current === null) marker.current = `team-provider-${++harness.teamSequence}`;
+      return {
+        instanceMarker: marker.current,
+        projectMarker: projectRoot,
+        doCloseTeam: vi.fn(),
+        resetForProjectSwitch: vi.fn()
+      };
+    }
+  };
+});
+
+vi.mock('../lib/hooks/use-claude-check', () => ({
+  useClaudeCheck: () => ({
+    claudeCheck: { state: 'ok' },
+    runClaudeCheck: vi.fn(async () => undefined)
+  })
+}));
+
+vi.mock('../components/AppShell', async () => {
+  const ReactModule = await import('react');
+  const context = await import('../lib/app-state-context');
+  return {
+    AppShell: () => {
+      const project = context.useProject() as ReturnType<typeof context.useProject> & {
+        instanceMarker: string;
+      };
+      const tabs = context.useTabs() as ReturnType<typeof context.useTabs> & {
+        instanceMarker: string;
+        projectMarker: string;
+      };
+      const team = context.useTeam() as ReturnType<typeof context.useTeam> & {
+        instanceMarker: string;
+        projectMarker: string;
+      };
+      return ReactModule.createElement(
+        'section',
+        {
+          'data-testid': 'app-shell-probe',
+          'data-project-instance': project.instanceMarker,
+          'data-tabs-instance': tabs.instanceMarker,
+          'data-team-instance': team.instanceMarker,
+          'data-project-root': project.projectRoot,
+          'data-tabs-project': tabs.projectMarker,
+          'data-team-project': team.projectMarker
+        },
+        ReactModule.createElement(
+          'button',
+          {
+            type: 'button',
+            onClick: () => void project.loadProject('C:\\project-b')
+          },
+          'switch project'
+        )
+      );
+    }
+  };
+});
+
+vi.mock('../stores/canvas', () => {
+  const state = { nodes: [] };
+  const useCanvasStore = Object.assign(
+    (selector: (value: typeof state) => unknown) => selector(state),
+    {
+      getState: () => state,
+      subscribe: () => vi.fn()
+    }
+  );
+  return { useCanvasStore };
+});
+
+vi.mock('../stores/canvas-selectors', () => ({
+  useCanvasViewport: () => ({ x: 0, y: 0, zoom: 1 })
+}));
+
+vi.mock('../stores/canvas-persistence', () => ({ takeCanvasRecoveryNotice: () => null }));
+
+vi.mock('../lib/hooks/use-canvas-add-card', () => ({
+  useCanvasAddCard: () => ({
+    stagger: vi.fn(() => ({ x: 0, y: 0 })),
+    addAgent: vi.fn(),
+    addCustomAgent: vi.fn(),
+    addApiAgent: vi.fn(),
+    addByType: vi.fn()
+  })
+}));
+
+vi.mock('../lib/hooks/use-canvas-spawn', () => ({
+  useCanvasSpawn: () => ({
+    recent: [],
+    setRecent: vi.fn(),
+    closeRecent: vi.fn(),
+    applyPreset: vi.fn(async () => undefined),
+    applySavedPreset: vi.fn(async () => undefined),
+    applyCustomAgentLeaderPreset: vi.fn(async () => undefined),
+    restoreRecent: vi.fn(async () => undefined),
+    spawnTeamPresetById: vi.fn(async () => undefined)
+  })
+}));
+
+vi.mock('../lib/hooks/use-canvas-menu-actions', () => ({
+  useCanvasMenuActions: () => ({
+    handleClickUpdate: vi.fn(),
+    handleNewProject: vi.fn(),
+    handleOpenFolder: vi.fn(),
+    handleOpenFile: vi.fn(),
+    handleAddWorkspaceFolder: vi.fn(),
+    handleOpenRecent: vi.fn(),
+    handleRestart: vi.fn(),
+    handleCheckUpdate: vi.fn(),
+    handleOpenGithub: vi.fn(),
+    clearCanvas: vi.fn()
+  })
+}));
+
+vi.mock('../lib/hooks/use-canvas-team-restore', () => ({ useCanvasTeamRestore: vi.fn() }));
+vi.mock('../lib/hooks/use-canvas-auto-save', () => ({ useCanvasAutoSave: vi.fn() }));
+vi.mock('../lib/hooks/use-layout-resize', () => ({
+  useLayoutResize: () => ({
+    onSidebarResizeStart: vi.fn(),
+    onSidebarResizeDouble: vi.fn()
+  })
+}));
+
+vi.mock('../components/canvas/Canvas', async () => {
+  const ReactModule = await import('react');
+  const context = await import('../lib/app-state-context');
+  return {
+    Canvas: () => {
+      const project = context.useProject() as ReturnType<typeof context.useProject> & {
+        instanceMarker: string;
+      };
+      const tabs = context.useTabs() as ReturnType<typeof context.useTabs> & {
+        instanceMarker: string;
+        projectMarker: string;
+      };
+      const team = context.useTeam() as ReturnType<typeof context.useTeam> & {
+        instanceMarker: string;
+        projectMarker: string;
+      };
+      ReactModule.useEffect(() => {
+        harness.canvasChildMounts += 1;
+        return () => {
+          harness.canvasChildUnmounts += 1;
+        };
+      }, []);
+      return ReactModule.createElement('div', {
+        'data-testid': 'canvas-child-probe',
+        'data-project-instance': project.instanceMarker,
+        'data-tabs-instance': tabs.instanceMarker,
+        'data-team-instance': team.instanceMarker,
+        'data-project-root': project.projectRoot,
+        'data-tabs-project': tabs.projectMarker,
+        'data-team-project': team.projectMarker
+      });
+    }
+  };
+});
+
+vi.mock('../components/canvas/CanvasSidebar', () => ({ CanvasSidebar: () => null }));
+vi.mock('../components/canvas/CanvasSpawnFab', () => ({ CanvasSpawnFab: () => null }));
+vi.mock('../components/canvas/VoiceControlButton', () => ({ VoiceControlButton: () => null }));
+vi.mock('../components/shell/Rail', () => ({ Rail: () => null }));
+vi.mock('../components/shell/Topbar', () => ({ Topbar: () => null }));
+vi.mock('../components/shell/AppMenuBar', () => ({ AppMenuBar: () => null }));
+vi.mock('../components/SettingsModal', () => ({ SettingsModal: () => null }));
+vi.mock('../lib/workspace-presets', () => ({ DEFAULT_SPAWN_PRESET: {} }));
+vi.mock('lucide-react', () => ({ Layout: () => null }));
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('main provider boundary', () => {
+  it('keeps the single real CanvasLayout inside the shared AppStateProvider across mode changes', async () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    const { useUiStore } = await import('../stores/ui');
+    useUiStore.setState({ viewMode: 'ide', sidebarCollapsed: true });
+
+    await import('../main');
+    expect(harness.renderedTree).not.toBeNull();
+
+    const view = render(harness.renderedTree as ReactElement);
+    const shell = screen.getByTestId('app-shell-probe');
+    const canvas = view.container.querySelector<HTMLElement>('.canvas-layout');
+    const canvasChild = screen.getByTestId('canvas-child-probe');
+    expect(canvas).not.toBeNull();
+    expect(view.container.querySelectorAll('.canvas-layout')).toHaveLength(1);
+    expect(shell.compareDocumentPosition(canvas as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    for (const key of ['project-instance', 'tabs-instance', 'team-instance']) {
+      expect(canvasChild.dataset[key]).toBe(shell.dataset[key]);
+    }
+    expect(canvas).toHaveStyle({ display: 'none' });
+    expect(canvas).toHaveAttribute('aria-hidden', 'true');
+
+    const initialCanvasNode = canvas;
+    const baselineMounts = harness.canvasChildMounts;
+    const baselineUnmounts = harness.canvasChildUnmounts;
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'switch project' }));
+    });
+    expect(shell).toHaveAttribute('data-project-root', 'C:\\project-b');
+    expect(canvasChild).toHaveAttribute('data-project-root', 'C:\\project-b');
+    expect(canvasChild).toHaveAttribute('data-tabs-project', 'C:\\project-b');
+    expect(canvasChild).toHaveAttribute('data-team-project', 'C:\\project-b');
+
+    act(() => useUiStore.getState().setViewMode('canvas'));
+    expect(view.container.querySelector('.canvas-layout')).toBe(initialCanvasNode);
+    expect(initialCanvasNode).not.toHaveStyle({ display: 'none' });
+    expect(initialCanvasNode).toHaveAttribute('aria-hidden', 'false');
+
+    act(() => useUiStore.getState().setViewMode('ide'));
+    expect(view.container.querySelector('.canvas-layout')).toBe(initialCanvasNode);
+    expect(initialCanvasNode).toHaveStyle({ display: 'none' });
+    expect(initialCanvasNode).toHaveAttribute('aria-hidden', 'true');
+    expect(harness.canvasChildMounts).toBe(baselineMounts);
+    expect(harness.canvasChildUnmounts).toBe(baselineUnmounts);
+  });
+});

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -22,7 +22,6 @@ import './styles/fonts.css';
 import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom/client';
 import { App } from './App';
-import { CanvasLayout } from './layouts/CanvasLayout';
 import { AppErrorBoundary } from './components/AppErrorBoundary';
 import { SettingsProvider } from './lib/settings-context';
 import { ToastProvider } from './lib/toast-context';
@@ -108,20 +107,10 @@ function Root(): JSX.Element {
     document.documentElement.dataset.viewMode = viewMode;
   }, [viewMode]);
 
-  // bug_027 対策: <App/> を unmount すると全 PTY が kill され、未保存エディタも失われる。
-  // そこで <App/> は常時マウントし、Canvas モードではその上に CanvasLayout を
-  // position:fixed でオーバーレイするだけに留める。これにより切替で
-  // terminalTabs / editorTabs / teams がすべて保持される。
-  //
-  // 同様の理由で <CanvasLayout/> も常時マウントし、IDE モードでは display:none で
-  // 隠す (CanvasLayout 自身が viewMode を読んでルート div を toggle する)。
-  // これで Canvas 上の AgentNodeCard も unmount されず、PTY が kill されない。
-  return (
-    <>
-      <App />
-      <CanvasLayout />
-    </>
-  );
+  // bug_027 対策: App は常時マウントする。CanvasLayout も AppStateProvider 内で
+  // App と同時に常時マウントされ、IDE モードでは CanvasLayout 自身が display:none
+  // に切り替える。これにより両画面の PTY / editorTabs / teams を保持する。
+  return <App />;
 }
 
 ReactDOM.createRoot(rootEl).render(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -19,6 +19,43 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1146
 - [x] `cargo check --locked --manifest-path src-tauri\\Cargo.toml --all-targets`: PASS
 - [x] `git diff --check`: PASS
 
+## Issue #1240 - v1.6.8 AppStateProvider境界違反の起動不能修正・リリース (2026-07-15 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1240
+Plan hash: `402caac06b8ec5e2959bc1c69092d2eacaf943d1db6c3c158608693bb6cfca13`
+
+### 計画
+
+- [x] `main.tsx` の Provider 外に残った `CanvasLayout` を、`App.tsx` の既存 `AppStateProvider` 配下へ移す。
+- [x] 実 bootstrap tree、実 Context guard、実 `CanvasLayout` を通す回帰テストを追加する。
+- [x] Provider 一意性、project/tabs/team 共有、Canvas 常時 mount、`display:none` 契約を固定する。
+- [x] typecheck、対象 Vitest、全 Vitest、lint、Vite build、Tauri build を実行する。
+- [ ] fresh diff review、PR、CI、CodeRabbit、vibe-editor-reviewer の指摘を解消する。
+- [ ] PR を main へ merge し、patch version を上げて release PR・tag・workflow・draft publish を完了する。
+- [ ] Windows ローカルPCへ公開版をインストールし、起動、IDE/Canvas往復、project切替、PTY継続を確認する。
+- [ ] Issue #1240へ完了根拠を投稿し、`implemented`、`CLOSED` を再確認する。
+
+### Next Steps
+
+- [x] Terra Build候補patchを取得し、SolがscopeとRCA接続を確認して適用する。
+- [x] canonical testとfresh diff reviewを実行する。
+- [ ] PR・release・ローカル実機確認・Issue closeoutまで継続する。
+
+### 進捗
+
+- [x] Terra Build run `a74bf9a31e4344629fd707ef5034f90e` を選定し、production 2ファイルへ最小差分を適用した。
+- [x] targeted Vitest 1/1、全Vitest 603/603、typecheck、lint、Vite build、JS契約lint、npm監査がPASSした。
+- [x] `cargo check --all-targets` と `cargo clippy --all-targets -- -D warnings` がPASSした。
+- [x] Windows release binaryとNSIS installerを生成した。Updater署名秘密鍵はCI専用のため、ローカルbuildの終了値のみ非0。
+- [x] Terra Review run `30e55fece813479aa9f6a78544289f6a` は対象hash `e4668c...b2d8a` にactionableなしと判定した。
+
+### Next Tasks
+
+- [ ] fix PRのCI・CodeRabbit・vibe-editor-reviewerを完了し、mainへmergeする。
+- [ ] v1.6.9 release PR・tag・release workflow・draft publishを完了する。
+- [ ] 公開版をWindowsへ導入してSymptom Goneを実証し、Issue #1240をcloseする。
+
+
 ## Issue #1164 - Zustand / marked の重複依存解消 (2026-07-15 / Codex)
 
 Issue: https://github.com/yusei531642/vibe-editor/issues/1164


### PR DESCRIPTION
## 概要

Issue #1240 の起動不能を修正します。

v1.6.8 では `main.tsx` が `App` と `CanvasLayout` を兄弟として描画していました。一方、`AppStateProvider` は `App` 内部にあるため、`CanvasLayout` の `useProject()` が Provider 外で実行され、起動直後に描画が停止していました。

## 変更

- `CanvasLayout` を既存の `AppStateProvider` 配下へ移動
- `main.tsx` から Provider 外の兄弟描画を削除
- 実bootstrap tree・実Context guard・実CanvasLayoutを通す回帰テストを追加
- project/tabs/team共有、Canvasの単一性、IDE時の常時mount、mode切替時の未unmountを固定

## 検証

- `npm run typecheck`: PASS
- targeted Vitest: PASS (1/1)
- `npm run test`: PASS (603/603)
- `npm run lint`: PASS (0 errors / existing 11 warnings)
- `npm run build:vite`: PASS
- JS契約lint一式: PASS
- npm production audit / signature audit: PASS
- `cargo check --locked --all-targets`: PASS
- `cargo clippy --locked --all-targets -- -D warnings`: PASS
- Windows release binary / NSIS installer: 生成成功
  - updater署名秘密鍵はCI専用のため、ローカルbuildコマンドの終了値のみ非0
- Terra fresh diff review: actionableなし
  - run: `30e55fece813479aa9f6a78544289f6a`
  - target: `sha256:e4668c05ee3184fcb22acaa2cb7706199a9b897d095bd79724a9d1f1ec2b2d8a`

## 補足

ローカルWindowsの全Rustテストは926件PASS。初回3件FAILのうちbridge 2件は直列再実行でPASSしました。残る1件は既存fixtureの `.claude/skills` が `cmd mklink` に `/skills` と解釈される問題で、本PRのrenderer差分とは独立しています。GitHub CIのLinux全RustテストとWindows既定PTYテストを最終ゲートにします。

Closes #1240
