### PR TITLE
fix(settings): #1243 project authority復元を安定化

### DIFF
--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -139,9 +139,7 @@ pub async fn assert_readable_project_root(
     let active = current_project_root(project_root_slot).unwrap_or_default();
     if !active.trim().is_empty() {
         if let Ok(active_canon) = tokio::fs::canonicalize(active.trim()).await {
-            if crate::commands::project_identity::canonical_root_key(&req_canon)
-                == crate::commands::project_identity::canonical_root_key(&active_canon)
-            {
+            if active_project::canonical_roots_match(&req_canon, &active_canon) {
                 return assert_active_project_root(
                     project_root_slot,
                     project_root_identity_slot,
@@ -401,27 +399,6 @@ mod tests {
             canon.as_path(),
             std::fs::canonicalize(project.path()).unwrap().as_path()
         );
-    }
-
-    #[cfg(windows)]
-    #[tokio::test]
-    async fn native_identity_canonical_root_accepts_windows_display_path() {
-        let project = tempdir().expect("project");
-        let approved = crate::commands::project_authority::capture_identity(project.path())
-            .await
-            .expect("capture native identity");
-        let active = ArcSwapOption::from(Some(std::sync::Arc::new(
-            approved.canonical_root.clone(),
-        )));
-        let identity = ArcSwapOption::from(Some(std::sync::Arc::new(approved)));
-        let requested = project.path().to_string_lossy();
-
-        assert_active_project_root(&active, &identity, &requested)
-            .await
-            .expect("strict gate should accept the native display path");
-        assert_readable_project_root(&active, &identity, &requested)
-            .await
-            .expect("readable gate should accept the native display path");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/authz.rs
+++ b/src-tauri/src/commands/authz.rs
@@ -139,7 +139,9 @@ pub async fn assert_readable_project_root(
     let active = current_project_root(project_root_slot).unwrap_or_default();
     if !active.trim().is_empty() {
         if let Ok(active_canon) = tokio::fs::canonicalize(active.trim()).await {
-            if req_canon == active_canon {
+            if crate::commands::project_identity::canonical_root_key(&req_canon)
+                == crate::commands::project_identity::canonical_root_key(&active_canon)
+            {
                 return assert_active_project_root(
                     project_root_slot,
                     project_root_identity_slot,
@@ -399,6 +401,27 @@ mod tests {
             canon.as_path(),
             std::fs::canonicalize(project.path()).unwrap().as_path()
         );
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn native_identity_canonical_root_accepts_windows_display_path() {
+        let project = tempdir().expect("project");
+        let approved = crate::commands::project_authority::capture_identity(project.path())
+            .await
+            .expect("capture native identity");
+        let active = ArcSwapOption::from(Some(std::sync::Arc::new(
+            approved.canonical_root.clone(),
+        )));
+        let identity = ArcSwapOption::from(Some(std::sync::Arc::new(approved)));
+        let requested = project.path().to_string_lossy();
+
+        assert_active_project_root(&active, &identity, &requested)
+            .await
+            .expect("strict gate should accept the native display path");
+        assert_readable_project_root(&active, &identity, &requested)
+            .await
+            .expect("readable gate should accept the native display path");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/authz/active_project.rs
+++ b/src-tauri/src/commands/authz/active_project.rs
@@ -6,6 +6,11 @@ use crate::commands::project_authority::ProjectRootIdentity;
 use crate::state::{current_project_root, current_project_root_identity};
 use arc_swap::ArcSwapOption;
 
+pub(super) fn canonical_roots_match(left: &std::path::Path, right: &std::path::Path) -> bool {
+    crate::commands::project_identity::canonical_root_key(left)
+        == crate::commands::project_identity::canonical_root_key(right)
+}
+
 /// active projectとの照合に成功した同一snapshotを表すcapability。
 /// requested rawは保持せず、Claude directory互換用のactive rawだけを保持する。
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -154,9 +159,7 @@ pub(crate) async fn assert_active_project_root_policy(
         }
     };
 
-    if crate::commands::project_identity::canonical_root_key(&req_canon)
-        != crate::commands::project_identity::canonical_root_key(&active_canon)
-    {
+    if !canonical_roots_match(&req_canon, &active_canon) {
         tracing::warn!(
             requested = %clamp_for_log(&req_canon.to_string_lossy()),
             active = %clamp_for_log(&active_canon.to_string_lossy()),
@@ -311,6 +314,27 @@ pub fn invalidate_identity_recheck() {
 #[cfg(test)]
 mod recheck_cache_tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn native_identity_canonical_root_accepts_windows_display_path() {
+        let project = tempfile::tempdir().expect("project");
+        let approved = crate::commands::project_authority::capture_identity(project.path())
+            .await
+            .expect("capture native identity");
+        let active = ArcSwapOption::from(Some(std::sync::Arc::new(
+            approved.canonical_root.clone(),
+        )));
+        let identity = ArcSwapOption::from(Some(std::sync::Arc::new(approved)));
+        let requested = project.path().to_string_lossy();
+
+        assert_active_project_root(&active, &identity, &requested)
+            .await
+            .expect("strict gate should accept the native display path");
+        super::super::assert_readable_project_root(&active, &identity, &requested)
+            .await
+            .expect("readable gate should accept the native display path");
+    }
 
     fn identity(root: &str, file_id: &str) -> ProjectRootIdentity {
         ProjectRootIdentity {

--- a/src-tauri/src/commands/authz/active_project.rs
+++ b/src-tauri/src/commands/authz/active_project.rs
@@ -154,7 +154,9 @@ pub(crate) async fn assert_active_project_root_policy(
         }
     };
 
-    if req_canon != active_canon {
+    if crate::commands::project_identity::canonical_root_key(&req_canon)
+        != crate::commands::project_identity::canonical_root_key(&active_canon)
+    {
         tracing::warn!(
             requested = %clamp_for_log(&req_canon.to_string_lossy()),
             active = %clamp_for_log(&active_canon.to_string_lossy()),

--- a/src/renderer/src/lib/hooks/__tests__/use-project-loader.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-project-loader.test.tsx
@@ -189,6 +189,28 @@ describe('useProjectLoader', () => {
     );
   });
 
+  it('native reconfirm失敗時はsettingsのrootを採用しない', async () => {
+    const untrustedRoot = 'C:\\Users\\zooyo\\Documents\\untrusted';
+    mocks.settingsValues.lastOpenedRoot = untrustedRoot;
+    const api = installApi();
+    api.app.reconfirmProjectRoot.mockRejectedValueOnce(new Error('reconfirm failed'));
+
+    const { result } = renderHook(() => useProjectLoader(options()));
+
+    await waitFor(() => expect(result.current.gitLoading).toBe(false));
+
+    expect(api.app.reconfirmProjectRoot).toHaveBeenCalledWith(
+      untrustedRoot,
+      'appMenu.openFolderDialogTitle'
+    );
+    expect(result.current.projectRoot).toBe('');
+    expect(api.git.status).not.toHaveBeenCalled();
+    expect(api.app.clearActiveProjectRoot).not.toHaveBeenCalled();
+    expect(mocks.setStatus).toHaveBeenLastCalledWith(
+      'project.initError: Error: reconfirm failed'
+    );
+  });
+
   it('recent pathはnative pickerの初期位置にだけ渡し、再選択結果をloadする', async () => {
     const api = installApi();
     api.app.restoreAuthorizedProjectRoot.mockResolvedValueOnce('/repo');

--- a/src/renderer/src/lib/hooks/__tests__/use-project-loader.test.tsx
+++ b/src/renderer/src/lib/hooks/__tests__/use-project-loader.test.tsx
@@ -136,14 +136,14 @@ describe('useProjectLoader', () => {
     vi.restoreAllMocks();
   });
 
-  it('保存済み root はauthorityに使わず、native pickerの結果だけを起動する', async () => {
+  it('保存済み root はauthorityに使わず、native reconfirmの結果だけを起動する', async () => {
     const invalidRoot = 'C:\\Users\\zooyo';
     const pickedRoot =
       'C:\\Users\\zooyo\\Documents\\GitHub\\DX\\digital-management-consulting-app';
     mocks.settingsValues.lastOpenedRoot = invalidRoot;
     mocks.settingsValues.claudeCwd = invalidRoot;
     const api = installApi();
-    api.app.pickAndActivateProjectRoot.mockResolvedValueOnce(pickedRoot);
+    api.app.reconfirmProjectRoot.mockResolvedValueOnce(pickedRoot);
     const onLoaded = vi.fn();
     const onProjectSwitched = vi.fn();
 
@@ -151,11 +151,15 @@ describe('useProjectLoader', () => {
       useProjectLoader(options({ onLoaded, onProjectSwitched }))
     );
 
-    await waitFor(() => expect(api.app.pickAndActivateProjectRoot).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(api.app.reconfirmProjectRoot).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(api.git.status).toHaveBeenCalledWith(pickedRoot));
 
     expect(api.app.restoreAuthorizedProjectRoot).toHaveBeenCalledTimes(1);
-    expect(api.app.pickAndActivateProjectRoot).toHaveBeenCalledWith('appMenu.openFolderDialogTitle');
+    expect(api.app.reconfirmProjectRoot).toHaveBeenCalledWith(
+      invalidRoot,
+      'appMenu.openFolderDialogTitle'
+    );
+    expect(api.app.pickAndActivateProjectRoot).not.toHaveBeenCalled();
     expect(mocks.updateSettings).toHaveBeenCalledWith({ lastOpenedRoot: pickedRoot });
     expect(result.current.projectRoot).toBe(pickedRoot);
     expect(onLoaded).toHaveBeenCalledWith({
@@ -163,6 +167,26 @@ describe('useProjectLoader', () => {
       sessions: []
     });
     expect(onProjectSwitched).not.toHaveBeenCalled();
+  });
+
+  it('初期IPC失敗時もnative authorityと選択rootを保持する', async () => {
+    const api = installApi();
+    api.app.restoreAuthorizedProjectRoot.mockResolvedValueOnce('/repo');
+    api.git.status.mockRejectedValueOnce(new Error('transient git failure'));
+    const onProjectSwitched = vi.fn();
+
+    const { result } = renderHook(() =>
+      useProjectLoader(options({ onProjectSwitched }))
+    );
+
+    await waitFor(() => expect(result.current.gitLoading).toBe(false));
+
+    expect(result.current.projectRoot).toBe('/repo');
+    expect(api.app.clearActiveProjectRoot).not.toHaveBeenCalled();
+    expect(onProjectSwitched).not.toHaveBeenCalled();
+    expect(mocks.setStatus).toHaveBeenLastCalledWith(
+      'project.initError: Error: transient git failure'
+    );
   });
 
   it('recent pathはnative pickerの初期位置にだけ渡し、再選択結果をloadする', async () => {

--- a/src/renderer/src/lib/hooks/use-project-loader.ts
+++ b/src/renderer/src/lib/hooks/use-project-loader.ts
@@ -170,9 +170,15 @@ export function useProjectLoader(
         // 起動時のauthorityに使わない。Rustのprivate ledgerが復元したactive rootだけを使う。
         let root = await window.api.app.restoreAuthorizedProjectRoot();
         if (!root) {
-          const picked = await window.api.app.pickAndActivateProjectRoot(
-            t('appMenu.openFolderDialogTitle')
-          );
+          // settingsの保存値はauthorityには使わず、native pickerの初期位置にだけ渡す。
+          const picked = lastOpenedRoot
+            ? await window.api.app.reconfirmProjectRoot(
+                lastOpenedRoot,
+                t('appMenu.openFolderDialogTitle')
+              )
+            : await window.api.app.pickAndActivateProjectRoot(
+                t('appMenu.openFolderDialogTitle')
+              );
           if (cancelled) return;
           if (!picked) {
             // ユーザーがキャンセルした場合は projectRoot 未設定のまま空状態を維持。
@@ -206,10 +212,9 @@ export function useProjectLoader(
         optsRef.current.onLoaded({ gitStatus: gs, sessions: sess });
         useUiStore.getState().setStatus(root.split(/[\\/]/).pop() ?? root);
       } catch (err) {
-        await window.api.app.clearActiveProjectRoot().catch(() => undefined);
-        setProjectRoot('');
+        // git/sessionの一時的な初期化失敗は、native承認済みauthorityを失効させる理由ではない。
+        // rootを保持し、ユーザーが再読込または別folder選択で復旧できる状態にする。
         setGitStatus(null);
-        optsRef.current.onProjectSwitched('');
         useUiStore.getState().setStatus(t('project.initError', { error: String(err) }));
         setGitLoading(false);
       }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -28,6 +28,7 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1243
 - [x] Security Invariant: 同一pathのfilesystem identity差し替え拒否テスト PASS。
 - [x] Frontend: typecheck、604 tests、Vite build PASS。lintは0 errors / 11 warnings。
 - [x] Rust: cargo check、clippy `-D warnings`、関連テスト PASS。
+- [x] CI file-size ratchet: 回帰テストを`active_project.rs`へ責務移動し、baseline引き上げなしでPASS。
 - [ ] Rust全体テストは928 PASS / 2 ignored / 2環境依存FAIL（junction fixture、Windows access denied）。
 - [ ] `cargo fmt --check`はmain既存の広範な未整形差分によりFAIL。今回外の一括整形は実施しない。
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,42 @@
 # vibe-editor Tauri ハイブリッド移行 + 無限キャンバス UI 革新 TODO
 
+## Issue #1243 - Windows project root authority復元修正 (2026-07-15 / Codex)
+
+Issue: https://github.com/yusei531642/vibe-editor/issues/1243
+
+### RCA結果
+
+- RCA Mode: Root Cause Confirmed
+- 症状: v1.6.9でnative承認済みrootがWindowsのcase/verbatim表記差により初期IPCで拒否される。
+- 原因箇所: `project_identity.rs`の保存用keyと`authz.rs` / `authz/active_project.rs`の`PathBuf`直接比較が不整合。
+- 独立証拠: 実機ログの`requested=\\?\C:\... not active project`とproductionコード経路が一致。
+- 修正方針: comparison keyを統一しidentity再照合を維持する。ledgerなし時はnative再承認を促し、一時的な初期IPC失敗でledgerを破壊しない。
+- 判定: A=YES, B=YES, C=YES, D=YES
+
+### 計画
+
+- [x] Windows path表記差の回帰テストを追加する（実機ログと旧コード経路をRED相当の証拠として採用）。
+- [x] strict/readable gateを共通comparison keyへ統一し、filesystem identity再照合を維持する。
+- [x] ledgerなし+`lastOpenedRoot`ありではnative reconfirm pickerを使う。
+- [x] 初期IPC失敗時にactive authorityを削除しない契約をテスト・実装する。
+- [x] targeted/full test、typecheck、lint、Rust checksを実行する。
+- [ ] fresh review、Fable one-shot、PR、CI/reviewer確認まで進める。
+
+### 進捗
+
+- [x] Symptom Gone: Windows native identityのdisplay pathをstrict/readable gateが受理する回帰テスト PASS。
+- [x] Security Invariant: 同一pathのfilesystem identity差し替え拒否テスト PASS。
+- [x] Frontend: typecheck、604 tests、Vite build PASS。lintは0 errors / 11 warnings。
+- [x] Rust: cargo check、clippy `-D warnings`、関連テスト PASS。
+- [ ] Rust全体テストは928 PASS / 2 ignored / 2環境依存FAIL（junction fixture、Windows access denied）。
+- [ ] `cargo fmt --check`はmain既存の広範な未整形差分によりFAIL。今回外の一括整形は実施しない。
+
+### Next Tasks
+
+- [ ] Fable one-shotでauthority保持時の安全境界を重点確認する。
+- [ ] feature branchをpushし、`Closes #1243`付きPRを作成する。
+- [ ] CIとvibe-editor-reviewerの本レビューを確認する。
+
 ## Issue #1146 - API agent session削除失敗を伝播 (2026-07-14 / Codex)
 
 Issue: https://github.com/yusei531642/vibe-editor/issues/1146

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -33,7 +33,7 @@ Issue: https://github.com/yusei531642/vibe-editor/issues/1243
 
 ### Next Tasks
 
-- [ ] Fable one-shotでauthority保持時の安全境界を重点確認する。
+- [x] Fable one-shotでauthority保持時の安全境界を重点確認する（実コード未添付由来の検証要求を照合し、reconfirm失敗のfail-closedテストを追加）。
 - [ ] feature branchをpushし、`Closes #1243`付きPRを作成する。
 - [ ] CIとvibe-editor-reviewerの本レビューを確認する。
 


### PR DESCRIPTION
## Summary
- Windowsのverbatim pathとledger keyの表記差を共通comparison keyで比較し、正当なproject rootの誤拒否を修正
- ledgerなし時は保存済みpathをnative reconfirmの初期位置にだけ使い、settings値をauthorityへ昇格しない
- 初期git/session IPC失敗時はnative authorityを保持し、再読み込みで復旧可能にする

Closes #1243

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`（0 errors / 11 existing warnings）
- [x] `npm test -- --run`（106 files / 604 tests）
- [x] `npm run build:vite`
- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets`
- [x] `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- [x] Windows native identity display path gate回帰テスト
- [x] same-path filesystem identity差し替え拒否テスト
- [x] reconfirm失敗時のfail-closed rendererテスト

## Known baseline constraints
- Rust全体テスト: 928 PASS / 2 ignored / 2 FAIL。失敗はjunction fixture作成不可とWindows一時設定ファイルのaccess deniedで、変更対象外
- `cargo fmt --check`: main既存の広範な未整形差分でFAIL。スコープ外の一括整形は未実施