### PR TITLE
chore(release): v1.6.9へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-editor",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-editor",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/geist-mono": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-editor",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "private": true,
   "description": "Tauri ベースの Claude Code / Codex 専用エディタ",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5770,7 +5770,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-editor"
-version = "1.6.8"
+version = "1.6.9"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-editor"
-version = "1.6.8"
+version = "1.6.9"
 description = "Electron→Tauri 移行版 vibe-editor (Claude Code / Codex 専用エディタ)"
 authors = ["yusei <yusei@yuseilab.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vibe-editor",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "identifier": "com.vibe-editor.app",
   "build": {
     "beforeDevCommand": "npm run dev:vite",

--- a/tasks/release-v1.6.9.md
+++ b/tasks/release-v1.6.9.md
@@ -1,0 +1,47 @@
+# Release v1.6.9
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1240
+
+## 計画
+
+- v1.6.8の起動不能を解消したmainをv1.6.9として公開する。
+- version filesを1.6.9へ同期する。
+- release PRのCIとreviewer botを確認してmergeする。
+- merge commitへannotated tag `v1.6.9`を作成してpushする。
+- release workflowの成果物とupdater metadataを確認し、draft releaseをpublishする。
+- 公開版を同一Windows PCへ導入し、Symptom Goneを確認する。
+
+## 主な変更
+
+- `CanvasLayout`を既存の`AppStateProvider`配下へ移し、v1.6.8起動直後のProvider guard例外を解消。
+- IDEとCanvasが同じproject/tabs/team stateを共有し、Canvas/PTYの常時mount契約を維持。
+- 実bootstrap treeと実Context guardを通す回帰テストを追加。
+
+## Next Steps
+
+- [x] `package.json` / `package-lock.json` / `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` / `src-tauri/tauri.conf.json`を1.6.9へ更新する。
+- [x] release前チェックを実行する。
+- [ ] release PRを作成し、CI / reviewer botを確認する。
+- [ ] PR merge後に`v1.6.9` tagをpushする。
+- [ ] release workflowを監視し、draft releaseのassetsと`latest.json`を確認する。
+- [ ] draft releaseをpublishする。
+- [ ] 公開版をWindowsへ導入してIssue #1240をcloseする。
+
+## 検証結果
+
+- [x] version同期
+- [x] `npm run typecheck`: PASS
+- [x] `npm run test`: PASS（106 files / 603 tests）
+- [x] `npm run build:vite`: PASS
+- [x] `npm run lint:release-workflow`: PASS
+- [x] `npm run lint:file-size`: PASS
+- [x] `npm audit --omit=dev --audit-level=moderate`: PASS（0 vulnerabilities）
+- [x] `npm audit signatures`: PASS（285 signatures / 74 attestations）
+- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`: PASS
+- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
+- [x] `git diff --check`: PASS
+
+### 検証計画の更新
+
+- 初回の全VitestはRust release前検査との並列負荷により、`main-provider-boundary.test.tsx`だけがassertion到達前に5秒timeoutした。
+- GitHub CIの同一HEADでは603/603 PASS済み。ローカルは負荷を分離し、対象テストと全Vitestを順次再実行して再現性を判定する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -30,7 +30,7 @@ Plan hash: `402caac06b8ec5e2959bc1c69092d2eacaf943d1db6c3c158608693bb6cfca13`
 - [x] 実 bootstrap tree、実 Context guard、実 `CanvasLayout` を通す回帰テストを追加する。
 - [x] Provider 一意性、project/tabs/team 共有、Canvas 常時 mount、`display:none` 契約を固定する。
 - [x] typecheck、対象 Vitest、全 Vitest、lint、Vite build、Tauri build を実行する。
-- [ ] fresh diff review、PR、CI、CodeRabbit、vibe-editor-reviewer の指摘を解消する。
+- [x] fresh diff review、PR、CI、CodeRabbit、vibe-editor-reviewer の指摘を解消する。
 - [ ] PR を main へ merge し、patch version を上げて release PR・tag・workflow・draft publish を完了する。
 - [ ] Windows ローカルPCへ公開版をインストールし、起動、IDE/Canvas往復、project切替、PTY継続を確認する。
 - [ ] Issue #1240へ完了根拠を投稿し、`implemented`、`CLOSED` を再確認する。
@@ -51,7 +51,7 @@ Plan hash: `402caac06b8ec5e2959bc1c69092d2eacaf943d1db6c3c158608693bb6cfca13`
 
 ### Next Tasks
 
-- [ ] fix PRのCI・CodeRabbit・vibe-editor-reviewerを完了し、mainへmergeする。
+- [x] fix PRのCI・CodeRabbit・vibe-editor-reviewerを完了し、mainへmergeする。
 - [ ] v1.6.9 release PR・tag・release workflow・draft publishを完了する。
 - [ ] 公開版をWindowsへ導入してSymptom Goneを実証し、Issue #1240をcloseする。
 


### PR DESCRIPTION
## 概要

Issue #1240 の起動不能修正をv1.6.9として公開するため、versionを同期します。

## 変更

- `package.json` / `package-lock.json`: 1.6.9
- `src-tauri/Cargo.toml` / `Cargo.lock`: 1.6.9
- `src-tauri/tauri.conf.json`: 1.6.9
- release計画・検証結果を記録

## 検証

- version 5ファイル同期: PASS
- typecheck: PASS
- targeted Vitest: PASS (1/1)
- full Vitest: PASS (106 files / 603 tests)
- Vite build: PASS
- release workflow contract / file-size: PASS
- npm production audit: PASS (0 vulnerabilities)
- npm signatures: PASS (285 signatures / 74 attestations)
- cargo check / clippy -D warnings: PASS
- git diff --check: PASS

初回の全VitestはRust検査との並列負荷により新規テストが5秒timeoutしましたが、負荷を分離した対象テストと全603件はいずれもPASSしました。fix PR #1241のGitHub CIも全SUCCESSです。

関連: #1240
